### PR TITLE
fix: handle stale DB connections in pipeline consumers and update gcs…

### DIFF
--- a/ai-brand-automator/data_ingestion/domain/path_generator.py
+++ b/ai-brand-automator/data_ingestion/domain/path_generator.py
@@ -59,6 +59,36 @@ def parse_gcs_uri(gcs_uri: str) -> Tuple[str, str]:
     return bucket, object_path
 
 
+def extract_object_path(destination_uri: str) -> str:
+    """Extract the relative object path from a GCS URI or return as-is.
+
+    For gs:// URIs, strips the scheme and bucket to return just the object path.
+    For non-gs:// inputs, treats the value as an object path already and returns
+    it unchanged (with leading slashes normalized).
+
+    Args:
+        destination_uri: Full GCS URI or relative object path
+
+    Returns:
+        Object path without bucket prefix
+
+    Examples:
+        >>> extract_object_path('gs://bucket/1/raw/2026/02/06/file.pdf')
+        '1/raw/2026/02/06/file.pdf'
+        >>> extract_object_path('1/raw/2026/02/06/file.pdf')
+        '1/raw/2026/02/06/file.pdf'
+        >>> extract_object_path('gs://bucket-only')
+        'bucket-only'
+    """
+    if destination_uri.startswith("gs://"):
+        stripped = destination_uri[5:]  # Remove 'gs://' prefix
+        parts = stripped.split("/", 1)
+        return parts[1] if len(parts) > 1 else stripped
+
+    # Non-gs:// input: treat as object path, just normalize leading slashes
+    return destination_uri.lstrip("/")
+
+
 def extract_filename(object_path: str) -> str:
     """
     Extract the filename from a GCS object path.

--- a/ai-brand-automator/data_ingestion/management/commands/run_ingestion.py
+++ b/ai-brand-automator/data_ingestion/management/commands/run_ingestion.py
@@ -58,47 +58,66 @@ def _update_asset_status(
     Returns:
         True if update succeeded, False otherwise
     """
-    try:
-        from onboarding.models import BrandAsset
+    from django.db import close_old_connections
+    from onboarding.models import BrandAsset
 
+    for attempt in range(2):
         try:
-            asset_id = int(file_id)
-            asset = BrandAsset.objects.filter(id=asset_id).first()
-        except (ValueError, TypeError):
-            try:
-                trace_uuid = uuid.UUID(file_id)
-                asset = BrandAsset.objects.filter(pipeline_trace_id=trace_uuid).first()
-            except (ValueError, TypeError):
-                asset = None
+            if attempt > 0:
+                # Retry: close stale connections so Django opens a fresh one.
+                # Long-running Kafka consumers hold connections that
+                # Neon/PostgreSQL can time out (cursor already closed).
+                close_old_connections()
 
-        if asset:
-            asset.pipeline_status = status
-            update_fields = ["pipeline_status"]
-            if new_gcs_path:
-                asset.gcs_path = _extract_gcs_path(new_gcs_path)
-                update_fields.append("gcs_path")
-            if status == "ingested":
-                # Clear any previous pipeline error on successful ingestion
-                asset.pipeline_error = ""
-                update_fields.append("pipeline_error")
-            elif error_msg:
-                asset.pipeline_error = error_msg
-                update_fields.append("pipeline_error")
-            asset.save(update_fields=update_fields)
-            logger.info(
-                "Updated BrandAsset %s: status=%s, gcs_path=%s",
-                asset.id,
-                status,
-                asset.gcs_path,
-            )
-            return True
-        else:
-            logger.warning("BrandAsset not found for file_id: %s", file_id)
+            try:
+                asset_id = int(file_id)
+                asset = BrandAsset.objects.filter(id=asset_id).first()
+            except (ValueError, TypeError):
+                try:
+                    trace_uuid = uuid.UUID(file_id)
+                    asset = BrandAsset.objects.filter(
+                        pipeline_trace_id=trace_uuid
+                    ).first()
+                except (ValueError, TypeError):
+                    asset = None
+
+            if asset:
+                asset.pipeline_status = status
+                update_fields = ["pipeline_status"]
+                if new_gcs_path:
+                    asset.gcs_path = _extract_gcs_path(new_gcs_path)
+                    update_fields.append("gcs_path")
+                if status == "ingested":
+                    # Clear any previous pipeline error on successful ingestion
+                    asset.pipeline_error = ""
+                    update_fields.append("pipeline_error")
+                elif error_msg:
+                    asset.pipeline_error = error_msg
+                    update_fields.append("pipeline_error")
+                asset.save(update_fields=update_fields)
+                logger.info(
+                    "Updated BrandAsset %s: status=%s, gcs_path=%s",
+                    asset.id,
+                    status,
+                    asset.gcs_path,
+                )
+                return True
+            else:
+                logger.warning("BrandAsset not found for file_id: %s", file_id)
+                return False
+
+        except Exception:
+            if attempt == 0:
+                logger.warning(
+                    "DB error updating BrandAsset (will retry): %s",
+                    file_id,
+                    exc_info=True,
+                )
+                continue
+            logger.exception("Failed to update BrandAsset status after retry")
             return False
 
-    except Exception:
-        logger.exception("Failed to update BrandAsset status")
-        return False
+    return False
 
 
 def _get_input_topic() -> str:

--- a/ai-brand-automator/data_ingestion/management/commands/run_ingestion.py
+++ b/ai-brand-automator/data_ingestion/management/commands/run_ingestion.py
@@ -27,7 +27,9 @@ from data_ingestion.domain.exceptions import (
 logger = logging.getLogger(__name__)
 
 
-from data_ingestion.domain.path_generator import extract_object_path as _extract_gcs_path  # noqa: E402
+from data_ingestion.domain.path_generator import (
+    extract_object_path as _extract_gcs_path,
+)  # noqa: E402
 
 
 def _update_asset_status(

--- a/ai-brand-automator/data_ingestion/management/commands/run_ingestion.py
+++ b/ai-brand-automator/data_ingestion/management/commands/run_ingestion.py
@@ -27,18 +27,7 @@ from data_ingestion.domain.exceptions import (
 logger = logging.getLogger(__name__)
 
 
-def _extract_gcs_path(destination_uri: str) -> str:
-    """Extract the path portion from a gs:// URI.
-
-    Args:
-        destination_uri: Full GCS URI (gs://bucket/path/to/file)
-
-    Returns:
-        Path without bucket prefix (e.g. '1/raw/2026/02/06/file.png')
-    """
-    stripped = destination_uri.replace("gs://", "")
-    parts = stripped.split("/", 1)
-    return parts[1] if len(parts) > 1 else stripped
+from data_ingestion.domain.path_generator import extract_object_path as _extract_gcs_path  # noqa: E402
 
 
 def _update_asset_status(

--- a/ai-brand-automator/data_ingestion/management/commands/run_ingestion.py
+++ b/ai-brand-automator/data_ingestion/management/commands/run_ingestion.py
@@ -22,14 +22,12 @@ from data_ingestion.domain.exceptions import (
     NonRetryableError,
     RetryableError,
 )
+from data_ingestion.domain.path_generator import (
+    extract_object_path as _extract_gcs_path,
+)
 
 
 logger = logging.getLogger(__name__)
-
-
-from data_ingestion.domain.path_generator import (
-    extract_object_path as _extract_gcs_path,
-)  # noqa: E402
 
 
 def _update_asset_status(

--- a/ai-brand-automator/data_ingestion/tasks.py
+++ b/ai-brand-automator/data_ingestion/tasks.py
@@ -24,15 +24,7 @@ from data_ingestion.domain.exceptions import (
 logger = logging.getLogger(__name__)
 
 
-def _extract_gcs_path(destination_uri: str) -> str:
-    """Extract the relative path from a gs:// URI.
-
-    Examples:
-        'gs://bucket/1/raw/2026/02/06/file.pdf' -> '1/raw/2026/02/06/file.pdf'
-    """
-    stripped = destination_uri.replace("gs://", "")
-    parts = stripped.split("/", 1)
-    return parts[1] if len(parts) > 1 else stripped
+from data_ingestion.domain.path_generator import extract_object_path as _extract_gcs_path  # noqa: E402
 
 
 def _update_asset_after_ingestion(

--- a/ai-brand-automator/data_ingestion/tasks.py
+++ b/ai-brand-automator/data_ingestion/tasks.py
@@ -19,14 +19,12 @@ from data_ingestion.domain.exceptions import (
     NonRetryableError,
     RetryableError,
 )
+from data_ingestion.domain.path_generator import (
+    extract_object_path as _extract_gcs_path,
+)
 
 
 logger = logging.getLogger(__name__)
-
-
-from data_ingestion.domain.path_generator import (
-    extract_object_path as _extract_gcs_path,
-)  # noqa: E402
 
 
 def _update_asset_after_ingestion(

--- a/ai-brand-automator/data_ingestion/tasks.py
+++ b/ai-brand-automator/data_ingestion/tasks.py
@@ -24,6 +24,86 @@ from data_ingestion.domain.exceptions import (
 logger = logging.getLogger(__name__)
 
 
+def _extract_gcs_path(destination_uri: str) -> str:
+    """Extract the relative path from a gs:// URI.
+
+    Examples:
+        'gs://bucket/1/raw/2026/02/06/file.pdf' -> '1/raw/2026/02/06/file.pdf'
+    """
+    stripped = destination_uri.replace("gs://", "")
+    parts = stripped.split("/", 1)
+    return parts[1] if len(parts) > 1 else stripped
+
+
+def _update_asset_after_ingestion(
+    asset_id: str,
+    status: str,
+    error_msg: str = "",
+    new_gcs_path: str = "",
+) -> bool:
+    """Update BrandAsset pipeline_status and gcs_path after ingestion.
+
+    Args:
+        asset_id: The asset ID (integer as string)
+        status: The new pipeline status (ingested, failed)
+        error_msg: Error message if status is failed
+        new_gcs_path: New GCS path after file was moved (gs:// URI)
+
+    Returns:
+        True if update succeeded, False otherwise
+    """
+    from django.db import close_old_connections
+    from onboarding.models import BrandAsset
+
+    for attempt in range(2):
+        try:
+            if attempt > 0:
+                close_old_connections()
+
+            try:
+                aid = int(asset_id)
+                asset = BrandAsset.objects.filter(id=aid).first()
+            except (ValueError, TypeError):
+                asset = None
+
+            if asset:
+                asset.pipeline_status = status
+                update_fields = ["pipeline_status"]
+                if new_gcs_path:
+                    asset.gcs_path = _extract_gcs_path(new_gcs_path)
+                    update_fields.append("gcs_path")
+                if status == "ingested":
+                    asset.pipeline_error = ""
+                    update_fields.append("pipeline_error")
+                elif error_msg:
+                    asset.pipeline_error = error_msg
+                    update_fields.append("pipeline_error")
+                asset.save(update_fields=update_fields)
+                logger.info(
+                    "Updated BrandAsset %s: status=%s, gcs_path=%s",
+                    asset.id,
+                    status,
+                    asset.gcs_path,
+                )
+                return True
+            else:
+                logger.warning("BrandAsset not found for asset_id: %s", asset_id)
+                return False
+
+        except Exception:
+            if attempt == 0:
+                logger.warning(
+                    "DB error updating BrandAsset (will retry): %s",
+                    asset_id,
+                    exc_info=True,
+                )
+                continue
+            logger.exception("Failed to update BrandAsset status after retry")
+            return False
+
+    return False
+
+
 @shared_task(
     bind=True,
     name="data_ingestion.process_ingestion_event",
@@ -95,6 +175,15 @@ def process_ingestion_event(
         # Create service and process
         service = create_ingestion_service()
         result = service.process_event(event)
+
+        # Update BrandAsset status and gcs_path after successful ingestion
+        asset_id = (metadata or {}).get("asset_id")
+        if asset_id:
+            _update_asset_after_ingestion(
+                str(asset_id),
+                "ingested",
+                new_gcs_path=result.destination_path,
+            )
 
         logger.info(
             "Event processed successfully via Celery",

--- a/ai-brand-automator/data_ingestion/tasks.py
+++ b/ai-brand-automator/data_ingestion/tasks.py
@@ -24,7 +24,9 @@ from data_ingestion.domain.exceptions import (
 logger = logging.getLogger(__name__)
 
 
-from data_ingestion.domain.path_generator import extract_object_path as _extract_gcs_path  # noqa: E402
+from data_ingestion.domain.path_generator import (
+    extract_object_path as _extract_gcs_path,
+)  # noqa: E402
 
 
 def _update_asset_after_ingestion(

--- a/ai-brand-automator/data_ingestion/tests/test_path_generator.py
+++ b/ai-brand-automator/data_ingestion/tests/test_path_generator.py
@@ -12,8 +12,32 @@ from data_ingestion.domain.path_generator import (
     parse_gcs_uri,
     sanitize_tenant_id,
     extract_filename,
+    extract_object_path,
 )
 from data_ingestion.domain.exceptions import PathGenerationError
+
+
+class TestExtractObjectPath:
+    """Tests for extract_object_path shared utility."""
+
+    def test_gs_uri_full(self):
+        assert extract_object_path("gs://bucket/1/raw/2026/02/06/file.png") == "1/raw/2026/02/06/file.png"
+
+    def test_gs_uri_bucket_only(self):
+        assert extract_object_path("gs://bucket-only") == "bucket-only"
+
+    def test_plain_path_returned_as_is(self):
+        assert extract_object_path("1/raw/2026/02/06/file.png") == "1/raw/2026/02/06/file.png"
+
+    def test_plain_path_with_leading_slash(self):
+        assert extract_object_path("/1/raw/file.png") == "1/raw/file.png"
+
+    def test_empty_string(self):
+        assert extract_object_path("") == ""
+
+    def test_non_gs_scheme(self):
+        """Non-gs:// schemes are treated as plain paths."""
+        assert extract_object_path("s3://bucket/key") == "s3://bucket/key"
 
 
 class TestParseGcsUri:

--- a/ai-brand-automator/data_ingestion/tests/test_path_generator.py
+++ b/ai-brand-automator/data_ingestion/tests/test_path_generator.py
@@ -21,13 +21,19 @@ class TestExtractObjectPath:
     """Tests for extract_object_path shared utility."""
 
     def test_gs_uri_full(self):
-        assert extract_object_path("gs://bucket/1/raw/2026/02/06/file.png") == "1/raw/2026/02/06/file.png"
+        assert (
+            extract_object_path("gs://bucket/1/raw/2026/02/06/file.png")
+            == "1/raw/2026/02/06/file.png"
+        )
 
     def test_gs_uri_bucket_only(self):
         assert extract_object_path("gs://bucket-only") == "bucket-only"
 
     def test_plain_path_returned_as_is(self):
-        assert extract_object_path("1/raw/2026/02/06/file.png") == "1/raw/2026/02/06/file.png"
+        assert (
+            extract_object_path("1/raw/2026/02/06/file.png")
+            == "1/raw/2026/02/06/file.png"
+        )
 
     def test_plain_path_with_leading_slash(self):
         assert extract_object_path("/1/raw/file.png") == "1/raw/file.png"

--- a/ai-brand-automator/data_ingestion/tests/test_run_ingestion_command.py
+++ b/ai-brand-automator/data_ingestion/tests/test_run_ingestion_command.py
@@ -34,9 +34,9 @@ class TestExtractGcsPath:
         assert _extract_gcs_path(uri) == "tenant/raw/subdir/image.jpg"
 
     def test_no_gs_prefix(self):
-        """If no gs:// prefix, splits on first slash."""
+        """If no gs:// prefix, returns the path unchanged."""
         path = "bucket/some/path.txt"
-        assert _extract_gcs_path(path) == "some/path.txt"
+        assert _extract_gcs_path(path) == "bucket/some/path.txt"
 
     def test_bucket_only(self):
         """Edge case: URI with bucket but no path returns bucket name."""

--- a/ai-brand-automator/data_ingestion/tests/test_tasks.py
+++ b/ai-brand-automator/data_ingestion/tests/test_tasks.py
@@ -1,0 +1,167 @@
+"""
+Tests for data_ingestion.tasks - Celery task gcs_path update.
+
+Verifies that process_ingestion_event updates BrandAsset.gcs_path on success.
+"""
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from data_ingestion.tasks import _update_asset_after_ingestion
+
+
+@pytest.mark.django_db
+class TestUpdateAssetAfterIngestion:
+    """Tests for _update_asset_after_ingestion (Celery task helper)."""
+
+    @pytest.fixture
+    def brand_asset(self):
+        """Create a BrandAsset for testing."""
+        from onboarding.models import BrandAsset, Company
+        from tenants.models import Tenant, Domain
+
+        tenant, _ = Tenant.objects.get_or_create(
+            schema_name="public",
+            defaults={"name": "public"},
+        )
+        Domain.objects.get_or_create(
+            domain="localhost",
+            defaults={"tenant": tenant, "is_primary": True},
+        )
+        company = Company.objects.create(
+            tenant=tenant,
+            name="Test Company",
+            industry="Technology",
+        )
+        asset = BrandAsset.objects.create(
+            tenant=tenant,
+            company=company,
+            file_name="report.pdf",
+            file_type="document",
+            file_size=2048,
+            gcs_path="1/_landing/report.pdf",
+            pipeline_status="pending",
+        )
+        return asset
+
+    def test_updates_gcs_path_from_gs_uri(self, brand_asset):
+        """gcs_path is updated by stripping the gs://bucket prefix."""
+        result = _update_asset_after_ingestion(
+            str(brand_asset.id),
+            "ingested",
+            new_gcs_path="gs://my-bucket/1/raw/2026/02/06/report.pdf",
+        )
+        assert result is True
+
+        brand_asset.refresh_from_db()
+        assert brand_asset.gcs_path == "1/raw/2026/02/06/report.pdf"
+        assert brand_asset.pipeline_status == "ingested"
+        assert brand_asset.pipeline_error == ""
+
+    def test_updates_gcs_path_from_plain_path(self, brand_asset):
+        """Non-gs:// paths are stored as-is (no corruption)."""
+        result = _update_asset_after_ingestion(
+            str(brand_asset.id),
+            "ingested",
+            new_gcs_path="1/raw/2026/02/06/report.pdf",
+        )
+        assert result is True
+
+        brand_asset.refresh_from_db()
+        assert brand_asset.gcs_path == "1/raw/2026/02/06/report.pdf"
+
+    def test_sets_failed_status_with_error(self, brand_asset):
+        """Failed status stores the error message."""
+        result = _update_asset_after_ingestion(
+            str(brand_asset.id),
+            "failed",
+            error_msg="Corrupt file",
+        )
+        assert result is True
+
+        brand_asset.refresh_from_db()
+        assert brand_asset.pipeline_status == "failed"
+        assert brand_asset.pipeline_error == "Corrupt file"
+
+    def test_asset_not_found_returns_false(self):
+        """Returns False when asset ID doesn't exist."""
+        result = _update_asset_after_ingestion("999999", "ingested")
+        assert result is False
+
+    def test_clears_error_on_ingested(self, brand_asset):
+        """Previous error is cleared when status becomes ingested."""
+        brand_asset.pipeline_status = "failed"
+        brand_asset.pipeline_error = "Old error"
+        brand_asset.save()
+
+        result = _update_asset_after_ingestion(str(brand_asset.id), "ingested")
+        assert result is True
+
+        brand_asset.refresh_from_db()
+        assert brand_asset.pipeline_error == ""
+
+
+@pytest.mark.django_db
+class TestCeleryTaskUpdatesGcsPath:
+    """Integration test: process_ingestion_event updates BrandAsset.gcs_path."""
+
+    @pytest.fixture
+    def brand_asset(self):
+        from onboarding.models import BrandAsset, Company
+        from tenants.models import Tenant, Domain
+
+        tenant, _ = Tenant.objects.get_or_create(
+            schema_name="public",
+            defaults={"name": "public"},
+        )
+        Domain.objects.get_or_create(
+            domain="localhost",
+            defaults={"tenant": tenant, "is_primary": True},
+        )
+        company = Company.objects.create(
+            tenant=tenant,
+            name="Test Company",
+            industry="Technology",
+        )
+        asset = BrandAsset.objects.create(
+            tenant=tenant,
+            company=company,
+            file_name="photo.png",
+            file_type="image",
+            file_size=512,
+            gcs_path="1/_landing/photo.png",
+            pipeline_status="pending",
+        )
+        return asset
+
+    @patch("data_ingestion.tasks.create_ingestion_service")
+    def test_process_event_updates_asset_gcs_path(
+        self, mock_create_service, brand_asset
+    ):
+        """Celery task updates BrandAsset.gcs_path after successful ingestion."""
+        from data_ingestion.tasks import process_ingestion_event
+
+        mock_service = MagicMock()
+        mock_result = MagicMock()
+        mock_result.destination_path = "gs://bucket/1/raw/2026/02/06/photo.png"
+        mock_service.process_event.return_value = mock_result
+        mock_create_service.return_value = mock_service
+
+        result = process_ingestion_event.apply(
+            args=[
+                str(uuid.uuid4()),  # event_id
+                "tenant-1",  # tenant_id
+                "gs://bucket/1/_landing/photo.png",  # file_path
+            ],
+            kwargs={
+                "metadata": {"asset_id": str(brand_asset.id)},
+            },
+        ).get()
+
+        assert result["status"] == "success"
+
+        brand_asset.refresh_from_db()
+        assert brand_asset.gcs_path == "1/raw/2026/02/06/photo.png"
+        assert brand_asset.pipeline_status == "ingested"

--- a/ai-brand-automator/media_curation/management/commands/run_curation_consumer.py
+++ b/ai-brand-automator/media_curation/management/commands/run_curation_consumer.py
@@ -43,35 +43,55 @@ def _update_asset_status(file_id: str, status: str, error_msg: str = "") -> bool
     Returns:
         True if update succeeded, False otherwise
     """
-    try:
-        from onboarding.models import BrandAsset
+    from django.db import close_old_connections
+    from onboarding.models import BrandAsset
 
-        # Try to find asset by ID (could be integer or UUID)
+    for attempt in range(2):
         try:
-            asset_id = int(file_id)
-            asset = BrandAsset.objects.filter(id=asset_id).first()
-        except (ValueError, TypeError):
-            # file_id might be a UUID - try matching by pipeline_trace_id
-            try:
-                trace_uuid = uuid.UUID(file_id)
-                asset = BrandAsset.objects.filter(pipeline_trace_id=trace_uuid).first()
-            except (ValueError, TypeError):
-                asset = None
+            if attempt > 0:
+                close_old_connections()
 
-        if asset:
-            asset.pipeline_status = status
-            if error_msg:
-                asset.pipeline_error = error_msg
-            asset.save(update_fields=["pipeline_status", "pipeline_error"])
-            logger.info(f"Updated BrandAsset {asset.id} pipeline_status to {status}")
-            return True
-        else:
-            logger.warning(f"BrandAsset not found for file_id: {file_id}")
+            # Try to find asset by ID (could be integer or UUID)
+            try:
+                asset_id = int(file_id)
+                asset = BrandAsset.objects.filter(id=asset_id).first()
+            except (ValueError, TypeError):
+                # file_id might be a UUID - try matching by pipeline_trace_id
+                try:
+                    trace_uuid = uuid.UUID(file_id)
+                    asset = BrandAsset.objects.filter(
+                        pipeline_trace_id=trace_uuid
+                    ).first()
+                except (ValueError, TypeError):
+                    asset = None
+
+            if asset:
+                asset.pipeline_status = status
+                if error_msg:
+                    asset.pipeline_error = error_msg
+                asset.save(update_fields=["pipeline_status", "pipeline_error"])
+                logger.info(
+                    "Updated BrandAsset %s pipeline_status to %s",
+                    asset.id,
+                    status,
+                )
+                return True
+            else:
+                logger.warning("BrandAsset not found for file_id: %s", file_id)
+                return False
+
+        except Exception:
+            if attempt == 0:
+                logger.warning(
+                    "DB error updating BrandAsset (will retry): %s",
+                    file_id,
+                    exc_info=True,
+                )
+                continue
+            logger.exception("Failed to update BrandAsset status after retry")
             return False
 
-    except Exception as e:
-        logger.error(f"Failed to update BrandAsset status: {e}")
-        return False
+    return False
 
 
 def _run_async(coro):

--- a/ai-brand-automator/onboarding/management/commands/fix_stale_gcs_paths.py
+++ b/ai-brand-automator/onboarding/management/commands/fix_stale_gcs_paths.py
@@ -36,6 +36,20 @@ class Command(BaseCommand):
             self.stderr.write(self.style.ERROR("GCS not configured"))
             return
 
+        # Resolve public tenant ID dynamically for fallback
+        from tenants.models import Tenant
+
+        try:
+            public_tenant = Tenant.objects.get(schema_name="public")
+            public_tenant_id = public_tenant.id
+        except Tenant.DoesNotExist:
+            public_tenant_id = 1
+            self.stdout.write(
+                self.style.WARNING(
+                    f"Public tenant not found, using fallback tenant_id={public_tenant_id}"
+                )
+            )
+
         stale_assets = BrandAsset.objects.filter(gcs_path__startswith="_landing/")
         self.stdout.write(
             f"Found {stale_assets.count()} assets with _landing/ gcs_path"
@@ -43,42 +57,65 @@ class Command(BaseCommand):
 
         fixed = 0
         not_found = 0
+        skipped = 0
 
         for asset in stale_assets:
             old_path = asset.gcs_path
             # Extract the filename (everything after the last /)
             filename = old_path.rsplit("/", 1)[-1]
 
-            # Search for the file in the raw/ zone
-            prefix = f"{asset.tenant_id}/raw/" if asset.tenant_id else "1/raw/"
-            blobs = list(
-                gcs_service.client.list_blobs(
-                    gcs_service.bucket_name,
-                    prefix=prefix,
-                    max_results=500,
-                )
-            )
-            matching = [b for b in blobs if b.name.endswith(filename)]
+            # Build a narrowed prefix using tenant_id and uploaded_at date
+            tenant_id = asset.tenant_id if asset.tenant_id else public_tenant_id
+            if asset.uploaded_at:
+                date_prefix = asset.uploaded_at.strftime("%Y/%m/%d")
+                prefix = f"{tenant_id}/raw/{date_prefix}/"
+            else:
+                prefix = f"{tenant_id}/raw/"
 
-            if matching:
-                new_path = matching[0].name
+            # Stream blobs and stop at first match (no max_results limit)
+            matching_blob = None
+            match_count = 0
+            for blob in gcs_service.client.list_blobs(
+                gcs_service.bucket_name,
+                prefix=prefix,
+            ):
+                if blob.name.endswith(filename):
+                    match_count += 1
+                    if matching_blob is None:
+                        matching_blob = blob
+                    if match_count > 1:
+                        break  # Found ambiguity, stop early
+
+            if match_count > 1:
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"  Asset {asset.id}: {old_path} - SKIPPED: "
+                        f"multiple files match '{filename}' in {prefix}"
+                    )
+                )
+                skipped += 1
+            elif matching_blob:
+                new_path = matching_blob.name
                 self.stdout.write(f"  Asset {asset.id}: {old_path} -> {new_path}")
                 if apply:
                     asset.gcs_path = new_path
                     asset.save(update_fields=["gcs_path"])
-                    self.stdout.write(self.style.SUCCESS(f"    Fixed!"))
+                    self.stdout.write(self.style.SUCCESS("    Fixed!"))
                 fixed += 1
             else:
                 self.stdout.write(
                     self.style.WARNING(
-                        f"  Asset {asset.id}: {old_path} - file NOT found in raw/"
+                        f"  Asset {asset.id}: {old_path} - file NOT found in {prefix}"
                     )
                 )
                 not_found += 1
 
         mode = "Fixed" if apply else "Would fix"
         self.stdout.write(
-            self.style.SUCCESS(f"\n{mode} {fixed} assets, {not_found} not found in GCS")
+            self.style.SUCCESS(
+                f"\n{mode} {fixed} assets, {not_found} not found, "
+                f"{skipped} skipped (ambiguous)"
+            )
         )
         if not apply and fixed > 0:
             self.stdout.write("Run with --apply to apply fixes")

--- a/ai-brand-automator/onboarding/management/commands/fix_stale_gcs_paths.py
+++ b/ai-brand-automator/onboarding/management/commands/fix_stale_gcs_paths.py
@@ -46,7 +46,8 @@ class Command(BaseCommand):
             public_tenant_id = 1
             self.stdout.write(
                 self.style.WARNING(
-                    f"Public tenant not found, using fallback tenant_id={public_tenant_id}"
+                    "Public tenant not found, "
+                    f"using fallback tenant_id={public_tenant_id}"
                 )
             )
 

--- a/ai-brand-automator/onboarding/management/commands/fix_stale_gcs_paths.py
+++ b/ai-brand-automator/onboarding/management/commands/fix_stale_gcs_paths.py
@@ -1,0 +1,84 @@
+"""
+Management command to fix stale gcs_path values on BrandAsset records.
+
+After the ingestion pipeline moves files from _landing/ to {tenant}/raw/,
+the gcs_path in the DB should be updated. This command finds assets whose
+gcs_path still points to _landing/ and corrects it by scanning for the
+actual file location in GCS.
+
+Usage:
+    python manage.py fix_stale_gcs_paths          # Dry run (default)
+    python manage.py fix_stale_gcs_paths --apply   # Apply fixes
+"""
+
+import logging
+from django.core.management.base import BaseCommand
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Fix BrandAsset records whose gcs_path still points to _landing/"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--apply",
+            action="store_true",
+            help="Apply fixes (default is dry run)",
+        )
+
+    def handle(self, *args, **options):
+        apply = options["apply"]
+        from onboarding.models import BrandAsset
+        from files.services import gcs_service
+
+        if not gcs_service.bucket:
+            self.stderr.write(self.style.ERROR("GCS not configured"))
+            return
+
+        stale_assets = BrandAsset.objects.filter(gcs_path__startswith="_landing/")
+        self.stdout.write(
+            f"Found {stale_assets.count()} assets with _landing/ gcs_path"
+        )
+
+        fixed = 0
+        not_found = 0
+
+        for asset in stale_assets:
+            old_path = asset.gcs_path
+            # Extract the filename (everything after the last /)
+            filename = old_path.rsplit("/", 1)[-1]
+
+            # Search for the file in the raw/ zone
+            prefix = f"{asset.tenant_id}/raw/" if asset.tenant_id else "1/raw/"
+            blobs = list(
+                gcs_service.client.list_blobs(
+                    gcs_service.bucket_name,
+                    prefix=prefix,
+                    max_results=500,
+                )
+            )
+            matching = [b for b in blobs if b.name.endswith(filename)]
+
+            if matching:
+                new_path = matching[0].name
+                self.stdout.write(f"  Asset {asset.id}: {old_path} -> {new_path}")
+                if apply:
+                    asset.gcs_path = new_path
+                    asset.save(update_fields=["gcs_path"])
+                    self.stdout.write(self.style.SUCCESS(f"    Fixed!"))
+                fixed += 1
+            else:
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"  Asset {asset.id}: {old_path} - file NOT found in raw/"
+                    )
+                )
+                not_found += 1
+
+        mode = "Fixed" if apply else "Would fix"
+        self.stdout.write(
+            self.style.SUCCESS(f"\n{mode} {fixed} assets, {not_found} not found in GCS")
+        )
+        if not apply and fixed > 0:
+            self.stdout.write("Run with --apply to apply fixes")

--- a/ai-brand-automator/rag_index/tasks/sync_tasks.py
+++ b/ai-brand-automator/rag_index/tasks/sync_tasks.py
@@ -33,29 +33,47 @@ def _update_asset_status(asset_id: str, status: str, error_msg: str = "") -> boo
     Returns:
         True if update succeeded, False otherwise
     """
-    try:
-        from onboarding.models import BrandAsset
+    from django.db import close_old_connections
+    from onboarding.models import BrandAsset
 
+    for attempt in range(2):
         try:
-            aid = int(asset_id)
-            asset = BrandAsset.objects.filter(id=aid).first()
-        except (ValueError, TypeError):
-            asset = None
+            if attempt > 0:
+                close_old_connections()
 
-        if asset:
-            asset.pipeline_status = status
-            if error_msg:
-                asset.pipeline_error = error_msg
-            asset.save(update_fields=["pipeline_status", "pipeline_error"])
-            logger.info(f"Updated BrandAsset {asset.id} pipeline_status to {status}")
-            return True
-        else:
-            logger.warning(f"BrandAsset not found for asset_id: {asset_id}")
+            try:
+                aid = int(asset_id)
+                asset = BrandAsset.objects.filter(id=aid).first()
+            except (ValueError, TypeError):
+                asset = None
+
+            if asset:
+                asset.pipeline_status = status
+                if error_msg:
+                    asset.pipeline_error = error_msg
+                asset.save(update_fields=["pipeline_status", "pipeline_error"])
+                logger.info(
+                    "Updated BrandAsset %s pipeline_status to %s",
+                    asset.id,
+                    status,
+                )
+                return True
+            else:
+                logger.warning("BrandAsset not found for asset_id: %s", asset_id)
+                return False
+
+        except Exception:
+            if attempt == 0:
+                logger.warning(
+                    "DB error updating BrandAsset (will retry): %s",
+                    asset_id,
+                    exc_info=True,
+                )
+                continue
+            logger.exception("Failed to update BrandAsset status after retry")
             return False
 
-    except Exception as e:
-        logger.error(f"Failed to update BrandAsset status: {e}")
-        return False
+    return False
 
 
 # ============================================================================


### PR DESCRIPTION
…_path after ingestion

- Add retry-on-failure pattern with close_old_connections() to all pipeline DB update functions (ingestion consumer, curation consumer, rag-index tasks)
- Fix: Neon PostgreSQL connection timeouts in long-running Kafka consumers caused 'cursor already closed' errors, silently failing gcs_path updates
- Add _update_asset_after_ingestion() to Celery ingestion task to update gcs_path after files are moved from _landing/ to raw/
- Add fix_stale_gcs_paths management command to repair existing assets with stale _landing/ paths in the database

Root cause: Long-running Kafka consumer processes held DB connections that Neon timed out. When _update_asset_status() ran, psycopg2.InterfaceError was raised and the function returned False, leaving gcs_path pointing to the old _landing/ location after files were moved to 1/raw/.