### PR TITLE
fix: dashboard analytics errors and JWT token refresh URL

### DIFF
--- a/ai-brand-automator-frontend/src/components/dashboard/SocialAnalytics.tsx
+++ b/ai-brand-automator-frontend/src/components/dashboard/SocialAnalytics.tsx
@@ -223,12 +223,14 @@ export default function SocialAnalytics() {
         setTwitterAnalyticsData(data);
       } else {
         const errData = await response.json().catch(() => ({}));
-        const msg = errData.error || `HTTP ${response.status}`;
+        const msg = errData.error || errData.detail || `HTTP ${response.status}`;
         console.error('Twitter analytics error:', msg);
+        setTwitterAnalyticsData(null);
         setTwitterAnalyticsError(msg);
       }
     } catch (error) {
       console.error('Failed to fetch Twitter analytics:', error);
+      setTwitterAnalyticsData(null);
       setTwitterAnalyticsError('Network error');
     } finally {
       setTwitterAnalyticsLoading(false);
@@ -281,12 +283,14 @@ export default function SocialAnalytics() {
         setLinkedInAnalyticsData(data);
       } else {
         const errData = await response.json().catch(() => ({}));
-        const msg = errData.error || `HTTP ${response.status}`;
+        const msg = errData.error || errData.detail || `HTTP ${response.status}`;
         console.error('LinkedIn analytics error:', msg);
+        setLinkedInAnalyticsData(null);
         setLinkedInAnalyticsError(msg);
       }
     } catch (error) {
       console.error('Failed to fetch LinkedIn analytics:', error);
+      setLinkedInAnalyticsData(null);
       setLinkedInAnalyticsError('Network error');
     } finally {
       setLinkedInAnalyticsLoading(false);
@@ -339,12 +343,14 @@ export default function SocialAnalytics() {
         setFacebookAnalyticsData(data);
       } else {
         const errData = await response.json().catch(() => ({}));
-        const msg = errData.error || `HTTP ${response.status}`;
+        const msg = errData.error || errData.detail || `HTTP ${response.status}`;
         console.error('Facebook analytics error:', msg);
+        setFacebookAnalyticsData(null);
         setFacebookAnalyticsError(msg);
       }
     } catch (error) {
       console.error('Failed to fetch Facebook analytics:', error);
+      setFacebookAnalyticsData(null);
       setFacebookAnalyticsError('Network error');
     } finally {
       setFacebookAnalyticsLoading(false);
@@ -397,12 +403,14 @@ export default function SocialAnalytics() {
         setInstagramAnalyticsData(data);
       } else {
         const errData = await response.json().catch(() => ({}));
-        const msg = errData.error || `HTTP ${response.status}`;
+        const msg = errData.error || errData.detail || `HTTP ${response.status}`;
         console.error('Instagram analytics error:', msg);
+        setInstagramAnalyticsData(null);
         setInstagramAnalyticsError(msg);
       }
     } catch (error) {
       console.error('Failed to fetch Instagram analytics:', error);
+      setInstagramAnalyticsData(null);
       setInstagramAnalyticsError('Network error');
     } finally {
       setInstagramAnalyticsLoading(false);

--- a/ai-brand-automator-frontend/src/components/dashboard/SocialAnalytics.tsx
+++ b/ai-brand-automator-frontend/src/components/dashboard/SocialAnalytics.tsx
@@ -184,6 +184,12 @@ export default function SocialAnalytics() {
   const [instagramUnreadCount, setInstagramUnreadCount] = useState(0);
   const [showInstagramNotifications, setShowInstagramNotifications] = useState(false);
 
+  // Analytics error states
+  const [twitterAnalyticsError, setTwitterAnalyticsError] = useState<string | null>(null);
+  const [linkedInAnalyticsError, setLinkedInAnalyticsError] = useState<string | null>(null);
+  const [facebookAnalyticsError, setFacebookAnalyticsError] = useState<string | null>(null);
+  const [instagramAnalyticsError, setInstagramAnalyticsError] = useState<string | null>(null);
+
   // Fetch profile status
   const fetchProfiles = useCallback(async () => {
     setProfilesError(null);
@@ -209,14 +215,21 @@ export default function SocialAnalytics() {
     if (!profiles?.twitter?.connected) return;
     
     setTwitterAnalyticsLoading(true);
+    setTwitterAnalyticsError(null);
     try {
       const response = await apiClient.get('/automation/twitter/analytics/');
       if (response.ok) {
         const data = await response.json();
         setTwitterAnalyticsData(data);
+      } else {
+        const errData = await response.json().catch(() => ({}));
+        const msg = errData.error || `HTTP ${response.status}`;
+        console.error('Twitter analytics error:', msg);
+        setTwitterAnalyticsError(msg);
       }
     } catch (error) {
       console.error('Failed to fetch Twitter analytics:', error);
+      setTwitterAnalyticsError('Network error');
     } finally {
       setTwitterAnalyticsLoading(false);
     }
@@ -260,14 +273,21 @@ export default function SocialAnalytics() {
     if (!profiles?.linkedin?.connected) return;
     
     setLinkedInAnalyticsLoading(true);
+    setLinkedInAnalyticsError(null);
     try {
       const response = await apiClient.get('/automation/linkedin/analytics/');
       if (response.ok) {
         const data = await response.json();
         setLinkedInAnalyticsData(data);
+      } else {
+        const errData = await response.json().catch(() => ({}));
+        const msg = errData.error || `HTTP ${response.status}`;
+        console.error('LinkedIn analytics error:', msg);
+        setLinkedInAnalyticsError(msg);
       }
     } catch (error) {
       console.error('Failed to fetch LinkedIn analytics:', error);
+      setLinkedInAnalyticsError('Network error');
     } finally {
       setLinkedInAnalyticsLoading(false);
     }
@@ -311,14 +331,21 @@ export default function SocialAnalytics() {
     if (!profiles?.facebook?.connected) return;
     
     setFacebookAnalyticsLoading(true);
+    setFacebookAnalyticsError(null);
     try {
       const response = await apiClient.get('/automation/facebook/analytics/');
       if (response.ok) {
         const data = await response.json();
         setFacebookAnalyticsData(data);
+      } else {
+        const errData = await response.json().catch(() => ({}));
+        const msg = errData.error || `HTTP ${response.status}`;
+        console.error('Facebook analytics error:', msg);
+        setFacebookAnalyticsError(msg);
       }
     } catch (error) {
       console.error('Failed to fetch Facebook analytics:', error);
+      setFacebookAnalyticsError('Network error');
     } finally {
       setFacebookAnalyticsLoading(false);
     }
@@ -362,14 +389,21 @@ export default function SocialAnalytics() {
     if (!profiles?.instagram?.connected) return;
     
     setInstagramAnalyticsLoading(true);
+    setInstagramAnalyticsError(null);
     try {
       const response = await apiClient.get('/automation/instagram/analytics/');
       if (response.ok) {
         const data = await response.json();
         setInstagramAnalyticsData(data);
+      } else {
+        const errData = await response.json().catch(() => ({}));
+        const msg = errData.error || `HTTP ${response.status}`;
+        console.error('Instagram analytics error:', msg);
+        setInstagramAnalyticsError(msg);
       }
     } catch (error) {
       console.error('Failed to fetch Instagram analytics:', error);
+      setInstagramAnalyticsError('Network error');
     } finally {
       setInstagramAnalyticsLoading(false);
     }
@@ -653,7 +687,10 @@ export default function SocialAnalytics() {
               ) : (
                 <div className="text-center py-4 text-brand-silver/70">
                   <p>Failed to load analytics.</p>
-                  <button onClick={fetchTwitterAnalytics} className="text-brand-electric hover:underline mt-1 text-sm">
+                  {twitterAnalyticsError && (
+                    <p className="text-xs text-yellow-400/80 mt-1">{twitterAnalyticsError}</p>
+                  )}
+                  <button onClick={fetchTwitterAnalytics} className="text-brand-electric hover:underline mt-2 text-sm">
                     Try again
                   </button>
                 </div>
@@ -835,7 +872,10 @@ export default function SocialAnalytics() {
               ) : (
                 <div className="text-center py-4 text-brand-silver/70">
                   <p>Failed to load analytics.</p>
-                  <button onClick={fetchLinkedInAnalytics} className="text-[#0A66C2] hover:underline mt-1 text-sm">
+                  {linkedInAnalyticsError && (
+                    <p className="text-xs text-yellow-400/80 mt-1">{linkedInAnalyticsError}</p>
+                  )}
+                  <button onClick={fetchLinkedInAnalytics} className="text-[#0A66C2] hover:underline mt-2 text-sm">
                     Try again
                   </button>
                 </div>
@@ -1040,7 +1080,10 @@ export default function SocialAnalytics() {
               ) : (
                 <div className="text-center py-4 text-brand-silver/70">
                   <p>Failed to load analytics.</p>
-                  <button onClick={fetchFacebookAnalytics} className="text-[#1877F2] hover:underline mt-1 text-sm">
+                  {facebookAnalyticsError && (
+                    <p className="text-xs text-yellow-400/80 mt-1">{facebookAnalyticsError}</p>
+                  )}
+                  <button onClick={fetchFacebookAnalytics} className="text-[#1877F2] hover:underline mt-2 text-sm">
                     Try again
                   </button>
                 </div>
@@ -1254,7 +1297,10 @@ export default function SocialAnalytics() {
               ) : (
                 <div className="text-center py-4 text-brand-silver/70">
                   <p>Failed to load analytics.</p>
-                  <button onClick={fetchInstagramAnalytics} className="text-pink-400 hover:underline mt-1 text-sm">
+                  {instagramAnalyticsError && (
+                    <p className="text-xs text-yellow-400/80 mt-1">{instagramAnalyticsError}</p>
+                  )}
+                  <button onClick={fetchInstagramAnalytics} className="text-pink-400 hover:underline mt-2 text-sm">
                     Try again
                   </button>
                 </div>

--- a/ai-brand-automator-frontend/src/lib/api.ts
+++ b/ai-brand-automator-frontend/src/lib/api.ts
@@ -24,7 +24,7 @@ const refreshAccessToken = async (): Promise<string | null> => {
   }
 
   try {
-    const response = await fetch(env.getApiUrl('/auth/token/refresh/'), {
+    const response = await fetch(env.getApiUrl('/auth/refresh/'), {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/ai-brand-automator/automation/models.py
+++ b/ai-brand-automator/automation/models.py
@@ -223,10 +223,15 @@ class SocialProfile(models.Model):
         This is the main method to use before making API calls.
         """
         token = self.refresh_token_if_needed()
-        # Guard against encryption key mismatch: if decryption did not change
-        # the stored value, assume decryption failed (e.g., key mismatch).
+        # Guard against encryption key mismatch: if the stored value is
+        # encrypted but decryption returned it unchanged, the key has changed.
         stored_ciphertext = getattr(self, "_access_token", None)
-        if token and stored_ciphertext and token == stored_ciphertext:
+        if (
+            token
+            and stored_ciphertext
+            and stored_ciphertext.startswith("enc:")
+            and token == stored_ciphertext
+        ):
             raise ValueError(
                 "Token decryption failed. The server encryption key may have "
                 "changed. Please reconnect your account."
@@ -1007,10 +1012,15 @@ class GoogleBusinessProfile(models.Model):
         This is the main method to use before making API calls.
         """
         token = self.refresh_token_if_needed()
-        # Guard against encryption key mismatch: if decryption did not change
-        # the stored value, assume decryption failed (e.g., key mismatch).
+        # Guard against encryption key mismatch: if the stored value is
+        # encrypted but decryption returned it unchanged, the key has changed.
         stored_ciphertext = getattr(self, "_access_token", None)
-        if token and stored_ciphertext and token == stored_ciphertext:
+        if (
+            token
+            and stored_ciphertext
+            and stored_ciphertext.startswith("enc:")
+            and token == stored_ciphertext
+        ):
             raise ValueError(
                 "Token decryption failed. The server encryption key may have "
                 "changed. Please reconnect your account."

--- a/ai-brand-automator/automation/models.py
+++ b/ai-brand-automator/automation/models.py
@@ -222,7 +222,16 @@ class SocialProfile(models.Model):
         Get a valid access token, refreshing if necessary.
         This is the main method to use before making API calls.
         """
-        return self.refresh_token_if_needed()
+        token = self.refresh_token_if_needed()
+        # Guard against encryption key mismatch — if the decrypted
+        # token still starts with "enc:" it means decryption failed
+        # (e.g. SECRET_KEY changed) and the raw ciphertext was returned.
+        if token and token.startswith("enc:"):
+            raise ValueError(
+                "Token decryption failed. The server encryption key may have "
+                "changed. Please reconnect your account."
+            )
+        return token
 
     def get_page_token(self):
         """
@@ -997,7 +1006,14 @@ class GoogleBusinessProfile(models.Model):
         Get a valid access token, refreshing if necessary.
         This is the main method to use before making API calls.
         """
-        return self.refresh_token_if_needed()
+        token = self.refresh_token_if_needed()
+        # Guard against encryption key mismatch
+        if token and token.startswith("enc:"):
+            raise ValueError(
+                "Token decryption failed. The server encryption key may have "
+                "changed. Please reconnect your account."
+            )
+        return token
 
     def disconnect(self):
         """Disconnect the Google Business Profile."""

--- a/ai-brand-automator/automation/models.py
+++ b/ai-brand-automator/automation/models.py
@@ -223,10 +223,10 @@ class SocialProfile(models.Model):
         This is the main method to use before making API calls.
         """
         token = self.refresh_token_if_needed()
-        # Guard against encryption key mismatch — if the decrypted
-        # token still starts with "enc:" it means decryption failed
-        # (e.g. SECRET_KEY changed) and the raw ciphertext was returned.
-        if token and token.startswith("enc:"):
+        # Guard against encryption key mismatch: if decryption did not change
+        # the stored value, assume decryption failed (e.g., key mismatch).
+        stored_ciphertext = getattr(self, "_access_token", None)
+        if token and stored_ciphertext and token == stored_ciphertext:
             raise ValueError(
                 "Token decryption failed. The server encryption key may have "
                 "changed. Please reconnect your account."
@@ -1007,8 +1007,10 @@ class GoogleBusinessProfile(models.Model):
         This is the main method to use before making API calls.
         """
         token = self.refresh_token_if_needed()
-        # Guard against encryption key mismatch
-        if token and token.startswith("enc:"):
+        # Guard against encryption key mismatch: if decryption did not change
+        # the stored value, assume decryption failed (e.g., key mismatch).
+        stored_ciphertext = getattr(self, "_access_token", None)
+        if token and stored_ciphertext and token == stored_ciphertext:
             raise ValueError(
                 "Token decryption failed. The server encryption key may have "
                 "changed. Please reconnect your account."

--- a/ai-brand-automator/automation/tests/test_models.py
+++ b/ai-brand-automator/automation/tests/test_models.py
@@ -7,6 +7,7 @@ and webhook event models.
 
 import pytest
 from datetime import timedelta
+from unittest import mock
 from django.contrib.auth import get_user_model
 from django.utils import timezone
 from django.db import IntegrityError
@@ -305,6 +306,44 @@ class TestSocialProfileModel:
         assert profiles[0] == profile3
         assert profiles[1] == profile2
         assert profiles[2] == profile1
+
+    def test_get_valid_access_token_raises_on_decryption_failure(self, user):
+        """Test that get_valid_access_token raises ValueError when
+        decryption fails (e.g., SECRET_KEY changed) and returns the
+        stored ciphertext instead of the plaintext token."""
+        profile = SocialProfile.objects.create(
+            user=user,
+            platform="linkedin",
+            status="connected",
+            token_expires_at=timezone.now() + timedelta(hours=1),
+        )
+        profile.access_token = "real_access_token"
+        profile.save()
+
+        # Simulate decryption failure: patch decrypt_token to return
+        # the raw ciphertext (i.e., the stored encrypted value)
+        stored_ciphertext = profile._access_token
+        with mock.patch(
+            "automation.models.decrypt_token", return_value=stored_ciphertext
+        ):
+            with pytest.raises(ValueError, match="Token decryption failed"):
+                profile.get_valid_access_token()
+
+    def test_get_valid_access_token_succeeds_when_decryption_works(self, user):
+        """Test that get_valid_access_token returns the token when
+        decryption works correctly (decrypted != stored ciphertext)."""
+        profile = SocialProfile.objects.create(
+            user=user,
+            platform="linkedin",
+            status="connected",
+            token_expires_at=timezone.now() + timedelta(hours=1),
+        )
+        profile.access_token = "real_access_token"
+        profile.save()
+
+        # Normal case: decryption works, token != ciphertext
+        token = profile.get_valid_access_token()
+        assert token == "real_access_token"
 
 
 # =============================================================================


### PR DESCRIPTION
- Fix JWT token refresh URL mismatch: frontend called /auth/token/refresh/ but backend URL is /auth/refresh/ — users would be logged out after 60min
- Add error state tracking for all 4 analytics platforms (Twitter, LinkedIn, Facebook, Instagram) in SocialAnalytics dashboard component
- Display actual backend error message instead of generic 'Failed to load analytics' so users can see what went wrong
- Add encryption key mismatch guard in get_valid_access_token() — if decrypted token still starts with 'enc:' (decryption failed due to SECRET_KEY change), raise a clear error instead of using garbage token to call external APIs