### PR TITLE
fix: support GCS credentials from env var for Railway deployment

### DIFF
--- a/ai-brand-automator/Dockerfile
+++ b/ai-brand-automator/Dockerfile
@@ -40,7 +40,8 @@ set -e
 # Write GCS credentials file from env var if provided (Railway/Heroku)
 if [ -n "$GCS_CREDENTIALS_JSON" ]; then
   echo "=== Writing GCS credentials file ==="
-  echo "$GCS_CREDENTIALS_JSON" > /app/gcs-credentials.json
+  printf '%s' "$GCS_CREDENTIALS_JSON" > /app/gcs-credentials.json
+  chmod 600 /app/gcs-credentials.json
   export GS_CREDENTIALS_PATH=/app/gcs-credentials.json
   export GOOGLE_APPLICATION_CREDENTIALS=/app/gcs-credentials.json
 fi

--- a/ai-brand-automator/Dockerfile
+++ b/ai-brand-automator/Dockerfile
@@ -32,10 +32,19 @@ RUN mkdir -p logs staticfiles
 # Expose port
 EXPOSE 8000
 
-# Create entrypoint script - v2 with production domains
+# Create entrypoint script - v3 with GCS credentials support
 RUN cat <<'EOF' > /app/entrypoint.sh && chmod +x /app/entrypoint.sh
 #!/bin/bash
 set -e
+
+# Write GCS credentials file from env var if provided (Railway/Heroku)
+if [ -n "$GCS_CREDENTIALS_JSON" ]; then
+  echo "=== Writing GCS credentials file ==="
+  echo "$GCS_CREDENTIALS_JSON" > /app/gcs-credentials.json
+  export GS_CREDENTIALS_PATH=/app/gcs-credentials.json
+  export GOOGLE_APPLICATION_CREDENTIALS=/app/gcs-credentials.json
+fi
+
 echo "=== Running migrations ==="
 python manage.py migrate --noinput
 echo "=== Setting up production domains ==="

--- a/ai-brand-automator/files/services.py
+++ b/ai-brand-automator/files/services.py
@@ -3,6 +3,7 @@ File Storage Services for BrandForge AI
 Integration with Google Cloud Storage
 """
 
+import json
 import os
 import time
 import logging
@@ -13,10 +14,17 @@ from google.oauth2 import service_account
 
 logger = logging.getLogger(__name__)
 
+GCS_SCOPES = ["https://www.googleapis.com/auth/devstorage.full_control"]
+
 
 class GCSService:
     """
-    Service for interacting with Google Cloud Storage
+    Service for interacting with Google Cloud Storage.
+
+    Credentials are resolved in order:
+    1. GCS_CREDENTIALS_JSON env var (inline JSON - for Railway/Heroku)
+    2. GS_CREDENTIALS_PATH file on disk (local dev with service account key)
+    3. Application Default Credentials (GCP-hosted environments)
     """
 
     def __init__(self):
@@ -26,26 +34,45 @@ class GCSService:
 
         # Initialize GCS client
         try:
-            if self.credentials_path and os.path.exists(self.credentials_path):
-                credentials = service_account.Credentials.from_service_account_file(
-                    self.credentials_path,
-                    scopes=["https://www.googleapis.com/auth/devstorage.full_control"],
-                )
+            credentials = self._resolve_credentials()
+            if credentials:
                 self.client = storage.Client(
                     credentials=credentials, project=self.project_id
                 )
             else:
-                # Try to use default credentials (for GCP environments)
+                # Application Default Credentials (GCP environments)
                 self.client = storage.Client(project=self.project_id)
         except Exception as e:
             # Fallback: create a mock client for development
-            print(f"GCS initialization failed: {e}. Using mock service.")
+            logger.warning("GCS initialization failed: %s. Using mock service.", e)
             self.client = None
 
         if self.client:
             self.bucket = self.client.bucket(self.bucket_name)
         else:
             self.bucket = None
+
+    def _resolve_credentials(self):
+        """Resolve GCS credentials from env var, file, or return None for ADC."""
+        # 1. Inline JSON from environment variable (Railway / Heroku / CI)
+        creds_json = os.environ.get("GCS_CREDENTIALS_JSON", "").strip()
+        if creds_json:
+            logger.info("Loading GCS credentials from GCS_CREDENTIALS_JSON env var")
+            info = json.loads(creds_json)
+            return service_account.Credentials.from_service_account_info(
+                info, scopes=GCS_SCOPES
+            )
+
+        # 2. Service account key file on disk (local development)
+        if self.credentials_path and os.path.exists(self.credentials_path):
+            logger.info("Loading GCS credentials from file: %s", self.credentials_path)
+            return service_account.Credentials.from_service_account_file(
+                self.credentials_path, scopes=GCS_SCOPES
+            )
+
+        # 3. Fall back to Application Default Credentials
+        logger.info("No explicit GCS credentials found, using ADC")
+        return None
 
     def upload_file(self, file_obj, file_path, content_type=None, max_retries=3):
         """

--- a/ai-brand-automator/files/services.py
+++ b/ai-brand-automator/files/services.py
@@ -8,6 +8,7 @@ import os
 import time
 import logging
 from datetime import timedelta
+import google.auth
 from django.conf import settings
 from google.cloud import storage
 from google.oauth2 import service_account
@@ -35,13 +36,9 @@ class GCSService:
         # Initialize GCS client
         try:
             credentials = self._resolve_credentials()
-            if credentials:
-                self.client = storage.Client(
-                    credentials=credentials, project=self.project_id
-                )
-            else:
-                # Application Default Credentials (GCP environments)
-                self.client = storage.Client(project=self.project_id)
+            self.client = storage.Client(
+                credentials=credentials, project=self.project_id
+            )
         except Exception as e:
             # Fallback: create a mock client for development
             logger.warning("GCS initialization failed: %s. Using mock service.", e)
@@ -58,10 +55,17 @@ class GCSService:
         creds_json = os.environ.get("GCS_CREDENTIALS_JSON", "").strip()
         if creds_json:
             logger.info("Loading GCS credentials from GCS_CREDENTIALS_JSON env var")
-            info = json.loads(creds_json)
-            return service_account.Credentials.from_service_account_info(
-                info, scopes=GCS_SCOPES
-            )
+            try:
+                info = json.loads(creds_json)
+                return service_account.Credentials.from_service_account_info(
+                    info, scopes=GCS_SCOPES
+                )
+            except (json.JSONDecodeError, ValueError) as e:
+                logger.warning(
+                    "Invalid GCS_CREDENTIALS_JSON env var; falling back to "
+                    "file/ADC credentials: %s",
+                    e,
+                )
 
         # 2. Service account key file on disk (local development)
         if self.credentials_path and os.path.exists(self.credentials_path):
@@ -70,9 +74,10 @@ class GCSService:
                 self.credentials_path, scopes=GCS_SCOPES
             )
 
-        # 3. Fall back to Application Default Credentials
+        # 3. Fall back to Application Default Credentials (with explicit scopes)
         logger.info("No explicit GCS credentials found, using ADC")
-        return None
+        credentials, project = google.auth.default(scopes=GCS_SCOPES)
+        return credentials
 
     def upload_file(self, file_obj, file_path, content_type=None, max_retries=3):
         """

--- a/ai-brand-automator/files/tests/test_gcs_credentials.py
+++ b/ai-brand-automator/files/tests/test_gcs_credentials.py
@@ -1,0 +1,136 @@
+"""
+Tests for GCSService._resolve_credentials() credential resolution logic.
+
+Covers all 3 priority paths:
+1. GCS_CREDENTIALS_JSON env var (inline JSON)
+2. GS_CREDENTIALS_PATH file on disk
+3. Application Default Credentials (ADC)
+"""
+
+import json
+import os
+from unittest import mock
+
+import pytest
+from google.oauth2 import service_account
+
+from files.services import GCS_SCOPES, GCSService
+
+# Minimal valid service account JSON structure
+FAKE_SA_INFO = {
+    "type": "service_account",
+    "project_id": "test-project",
+    "private_key_id": "key123",
+    "private_key": (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "MIIEowIBAAKCAQEA2a2rwplBQLF29amygykEMmYz0+Kcj3bKBp29DiB/MFJi4EZ\n"
+        "qF5IbGFiMFMCDRBEXlS9d3ZgWKMydnkJMk0mT3Y3gRlKP7mPMpT1GMOeQUo6YNh\n"
+        "YFBPUKViBhGP7advz4WZYC2DrLpK+HN3t6WbFB6LzbhS3bFIb6qBOJq5elI1PFn9\n"
+        "bAUjt0FhTQCyLOJj2KG7vM9HLPMxx0leodBlJ+sY32K2BVgwfRDz9rMWd2KmDHzy\n"
+        "T3DPaXCDRCL+bMCq/PoFfFDu2eLLSWqFrjBmCx+e3P3IKfNFJPavqyLOR5jeobk/\n"
+        "s0R7DQoKzxq2RZLPFqmRwIDAQABAoIBADJTKEEwPvQ8b/dl6wd5k0lFH3+lRDrUU\n"
+        "-----END RSA PRIVATE KEY-----\n"
+    ),
+    "client_email": "test@test-project.iam.gserviceaccount.com",
+    "client_id": "123456789",
+    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+    "token_uri": "https://oauth2.googleapis.com/token",
+}
+
+
+@pytest.fixture
+def _disable_gcs_init():
+    """Patch settings and storage.Client so GCSService.__init__ doesn't hit GCP."""
+    with (
+        mock.patch("files.services.settings") as mock_settings,
+        mock.patch("files.services.storage.Client"),
+    ):
+        mock_settings.GS_BUCKET_NAME = "test-bucket"
+        mock_settings.GS_PROJECT_ID = "test-project"
+        mock_settings.GS_CREDENTIALS_PATH = ""
+        yield mock_settings
+
+
+@pytest.mark.django_db
+class TestResolveCredentialsEnvVar:
+    """Priority 1: GCS_CREDENTIALS_JSON env var."""
+
+    def test_valid_json_env_var(self, _disable_gcs_init):
+        """Valid JSON env var returns scoped service account credentials."""
+        env = {"GCS_CREDENTIALS_JSON": json.dumps(FAKE_SA_INFO)}
+        with mock.patch.dict(os.environ, env, clear=False):
+            with mock.patch.object(
+                service_account.Credentials,
+                "from_service_account_info",
+                return_value=mock.sentinel.creds,
+            ) as mock_from_info:
+                GCSService()  # noqa: F841 - triggers __init__
+                # _resolve_credentials was called by __init__
+                mock_from_info.assert_called_once_with(FAKE_SA_INFO, scopes=GCS_SCOPES)
+
+    def test_invalid_json_falls_through(self, _disable_gcs_init):
+        """Malformed JSON env var logs a warning and falls through to ADC."""
+        env = {"GCS_CREDENTIALS_JSON": "NOT-VALID-JSON"}
+        with mock.patch.dict(os.environ, env, clear=False):
+            with mock.patch("google.auth.default") as mock_adc:
+                mock_adc.return_value = (mock.sentinel.creds, "project")
+                GCSService()  # triggers __init__ → _resolve_credentials
+                # Should have fallen through to ADC
+                mock_adc.assert_called_once_with(scopes=GCS_SCOPES)
+
+    def test_empty_env_var_skipped(self, _disable_gcs_init):
+        """Empty or whitespace-only GCS_CREDENTIALS_JSON is treated as absent."""
+        env = {"GCS_CREDENTIALS_JSON": "   "}
+        with mock.patch.dict(os.environ, env, clear=False):
+            with mock.patch("google.auth.default") as mock_adc:
+                mock_adc.return_value = (mock.sentinel.creds, "project")
+                GCSService()  # triggers __init__ → _resolve_credentials
+                mock_adc.assert_called_once_with(scopes=GCS_SCOPES)
+
+
+@pytest.mark.django_db
+class TestResolveCredentialsFile:
+    """Priority 2: GS_CREDENTIALS_PATH file on disk."""
+
+    def test_existing_file_path(self, _disable_gcs_init, tmp_path):
+        """Existing credentials file is loaded with scopes."""
+        cred_file = tmp_path / "sa.json"
+        cred_file.write_text(json.dumps(FAKE_SA_INFO))
+
+        _disable_gcs_init.GS_CREDENTIALS_PATH = str(cred_file)
+        env = {"GCS_CREDENTIALS_JSON": ""}  # Ensure env var path is skipped
+        with mock.patch.dict(os.environ, env, clear=False):
+            with mock.patch.object(
+                service_account.Credentials,
+                "from_service_account_file",
+                return_value=mock.sentinel.creds,
+            ) as mock_from_file:
+                GCSService()  # triggers __init__ → _resolve_credentials
+                mock_from_file.assert_called_once_with(
+                    str(cred_file), scopes=GCS_SCOPES
+                )
+
+    def test_nonexistent_file_falls_through(self, _disable_gcs_init):
+        """Missing credentials file falls through to ADC."""
+        _disable_gcs_init.GS_CREDENTIALS_PATH = "/nonexistent/path.json"
+        env = {"GCS_CREDENTIALS_JSON": ""}
+        with mock.patch.dict(os.environ, env, clear=False):
+            with mock.patch("google.auth.default") as mock_adc:
+                mock_adc.return_value = (mock.sentinel.creds, "project")
+                GCSService()  # triggers __init__ → _resolve_credentials
+                mock_adc.assert_called_once_with(scopes=GCS_SCOPES)
+
+
+@pytest.mark.django_db
+class TestResolveCredentialsADC:
+    """Priority 3: Application Default Credentials."""
+
+    def test_adc_called_with_scopes(self, _disable_gcs_init):
+        """When no env var or file, ADC is used with explicit GCS scopes."""
+        _disable_gcs_init.GS_CREDENTIALS_PATH = ""
+        env = {"GCS_CREDENTIALS_JSON": ""}
+        with mock.patch.dict(os.environ, env, clear=False):
+            with mock.patch("google.auth.default") as mock_adc:
+                mock_adc.return_value = (mock.sentinel.creds, "project")
+                GCSService()  # triggers __init__ → _resolve_credentials
+                mock_adc.assert_called_once_with(scopes=GCS_SCOPES)


### PR DESCRIPTION
Root cause: The credentials file is gitignored, so on Railway GS_CREDENTIALS_PATH points to a non-existent file. The code fell through to Application Default Credentials without storage scopes, causing 403 'Provided scope(s) are not authorized'.

Changes:
- GCSService now resolves credentials in priority order:
  1. GCS_CREDENTIALS_JSON env var (inline JSON for Railway/Heroku)
  2. GS_CREDENTIALS_PATH file on disk (local dev)
  3. Application Default Credentials (GCP-hosted)
- All credential paths now include devstorage.full_control scope
- Entrypoint writes GCS_CREDENTIALS_JSON to disk at startup
- Replaced print() with logger.warning() for init failures