### PR TITLE
fix: make Railway DATABASE_URL reading crash-proof with diagnostics

### DIFF
--- a/ai-brand-automator/.dockerignore
+++ b/ai-brand-automator/.dockerignore
@@ -1,10 +1,12 @@
 # Prevent local environment files from entering Docker image
 # Railway/Heroku inject env vars via os.environ, not .env files
 .env
+.env.*
 .env.local
 .env.*.local
 .env.docker
 .env.docker.local
+.env.example
 .env.test
 
 # Python cache

--- a/ai-brand-automator/Dockerfile
+++ b/ai-brand-automator/Dockerfile
@@ -47,9 +47,11 @@ if [ -n "$GCS_CREDENTIALS_JSON" ]; then
   export GOOGLE_APPLICATION_CREDENTIALS=/app/gcs-credentials.json
 fi
 
-# Run database URL diagnostic before anything else
-echo "=== Database URL Diagnostic ==="
-python scripts/check_database_url.py || echo "WARNING: Diagnostic script failed (non-fatal)"
+# Run database URL diagnostic only when explicitly enabled
+if [ "${DB_DIAGNOSTICS:-false}" = "true" ]; then
+  echo "=== Database URL Diagnostic ==="
+  python scripts/check_database_url.py || echo "WARNING: Diagnostic script failed (non-fatal)"
+fi
 
 echo "=== Running migrations ==="
 python manage.py migrate_schemas --shared --noinput

--- a/ai-brand-automator/Dockerfile
+++ b/ai-brand-automator/Dockerfile
@@ -47,28 +47,9 @@ if [ -n "$GCS_CREDENTIALS_JSON" ]; then
   export GOOGLE_APPLICATION_CREDENTIALS=/app/gcs-credentials.json
 fi
 
-# Startup diagnostics — helps debug deployment issues
-echo "=== Environment Check ==="
-if [ -n "$DATABASE_URL" ]; then
-  echo "DATABASE_URL: set"
-else
-  echo "WARNING: DATABASE_URL is NOT set in the container environment."
-  echo "  - Verify Railway service variables and any environment groups."
-  echo "  - Confirm the variable is attached to this deployment/service."
-fi
-echo "DJANGO_SETTINGS_MODULE: ${DJANGO_SETTINGS_MODULE:-brand_automator.settings}"
-
-echo "=== python-decouple DATABASE_URL check ==="
-python -c "
-from decouple import config
-value = config('DATABASE_URL', default='', cast=str)
-if not value:
-    print('python-decouple: DATABASE_URL is empty or missing')
-elif '://' not in value:
-    print('python-decouple: DATABASE_URL is missing a URL scheme (e.g. postgres://)')
-else:
-    print('python-decouple: DATABASE_URL OK')
-"
+# Run database URL diagnostic before anything else
+echo "=== Database URL Diagnostic ==="
+python scripts/check_database_url.py || echo "WARNING: Diagnostic script failed (non-fatal)"
 
 echo "=== Running migrations ==="
 python manage.py migrate_schemas --shared --noinput

--- a/ai-brand-automator/brand_automator/settings.py
+++ b/ai-brand-automator/brand_automator/settings.py
@@ -168,11 +168,7 @@ TESTING = "pytest" in sys.modules or "test" in sys.argv
 
 # Database configuration - supports both DATABASE_URL and individual DB_* vars
 # python-decouple checks os.environ FIRST, then falls back to .env files.
-# Safety net: also check os.environ directly in case decouple can't find the
-# value (e.g. no .env file in Docker container and decouple search fails).
 DATABASE_URL = config("DATABASE_URL", default="").strip()
-if not DATABASE_URL:
-    DATABASE_URL = os.environ.get("DATABASE_URL", "").strip()
 
 # Validate DATABASE_URL has a real scheme (not empty or whitespace-only)
 _db_url_valid = bool(DATABASE_URL) and DATABASE_URL.find("://") > 0

--- a/ai-brand-automator/brand_automator/settings.py
+++ b/ai-brand-automator/brand_automator/settings.py
@@ -168,25 +168,39 @@ TESTING = "pytest" in sys.modules or "test" in sys.argv
 
 # Database configuration - supports both DATABASE_URL and individual DB_* vars
 # python-decouple checks os.environ FIRST, then falls back to .env files.
+# Safety net: also check os.environ directly in case decouple can't find the
+# value (e.g. no .env file in Docker container and decouple search fails).
 DATABASE_URL = config("DATABASE_URL", default="").strip()
+if not DATABASE_URL:
+    DATABASE_URL = os.environ.get("DATABASE_URL", "").strip()
 
 # Validate DATABASE_URL has a real scheme (not empty or whitespace-only)
 _db_url_valid = bool(DATABASE_URL) and DATABASE_URL.find("://") > 0
 
 if _db_url_valid:
     # Use DATABASE_URL if available (Railway, Heroku, etc.)
-    # Use parse() with the explicit decouple value to avoid dj_database_url
+    # Use parse() with the explicit value to avoid dj_database_url
     # re-reading os.environ["DATABASE_URL"] independently.
-    DATABASES = {
-        "default": dj_database_url.parse(
-            DATABASE_URL,
-            conn_max_age=600,
-            conn_health_checks=True,
+    try:
+        DATABASES = {
+            "default": dj_database_url.parse(
+                DATABASE_URL,
+                conn_max_age=600,
+                conn_health_checks=True,
+            )
+        }
+        # Set engine for django-tenants
+        DATABASES["default"]["ENGINE"] = "django_tenants.postgresql_backend"
+    except (ValueError, KeyError) as exc:
+        import logging
+
+        logging.getLogger(__name__).error(
+            "Failed to parse DATABASE_URL: %s. Falling back to individual DB_* vars.",
+            exc,
         )
-    }
-    # Set engine for django-tenants (dj_database_url uses default postgres engine)
-    DATABASES["default"]["ENGINE"] = "django_tenants.postgresql_backend"
-else:
+        _db_url_valid = False
+
+if not _db_url_valid:
     # Fall back to individual DB_* variables (local development)
     DATABASES = {
         "default": {

--- a/ai-brand-automator/scripts/check_database_url.py
+++ b/ai-brand-automator/scripts/check_database_url.py
@@ -1,0 +1,95 @@
+"""
+Diagnostic script for Railway deployment.
+Runs before migrations to verify DATABASE_URL is readable and parseable.
+"""
+
+import os
+import sys
+import urllib.parse
+
+
+def mask_url(url):
+    """Return URL with password masked for safe logging."""
+    if not url:
+        return repr(url)
+    try:
+        parsed = urllib.parse.urlsplit(url)
+        if parsed.password:
+            masked = url.replace(parsed.password, "***")
+            return masked
+        return url
+    except Exception:
+        # Show first 20 chars + length if unparseable
+        safe = url[:20].replace("\n", "\\n").replace("\r", "\\r")
+        return f"{safe}... (len={len(url)})"
+
+
+def main():
+    print("=" * 60)
+    print("DATABASE_URL Diagnostic")
+    print("=" * 60)
+
+    # 1. Check os.environ directly
+    raw = os.environ.get("DATABASE_URL")
+    if raw is None:
+        print("[os.environ] DATABASE_URL: NOT SET")
+    elif not raw.strip():
+        print(f"[os.environ] DATABASE_URL: SET but EMPTY (len={len(raw)})")
+    else:
+        print(f"[os.environ] DATABASE_URL: SET (len={len(raw)})")
+        print(f"[os.environ] Masked URL: {mask_url(raw.strip())}")
+        # Parse scheme
+        parsed = urllib.parse.urlsplit(raw.strip())
+        print(f"[os.environ] Scheme: {parsed.scheme!r}")
+        print(f"[os.environ] Host: {parsed.hostname!r}")
+
+    # 2. Check python-decouple
+    try:
+        from decouple import config
+
+        value = config("DATABASE_URL", default="__NOT_SET__")
+        if value == "__NOT_SET__":
+            print("[decouple]   DATABASE_URL: NOT SET (got default)")
+        elif not value.strip():
+            print(f"[decouple]   DATABASE_URL: EMPTY (len={len(value)})")
+        else:
+            print(f"[decouple]   DATABASE_URL: SET (len={len(value)})")
+            print(f"[decouple]   Masked URL: {mask_url(value.strip())}")
+            parsed = urllib.parse.urlsplit(value.strip())
+            print(f"[decouple]   Scheme: {parsed.scheme!r}")
+
+        # Check if os.environ and decouple agree
+        if raw is not None and value != "__NOT_SET__":
+            if raw.strip() == value.strip():
+                print("[match]      os.environ and decouple AGREE")
+            else:
+                print("[MISMATCH]   os.environ and decouple DISAGREE!")
+                print(f"  os.environ len={len(raw)}, decouple len={len(value)}")
+    except Exception as exc:
+        print(f"[decouple]   ERROR: {exc!r}")
+
+    # 3. Check for .env files that decouple might read
+    print("\n[files]      .env files in /app/:")
+    app_dir = "/app" if os.path.isdir("/app") else os.getcwd()
+    for f in sorted(os.listdir(app_dir)):
+        if f.startswith(".env"):
+            fpath = os.path.join(app_dir, f)
+            print(f"  {f} ({os.path.getsize(fpath)} bytes)")
+
+    # 4. Test dj_database_url.parse
+    url_to_parse = (raw or "").strip() if raw else ""
+    if url_to_parse:
+        try:
+            import dj_database_url
+
+            result = dj_database_url.parse(url_to_parse)
+            print(f"\n[dj_db_url]  Parse OK: engine={result.get('ENGINE')}")
+        except Exception as exc:
+            print(f"\n[dj_db_url]  Parse FAILED: {exc}")
+
+    print("=" * 60)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ai-brand-automator/scripts/check_database_url.py
+++ b/ai-brand-automator/scripts/check_database_url.py
@@ -8,20 +8,15 @@ import sys
 import urllib.parse
 
 
-def mask_url(url):
-    """Return URL with password masked for safe logging."""
+def safe_summary(url):
+    """Return only scheme + length for safe logging (no credentials or host)."""
     if not url:
-        return repr(url)
+        return "empty"
     try:
         parsed = urllib.parse.urlsplit(url)
-        if parsed.password:
-            masked = url.replace(parsed.password, "***")
-            return masked
-        return url
+        return f"scheme={parsed.scheme!r}, len={len(url)}"
     except Exception:
-        # Show first 20 chars + length if unparseable
-        safe = url[:20].replace("\n", "\\n").replace("\r", "\\r")
-        return f"{safe}... (len={len(url)})"
+        return f"unparseable, len={len(url)}"
 
 
 def main():
@@ -34,29 +29,23 @@ def main():
     if raw is None:
         print("[os.environ] DATABASE_URL: NOT SET")
     elif not raw.strip():
-        print(f"[os.environ] DATABASE_URL: SET but EMPTY (len={len(raw)})")
+        print("[os.environ] DATABASE_URL: SET but EMPTY")
     else:
-        print(f"[os.environ] DATABASE_URL: SET (len={len(raw)})")
-        print(f"[os.environ] Masked URL: {mask_url(raw.strip())}")
-        # Parse scheme
-        parsed = urllib.parse.urlsplit(raw.strip())
-        print(f"[os.environ] Scheme: {parsed.scheme!r}")
-        print(f"[os.environ] Host: {parsed.hostname!r}")
+        print(f"[os.environ] DATABASE_URL: SET ({safe_summary(raw.strip())})")
 
     # 2. Check python-decouple
+    decouple_url = ""
     try:
-        from decouple import config
+        from decouple import config as decouple_config
 
-        value = config("DATABASE_URL", default="__NOT_SET__")
+        value = decouple_config("DATABASE_URL", default="__NOT_SET__")
         if value == "__NOT_SET__":
             print("[decouple]   DATABASE_URL: NOT SET (got default)")
         elif not value.strip():
-            print(f"[decouple]   DATABASE_URL: EMPTY (len={len(value)})")
+            print("[decouple]   DATABASE_URL: EMPTY")
         else:
-            print(f"[decouple]   DATABASE_URL: SET (len={len(value)})")
-            print(f"[decouple]   Masked URL: {mask_url(value.strip())}")
-            parsed = urllib.parse.urlsplit(value.strip())
-            print(f"[decouple]   Scheme: {parsed.scheme!r}")
+            decouple_url = value.strip()
+            print(f"[decouple]   DATABASE_URL: SET ({safe_summary(decouple_url)})")
 
         # Check if os.environ and decouple agree
         if raw is not None and value != "__NOT_SET__":
@@ -64,7 +53,6 @@ def main():
                 print("[match]      os.environ and decouple AGREE")
             else:
                 print("[MISMATCH]   os.environ and decouple DISAGREE!")
-                print(f"  os.environ len={len(raw)}, decouple len={len(value)}")
     except Exception as exc:
         print(f"[decouple]   ERROR: {exc!r}")
 
@@ -76,16 +64,38 @@ def main():
             fpath = os.path.join(app_dir, f)
             print(f"  {f} ({os.path.getsize(fpath)} bytes)")
 
-    # 4. Test dj_database_url.parse
-    url_to_parse = (raw or "").strip() if raw else ""
-    if url_to_parse:
-        try:
-            import dj_database_url
+    # 4. Test dj_database_url.parse for BOTH sources
+    try:
+        import dj_database_url
+    except Exception as exc:
+        print(f"\n[dj_db_url]  ERROR: could not import dj_database_url: {exc}")
+        dj_database_url = None
 
-            result = dj_database_url.parse(url_to_parse)
-            print(f"\n[dj_db_url]  Parse OK: engine={result.get('ENGINE')}")
-        except Exception as exc:
-            print(f"\n[dj_db_url]  Parse FAILED: {exc}")
+    if dj_database_url:
+        env_url = (raw or "").strip()
+        if env_url:
+            try:
+                result = dj_database_url.parse(env_url)
+                print(
+                    f"\n[dj_db_url]  os.environ parse: OK "
+                    f"(engine={result.get('ENGINE')})"
+                )
+            except Exception as exc:
+                print(f"\n[dj_db_url]  os.environ parse: FAILED ({exc})")
+        else:
+            print("\n[dj_db_url]  os.environ parse: skipped (not set)")
+
+        if decouple_url:
+            try:
+                result = dj_database_url.parse(decouple_url)
+                print(
+                    f"[dj_db_url]  decouple parse: OK "
+                    f"(engine={result.get('ENGINE')})"
+                )
+            except Exception as exc:
+                print(f"[dj_db_url]  decouple parse: FAILED ({exc})")
+        else:
+            print("[dj_db_url]  decouple parse: skipped (not set)")
 
     print("=" * 60)
     return 0


### PR DESCRIPTION
The guard (_db_url_valid) passes but dj_database_url.parse() still crashes with ValueError: empty scheme. This means decouple returns something unexpected in the Docker container.

Three-layer fix:
1. settings.py: Add os.environ fallback ONLY when decouple returns empty (safety net for Docker containers where decouple search may fail). Wrap dj_database_url.parse() in try/except to gracefully fall back to individual DB_* variables instead of crashing.
2. Dockerfile: Replace inline diagnostics with scripts/check_database_url.py that logs os.environ vs decouple values, URL scheme, and .env files present in the container to identify root cause.
3. .dockerignore: Add .env.* wildcard to exclude ALL .env variants (including .env.example) from the Docker image.