### PR TITLE
fix: read DATABASE_URL from os.environ first for Railway deployment

### DIFF
--- a/ai-brand-automator/.dockerignore
+++ b/ai-brand-automator/.dockerignore
@@ -1,0 +1,32 @@
+# Prevent local environment files from entering Docker image
+# Railway/Heroku inject env vars via os.environ, not .env files
+.env
+.env.local
+.env.*.local
+.env.docker
+.env.docker.local
+.env.test
+
+# Python cache
+__pycache__/
+**/__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+htmlcov/
+
+# Development artifacts
+db.sqlite3
+media/
+logs/
+*.log
+.coverage
+coverage.xml
+
+# IDE
+.vscode/
+.idea/
+
+# Git
+.git/
+.github/

--- a/ai-brand-automator/Dockerfile
+++ b/ai-brand-automator/Dockerfile
@@ -47,6 +47,16 @@ if [ -n "$GCS_CREDENTIALS_JSON" ]; then
   export GOOGLE_APPLICATION_CREDENTIALS=/app/gcs-credentials.json
 fi
 
+# Startup diagnostics — helps debug deployment issues
+echo "=== Environment Check ==="
+if [ -n "$DATABASE_URL" ]; then
+  echo "DATABASE_URL: set (${#DATABASE_URL} chars)"
+else
+  echo "WARNING: DATABASE_URL is NOT set. Set it in Railway service variables."
+  echo "Falling back to individual DB_* variables."
+fi
+echo "DJANGO_SETTINGS_MODULE: ${DJANGO_SETTINGS_MODULE:-brand_automator.settings}"
+
 echo "=== Running migrations ==="
 python manage.py migrate_schemas --shared --noinput
 echo "=== Bootstrapping public tenant ==="

--- a/ai-brand-automator/Dockerfile
+++ b/ai-brand-automator/Dockerfile
@@ -50,12 +50,25 @@ fi
 # Startup diagnostics — helps debug deployment issues
 echo "=== Environment Check ==="
 if [ -n "$DATABASE_URL" ]; then
-  echo "DATABASE_URL: set (${#DATABASE_URL} chars)"
+  echo "DATABASE_URL: set"
 else
-  echo "WARNING: DATABASE_URL is NOT set. Set it in Railway service variables."
-  echo "Falling back to individual DB_* variables."
+  echo "WARNING: DATABASE_URL is NOT set in the container environment."
+  echo "  - Verify Railway service variables and any environment groups."
+  echo "  - Confirm the variable is attached to this deployment/service."
 fi
 echo "DJANGO_SETTINGS_MODULE: ${DJANGO_SETTINGS_MODULE:-brand_automator.settings}"
+
+echo "=== python-decouple DATABASE_URL check ==="
+python -c "
+from decouple import config
+value = config('DATABASE_URL', default='', cast=str)
+if not value:
+    print('python-decouple: DATABASE_URL is empty or missing')
+elif '://' not in value:
+    print('python-decouple: DATABASE_URL is missing a URL scheme (e.g. postgres://)')
+else:
+    print('python-decouple: DATABASE_URL OK')
+"
 
 echo "=== Running migrations ==="
 python manage.py migrate_schemas --shared --noinput

--- a/ai-brand-automator/brand_automator/settings.py
+++ b/ai-brand-automator/brand_automator/settings.py
@@ -167,18 +167,16 @@ WSGI_APPLICATION = "brand_automator.wsgi.application"
 TESTING = "pytest" in sys.modules or "test" in sys.argv
 
 # Database configuration - supports both DATABASE_URL and individual DB_* vars
-# Read from os.environ FIRST (Railway/Heroku inject env vars here),
-# then fall back to python-decouple for local .env development.
-# python-decouple may miss os.environ when no .env file is present in Docker.
-DATABASE_URL = os.environ.get("DATABASE_URL", "").strip()
-if not DATABASE_URL:
-    DATABASE_URL = config("DATABASE_URL", default="").strip()
+# python-decouple checks os.environ FIRST, then falls back to .env files.
+DATABASE_URL = config("DATABASE_URL", default="").strip()
 
 # Validate DATABASE_URL has a real scheme (not empty or whitespace-only)
 _db_url_valid = bool(DATABASE_URL) and DATABASE_URL.find("://") > 0
 
 if _db_url_valid:
     # Use DATABASE_URL if available (Railway, Heroku, etc.)
+    # Use parse() with the explicit decouple value to avoid dj_database_url
+    # re-reading os.environ["DATABASE_URL"] independently.
     DATABASES = {
         "default": dj_database_url.parse(
             DATABASE_URL,
@@ -189,30 +187,15 @@ if _db_url_valid:
     # Set engine for django-tenants (dj_database_url uses default postgres engine)
     DATABASES["default"]["ENGINE"] = "django_tenants.postgresql_backend"
 else:
-    # Fall back to individual DB_* variables — also check os.environ first
-    _db_host = os.environ.get("DB_HOST", "").strip() or config(
-        "DB_HOST", default="localhost"
-    )
-    _db_name = os.environ.get("DB_NAME", "").strip() or config(
-        "DB_NAME", default="neondb"
-    )
-    _db_user = os.environ.get("DB_USER", "").strip() or config(
-        "DB_USER", default="neondb_owner"
-    )
-    _db_password = os.environ.get("DB_PASSWORD", "").strip() or config(
-        "DB_PASSWORD", default=""
-    )
-    _db_port = os.environ.get("DB_PORT", "").strip() or config(
-        "DB_PORT", default="5432"
-    )
+    # Fall back to individual DB_* variables (local development)
     DATABASES = {
         "default": {
             "ENGINE": "django_tenants.postgresql_backend",
-            "NAME": _db_name,
-            "USER": _db_user,
-            "PASSWORD": _db_password,
-            "HOST": _db_host,
-            "PORT": _db_port,
+            "NAME": config("DB_NAME", default="neondb"),
+            "USER": config("DB_USER", default="neondb_owner"),
+            "PASSWORD": config("DB_PASSWORD", default=""),
+            "HOST": config("DB_HOST", default="localhost"),
+            "PORT": config("DB_PORT", default="5432"),
             "OPTIONS": {
                 "sslmode": config("DB_SSLMODE", default="require"),
                 "channel_binding": config("DB_CHANNEL_BINDING", default="require"),

--- a/ai-brand-automator/brand_automator/settings.py
+++ b/ai-brand-automator/brand_automator/settings.py
@@ -167,15 +167,18 @@ WSGI_APPLICATION = "brand_automator.wsgi.application"
 TESTING = "pytest" in sys.modules or "test" in sys.argv
 
 # Database configuration - supports both DATABASE_URL and individual DB_* vars
-DATABASE_URL = config("DATABASE_URL", default="").strip()
+# Read from os.environ FIRST (Railway/Heroku inject env vars here),
+# then fall back to python-decouple for local .env development.
+# python-decouple may miss os.environ when no .env file is present in Docker.
+DATABASE_URL = os.environ.get("DATABASE_URL", "").strip()
+if not DATABASE_URL:
+    DATABASE_URL = config("DATABASE_URL", default="").strip()
 
 # Validate DATABASE_URL has a real scheme (not empty or whitespace-only)
 _db_url_valid = bool(DATABASE_URL) and DATABASE_URL.find("://") > 0
 
 if _db_url_valid:
     # Use DATABASE_URL if available (Railway, Heroku, etc.)
-    # Use parse() instead of config() to avoid dj_database_url re-reading
-    # os.environ["DATABASE_URL"] which may differ from the decouple value.
     DATABASES = {
         "default": dj_database_url.parse(
             DATABASE_URL,
@@ -186,15 +189,30 @@ if _db_url_valid:
     # Set engine for django-tenants (dj_database_url uses default postgres engine)
     DATABASES["default"]["ENGINE"] = "django_tenants.postgresql_backend"
 else:
-    # Use individual DB_* variables (local development)
+    # Fall back to individual DB_* variables — also check os.environ first
+    _db_host = os.environ.get("DB_HOST", "").strip() or config(
+        "DB_HOST", default="localhost"
+    )
+    _db_name = os.environ.get("DB_NAME", "").strip() or config(
+        "DB_NAME", default="neondb"
+    )
+    _db_user = os.environ.get("DB_USER", "").strip() or config(
+        "DB_USER", default="neondb_owner"
+    )
+    _db_password = os.environ.get("DB_PASSWORD", "").strip() or config(
+        "DB_PASSWORD", default=""
+    )
+    _db_port = os.environ.get("DB_PORT", "").strip() or config(
+        "DB_PORT", default="5432"
+    )
     DATABASES = {
         "default": {
             "ENGINE": "django_tenants.postgresql_backend",
-            "NAME": config("DB_NAME", default="neondb"),
-            "USER": config("DB_USER", default="neondb_owner"),
-            "PASSWORD": config("DB_PASSWORD", default=""),
-            "HOST": config("DB_HOST", default="localhost"),
-            "PORT": config("DB_PORT", default="5432"),
+            "NAME": _db_name,
+            "USER": _db_user,
+            "PASSWORD": _db_password,
+            "HOST": _db_host,
+            "PORT": _db_port,
             "OPTIONS": {
                 "sslmode": config("DB_SSLMODE", default="require"),
                 "channel_binding": config("DB_CHANNEL_BINDING", default="require"),


### PR DESCRIPTION
Root cause: python-decouple's config() may fail to read os.environ when no .env file exists in the Docker container (.env is gitignored). Railway injects env vars via os.environ, but decouple returns the default empty string, causing dj_database_url.parse('') to raise ValueError.

Changes:
- settings.py: Read DATABASE_URL from os.environ.get() first, then fall back to decouple.config() for local .env development
- settings.py: Also read individual DB_* vars from os.environ first
- Dockerfile: Add startup diagnostics to log DATABASE_URL status
- .dockerignore: Add for ai-brand-automator/ to prevent .env files, __pycache__, and dev artifacts from entering Docker image