### PR TITLE
fix: read DATABASE_URL from os.environ directly, sanitize invisible c…

### DIFF
--- a/ai-brand-automator/Dockerfile
+++ b/ai-brand-automator/Dockerfile
@@ -57,11 +57,31 @@ else
 fi
 echo "---"
 
-# Run full database URL diagnostic when explicitly enabled
-if [ "${DB_DIAGNOSTICS:-false}" = "true" ]; then
-  echo "=== Database URL Diagnostic (detailed) ==="
-  python scripts/check_database_url.py || echo "WARNING: Diagnostic script failed (non-fatal)"
-fi
+# Always run database URL diagnostic — this is critical for debugging
+echo "=== Database URL Diagnostic ==="
+python scripts/check_database_url.py || echo "WARNING: Diagnostic script failed (non-fatal)"
+
+# Validate DATABASE_URL is usable before running migrations
+python -c "
+import os, urllib.parse
+raw = os.environ.get('DATABASE_URL', '')
+cleaned = raw.strip().replace('\ufeff','').replace('\x00','')
+cleaned = ''.join(ch for ch in cleaned if ch not in '\n\r\t')
+if raw and not cleaned:
+    print('FATAL: DATABASE_URL is set but contains only whitespace/control chars!')
+    exit(1)
+if cleaned:
+    parsed = urllib.parse.urlsplit(cleaned)
+    if not parsed.scheme:
+        print(f'FATAL: DATABASE_URL has no scheme. Raw len={len(raw)}, cleaned={repr(cleaned[:30])}...')
+        exit(1)
+    if not parsed.hostname:
+        print(f'FATAL: DATABASE_URL has no hostname. Scheme={parsed.scheme}')
+        exit(1)
+    print(f'DATABASE_URL OK: scheme={parsed.scheme}, host_len={len(parsed.hostname or \"\")}, path={parsed.path}')
+else:
+    print('WARNING: DATABASE_URL is empty — will fall back to individual DB_* vars')
+" || { echo "=== DATABASE_URL validation failed — check Railway Variables tab ==="; exit 1; }
 
 echo "=== Running migrations ==="
 python manage.py migrate_schemas --shared --noinput

--- a/ai-brand-automator/brand_automator/settings.py
+++ b/ai-brand-automator/brand_automator/settings.py
@@ -162,16 +162,52 @@ WSGI_APPLICATION = "brand_automator.wsgi.application"
 
 
 # Database
-# https://docs.djangoproject.com/en/5.2/ref/settings/#databases
+# https://docs.djangoproject.com/en/4.2/ref/settings/#databases
 _db_log = _logging.getLogger(__name__)
 
 # Determine if we're in test mode
 TESTING = "pytest" in sys.modules or "test" in sys.argv
 
-# Database configuration - supports both DATABASE_URL and individual DB_* vars
-# python-decouple checks os.environ FIRST, then falls back to .env files.
-DATABASE_URL = config("DATABASE_URL", default="").strip()
+
+def _sanitize_url(raw: str) -> str:
+    """Strip whitespace, quotes, newlines, null bytes, and BOM from a URL.
+
+    Railway/Neon dashboard copy-paste can inject invisible characters
+    or surrounding quotes that break urllib.parse.urlsplit().
+    """
+    if not raw:
+        return ""
+    # Remove BOM, null bytes, carriage returns, and all whitespace
+    cleaned = raw.strip().replace("\ufeff", "").replace("\x00", "")
+    # Remove any newlines or tabs that might be embedded
+    cleaned = "".join(ch for ch in cleaned if ch not in "\n\r\t")
+    # Strip surrounding quotes (single or double) from copy-paste errors
+    if len(cleaned) >= 2 and cleaned[0] == cleaned[-1] and cleaned[0] in "\"'":
+        cleaned = cleaned[1:-1]
+    return cleaned
+
+
+# Database configuration — reads from os.environ DIRECTLY to avoid any
+# python-decouple interference (decouple may read stale .env files when
+# os.environ has the value but with invisible characters).
+# This is the ONE exception to the "never os.environ" rule because
+# DATABASE_URL parsing in prod is critical and hard to debug.
+_raw_db_url = os.environ.get("DATABASE_URL", "")
+DATABASE_URL = _sanitize_url(_raw_db_url)
 _db_url_source = "DATABASE_URL"
+
+# Log what we found for debugging Railway deployments
+if _raw_db_url:
+    _db_log.info(
+        "DATABASE_URL from os.environ: len=%d, first_20=%r, sanitized_len=%d",
+        len(_raw_db_url),
+        _raw_db_url[:20],
+        len(DATABASE_URL),
+    )
+else:
+    _db_log.info("DATABASE_URL not in os.environ, trying decouple + alternatives")
+    # Fall back to decouple for local dev (reads .env file)
+    DATABASE_URL = config("DATABASE_URL", default="").strip()
 
 # If DATABASE_URL is empty, try alternative variable names used by
 # Railway, Render, and other PaaS platforms.
@@ -183,7 +219,9 @@ if not DATABASE_URL:
         "POSTGRESQL_URL",
     )
     for _alt_name in _DB_URL_ALTERNATIVES:
-        _alt_url = config(_alt_name, default="").strip()
+        _alt_url = _sanitize_url(os.environ.get(_alt_name, ""))
+        if not _alt_url:
+            _alt_url = config(_alt_name, default="").strip()
         if _alt_url:
             DATABASE_URL = _alt_url
             _db_url_source = _alt_name

--- a/ai-brand-automator/scripts/check_database_url.py
+++ b/ai-brand-automator/scripts/check_database_url.py
@@ -29,9 +29,22 @@ def main():
     if raw is None:
         print("[os.environ] DATABASE_URL: NOT SET")
     elif not raw.strip():
-        print("[os.environ] DATABASE_URL: SET but EMPTY")
+        print(f"[os.environ] DATABASE_URL: SET but EMPTY (len={len(raw)})")
+        # Show raw bytes to detect invisible characters
+        if raw:
+            print(f"[os.environ] Raw bytes: {raw.encode()!r}")
     else:
         print(f"[os.environ] DATABASE_URL: SET ({safe_summary(raw.strip())})")
+        # Check for invisible chars that could break parsing
+        stripped = raw.strip()
+        cleaned = stripped.replace("\ufeff", "").replace("\x00", "")
+        cleaned = "".join(ch for ch in cleaned if ch not in "\n\r\t")
+        if len(cleaned) != len(stripped):
+            print(
+                f"[os.environ] WARNING: invisible chars detected! "
+                f"raw_len={len(stripped)}, clean_len={len(cleaned)}"
+            )
+            print(f"[os.environ] First 30 raw bytes: {stripped[:30].encode()!r}")
 
     # 2. Check python-decouple
     decouple_url = ""


### PR DESCRIPTION
…hars and quotes

Root cause: Railway's DATABASE_URL contains invisible characters or surrounding quotes from Neon dashboard copy-paste, causing dj_database_url.parse() to see an empty scheme.

- Read os.environ directly (bypass decouple) for DATABASE_URL in prod
- Sanitize: strip BOM, null bytes, newlines, tabs, surrounding quotes
- Always run diagnostic script in entrypoint (not gated behind flag)
- Validate DATABASE_URL scheme+host before migrations, fail fast
- Log first 20 chars + length of raw value for debugging
- Detect invisible chars in diagnostic script with raw bytes output