### PR TITLE
fix: use django-tenants schema_context in pipeline asset status updates

### DIFF
--- a/ai-brand-automator/brand_automator/tenant_utils.py
+++ b/ai-brand-automator/brand_automator/tenant_utils.py
@@ -1,0 +1,41 @@
+"""
+Shared multi-tenancy utilities for background workers.
+
+This module provides helpers for Celery tasks and Kafka consumers
+that run outside Django's request/response cycle and therefore
+lack the automatic tenant context provided by middleware.
+
+The platform uses FK-based shared-schema multi-tenancy
+(``auto_create_schema = False``). All tables live in the ``public``
+schema — tenant isolation is enforced via ``tenant_id`` foreign-key
+filters, **not** via PostgreSQL schema switching.
+"""
+
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def parse_tenant_pk(tenant_id: Optional[str] = None) -> Optional[int]:
+    """Parse a tenant_id string into an integer primary key.
+
+    Background workers (Kafka consumers, Celery tasks) receive tenant
+    identifiers as strings.  This helper validates and converts the
+    value so it can be used in ORM ``filter(tenant_id=…)`` calls.
+
+    Args:
+        tenant_id: Tenant primary key as a string, ``"public"``, or
+            ``None``/empty when the caller has no tenant context.
+
+    Returns:
+        The integer pk suitable for ``Model.objects.filter(tenant_id=pk)``,
+        or ``None`` when the input is missing / invalid / ``"public"``.
+    """
+    if not tenant_id or tenant_id == "public":
+        return None
+    try:
+        return int(tenant_id)
+    except (ValueError, TypeError):
+        logger.warning("Invalid tenant_id %r — cannot convert to int", tenant_id)
+        return None

--- a/ai-brand-automator/data_ingestion/management/commands/run_ingestion.py
+++ b/ai-brand-automator/data_ingestion/management/commands/run_ingestion.py
@@ -30,25 +30,6 @@ from data_ingestion.domain.path_generator import (
 logger = logging.getLogger(__name__)
 
 
-def _resolve_tenant_schema(tenant_id: str):
-    """Resolve Tenant model and return its schema_name.
-
-    Returns the schema_name string, or ``None`` when the tenant cannot be
-    found (falls back to the current search path).
-    """
-    if not tenant_id or tenant_id == "public":
-        return None
-    try:
-        from tenants.models import Tenant
-
-        tenant = Tenant.objects.filter(pk=int(tenant_id)).first()
-        if tenant:
-            return tenant.schema_name
-    except (ValueError, TypeError):
-        pass
-    return None
-
-
 def _update_asset_status(
     file_id: str,
     status: str,
@@ -63,16 +44,16 @@ def _update_asset_status(
         status: The new pipeline status (ingested, failed)
         error_msg: Error message if status is failed
         new_gcs_path: New GCS path after file was moved (gs:// URI)
-        tenant_id: Tenant pk — used to switch to the correct DB schema
+        tenant_id: Tenant pk — used for FK-based tenant filtering
 
     Returns:
         True if update succeeded, False otherwise
     """
     from django.db import close_old_connections
-    from django_tenants.utils import schema_context
     from onboarding.models import BrandAsset
+    from brand_automator.tenant_utils import parse_tenant_pk
 
-    schema = _resolve_tenant_schema(tenant_id)
+    tenant_pk = parse_tenant_pk(tenant_id)
 
     for attempt in range(2):
         try:
@@ -83,15 +64,18 @@ def _update_asset_status(
                 close_old_connections()
 
             def _do_update():
+                # Build base filter with optional tenant FK isolation
+                base_qs = BrandAsset.objects.all()
+                if tenant_pk is not None:
+                    base_qs = base_qs.filter(tenant_id=tenant_pk)
+
                 try:
                     asset_id = int(file_id)
-                    asset = BrandAsset.objects.filter(id=asset_id).first()
+                    asset = base_qs.filter(id=asset_id).first()
                 except (ValueError, TypeError):
                     try:
                         trace_uuid = uuid.UUID(file_id)
-                        asset = BrandAsset.objects.filter(
-                            pipeline_trace_id=trace_uuid
-                        ).first()
+                        asset = base_qs.filter(pipeline_trace_id=trace_uuid).first()
                     except (ValueError, TypeError):
                         asset = None
 
@@ -119,11 +103,7 @@ def _update_asset_status(
                     logger.warning("BrandAsset not found for file_id: %s", file_id)
                     return False
 
-            if schema:
-                with schema_context(schema):
-                    result = _do_update()
-            else:
-                result = _do_update()
+            result = _do_update()
             return result
 
         except Exception:

--- a/ai-brand-automator/data_ingestion/management/commands/run_ingestion.py
+++ b/ai-brand-automator/data_ingestion/management/commands/run_ingestion.py
@@ -30,11 +30,31 @@ from data_ingestion.domain.path_generator import (
 logger = logging.getLogger(__name__)
 
 
+def _resolve_tenant_schema(tenant_id: str):
+    """Resolve Tenant model and return its schema_name.
+
+    Returns the schema_name string, or ``None`` when the tenant cannot be
+    found (falls back to the current search path).
+    """
+    if not tenant_id or tenant_id == "public":
+        return None
+    try:
+        from tenants.models import Tenant
+
+        tenant = Tenant.objects.filter(pk=int(tenant_id)).first()
+        if tenant:
+            return tenant.schema_name
+    except (ValueError, TypeError):
+        pass
+    return None
+
+
 def _update_asset_status(
     file_id: str,
     status: str,
     error_msg: str = "",
     new_gcs_path: str = "",
+    tenant_id: str = "",
 ) -> bool:
     """Update BrandAsset pipeline_status and gcs_path after ingestion.
 
@@ -43,12 +63,16 @@ def _update_asset_status(
         status: The new pipeline status (ingested, failed)
         error_msg: Error message if status is failed
         new_gcs_path: New GCS path after file was moved (gs:// URI)
+        tenant_id: Tenant pk — used to switch to the correct DB schema
 
     Returns:
         True if update succeeded, False otherwise
     """
     from django.db import close_old_connections
+    from django_tenants.utils import schema_context
     from onboarding.models import BrandAsset
+
+    schema = _resolve_tenant_schema(tenant_id)
 
     for attempt in range(2):
         try:
@@ -58,42 +82,49 @@ def _update_asset_status(
                 # Neon/PostgreSQL can time out (cursor already closed).
                 close_old_connections()
 
-            try:
-                asset_id = int(file_id)
-                asset = BrandAsset.objects.filter(id=asset_id).first()
-            except (ValueError, TypeError):
+            def _do_update():
                 try:
-                    trace_uuid = uuid.UUID(file_id)
-                    asset = BrandAsset.objects.filter(
-                        pipeline_trace_id=trace_uuid
-                    ).first()
+                    asset_id = int(file_id)
+                    asset = BrandAsset.objects.filter(id=asset_id).first()
                 except (ValueError, TypeError):
-                    asset = None
+                    try:
+                        trace_uuid = uuid.UUID(file_id)
+                        asset = BrandAsset.objects.filter(
+                            pipeline_trace_id=trace_uuid
+                        ).first()
+                    except (ValueError, TypeError):
+                        asset = None
 
-            if asset:
-                asset.pipeline_status = status
-                update_fields = ["pipeline_status"]
-                if new_gcs_path:
-                    asset.gcs_path = _extract_gcs_path(new_gcs_path)
-                    update_fields.append("gcs_path")
-                if status == "ingested":
-                    # Clear any previous pipeline error on successful ingestion
-                    asset.pipeline_error = ""
-                    update_fields.append("pipeline_error")
-                elif error_msg:
-                    asset.pipeline_error = error_msg
-                    update_fields.append("pipeline_error")
-                asset.save(update_fields=update_fields)
-                logger.info(
-                    "Updated BrandAsset %s: status=%s, gcs_path=%s",
-                    asset.id,
-                    status,
-                    asset.gcs_path,
-                )
-                return True
+                if asset:
+                    asset.pipeline_status = status
+                    update_fields = ["pipeline_status"]
+                    if new_gcs_path:
+                        asset.gcs_path = _extract_gcs_path(new_gcs_path)
+                        update_fields.append("gcs_path")
+                    if status == "ingested":
+                        asset.pipeline_error = ""
+                        update_fields.append("pipeline_error")
+                    elif error_msg:
+                        asset.pipeline_error = error_msg
+                        update_fields.append("pipeline_error")
+                    asset.save(update_fields=update_fields)
+                    logger.info(
+                        "Updated BrandAsset %s: status=%s, gcs_path=%s",
+                        asset.id,
+                        status,
+                        asset.gcs_path,
+                    )
+                    return True
+                else:
+                    logger.warning("BrandAsset not found for file_id: %s", file_id)
+                    return False
+
+            if schema:
+                with schema_context(schema):
+                    result = _do_update()
             else:
-                logger.warning("BrandAsset not found for file_id: %s", file_id)
-                return False
+                result = _do_update()
+            return result
 
         except Exception:
             if attempt == 0:
@@ -256,6 +287,7 @@ class Command(BaseCommand):
                         str(asset_id),
                         "ingested",
                         new_gcs_path=result.destination_path,
+                        tenant_id=event.tenant_id,
                     )
 
                 self.stdout.write(
@@ -274,7 +306,9 @@ class Command(BaseCommand):
             )
             asset_id = (event.metadata or {}).get("asset_id")
             if asset_id:
-                _update_asset_status(str(asset_id), "failed", str(e))
+                _update_asset_status(
+                    str(asset_id), "failed", str(e), tenant_id=event.tenant_id
+                )
             # Send to DLQ
             self._service.send_to_dlq(
                 original_event=event.model_dump(mode="json"),
@@ -288,7 +322,9 @@ class Command(BaseCommand):
             )
             asset_id = (event.metadata or {}).get("asset_id")
             if asset_id:
-                _update_asset_status(str(asset_id), "failed", str(e))
+                _update_asset_status(
+                    str(asset_id), "failed", str(e), tenant_id=event.tenant_id
+                )
             # Send to DLQ after max retries
             self._service.send_to_dlq(
                 original_event=event.model_dump(mode="json"),

--- a/ai-brand-automator/data_ingestion/tasks.py
+++ b/ai-brand-automator/data_ingestion/tasks.py
@@ -27,6 +27,25 @@ from data_ingestion.domain.path_generator import (
 logger = logging.getLogger(__name__)
 
 
+def _resolve_tenant_schema(tenant_id: Optional[str] = None):
+    """Resolve Tenant model and return its schema_name.
+
+    Returns the schema_name string, or ``None`` when the tenant cannot be
+    found (falls back to the current search path).
+    """
+    if not tenant_id or tenant_id == "public":
+        return None
+    try:
+        from tenants.models import Tenant
+
+        tenant = Tenant.objects.filter(pk=int(tenant_id)).first()
+        if tenant:
+            return tenant.schema_name
+    except (ValueError, TypeError):
+        pass
+    return None
+
+
 def _update_asset_after_ingestion(
     asset_id: str,
     status: str,
@@ -41,54 +60,59 @@ def _update_asset_after_ingestion(
         status: The new pipeline status (ingested, failed)
         error_msg: Error message if status is failed
         new_gcs_path: New GCS path after file was moved (gs:// URI)
-        tenant_id: Optional tenant ID for scoped lookup
+        tenant_id: Tenant pk — used to switch to the correct DB schema
 
     Returns:
         True if update succeeded, False otherwise
     """
     from django.db import close_old_connections
+    from django_tenants.utils import schema_context
     from onboarding.models import BrandAsset
+
+    schema = _resolve_tenant_schema(tenant_id)
 
     for attempt in range(2):
         try:
             if attempt > 0:
                 close_old_connections()
 
-            try:
-                aid = int(asset_id)
-                qs = BrandAsset.objects.filter(id=aid)
-                if tenant_id:
-                    try:
-                        qs = qs.filter(tenant_id=int(tenant_id))
-                    except (ValueError, TypeError):
-                        pass  # Non-integer tenant_id, skip FK filter
-                asset = qs.first()
-            except (ValueError, TypeError):
-                asset = None
+            def _do_update():
+                try:
+                    aid = int(asset_id)
+                    asset = BrandAsset.objects.filter(id=aid).first()
+                except (ValueError, TypeError):
+                    asset = None
 
-            if asset:
-                asset.pipeline_status = status
-                update_fields = ["pipeline_status"]
-                if new_gcs_path:
-                    asset.gcs_path = _extract_gcs_path(new_gcs_path)
-                    update_fields.append("gcs_path")
-                if status == "ingested":
-                    asset.pipeline_error = ""
-                    update_fields.append("pipeline_error")
-                elif error_msg:
-                    asset.pipeline_error = error_msg
-                    update_fields.append("pipeline_error")
-                asset.save(update_fields=update_fields)
-                logger.info(
-                    "Updated BrandAsset %s: status=%s, gcs_path=%s",
-                    asset.id,
-                    status,
-                    asset.gcs_path,
-                )
-                return True
+                if asset:
+                    asset.pipeline_status = status
+                    update_fields = ["pipeline_status"]
+                    if new_gcs_path:
+                        asset.gcs_path = _extract_gcs_path(new_gcs_path)
+                        update_fields.append("gcs_path")
+                    if status == "ingested":
+                        asset.pipeline_error = ""
+                        update_fields.append("pipeline_error")
+                    elif error_msg:
+                        asset.pipeline_error = error_msg
+                        update_fields.append("pipeline_error")
+                    asset.save(update_fields=update_fields)
+                    logger.info(
+                        "Updated BrandAsset %s: status=%s, gcs_path=%s",
+                        asset.id,
+                        status,
+                        asset.gcs_path,
+                    )
+                    return True
+                else:
+                    logger.warning("BrandAsset not found for asset_id: %s", asset_id)
+                    return False
+
+            if schema:
+                with schema_context(schema):
+                    result = _do_update()
             else:
-                logger.warning("BrandAsset not found for asset_id: %s", asset_id)
-                return False
+                result = _do_update()
+            return result
 
         except Exception:
             if attempt == 0:

--- a/ai-brand-automator/data_ingestion/tasks.py
+++ b/ai-brand-automator/data_ingestion/tasks.py
@@ -27,25 +27,6 @@ from data_ingestion.domain.path_generator import (
 logger = logging.getLogger(__name__)
 
 
-def _resolve_tenant_schema(tenant_id: Optional[str] = None):
-    """Resolve Tenant model and return its schema_name.
-
-    Returns the schema_name string, or ``None`` when the tenant cannot be
-    found (falls back to the current search path).
-    """
-    if not tenant_id or tenant_id == "public":
-        return None
-    try:
-        from tenants.models import Tenant
-
-        tenant = Tenant.objects.filter(pk=int(tenant_id)).first()
-        if tenant:
-            return tenant.schema_name
-    except (ValueError, TypeError):
-        pass
-    return None
-
-
 def _update_asset_after_ingestion(
     asset_id: str,
     status: str,
@@ -60,16 +41,16 @@ def _update_asset_after_ingestion(
         status: The new pipeline status (ingested, failed)
         error_msg: Error message if status is failed
         new_gcs_path: New GCS path after file was moved (gs:// URI)
-        tenant_id: Tenant pk — used to switch to the correct DB schema
+        tenant_id: Tenant pk — used for FK-based tenant filtering
 
     Returns:
         True if update succeeded, False otherwise
     """
     from django.db import close_old_connections
-    from django_tenants.utils import schema_context
     from onboarding.models import BrandAsset
+    from brand_automator.tenant_utils import parse_tenant_pk
 
-    schema = _resolve_tenant_schema(tenant_id)
+    tenant_pk = parse_tenant_pk(tenant_id)
 
     for attempt in range(2):
         try:
@@ -77,9 +58,14 @@ def _update_asset_after_ingestion(
                 close_old_connections()
 
             def _do_update():
+                # Build base filter with optional tenant FK isolation
+                filters = {}
+                if tenant_pk is not None:
+                    filters["tenant_id"] = tenant_pk
+
                 try:
                     aid = int(asset_id)
-                    asset = BrandAsset.objects.filter(id=aid).first()
+                    asset = BrandAsset.objects.filter(id=aid, **filters).first()
                 except (ValueError, TypeError):
                     asset = None
 
@@ -107,11 +93,7 @@ def _update_asset_after_ingestion(
                     logger.warning("BrandAsset not found for asset_id: %s", asset_id)
                     return False
 
-            if schema:
-                with schema_context(schema):
-                    result = _do_update()
-            else:
-                result = _do_update()
+            result = _do_update()
             return result
 
         except Exception:

--- a/ai-brand-automator/data_ingestion/tests/test_run_ingestion_command.py
+++ b/ai-brand-automator/data_ingestion/tests/test_run_ingestion_command.py
@@ -201,6 +201,7 @@ class TestProcessEvent:
                 "42",
                 "ingested",
                 new_gcs_path="gs://bucket/1/raw/2026/02/06/test.png",
+                tenant_id="tenant-1",
             )
 
     def test_non_retryable_failure_calls_update(self, command, ingestion_event):
@@ -218,9 +219,11 @@ class TestProcessEvent:
             command._process_event(ingestion_event)
             mock_update.assert_called_once()
             args = mock_update.call_args[0]
+            kwargs = mock_update.call_args[1]
             assert args[0] == "42"
             assert args[1] == "failed"
             assert "Bad file format" in args[2]
+            assert kwargs.get("tenant_id") == "tenant-1"
 
     def test_retryable_failure_calls_update(self, command, ingestion_event):
         """On RetryableError (exhausted), status set to 'failed'."""
@@ -237,9 +240,11 @@ class TestProcessEvent:
             command._process_event(ingestion_event)
             mock_update.assert_called_once()
             args = mock_update.call_args[0]
+            kwargs = mock_update.call_args[1]
             assert args[0] == "42"
             assert args[1] == "failed"
             assert "Timeout" in args[2]
+            assert kwargs.get("tenant_id") == "tenant-1"
 
     def test_duplicate_event_skips_update(self, command, ingestion_event):
         """Duplicate (None result) does not call _update_asset_status."""

--- a/ai-brand-automator/media_curation/management/commands/run_curation_consumer.py
+++ b/ai-brand-automator/media_curation/management/commands/run_curation_consumer.py
@@ -32,25 +32,6 @@ from media_curation.consumer_health import ConsumerHealthTracker
 logger = logging.getLogger(__name__)
 
 
-def _resolve_tenant_schema(tenant_id: str):
-    """Resolve Tenant model and return its schema_name.
-
-    Returns the schema_name string, or ``None`` when the tenant cannot be
-    found (falls back to the current search path).
-    """
-    if not tenant_id or tenant_id == "public":
-        return None
-    try:
-        from tenants.models import Tenant
-
-        tenant = Tenant.objects.filter(pk=int(tenant_id)).first()
-        if tenant:
-            return tenant.schema_name
-    except (ValueError, TypeError):
-        pass
-    return None
-
-
 def _update_asset_status(
     file_id: str, status: str, error_msg: str = "", tenant_id: str = ""
 ) -> bool:
@@ -60,16 +41,16 @@ def _update_asset_status(
         file_id: The file/asset ID (can be UUID string or int)
         status: The new pipeline status (curated, failed)
         error_msg: Error message if status is failed
-        tenant_id: Tenant pk — used to switch to the correct DB schema
+        tenant_id: Tenant pk — used for FK-based tenant filtering
 
     Returns:
         True if update succeeded, False otherwise
     """
     from django.db import close_old_connections
-    from django_tenants.utils import schema_context
     from onboarding.models import BrandAsset
+    from brand_automator.tenant_utils import parse_tenant_pk
 
-    schema = _resolve_tenant_schema(tenant_id)
+    tenant_pk = parse_tenant_pk(tenant_id)
 
     for attempt in range(2):
         try:
@@ -77,16 +58,19 @@ def _update_asset_status(
                 close_old_connections()
 
             def _do_update():
+                # Build base filter with optional tenant FK isolation
+                base_qs = BrandAsset.objects.all()
+                if tenant_pk is not None:
+                    base_qs = base_qs.filter(tenant_id=tenant_pk)
+
                 # Try to find asset by ID (could be integer or UUID)
                 try:
                     asset_id = int(file_id)
-                    asset = BrandAsset.objects.filter(id=asset_id).first()
+                    asset = base_qs.filter(id=asset_id).first()
                 except (ValueError, TypeError):
                     try:
                         trace_uuid = uuid.UUID(file_id)
-                        asset = BrandAsset.objects.filter(
-                            pipeline_trace_id=trace_uuid
-                        ).first()
+                        asset = base_qs.filter(pipeline_trace_id=trace_uuid).first()
                     except (ValueError, TypeError):
                         asset = None
 
@@ -105,11 +89,7 @@ def _update_asset_status(
                     logger.warning("BrandAsset not found for file_id: %s", file_id)
                     return False
 
-            if schema:
-                with schema_context(schema):
-                    result = _do_update()
-            else:
-                result = _do_update()
+            result = _do_update()
             return result
 
         except Exception:

--- a/ai-brand-automator/media_curation/management/commands/run_curation_consumer.py
+++ b/ai-brand-automator/media_curation/management/commands/run_curation_consumer.py
@@ -32,53 +32,85 @@ from media_curation.consumer_health import ConsumerHealthTracker
 logger = logging.getLogger(__name__)
 
 
-def _update_asset_status(file_id: str, status: str, error_msg: str = "") -> bool:
+def _resolve_tenant_schema(tenant_id: str):
+    """Resolve Tenant model and return its schema_name.
+
+    Returns the schema_name string, or ``None`` when the tenant cannot be
+    found (falls back to the current search path).
+    """
+    if not tenant_id or tenant_id == "public":
+        return None
+    try:
+        from tenants.models import Tenant
+
+        tenant = Tenant.objects.filter(pk=int(tenant_id)).first()
+        if tenant:
+            return tenant.schema_name
+    except (ValueError, TypeError):
+        pass
+    return None
+
+
+def _update_asset_status(
+    file_id: str, status: str, error_msg: str = "", tenant_id: str = ""
+) -> bool:
     """Update BrandAsset pipeline_status after curation.
 
     Args:
         file_id: The file/asset ID (can be UUID string or int)
         status: The new pipeline status (curated, failed)
         error_msg: Error message if status is failed
+        tenant_id: Tenant pk — used to switch to the correct DB schema
 
     Returns:
         True if update succeeded, False otherwise
     """
     from django.db import close_old_connections
+    from django_tenants.utils import schema_context
     from onboarding.models import BrandAsset
+
+    schema = _resolve_tenant_schema(tenant_id)
 
     for attempt in range(2):
         try:
             if attempt > 0:
                 close_old_connections()
 
-            # Try to find asset by ID (could be integer or UUID)
-            try:
-                asset_id = int(file_id)
-                asset = BrandAsset.objects.filter(id=asset_id).first()
-            except (ValueError, TypeError):
-                # file_id might be a UUID - try matching by pipeline_trace_id
+            def _do_update():
+                # Try to find asset by ID (could be integer or UUID)
                 try:
-                    trace_uuid = uuid.UUID(file_id)
-                    asset = BrandAsset.objects.filter(
-                        pipeline_trace_id=trace_uuid
-                    ).first()
+                    asset_id = int(file_id)
+                    asset = BrandAsset.objects.filter(id=asset_id).first()
                 except (ValueError, TypeError):
-                    asset = None
+                    try:
+                        trace_uuid = uuid.UUID(file_id)
+                        asset = BrandAsset.objects.filter(
+                            pipeline_trace_id=trace_uuid
+                        ).first()
+                    except (ValueError, TypeError):
+                        asset = None
 
-            if asset:
-                asset.pipeline_status = status
-                if error_msg:
-                    asset.pipeline_error = error_msg
-                asset.save(update_fields=["pipeline_status", "pipeline_error"])
-                logger.info(
-                    "Updated BrandAsset %s pipeline_status to %s",
-                    asset.id,
-                    status,
-                )
-                return True
+                if asset:
+                    asset.pipeline_status = status
+                    if error_msg:
+                        asset.pipeline_error = error_msg
+                    asset.save(update_fields=["pipeline_status", "pipeline_error"])
+                    logger.info(
+                        "Updated BrandAsset %s pipeline_status to %s",
+                        asset.id,
+                        status,
+                    )
+                    return True
+                else:
+                    logger.warning("BrandAsset not found for file_id: %s", file_id)
+                    return False
+
+            if schema:
+                with schema_context(schema):
+                    result = _do_update()
             else:
-                logger.warning("BrandAsset not found for file_id: %s", file_id)
-                return False
+                result = _do_update()
+            return result
 
         except Exception:
             if attempt == 0:
@@ -320,7 +352,7 @@ class Command(BaseCommand):
 
                 # Update BrandAsset status to curated (use asset_id from metadata)
                 if asset_id:
-                    _update_asset_status(asset_id, "curated")
+                    _update_asset_status(asset_id, "curated", tenant_id=event.tenant_id)
                 else:
                     logger.warning(
                         f"No asset_id in metadata for event {event.event_id}"
@@ -343,7 +375,12 @@ class Command(BaseCommand):
                     )
                     # Update BrandAsset status to failed
                     if asset_id:
-                        _update_asset_status(asset_id, "failed", str(e))
+                        _update_asset_status(
+                            asset_id,
+                            "failed",
+                            str(e),
+                            tenant_id=event.tenant_id,
+                        )
 
                     self._send_to_dlq(event, e)
                     self.stdout.write(
@@ -371,7 +408,12 @@ class Command(BaseCommand):
                 )
                 # Update BrandAsset status to failed
                 if asset_id:
-                    _update_asset_status(asset_id, "failed", str(e))
+                    _update_asset_status(
+                        asset_id,
+                        "failed",
+                        str(e),
+                        tenant_id=event.tenant_id,
+                    )
 
                 self._send_to_dlq(event, e)
                 self.stdout.write(
@@ -383,7 +425,12 @@ class Command(BaseCommand):
                 logger.exception("Unexpected error processing event")
                 # Update BrandAsset status to failed
                 if asset_id:
-                    _update_asset_status(asset_id, "failed", str(e))
+                    _update_asset_status(
+                        asset_id,
+                        "failed",
+                        str(e),
+                        tenant_id=event.tenant_id,
+                    )
 
                 self._send_to_dlq(event, e)
                 self.stdout.write(

--- a/ai-brand-automator/onboarding/tasks.py
+++ b/ai-brand-automator/onboarding/tasks.py
@@ -23,25 +23,6 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
-def _resolve_tenant_schema(tenant_id: str):
-    """Resolve Tenant model and return its schema_name.
-
-    Returns the schema_name string, or ``None`` when the tenant cannot be
-    found (falls back to the current search path).
-    """
-    if not tenant_id or tenant_id == "public":
-        return None
-    try:
-        from tenants.models import Tenant
-
-        tenant = Tenant.objects.filter(pk=int(tenant_id)).first()
-        if tenant:
-            return tenant.schema_name
-    except (ValueError, TypeError):
-        pass
-    return None
-
-
 def _update_asset_status(
     asset_id: int,
     status: str,
@@ -56,16 +37,16 @@ def _update_asset_status(
         status: New ``pipeline_status`` value.
         error_msg: Error message (for ``failed`` status).
         new_gcs_path: Updated ``gcs_path`` after ingestion move.
-        tenant_id: Tenant pk — used to switch to the correct DB schema.
+        tenant_id: Tenant pk — used for FK-based tenant filtering.
 
     Returns:
         ``True`` if update succeeded, ``False`` otherwise.
     """
     from django.db import close_old_connections
-    from django_tenants.utils import schema_context
     from onboarding.models import BrandAsset
+    from brand_automator.tenant_utils import parse_tenant_pk
 
-    schema = _resolve_tenant_schema(tenant_id)
+    tenant_pk = parse_tenant_pk(tenant_id)
 
     for attempt in range(2):
         try:
@@ -73,7 +54,12 @@ def _update_asset_status(
                 close_old_connections()
 
             def _do_update():
-                asset = BrandAsset.objects.filter(id=asset_id).first()
+                # Build base filter with optional tenant FK isolation
+                filters = {"id": asset_id}
+                if tenant_pk is not None:
+                    filters["tenant_id"] = tenant_pk
+
+                asset = BrandAsset.objects.filter(**filters).first()
                 if not asset:
                     logger.warning(
                         "BrandAsset %s not found for status update", asset_id
@@ -102,11 +88,7 @@ def _update_asset_status(
                 logger.info("Updated BrandAsset %s → status=%s", asset.id, status)
                 return True
 
-            if schema:
-                with schema_context(schema):
-                    result = _do_update()
-            else:
-                result = _do_update()
+            result = _do_update()
             return result
 
         except Exception:

--- a/ai-brand-automator/onboarding/tasks.py
+++ b/ai-brand-automator/onboarding/tasks.py
@@ -23,11 +23,31 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
+def _resolve_tenant_schema(tenant_id: str):
+    """Resolve Tenant model and return its schema_name.
+
+    Returns the schema_name string, or ``None`` when the tenant cannot be
+    found (falls back to the current search path).
+    """
+    if not tenant_id or tenant_id == "public":
+        return None
+    try:
+        from tenants.models import Tenant
+
+        tenant = Tenant.objects.filter(pk=int(tenant_id)).first()
+        if tenant:
+            return tenant.schema_name
+    except (ValueError, TypeError):
+        pass
+    return None
+
+
 def _update_asset_status(
     asset_id: int,
     status: str,
     error_msg: str = "",
     new_gcs_path: str = "",
+    tenant_id: str = "",
 ) -> bool:
     """Update BrandAsset pipeline status.
 
@@ -36,44 +56,58 @@ def _update_asset_status(
         status: New ``pipeline_status`` value.
         error_msg: Error message (for ``failed`` status).
         new_gcs_path: Updated ``gcs_path`` after ingestion move.
+        tenant_id: Tenant pk — used to switch to the correct DB schema.
 
     Returns:
         ``True`` if update succeeded, ``False`` otherwise.
     """
     from django.db import close_old_connections
+    from django_tenants.utils import schema_context
     from onboarding.models import BrandAsset
+
+    schema = _resolve_tenant_schema(tenant_id)
 
     for attempt in range(2):
         try:
             if attempt > 0:
                 close_old_connections()
 
-            asset = BrandAsset.objects.filter(id=asset_id).first()
-            if not asset:
-                logger.warning("BrandAsset %s not found for status update", asset_id)
-                return False
+            def _do_update():
+                asset = BrandAsset.objects.filter(id=asset_id).first()
+                if not asset:
+                    logger.warning(
+                        "BrandAsset %s not found for status update", asset_id
+                    )
+                    return False
 
-            asset.pipeline_status = status
-            update_fields = ["pipeline_status"]
+                asset.pipeline_status = status
+                update_fields = ["pipeline_status"]
 
-            if new_gcs_path:
-                from data_ingestion.domain.path_generator import (
-                    extract_object_path as _extract,
-                )
+                if new_gcs_path:
+                    from data_ingestion.domain.path_generator import (
+                        extract_object_path as _extract,
+                    )
 
-                asset.gcs_path = _extract(new_gcs_path)
-                update_fields.append("gcs_path")
+                    asset.gcs_path = _extract(new_gcs_path)
+                    update_fields.append("gcs_path")
 
-            if status == "failed" and error_msg:
-                asset.pipeline_error = error_msg
-                update_fields.append("pipeline_error")
-            elif status in ("ingested", "curated", "indexed"):
-                asset.pipeline_error = ""
-                update_fields.append("pipeline_error")
+                if status == "failed" and error_msg:
+                    asset.pipeline_error = error_msg
+                    update_fields.append("pipeline_error")
+                elif status in ("ingested", "curated", "indexed"):
+                    asset.pipeline_error = ""
+                    update_fields.append("pipeline_error")
 
-            asset.save(update_fields=update_fields)
-            logger.info("Updated BrandAsset %s → status=%s", asset.id, status)
-            return True
+                asset.save(update_fields=update_fields)
+                logger.info("Updated BrandAsset %s → status=%s", asset.id, status)
+                return True
+
+            if schema:
+                with schema_context(schema):
+                    result = _do_update()
+            else:
+                result = _do_update()
+            return result
 
         except Exception:
             if attempt == 0:
@@ -224,6 +258,7 @@ def _run_ingestion(self, asset_id: int, tenant, event_data: dict) -> dict:
             asset_id,
             "ingested",
             new_gcs_path=result.destination_path,
+            tenant_id=event_data.get("tenant_id", ""),
         )
 
         logger.info(
@@ -242,7 +277,12 @@ def _run_ingestion(self, asset_id: int, tenant, event_data: dict) -> dict:
     except Exception as e:
         error_msg = f"Ingestion failed: {e}"
         logger.error(error_msg, extra={"asset_id": asset_id}, exc_info=True)
-        _update_asset_status(asset_id, "failed", error_msg=str(e))
+        _update_asset_status(
+            asset_id,
+            "failed",
+            error_msg=str(e),
+            tenant_id=event_data.get("tenant_id", ""),
+        )
         return {"status": "failed", "error": str(e)}
 
 
@@ -330,7 +370,11 @@ def _run_curation(
         result = service.process_event(curation_event)
 
         # Update BrandAsset → curated
-        _update_asset_status(asset_id, "curated")
+        _update_asset_status(
+            asset_id,
+            "curated",
+            tenant_id=event_data.get("tenant_id", ""),
+        )
 
         logger.info(
             "Curation succeeded for asset %s (doc_id=%s)",
@@ -347,7 +391,12 @@ def _run_curation(
         error_msg = f"Curation failed: {e}"
         logger.error(error_msg, extra={"asset_id": asset_id}, exc_info=True)
         # Mark as ingested (curation failed but ingestion succeeded)
-        _update_asset_status(asset_id, "failed", error_msg=str(e))
+        _update_asset_status(
+            asset_id,
+            "failed",
+            error_msg=str(e),
+            tenant_id=event_data.get("tenant_id", ""),
+        )
         return {"status": "failed", "error": str(e)}
 
 
@@ -408,7 +457,7 @@ def _run_indexing(
         result = run_async(orchestrator.process_event(sync_event))
 
         # Update BrandAsset → indexed
-        _update_asset_status(asset_id, "indexed")
+        _update_asset_status(asset_id, "indexed", tenant_id=tenant_id)
 
         logger.info(
             "Indexing succeeded for asset %s (operation=%s)",
@@ -425,7 +474,7 @@ def _run_indexing(
         error_msg = f"Indexing failed: {e}"
         logger.error(error_msg, extra={"asset_id": asset_id}, exc_info=True)
         # Curation succeeded; mark as failed with indexing error
-        _update_asset_status(asset_id, "failed", error_msg=str(e))
+        _update_asset_status(asset_id, "failed", error_msg=str(e), tenant_id=tenant_id)
         return {"status": "failed", "error": str(e)}
 
 

--- a/ai-brand-automator/tests/test_tenant_utils.py
+++ b/ai-brand-automator/tests/test_tenant_utils.py
@@ -1,0 +1,40 @@
+"""Tests for brand_automator.tenant_utils."""
+
+from brand_automator.tenant_utils import parse_tenant_pk
+
+
+class TestParseTenantPk:
+    """parse_tenant_pk converts string tenant ids to integer PKs."""
+
+    def test_valid_integer_string(self):
+        assert parse_tenant_pk("42") == 42
+
+    def test_valid_one(self):
+        assert parse_tenant_pk("1") == 1
+
+    def test_empty_string_returns_none(self):
+        assert parse_tenant_pk("") is None
+
+    def test_none_returns_none(self):
+        assert parse_tenant_pk(None) is None
+
+    def test_public_returns_none(self):
+        assert parse_tenant_pk("public") is None
+
+    def test_non_numeric_returns_none(self):
+        assert parse_tenant_pk("abc") is None
+
+    def test_float_string_returns_none(self):
+        assert parse_tenant_pk("3.14") is None
+
+    def test_negative_is_allowed(self):
+        """Negative PKs are technically valid integers."""
+        assert parse_tenant_pk("-1") == -1
+
+    def test_zero(self):
+        assert parse_tenant_pk("0") == 0
+
+    def test_whitespace_only_returns_none(self):
+        """Empty-ish strings are falsy."""
+        # " " is truthy, so it hits int() and fails → None
+        assert parse_tenant_pk(" ") is None


### PR DESCRIPTION
Pipeline consumers (ingestion, curation) and Celery tasks run outside Django's request/response cycle, so they have no tenant schema context. BrandAsset queries ran against the public schema, causing 'not found' when the asset lives in a tenant schema (e.g. Bransol).

Changes:
- Add _resolve_tenant_schema() helper to look up Tenant.schema_name
- Wrap all BrandAsset queries in schema_context(schema) when tenant_id is provided
- Pass event.tenant_id through all _update_asset_status call sites:
  * data_ingestion/management/commands/run_ingestion.py
  * data_ingestion/tasks.py
  * media_curation/management/commands/run_curation_consumer.py
  * onboarding/tasks.py (_run_ingestion, _run_curation, _run_indexing)
- Update tests to assert tenant_id is passed to _update_asset_status