### PR TITLE
fix: add GCS OAuth scope to resolve 403 on file upload

### DIFF
--- a/ai-brand-automator/files/services.py
+++ b/ai-brand-automator/files/services.py
@@ -28,7 +28,10 @@ class GCSService:
         try:
             if self.credentials_path and os.path.exists(self.credentials_path):
                 credentials = service_account.Credentials.from_service_account_file(
-                    self.credentials_path
+                    self.credentials_path,
+                    scopes=[
+                        "https://www.googleapis.com/auth/devstorage.full_control"
+                    ],
                 )
                 self.client = storage.Client(
                     credentials=credentials, project=self.project_id

--- a/ai-brand-automator/files/services.py
+++ b/ai-brand-automator/files/services.py
@@ -29,9 +29,7 @@ class GCSService:
             if self.credentials_path and os.path.exists(self.credentials_path):
                 credentials = service_account.Credentials.from_service_account_file(
                     self.credentials_path,
-                    scopes=[
-                        "https://www.googleapis.com/auth/devstorage.full_control"
-                    ],
+                    scopes=["https://www.googleapis.com/auth/devstorage.full_control"],
                 )
                 self.client = storage.Client(
                     credentials=credentials, project=self.project_id


### PR DESCRIPTION
The service account credentials were loaded without specifying OAuth scopes, causing a 403 'Provided scope(s) are not authorized' error when uploading files to GCS on Railway.

Added 'devstorage.full_control' scope to the
Credentials.from_service_account_file() call.