### PR TITLE
feat: add Kafka SASL/SSL support for managed Kafka on Railway

### DIFF
--- a/ai-brand-automator/Dockerfile
+++ b/ai-brand-automator/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y \
     postgresql-client \
     build-essential \
     libpq-dev \
+    librdkafka-dev \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
@@ -32,7 +33,7 @@ RUN mkdir -p logs staticfiles
 # Expose port
 EXPOSE 8000
 
-# Create entrypoint script - v3 with GCS credentials support
+# Create entrypoint script - v4 with GCS credentials + Kafka consumer support
 RUN cat <<'EOF' > /app/entrypoint.sh && chmod +x /app/entrypoint.sh
 #!/bin/bash
 set -e
@@ -54,6 +55,23 @@ echo "=== Collecting static files ==="
 python manage.py collectstatic --noinput || true
 echo "=== Starting Gunicorn on port $PORT ==="
 exec gunicorn brand_automator.wsgi:application --bind 0.0.0.0:${PORT:-8000} --workers 2 --threads 2 --timeout 120 --access-logfile - --error-logfile -
+EOF
+
+# Create worker entrypoint (for Kafka consumers and Celery workers on Railway)
+RUN cat <<'EOF' > /app/entrypoint-worker.sh && chmod +x /app/entrypoint-worker.sh
+#!/bin/bash
+set -e
+
+# Write GCS credentials file from env var if provided (Railway/Heroku)
+if [ -n "$GCS_CREDENTIALS_JSON" ]; then
+  printf '%s' "$GCS_CREDENTIALS_JSON" > /app/gcs-credentials.json
+  chmod 600 /app/gcs-credentials.json
+  export GS_CREDENTIALS_PATH=/app/gcs-credentials.json
+  export GOOGLE_APPLICATION_CREDENTIALS=/app/gcs-credentials.json
+fi
+
+# Execute the command passed as arguments
+exec "$@"
 EOF
 
 # Run entrypoint

--- a/ai-brand-automator/Dockerfile.curation-consumer
+++ b/ai-brand-automator/Dockerfile.curation-consumer
@@ -33,9 +33,33 @@ RUN addgroup --system --gid 1001 curation \
 
 USER curation
 
-# Health check
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD python -c "import redis; r = redis.from_url('${REDIS_URL:-redis://localhost:6379/0}'); r.ping()" || exit 1
+# Health check - verify Kafka connectivity
+HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
+    CMD python -c "\
+import os; \
+try:\n    import redis; r = redis.from_url(os.environ.get('REDIS_URL', 'redis://localhost:6379/0')); r.ping(); print('Redis OK')\nexcept: pass\n\
+try:\n    from confluent_kafka.admin import AdminClient; \
+    cfg = {'bootstrap.servers': os.environ.get('KAFKA_BOOTSTRAP_SERVERS', 'localhost:9092')}; \
+    sp = os.environ.get('KAFKA_SECURITY_PROTOCOL', ''); \
+    cfg.update({'security.protocol': sp, 'sasl.mechanism': os.environ.get('KAFKA_SASL_MECHANISM', 'PLAIN'), 'sasl.username': os.environ.get('KAFKA_SASL_USERNAME', ''), 'sasl.password': os.environ.get('KAFKA_SASL_PASSWORD', '')} if sp else {}); \
+    a = AdminClient(cfg); m = a.list_topics(timeout=5); print('Kafka OK')\nexcept Exception as e: print(f'Kafka check: {e}')\n\
+" || exit 0
+
+# Create entrypoint for GCS credentials setup
+RUN cat <<'ENTRYPOINT_EOF' > /app/entrypoint-curation.sh && chmod +x /app/entrypoint-curation.sh
+#!/bin/bash
+set -e
+
+# Write GCS credentials file from env var if provided
+if [ -n "$GCS_CREDENTIALS_JSON" ]; then
+  printf '%s' "$GCS_CREDENTIALS_JSON" > /app/gcs-credentials.json
+  chmod 600 /app/gcs-credentials.json
+  export GS_CREDENTIALS_PATH=/app/gcs-credentials.json
+  export GOOGLE_APPLICATION_CREDENTIALS=/app/gcs-credentials.json
+fi
+
+exec "$@"
+ENTRYPOINT_EOF
 
 # Default command - run the Kafka consumer
-CMD ["python", "manage.py", "run_curation_consumer", "--batch-size", "10", "--poll-timeout", "1.0"]
+CMD ["/app/entrypoint-curation.sh", "python", "manage.py", "run_curation_consumer", "--batch-size", "10", "--poll-timeout", "1.0"]

--- a/ai-brand-automator/Dockerfile.curation-consumer
+++ b/ai-brand-automator/Dockerfile.curation-consumer
@@ -33,17 +33,17 @@ RUN addgroup --system --gid 1001 curation \
 
 USER curation
 
-# Health check - verify Kafka connectivity
-HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
+# Health check - verify Kafka connectivity (exits non-zero on failure)
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
     CMD python -c "\
-import os; \
-try:\n    import redis; r = redis.from_url(os.environ.get('REDIS_URL', 'redis://localhost:6379/0')); r.ping(); print('Redis OK')\nexcept: pass\n\
+import os, sys; \
+try:\n    import redis; r = redis.from_url(os.environ.get('REDIS_URL', 'redis://localhost:6379/0')); r.ping(); print('Redis OK')\nexcept Exception as e: print(f'Redis check failed: {e}')\n\
 try:\n    from confluent_kafka.admin import AdminClient; \
     cfg = {'bootstrap.servers': os.environ.get('KAFKA_BOOTSTRAP_SERVERS', 'localhost:9092')}; \
     sp = os.environ.get('KAFKA_SECURITY_PROTOCOL', ''); \
     cfg.update({'security.protocol': sp, 'sasl.mechanism': os.environ.get('KAFKA_SASL_MECHANISM', 'PLAIN'), 'sasl.username': os.environ.get('KAFKA_SASL_USERNAME', ''), 'sasl.password': os.environ.get('KAFKA_SASL_PASSWORD', '')} if sp else {}); \
-    a = AdminClient(cfg); m = a.list_topics(timeout=5); print('Kafka OK')\nexcept Exception as e: print(f'Kafka check: {e}')\n\
-" || exit 0
+    a = AdminClient(cfg); a.list_topics(timeout=5); print('Kafka OK')\nexcept Exception as e: print(f'Kafka check failed: {e}'); sys.exit(1)\n\
+"
 
 # Create entrypoint for GCS credentials setup
 RUN cat <<'ENTRYPOINT_EOF' > /app/entrypoint-curation.sh && chmod +x /app/entrypoint-curation.sh

--- a/ai-brand-automator/Procfile
+++ b/ai-brand-automator/Procfile
@@ -1,1 +1,7 @@
 web: gunicorn brand_automator.wsgi:application --bind 0.0.0.0:$PORT --workers 4 --threads 2 --timeout 120
+worker: celery -A brand_automator worker -l info --concurrency=2
+beat: celery -A brand_automator beat -l info --scheduler django_celery_beat.schedulers:DatabaseScheduler
+ingestion-worker: celery -A brand_automator worker -Q ingestion -l info --concurrency=2
+ingestion-consumer: python manage.py run_ingestion --batch-size 10 --poll-timeout 1.0
+curation-worker: celery -A brand_automator worker -Q curation -l info --concurrency=2
+curation-consumer: python manage.py run_curation_consumer --batch-size 10 --poll-timeout 1.0

--- a/ai-brand-automator/brand_automator/settings.py
+++ b/ai-brand-automator/brand_automator/settings.py
@@ -717,9 +717,13 @@ CELERY_BEAT_SCHEDULE = {
     },
 }
 
-# Kafka consumer tasks — only register when Kafka is configured
+# Explicit flag to enable Kafka consumer Celery tasks.
+# Set to True when a Kafka broker is available (managed or local).
+KAFKA_CONSUMERS_ENABLED = config("KAFKA_CONSUMERS_ENABLED", default=False, cast=bool)
+
+# Kafka consumer tasks — only register when explicitly enabled
 # (prevents error-flooding logs when no Kafka broker is available)
-if KAFKA_BOOTSTRAP_SERVERS and KAFKA_BOOTSTRAP_SERVERS != "localhost:9092":
+if KAFKA_CONSUMERS_ENABLED:
     CELERY_BEAT_SCHEDULE.update(
         {
             "consume-gateway-logs-every-minute": {

--- a/ai-brand-automator/brand_automator/settings.py
+++ b/ai-brand-automator/brand_automator/settings.py
@@ -553,10 +553,29 @@ KAFKA_AUTO_OFFSET_RESET = config("KAFKA_AUTO_OFFSET_RESET", default="earliest")
 KAFKA_ENABLE_AUTO_COMMIT = config("KAFKA_ENABLE_AUTO_COMMIT", default=True, cast=bool)
 KAFKA_SESSION_TIMEOUT_MS = config("KAFKA_SESSION_TIMEOUT_MS", default=30000, cast=int)
 
+# Kafka SASL/SSL Authentication (for managed Kafka: Confluent Cloud, Upstash, etc.)
+KAFKA_SECURITY_PROTOCOL = config("KAFKA_SECURITY_PROTOCOL", default="")
+KAFKA_SASL_MECHANISM = config("KAFKA_SASL_MECHANISM", default="PLAIN")
+KAFKA_SASL_USERNAME = config("KAFKA_SASL_USERNAME", default="")
+KAFKA_SASL_PASSWORD = config("KAFKA_SASL_PASSWORD", default="")
+
 # Kafka Topics
 KAFKA_TOPIC_GATEWAY_LOGS = "gateway-logs"
 KAFKA_TOPIC_RAW_INGESTION = "raw-ingestion-topic"
 KAFKA_TOPIC_DLQ = "dlq-events"
+
+# Build SASL/SSL config dict for confluent-kafka Producer/Consumer.
+# Empty dict when KAFKA_SECURITY_PROTOCOL is not set (local dev).
+KAFKA_SASL_CONFIG = (
+    {
+        "security.protocol": KAFKA_SECURITY_PROTOCOL,
+        "sasl.mechanism": KAFKA_SASL_MECHANISM,
+        "sasl.username": KAFKA_SASL_USERNAME,
+        "sasl.password": KAFKA_SASL_PASSWORD,
+    }
+    if KAFKA_SECURITY_PROTOCOL
+    else {}
+)
 
 # =============================================================================
 # Data Ingestion Configuration (Hexagonal Architecture Pipeline)
@@ -696,20 +715,27 @@ CELERY_BEAT_SCHEDULE = {
         # of timely delivery. For lower frequency, change to 300.0 (5 min).
         "schedule": 60.0,
     },
-    # Kafka consumer tasks (when Kafka is enabled)
-    "consume-gateway-logs-every-minute": {
-        "task": "kafka_service.tasks.consume_gateway_logs",
-        "schedule": 60.0,  # Every minute
-        "kwargs": {"max_messages": 100},
-    },
-    "consume-raw-events-every-30s": {
-        "task": "kafka_service.tasks.consume_raw_events",
-        "schedule": 30.0,  # Every 30 seconds
-        "kwargs": {"max_messages": 50},
-    },
-    "process-dlq-every-5-minutes": {
-        "task": "kafka_service.tasks.process_dlq_events",
-        "schedule": 300.0,  # Every 5 minutes
-        "kwargs": {"max_messages": 20},
-    },
 }
+
+# Kafka consumer tasks — only register when Kafka is configured
+# (prevents error-flooding logs when no Kafka broker is available)
+if KAFKA_BOOTSTRAP_SERVERS and KAFKA_BOOTSTRAP_SERVERS != "localhost:9092":
+    CELERY_BEAT_SCHEDULE.update(
+        {
+            "consume-gateway-logs-every-minute": {
+                "task": "kafka_service.tasks.consume_gateway_logs",
+                "schedule": 60.0,
+                "kwargs": {"max_messages": 100},
+            },
+            "consume-raw-events-every-30s": {
+                "task": "kafka_service.tasks.consume_raw_events",
+                "schedule": 30.0,
+                "kwargs": {"max_messages": 50},
+            },
+            "process-dlq-every-5-minutes": {
+                "task": "kafka_service.tasks.process_dlq_events",
+                "schedule": 300.0,
+                "kwargs": {"max_messages": 20},
+            },
+        }
+    )

--- a/ai-brand-automator/data_ingestion/adapters/kafka_adapter.py
+++ b/ai-brand-automator/data_ingestion/adapters/kafka_adapter.py
@@ -41,6 +41,7 @@ class KafkaProducerAdapter(EventProducerPort):
         retries: int = 3,
         retry_backoff_ms: int = 100,
         dlq_topic: Optional[str] = None,
+        sasl_config: Optional[dict] = None,
         **kafka_config,
     ):
         """
@@ -53,6 +54,7 @@ class KafkaProducerAdapter(EventProducerPort):
             retries: Number of retries for failed sends
             retry_backoff_ms: Backoff between retries
             dlq_topic: Dead letter queue topic name
+            sasl_config: SASL/SSL config dict for managed Kafka
             **kafka_config: Additional Kafka producer config
         """
         self.bootstrap_servers = bootstrap_servers
@@ -64,6 +66,7 @@ class KafkaProducerAdapter(EventProducerPort):
             "acks": acks,
             "retries": retries,
             "retry.backoff.ms": retry_backoff_ms,
+            **(sasl_config or {}),
             **kafka_config,
         }
 
@@ -338,6 +341,7 @@ class KafkaConsumerAdapter(EventConsumerPort):
         enable_auto_commit: bool = False,
         max_poll_interval_ms: int = 300000,
         session_timeout_ms: int = 45000,
+        sasl_config: Optional[dict] = None,
         **kafka_config,
     ):
         """
@@ -352,6 +356,7 @@ class KafkaConsumerAdapter(EventConsumerPort):
             enable_auto_commit: Whether to auto-commit offsets
             max_poll_interval_ms: Max time between polls
             session_timeout_ms: Session timeout
+            sasl_config: SASL/SSL config dict for managed Kafka
             **kafka_config: Additional Kafka consumer config
         """
         self.bootstrap_servers = bootstrap_servers
@@ -368,6 +373,7 @@ class KafkaConsumerAdapter(EventConsumerPort):
             "enable.auto.commit": enable_auto_commit,
             "max.poll.interval.ms": max_poll_interval_ms,
             "session.timeout.ms": session_timeout_ms,
+            **(sasl_config or {}),
             **kafka_config,
         }
 

--- a/ai-brand-automator/data_ingestion/factory.py
+++ b/ai-brand-automator/data_ingestion/factory.py
@@ -112,6 +112,9 @@ def create_kafka_producer(config: Optional[dict] = None) -> KafkaProducerAdapter
         ),
     )
 
+    # Get SASL/SSL config from Django settings
+    sasl_config = getattr(settings, "KAFKA_SASL_CONFIG", {})
+
     return KafkaProducerAdapter(
         bootstrap_servers=bootstrap_servers,
         client_id=kafka_config.get(
@@ -122,6 +125,7 @@ def create_kafka_producer(config: Optional[dict] = None) -> KafkaProducerAdapter
             "DLQ_TOPIC",
             config.get("KAFKA_DLQ_TOPIC", "ingestion-dlq"),
         ),
+        sasl_config=sasl_config,
     )
 
 
@@ -151,6 +155,9 @@ def create_kafka_consumer(config: Optional[dict] = None) -> KafkaConsumerAdapter
         config.get("KAFKA_INPUT_TOPIC", "raw-ingestion-topic"),
     )
 
+    # Get SASL/SSL config from Django settings
+    sasl_config = getattr(settings, "KAFKA_SASL_CONFIG", {})
+
     return KafkaConsumerAdapter(
         bootstrap_servers=bootstrap_servers,
         group_id=kafka_config.get(
@@ -170,6 +177,7 @@ def create_kafka_consumer(config: Optional[dict] = None) -> KafkaConsumerAdapter
             "ENABLE_AUTO_COMMIT",
             config.get("KAFKA_ENABLE_AUTO_COMMIT", False),
         ),
+        sasl_config=sasl_config,
     )
 
 

--- a/ai-brand-automator/kafka_service/consumer.py
+++ b/ai-brand-automator/kafka_service/consumer.py
@@ -36,10 +36,31 @@ class KafkaConfig:
     ENABLE_AUTO_COMMIT = config("KAFKA_ENABLE_AUTO_COMMIT", default=True, cast=bool)
     SESSION_TIMEOUT_MS = config("KAFKA_SESSION_TIMEOUT_MS", default=30000, cast=int)
 
+    # SASL/SSL Authentication (for managed Kafka: Confluent Cloud, Upstash)
+    SECURITY_PROTOCOL = config("KAFKA_SECURITY_PROTOCOL", default="")
+    SASL_MECHANISM = config("KAFKA_SASL_MECHANISM", default="PLAIN")
+    SASL_USERNAME = config("KAFKA_SASL_USERNAME", default="")
+    SASL_PASSWORD = config("KAFKA_SASL_PASSWORD", default="")
+
     # Topics
     TOPIC_GATEWAY_LOGS = "gateway-logs"
     TOPIC_RAW_INGESTION = "raw-ingestion-topic"
     TOPIC_DLQ = "dlq-events"
+
+    @classmethod
+    def get_sasl_config(cls) -> dict:
+        """
+        Build SASL/SSL config dict for confluent-kafka.
+        Returns empty dict when SECURITY_PROTOCOL is not set (local dev).
+        """
+        if not cls.SECURITY_PROTOCOL:
+            return {}
+        return {
+            "security.protocol": cls.SECURITY_PROTOCOL,
+            "sasl.mechanism": cls.SASL_MECHANISM,
+            "sasl.username": cls.SASL_USERNAME,
+            "sasl.password": cls.SASL_PASSWORD,
+        }
 
 
 class KafkaConsumerService:
@@ -82,6 +103,7 @@ class KafkaConsumerService:
                 "auto.offset.reset": KafkaConfig.AUTO_OFFSET_RESET,
                 "enable.auto.commit": KafkaConfig.ENABLE_AUTO_COMMIT,
                 "session.timeout.ms": KafkaConfig.SESSION_TIMEOUT_MS,
+                **KafkaConfig.get_sasl_config(),
             }
 
             self.consumer = Consumer(config)
@@ -356,6 +378,7 @@ class KafkaProducerService:
                 {
                     "bootstrap.servers": KafkaConfig.BOOTSTRAP_SERVERS,
                     "acks": "all",
+                    **KafkaConfig.get_sasl_config(),
                 }
             )
             logger.info("Kafka producer created")

--- a/ai-brand-automator/media_curation/adapters/kafka_adapter.py
+++ b/ai-brand-automator/media_curation/adapters/kafka_adapter.py
@@ -55,6 +55,7 @@ class KafkaProducerAdapter(EventProducerPort):
         client_id: str = "curation-producer",
         dlq_topic: Optional[str] = None,
         output_topic: Optional[str] = None,
+        sasl_config: Optional[dict] = None,
         **kafka_config,
     ):
         """
@@ -65,6 +66,7 @@ class KafkaProducerAdapter(EventProducerPort):
             client_id: Client identifier
             dlq_topic: Dead letter queue topic name
             output_topic: Default output topic for curated documents
+            sasl_config: SASL/SSL config dict for managed Kafka
             **kafka_config: Additional Kafka producer config
         """
         # Lazy import to avoid issues when confluent-kafka is not installed
@@ -95,6 +97,7 @@ class KafkaProducerAdapter(EventProducerPort):
             "acks": "all",
             "retries": 3,
             "retry.backoff.ms": 100,
+            **(sasl_config or {}),
             **kafka_config,
         }
 
@@ -316,6 +319,7 @@ class KafkaConsumerAdapter(EventConsumerPort):
         group_id: str = "curation-consumer",
         input_topic: Optional[str] = None,
         auto_commit: bool = False,
+        sasl_config: Optional[dict] = None,
         **kafka_config,
     ):
         """
@@ -326,6 +330,7 @@ class KafkaConsumerAdapter(EventConsumerPort):
             group_id: Consumer group ID
             input_topic: Default input topic to subscribe to
             auto_commit: Enable auto-commit (False for manual commits)
+            sasl_config: SASL/SSL config dict for managed Kafka
             **kafka_config: Additional Kafka consumer config
         """
         # Lazy import to avoid issues when confluent-kafka is not installed
@@ -355,6 +360,7 @@ class KafkaConsumerAdapter(EventConsumerPort):
             "group.id": group_id,
             "auto.offset.reset": "earliest",
             "enable.auto.commit": auto_commit,
+            **(sasl_config or {}),
             **kafka_config,
         }
 

--- a/ai-brand-automator/media_curation/factory.py
+++ b/ai-brand-automator/media_curation/factory.py
@@ -257,10 +257,14 @@ def create_kafka_producer(config: Optional[dict] = None):
     config = config or get_media_curation_config()
     kafka_config = config.get("KAFKA", {})
 
+    # Get SASL/SSL config from Django settings
+    sasl_config = getattr(settings, "KAFKA_SASL_CONFIG", {})
+
     adapter = KafkaProducerAdapter(
         bootstrap_servers=kafka_config.get("BOOTSTRAP_SERVERS", "localhost:9092"),
         dlq_topic=kafka_config.get("DLQ_TOPIC", "curation-dlq"),
         output_topic=kafka_config.get("OUTPUT_TOPIC", "curation-completed"),
+        sasl_config=sasl_config,
     )
 
     logger.info("Kafka producer created")
@@ -282,10 +286,14 @@ def create_kafka_consumer(config: Optional[dict] = None):
     config = config or get_media_curation_config()
     kafka_config = config.get("KAFKA", {})
 
+    # Get SASL/SSL config from Django settings
+    sasl_config = getattr(settings, "KAFKA_SASL_CONFIG", {})
+
     adapter = KafkaConsumerAdapter(
         bootstrap_servers=kafka_config.get("BOOTSTRAP_SERVERS", "localhost:9092"),
         group_id=kafka_config.get("CONSUMER_GROUP", "media-curation-consumers"),
         input_topic=kafka_config.get("INPUT_TOPIC", "curation-needed"),
+        sasl_config=sasl_config,
     )
 
     logger.info("Kafka consumer created")

--- a/ai-brand-automator/railway.json
+++ b/ai-brand-automator/railway.json
@@ -12,25 +12,25 @@
   },
   "services": {
     "web": {
-      "startCommand": "gunicorn brand_automator.wsgi:application --bind 0.0.0.0:$PORT --workers 2 --threads 2 --timeout 120"
+      "startCommand": "/app/entrypoint.sh"
     },
     "celery-worker": {
-      "startCommand": "celery -A brand_automator worker -l info --concurrency=2"
+      "startCommand": "/app/entrypoint-worker.sh celery -A brand_automator worker -l info --concurrency=2"
     },
     "celery-beat": {
-      "startCommand": "celery -A brand_automator beat -l info --scheduler django_celery_beat.schedulers:DatabaseScheduler"
+      "startCommand": "/app/entrypoint-worker.sh celery -A brand_automator beat -l info --scheduler django_celery_beat.schedulers:DatabaseScheduler"
     },
     "ingestion-worker": {
-      "startCommand": "celery -A brand_automator worker -Q ingestion -l info --concurrency=2"
+      "startCommand": "/app/entrypoint-worker.sh celery -A brand_automator worker -Q ingestion -l info --concurrency=2"
     },
     "ingestion-consumer": {
-      "startCommand": "python manage.py run_ingestion --batch-size 10 --poll-timeout 1.0"
+      "startCommand": "/app/entrypoint-worker.sh python manage.py run_ingestion --batch-size 10 --poll-timeout 1.0"
     },
     "curation-worker": {
-      "startCommand": "celery -A brand_automator worker -Q curation -l info --concurrency=2"
+      "startCommand": "/app/entrypoint-worker.sh celery -A brand_automator worker -Q curation -l info --concurrency=2"
     },
     "curation-consumer": {
-      "startCommand": "python manage.py run_curation_consumer --batch-size 10 --poll-timeout 1.0"
+      "startCommand": "/app/entrypoint-worker.sh python manage.py run_curation_consumer --batch-size 10 --poll-timeout 1.0"
     }
   }
 }

--- a/ai-brand-automator/test_kafka_config.py
+++ b/ai-brand-automator/test_kafka_config.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+"""Quick validation of Kafka SASL/SSL configuration changes."""
+import django
+import os
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "brand_automator.settings")
+django.setup()
+
+from django.conf import settings  # noqa: E402
+
+print("=" * 60)
+print("Kafka Configuration Validation")
+print("=" * 60)
+
+print(f"\nKAFKA_BOOTSTRAP_SERVERS: {settings.KAFKA_BOOTSTRAP_SERVERS}")
+print(f"KAFKA_SECURITY_PROTOCOL: {repr(settings.KAFKA_SECURITY_PROTOCOL)}")
+print(f"KAFKA_SASL_MECHANISM: {repr(settings.KAFKA_SASL_MECHANISM)}")
+print(f"KAFKA_SASL_USERNAME: {repr(settings.KAFKA_SASL_USERNAME)}")
+pwd_display = (
+    "***" if settings.KAFKA_SASL_PASSWORD else repr(settings.KAFKA_SASL_PASSWORD)
+)
+print(f"KAFKA_SASL_PASSWORD: {pwd_display}")
+
+print("\n--- KAFKA_SASL_CONFIG ---")
+sasl_config = settings.KAFKA_SASL_CONFIG
+print(f"Result: {sasl_config}")
+print("(empty dict = local dev, no SASL needed)")
+
+print("\n--- Celery Beat Schedule ---")
+for task_name in settings.CELERY_BEAT_SCHEDULE:
+    print(f"  - {task_name}")
+
+print("\n--- Factory Import Test ---")
+try:
+    from data_ingestion.factory import create_kafka_producer  # noqa: F401
+
+    print("  data_ingestion.factory.create_kafka_producer: OK")
+except Exception as e:
+    print(f"  data_ingestion.factory.create_kafka_producer: FAIL - {e}")
+
+try:
+    from media_curation.factory import (  # noqa: F401, F811
+        create_kafka_producer,
+    )
+
+    print("  media_curation.factory.create_kafka_producer: OK")
+except Exception as e:
+    print(f"  media_curation.factory.create_kafka_producer: FAIL - {e}")
+
+try:
+    from kafka_service.consumer import KafkaConfig
+
+    sasl = KafkaConfig.get_sasl_config()
+    print(f"  kafka_service.KafkaConfig.get_sasl_config(): {sasl}")
+except Exception as e:
+    print(f"  kafka_service.KafkaConfig: FAIL - {e}")
+
+print("\n" + "=" * 60)
+print("All checks passed!" if True else "Some checks failed!")
+print("=" * 60)

--- a/ai-brand-automator/test_kafka_config.py
+++ b/ai-brand-automator/test_kafka_config.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 """Quick validation of Kafka SASL/SSL configuration changes."""
+import sys
+
 import django
 import os
 
@@ -7,6 +9,8 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "brand_automator.settings")
 django.setup()
 
 from django.conf import settings  # noqa: E402
+
+failed = False
 
 print("=" * 60)
 print("Kafka Configuration Validation")
@@ -23,7 +27,9 @@ print(f"KAFKA_SASL_PASSWORD: {pwd_display}")
 
 print("\n--- KAFKA_SASL_CONFIG ---")
 sasl_config = settings.KAFKA_SASL_CONFIG
-print(f"Result: {sasl_config}")
+# Redact password before printing
+redacted = {k: ("***" if "password" in k else v) for k, v in sasl_config.items()}
+print(f"Result: {redacted}")
 print("(empty dict = local dev, no SASL needed)")
 
 print("\n--- Celery Beat Schedule ---")
@@ -37,6 +43,7 @@ try:
     print("  data_ingestion.factory.create_kafka_producer: OK")
 except Exception as e:
     print(f"  data_ingestion.factory.create_kafka_producer: FAIL - {e}")
+    failed = True
 
 try:
     from media_curation.factory import (  # noqa: F401, F811
@@ -46,15 +53,24 @@ try:
     print("  media_curation.factory.create_kafka_producer: OK")
 except Exception as e:
     print(f"  media_curation.factory.create_kafka_producer: FAIL - {e}")
+    failed = True
 
 try:
     from kafka_service.consumer import KafkaConfig
 
     sasl = KafkaConfig.get_sasl_config()
-    print(f"  kafka_service.KafkaConfig.get_sasl_config(): {sasl}")
+    # Redact password
+    redacted_sasl = {k: ("***" if "password" in k else v) for k, v in sasl.items()}
+    print(f"  kafka_service.KafkaConfig.get_sasl_config(): {redacted_sasl}")
 except Exception as e:
     print(f"  kafka_service.KafkaConfig: FAIL - {e}")
+    failed = True
 
 print("\n" + "=" * 60)
-print("All checks passed!" if True else "Some checks failed!")
-print("=" * 60)
+if failed:
+    print("Some checks FAILED!")
+    print("=" * 60)
+    sys.exit(1)
+else:
+    print("All checks passed!")
+    print("=" * 60)

--- a/deployment/railway/RAILWAY_ENV_VARIABLES.md
+++ b/deployment/railway/RAILWAY_ENV_VARIABLES.md
@@ -40,15 +40,24 @@ ALLOWED_HOSTS=your-backend.railway.app,your-kong.railway.app,localhost
 # =============================================================================
 # Kafka Settings (Use Confluent Cloud or Upstash)
 # =============================================================================
-# Railway doesn't support Kafka directly - use external service
-# Confluent Cloud: https://confluent.cloud/
+# Railway doesn't support Kafka directly - use an external managed service.
+# Confluent Cloud: https://confluent.cloud/ (recommended - free tier available)
 # Upstash Kafka: https://upstash.com/
+#
+# These env vars MUST be set on ALL Railway services that use Kafka:
+#   web, ingestion-consumer, ingestion-worker, curation-consumer, curation-worker
+#
+# After setting these, deploy the ingestion-consumer and curation-consumer
+# services using the startCommands from railway.json.
 
 KAFKA_BOOTSTRAP_SERVERS=<confluent-cloud-bootstrap-servers>
 KAFKA_SASL_USERNAME=<confluent-cloud-api-key>
 KAFKA_SASL_PASSWORD=<confluent-cloud-api-secret>
 KAFKA_SECURITY_PROTOCOL=SASL_SSL
 KAFKA_SASL_MECHANISM=PLAIN
+
+# Enable Kafka publishing from onboarding file uploads (default: true)
+ONBOARDING_KAFKA_ENABLED=true
 
 # =============================================================================
 # External Services


### PR DESCRIPTION
- Add KAFKA_SECURITY_PROTOCOL, KAFKA_SASL_MECHANISM, KAFKA_SASL_USERNAME, KAFKA_SASL_PASSWORD settings and KAFKA_SASL_CONFIG dict
- Pass sasl_config to all Kafka producer/consumer adapters (data_ingestion, media_curation, kafka_service)
- Make Celery beat Kafka tasks conditional on broker availability
- Add worker entrypoint to Dockerfile for GCS credentials in workers
- Update Dockerfile.curation-consumer with GCS entrypoint + health check
- Update railway.json to use entrypoint scripts for all services
- Add Procfile entries for all worker/consumer processes
- Update RAILWAY_ENV_VARIABLES.md with Kafka SASL vars
- Add test_kafka_config.py validation script