### PR TITLE
fix: force download for non-browser-viewable files (.docx, .xlsx, etc.)

### DIFF
--- a/ai-brand-automator/files/services.py
+++ b/ai-brand-automator/files/services.py
@@ -17,6 +17,52 @@ logger = logging.getLogger(__name__)
 
 GCS_SCOPES = ["https://www.googleapis.com/auth/devstorage.full_control"]
 
+# MIME types that browsers can display inline (used by generate_signed_url)
+_BROWSER_VIEWABLE_TYPES = {
+    "application/pdf",
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/webp",
+    "image/svg+xml",
+    "text/plain",
+    "text/html",
+    "text/csv",
+    "video/mp4",
+    "video/webm",
+    "audio/mpeg",
+    "audio/wav",
+    "audio/ogg",
+}
+
+# Explicit extension → MIME map for reliable content-type on signed URLs
+_EXTENSION_CONTENT_TYPE = {
+    ".pdf": "application/pdf",
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".svg": "image/svg+xml",
+    ".txt": "text/plain",
+    ".csv": "text/csv",
+    ".mp4": "video/mp4",
+    ".webm": "video/webm",
+    ".mp3": "audio/mpeg",
+    ".wav": "audio/wav",
+    ".ogg": "audio/ogg",
+    ".doc": "application/msword",
+    ".docx": (
+        "application/vnd.openxmlformats-officedocument" ".wordprocessingml.document"
+    ),
+    ".xls": "application/vnd.ms-excel",
+    ".xlsx": ("application/vnd.openxmlformats-officedocument" ".spreadsheetml.sheet"),
+    ".ppt": "application/vnd.ms-powerpoint",
+    ".pptx": (
+        "application/vnd.openxmlformats-officedocument" ".presentationml.presentation"
+    ),
+}
+
 
 class GCSService:
     """
@@ -173,61 +219,14 @@ class GCSService:
         Args:
             file_path: Path of the file in GCS
             expiration_minutes: How long the URL should be valid (default: 15)
-            for_download: If True, sets content-disposition to attachment
+            for_download: If True, sets content-disposition to attachment.
+                Non-browser-viewable types (e.g. .docx, .xlsx, .pptx) will
+                always be served as attachments even when for_download=False.
             filename: Original filename for download (used with for_download)
 
         Returns:
             dict: Contains 'url' and 'expires_at' timestamp
         """
-        # MIME types that browsers can display inline
-        _BROWSER_VIEWABLE_TYPES = {
-            "application/pdf",
-            "image/png",
-            "image/jpeg",
-            "image/gif",
-            "image/webp",
-            "image/svg+xml",
-            "text/plain",
-            "text/html",
-            "text/csv",
-            "video/mp4",
-            "video/webm",
-            "audio/mpeg",
-            "audio/wav",
-            "audio/ogg",
-        }
-
-        # Explicit MIME map for reliable content-type on signed URLs
-        _EXTENSION_CONTENT_TYPE = {
-            ".pdf": "application/pdf",
-            ".png": "image/png",
-            ".jpg": "image/jpeg",
-            ".jpeg": "image/jpeg",
-            ".gif": "image/gif",
-            ".webp": "image/webp",
-            ".svg": "image/svg+xml",
-            ".txt": "text/plain",
-            ".csv": "text/csv",
-            ".mp4": "video/mp4",
-            ".webm": "video/webm",
-            ".mp3": "audio/mpeg",
-            ".wav": "audio/wav",
-            ".ogg": "audio/ogg",
-            ".doc": "application/msword",
-            ".docx": (
-                "application/vnd.openxmlformats-officedocument"
-                ".wordprocessingml.document"
-            ),
-            ".xls": "application/vnd.ms-excel",
-            ".xlsx": (
-                "application/vnd.openxmlformats-officedocument" ".spreadsheetml.sheet"
-            ),
-            ".ppt": "application/vnd.ms-powerpoint",
-            ".pptx": (
-                "application/vnd.openxmlformats-officedocument"
-                ".presentationml.presentation"
-            ),
-        }
 
         if not self.bucket:
             # Mock URL for development
@@ -247,24 +246,25 @@ class GCSService:
 
         try:
             from datetime import datetime, timezone
-            import os as _os
 
             blob = self.bucket.blob(file_path)
 
             # Determine content type from file extension
-            ext = _os.path.splitext(file_path)[1].lower()
+            ext = os.path.splitext(file_path)[1].lower()
             content_type = _EXTENSION_CONTENT_TYPE.get(ext)
 
-            # For non-browser-viewable types, always force download even when
-            # the caller asks for a "view" URL. Browsers cannot render .docx,
-            # .xlsx, .pptx etc. inline and will show "could not load plugin".
+            # For non-browser-viewable types, always force
+            # Content-Disposition: attachment even when for_download=False
+            # (i.e. when the caller asks for a "view" URL). Browsers cannot
+            # render .docx, .xlsx, .pptx etc. inline and will show "could not
+            # load plugin", so we override the caller's preference.
             force_download = (
                 content_type is not None and content_type not in _BROWSER_VIEWABLE_TYPES
             )
 
             # Build response disposition header
             response_disposition = None
-            safe_name = (filename or _os.path.basename(file_path)).replace('"', '\\"')
+            safe_name = (filename or os.path.basename(file_path)).replace('"', '\\"')
             if for_download or force_download:
                 response_disposition = f'attachment; filename="{safe_name}"'
 

--- a/ai-brand-automator/files/services.py
+++ b/ai-brand-automator/files/services.py
@@ -179,6 +179,56 @@ class GCSService:
         Returns:
             dict: Contains 'url' and 'expires_at' timestamp
         """
+        # MIME types that browsers can display inline
+        _BROWSER_VIEWABLE_TYPES = {
+            "application/pdf",
+            "image/png",
+            "image/jpeg",
+            "image/gif",
+            "image/webp",
+            "image/svg+xml",
+            "text/plain",
+            "text/html",
+            "text/csv",
+            "video/mp4",
+            "video/webm",
+            "audio/mpeg",
+            "audio/wav",
+            "audio/ogg",
+        }
+
+        # Explicit MIME map for reliable content-type on signed URLs
+        _EXTENSION_CONTENT_TYPE = {
+            ".pdf": "application/pdf",
+            ".png": "image/png",
+            ".jpg": "image/jpeg",
+            ".jpeg": "image/jpeg",
+            ".gif": "image/gif",
+            ".webp": "image/webp",
+            ".svg": "image/svg+xml",
+            ".txt": "text/plain",
+            ".csv": "text/csv",
+            ".mp4": "video/mp4",
+            ".webm": "video/webm",
+            ".mp3": "audio/mpeg",
+            ".wav": "audio/wav",
+            ".ogg": "audio/ogg",
+            ".doc": "application/msword",
+            ".docx": (
+                "application/vnd.openxmlformats-officedocument"
+                ".wordprocessingml.document"
+            ),
+            ".xls": "application/vnd.ms-excel",
+            ".xlsx": (
+                "application/vnd.openxmlformats-officedocument" ".spreadsheetml.sheet"
+            ),
+            ".ppt": "application/vnd.ms-powerpoint",
+            ".pptx": (
+                "application/vnd.openxmlformats-officedocument"
+                ".presentationml.presentation"
+            ),
+        }
+
         if not self.bucket:
             # Mock URL for development
             from datetime import datetime, timezone
@@ -197,28 +247,41 @@ class GCSService:
 
         try:
             from datetime import datetime, timezone
+            import os as _os
 
             blob = self.bucket.blob(file_path)
 
-            # Note: We don't check if file exists - signed URL generation works
-            # even for non-existent files. GCS returns 404 when accessed.
-            # This allows viewing files in different paths or being processed.
+            # Determine content type from file extension
+            ext = _os.path.splitext(file_path)[1].lower()
+            content_type = _EXTENSION_CONTENT_TYPE.get(ext)
 
-            # Build response disposition header if downloading
+            # For non-browser-viewable types, always force download even when
+            # the caller asks for a "view" URL. Browsers cannot render .docx,
+            # .xlsx, .pptx etc. inline and will show "could not load plugin".
+            force_download = (
+                content_type is not None and content_type not in _BROWSER_VIEWABLE_TYPES
+            )
+
+            # Build response disposition header
             response_disposition = None
-            if for_download and filename:
-                # Sanitize filename for header
-                safe_filename = filename.replace('"', '\\"')
-                response_disposition = f'attachment; filename="{safe_filename}"'
+            safe_name = (filename or _os.path.basename(file_path)).replace('"', '\\"')
+            if for_download or force_download:
+                response_disposition = f'attachment; filename="{safe_name}"'
 
             # Generate signed URL
             expiration = timedelta(minutes=expiration_minutes)
-            url = blob.generate_signed_url(
-                version="v4",
-                expiration=expiration,
-                method="GET",
-                response_disposition=response_disposition,
-            )
+
+            url_kwargs = {
+                "version": "v4",
+                "expiration": expiration,
+                "method": "GET",
+            }
+            if response_disposition:
+                url_kwargs["response_disposition"] = response_disposition
+            if content_type:
+                url_kwargs["response_type"] = content_type
+
+            url = blob.generate_signed_url(**url_kwargs)
 
             expires_at = datetime.now(timezone.utc) + expiration
 

--- a/ai-brand-automator/files/tests/test_signed_url.py
+++ b/ai-brand-automator/files/tests/test_signed_url.py
@@ -1,0 +1,234 @@
+"""
+Tests for GCSService.generate_signed_url() signed-URL generation logic.
+
+Covers:
+- Browser-viewable files (PDF, images) served inline when for_download=False
+- Non-browser-viewable files (.docx, .xlsx, .pptx) force attachment even when
+  for_download=False
+- Explicit download requests always set attachment disposition
+- response_type is set to the correct MIME type
+"""
+
+from unittest import mock
+
+import pytest
+
+from files.services import (
+    GCSService,
+    _BROWSER_VIEWABLE_TYPES,
+    _EXTENSION_CONTENT_TYPE,
+)
+
+
+@pytest.fixture
+def gcs_service():
+    """GCSService with a mocked bucket and blob."""
+    with (
+        mock.patch("files.services.settings") as mock_settings,
+        mock.patch("files.services.storage.Client"),
+    ):
+        mock_settings.GS_BUCKET_NAME = "test-bucket"
+        mock_settings.GS_PROJECT_ID = "test-project"
+        mock_settings.GS_CREDENTIALS_PATH = ""
+        service = GCSService()
+        # Replace bucket with a mock that returns a mock blob
+        service.bucket = mock.MagicMock()
+        yield service
+
+
+class TestSignedUrlForceDownload:
+    """Non-browser-viewable types must force Content-Disposition: attachment."""
+
+    @pytest.mark.parametrize(
+        "file_path,expected_content_type",
+        [
+            (
+                "uploads/report.docx",
+                "application/vnd.openxmlformats-officedocument"
+                ".wordprocessingml.document",
+            ),
+            (
+                "uploads/data.xlsx",
+                "application/vnd.openxmlformats-officedocument" ".spreadsheetml.sheet",
+            ),
+            (
+                "uploads/slides.pptx",
+                "application/vnd.openxmlformats-officedocument"
+                ".presentationml.presentation",
+            ),
+            ("uploads/legacy.doc", "application/msword"),
+            ("uploads/legacy.xls", "application/vnd.ms-excel"),
+            ("uploads/legacy.ppt", "application/vnd.ms-powerpoint"),
+        ],
+    )
+    def test_view_url_forces_attachment_for_office_files(
+        self, gcs_service, file_path, expected_content_type
+    ):
+        """A 'view' URL (for_download=False) for Office files should still
+        pass response_disposition=attachment and set response_type."""
+        mock_blob = gcs_service.bucket.blob.return_value
+        mock_blob.generate_signed_url.return_value = "https://signed.url/test"
+
+        result = gcs_service.generate_signed_url(file_path, for_download=False)
+
+        assert "url" in result
+        call_kwargs = mock_blob.generate_signed_url.call_args[1]
+        # Must have attachment disposition even though for_download=False
+        assert "response_disposition" in call_kwargs
+        assert "attachment" in call_kwargs["response_disposition"]
+        # Must set response_type to the correct MIME type
+        assert call_kwargs["response_type"] == expected_content_type
+
+    @pytest.mark.parametrize(
+        "file_path,expected_content_type",
+        [
+            ("uploads/report.docx", _EXTENSION_CONTENT_TYPE[".docx"]),
+            ("uploads/data.xlsx", _EXTENSION_CONTENT_TYPE[".xlsx"]),
+        ],
+    )
+    def test_download_url_also_sets_attachment_for_office_files(
+        self, gcs_service, file_path, expected_content_type
+    ):
+        """Explicit download (for_download=True) for Office files should
+        also set attachment disposition and response_type."""
+        mock_blob = gcs_service.bucket.blob.return_value
+        mock_blob.generate_signed_url.return_value = "https://signed.url/test"
+
+        result = gcs_service.generate_signed_url(file_path, for_download=True)
+
+        assert "url" in result
+        call_kwargs = mock_blob.generate_signed_url.call_args[1]
+        assert "attachment" in call_kwargs["response_disposition"]
+        assert call_kwargs["response_type"] == expected_content_type
+
+
+class TestSignedUrlInlineViewable:
+    """Browser-viewable types should NOT force attachment on view URLs."""
+
+    @pytest.mark.parametrize(
+        "file_path",
+        [
+            "uploads/doc.pdf",
+            "uploads/photo.png",
+            "uploads/photo.jpg",
+            "uploads/animation.gif",
+            "uploads/notes.txt",
+            "uploads/video.mp4",
+        ],
+    )
+    def test_view_url_no_attachment_for_viewable_files(self, gcs_service, file_path):
+        """A 'view' URL for browser-viewable files should NOT set
+        response_disposition (allows inline display)."""
+        mock_blob = gcs_service.bucket.blob.return_value
+        mock_blob.generate_signed_url.return_value = "https://signed.url/test"
+
+        gcs_service.generate_signed_url(file_path, for_download=False)
+
+        call_kwargs = mock_blob.generate_signed_url.call_args[1]
+        assert "response_disposition" not in call_kwargs
+
+    @pytest.mark.parametrize(
+        "file_path",
+        [
+            "uploads/doc.pdf",
+            "uploads/photo.png",
+        ],
+    )
+    def test_download_url_sets_attachment_for_viewable_files(
+        self, gcs_service, file_path
+    ):
+        """Explicit download (for_download=True) for viewable files should
+        set response_disposition to attachment."""
+        mock_blob = gcs_service.bucket.blob.return_value
+        mock_blob.generate_signed_url.return_value = "https://signed.url/test"
+
+        gcs_service.generate_signed_url(file_path, for_download=True)
+
+        call_kwargs = mock_blob.generate_signed_url.call_args[1]
+        assert "response_disposition" in call_kwargs
+        assert "attachment" in call_kwargs["response_disposition"]
+
+
+class TestSignedUrlResponseType:
+    """response_type should always be set when extension is in the map."""
+
+    def test_response_type_set_for_known_extensions(self, gcs_service):
+        """Known file extensions should set response_type."""
+        mock_blob = gcs_service.bucket.blob.return_value
+        mock_blob.generate_signed_url.return_value = "https://signed.url/test"
+
+        gcs_service.generate_signed_url("uploads/doc.pdf", for_download=False)
+
+        call_kwargs = mock_blob.generate_signed_url.call_args[1]
+        assert call_kwargs["response_type"] == "application/pdf"
+
+    def test_response_type_not_set_for_unknown_extensions(self, gcs_service):
+        """Unknown file extensions should NOT set response_type."""
+        mock_blob = gcs_service.bucket.blob.return_value
+        mock_blob.generate_signed_url.return_value = "https://signed.url/test"
+
+        gcs_service.generate_signed_url("uploads/archive.xyz", for_download=False)
+
+        call_kwargs = mock_blob.generate_signed_url.call_args[1]
+        assert "response_type" not in call_kwargs
+
+    def test_unknown_extension_no_forced_download(self, gcs_service):
+        """Unknown extensions should NOT force download on view URLs."""
+        mock_blob = gcs_service.bucket.blob.return_value
+        mock_blob.generate_signed_url.return_value = "https://signed.url/test"
+
+        gcs_service.generate_signed_url("uploads/archive.xyz", for_download=False)
+
+        call_kwargs = mock_blob.generate_signed_url.call_args[1]
+        assert "response_disposition" not in call_kwargs
+
+
+class TestSignedUrlFilename:
+    """The filename in Content-Disposition should be correct."""
+
+    def test_custom_filename_in_disposition(self, gcs_service):
+        """Custom filename should appear in Content-Disposition header."""
+        mock_blob = gcs_service.bucket.blob.return_value
+        mock_blob.generate_signed_url.return_value = "https://signed.url/test"
+
+        gcs_service.generate_signed_url(
+            "uploads/report.docx",
+            for_download=False,
+            filename="My Report.docx",
+        )
+
+        call_kwargs = mock_blob.generate_signed_url.call_args[1]
+        assert "My Report.docx" in call_kwargs["response_disposition"]
+
+    def test_basename_used_when_no_filename(self, gcs_service):
+        """When no filename is provided, the file's basename should be used."""
+        mock_blob = gcs_service.bucket.blob.return_value
+        mock_blob.generate_signed_url.return_value = "https://signed.url/test"
+
+        gcs_service.generate_signed_url("uploads/report.docx", for_download=True)
+
+        call_kwargs = mock_blob.generate_signed_url.call_args[1]
+        assert "report.docx" in call_kwargs["response_disposition"]
+
+
+class TestModuleLevelConstants:
+    """Verify that the module-level constants are properly defined."""
+
+    def test_browser_viewable_types_contains_pdf(self):
+        assert "application/pdf" in _BROWSER_VIEWABLE_TYPES
+
+    def test_browser_viewable_types_excludes_office(self):
+        docx_type = _EXTENSION_CONTENT_TYPE[".docx"]
+        xlsx_type = _EXTENSION_CONTENT_TYPE[".xlsx"]
+        pptx_type = _EXTENSION_CONTENT_TYPE[".pptx"]
+        assert docx_type not in _BROWSER_VIEWABLE_TYPES
+        assert xlsx_type not in _BROWSER_VIEWABLE_TYPES
+        assert pptx_type not in _BROWSER_VIEWABLE_TYPES
+
+    def test_extension_content_type_has_office_formats(self):
+        assert ".docx" in _EXTENSION_CONTENT_TYPE
+        assert ".xlsx" in _EXTENSION_CONTENT_TYPE
+        assert ".pptx" in _EXTENSION_CONTENT_TYPE
+        assert ".doc" in _EXTENSION_CONTENT_TYPE
+        assert ".xls" in _EXTENSION_CONTENT_TYPE
+        assert ".ppt" in _EXTENSION_CONTENT_TYPE


### PR DESCRIPTION
Signed URLs for file types that browsers cannot render inline (e.g. docx, xlsx, pptx) now set Content-Disposition: attachment and explicit Content-Type via response_type. Prevents 'could not load plugin' error when clicking view links for Office documents.