### PR TITLE
fix: unify brand equity calculation between chat and pipeline flows

### DIFF
--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -25,6 +25,10 @@ jobs:
       orchestrator-changed: ${{ steps.changes.outputs.orchestrator }}
       discovery-changed: ${{ steps.changes.outputs.discovery }}
       intelligence-changed: ${{ steps.changes.outputs.intelligence }}
+      titling-changed: ${{ steps.changes.outputs.titling }}
+      content-changed: ${{ steps.changes.outputs.content }}
+      social-changed: ${{ steps.changes.outputs.social }}
+      rag-uploader-changed: ${{ steps.changes.outputs.rag-uploader }}
     
     steps:
       - uses: actions/checkout@v4
@@ -43,6 +47,10 @@ jobs:
             echo "orchestrator=true" >> "$GITHUB_OUTPUT"
             echo "discovery=true" >> "$GITHUB_OUTPUT"
             echo "intelligence=true" >> "$GITHUB_OUTPUT"
+            echo "titling=true" >> "$GITHUB_OUTPUT"
+            echo "content=true" >> "$GITHUB_OUTPUT"
+            echo "social=true" >> "$GITHUB_OUTPUT"
+            echo "rag-uploader=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           
@@ -79,6 +87,34 @@ jobs:
             echo "intelligence=true" >> "$GITHUB_OUTPUT"
           else
             echo "intelligence=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Check if chat-titling-worker changed
+          if git diff --name-only HEAD~1 | grep -qE '^chat-titling-worker/'; then
+            echo "titling=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "titling=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Check if content-agent-service changed
+          if git diff --name-only HEAD~1 | grep -qE '^content-agent-service/'; then
+            echo "content=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "content=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Check if social-agent-service changed
+          if git diff --name-only HEAD~1 | grep -qE '^social-agent-service/'; then
+            echo "social=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "social=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Check if rag-uploader-agent-service changed
+          if git diff --name-only HEAD~1 | grep -qE '^rag-uploader-agent-service/'; then
+            echo "rag-uploader=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "rag-uploader=false" >> "$GITHUB_OUTPUT"
           fi
 
   # ==========================================================================
@@ -361,11 +397,171 @@ jobs:
           fi
 
   # ==========================================================================
+  # Deploy Chat Titling Worker to Railway
+  # ==========================================================================
+  deploy-chat-titling:
+    runs-on: ubuntu-latest
+    needs: [pre-deploy-checks]
+    if: always() && (needs.pre-deploy-checks.outputs.titling-changed == 'true' || github.event_name == 'workflow_dispatch')
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy Chat Titling Worker
+        working-directory: chat-titling-worker
+        run: |
+          if [ -n "${{ secrets.RAILWAY_CHAT_TITLING_SERVICE }}" ]; then
+            railway up --service ${{ secrets.RAILWAY_CHAT_TITLING_SERVICE }} --detach
+          else
+            echo "RAILWAY_CHAT_TITLING_SERVICE not set, skipping chat-titling deployment"
+          fi
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+
+      - name: Wait for deployment
+        run: |
+          echo "Waiting for chat-titling deployment to complete..."
+          sleep 30
+
+      - name: Health check
+        run: |
+          TITLING_URL="${{ secrets.RAILWAY_CHAT_TITLING_URL }}"
+          if [ -n "$TITLING_URL" ]; then
+            curl -f "${TITLING_URL}/health" || echo "Health check failed - deployment may still be in progress"
+          else
+            echo "RAILWAY_CHAT_TITLING_URL not set, skipping health check"
+          fi
+
+  # ==========================================================================
+  # Deploy Content Agent to Railway
+  # ==========================================================================
+  deploy-content-agent:
+    runs-on: ubuntu-latest
+    needs: [pre-deploy-checks]
+    if: always() && (needs.pre-deploy-checks.outputs.content-changed == 'true' || github.event_name == 'workflow_dispatch')
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy Content Agent
+        working-directory: content-agent-service
+        run: |
+          if [ -n "${{ secrets.RAILWAY_CONTENT_AGENT_SERVICE }}" ]; then
+            railway up --service ${{ secrets.RAILWAY_CONTENT_AGENT_SERVICE }} --detach
+          else
+            echo "RAILWAY_CONTENT_AGENT_SERVICE not set, skipping content-agent deployment"
+          fi
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+
+      - name: Wait for deployment
+        run: |
+          echo "Waiting for content-agent deployment to complete..."
+          sleep 30
+
+      - name: Health check
+        run: |
+          CONTENT_URL="${{ secrets.RAILWAY_CONTENT_AGENT_URL }}"
+          if [ -n "$CONTENT_URL" ]; then
+            curl -f "${CONTENT_URL}/health" || echo "Health check failed - deployment may still be in progress"
+          else
+            echo "RAILWAY_CONTENT_AGENT_URL not set, skipping health check"
+          fi
+
+  # ==========================================================================
+  # Deploy Social Agent to Railway
+  # ==========================================================================
+  deploy-social-agent:
+    runs-on: ubuntu-latest
+    needs: [pre-deploy-checks]
+    if: always() && (needs.pre-deploy-checks.outputs.social-changed == 'true' || github.event_name == 'workflow_dispatch')
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy Social Agent
+        working-directory: social-agent-service
+        run: |
+          if [ -n "${{ secrets.RAILWAY_SOCIAL_AGENT_SERVICE }}" ]; then
+            railway up --service ${{ secrets.RAILWAY_SOCIAL_AGENT_SERVICE }} --detach
+          else
+            echo "RAILWAY_SOCIAL_AGENT_SERVICE not set, skipping social-agent deployment"
+          fi
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+
+      - name: Wait for deployment
+        run: |
+          echo "Waiting for social-agent deployment to complete..."
+          sleep 30
+
+      - name: Health check
+        run: |
+          SOCIAL_URL="${{ secrets.RAILWAY_SOCIAL_AGENT_URL }}"
+          if [ -n "$SOCIAL_URL" ]; then
+            curl -f "${SOCIAL_URL}/health" || echo "Health check failed - deployment may still be in progress"
+          else
+            echo "RAILWAY_SOCIAL_AGENT_URL not set, skipping health check"
+          fi
+
+  # ==========================================================================
+  # Deploy RAG Uploader Agent to Railway
+  # ==========================================================================
+  deploy-rag-uploader:
+    runs-on: ubuntu-latest
+    needs: [pre-deploy-checks]
+    if: always() && (needs.pre-deploy-checks.outputs.rag-uploader-changed == 'true' || github.event_name == 'workflow_dispatch')
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy RAG Uploader
+        working-directory: rag-uploader-agent-service
+        run: |
+          if [ -n "${{ secrets.RAILWAY_RAG_UPLOADER_SERVICE }}" ]; then
+            railway up --service ${{ secrets.RAILWAY_RAG_UPLOADER_SERVICE }} --detach
+          else
+            echo "RAILWAY_RAG_UPLOADER_SERVICE not set, skipping rag-uploader deployment"
+          fi
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+
+      - name: Wait for deployment
+        run: |
+          echo "Waiting for rag-uploader deployment to complete..."
+          sleep 30
+
+      - name: Health check
+        run: |
+          RAG_URL="${{ secrets.RAILWAY_RAG_UPLOADER_URL }}"
+          if [ -n "$RAG_URL" ]; then
+            curl -f "${RAG_URL}/health" || echo "Health check failed - deployment may still be in progress"
+          else
+            echo "RAILWAY_RAG_UPLOADER_URL not set, skipping health check"
+          fi
+
+  # ==========================================================================
   # Post-Deployment Notification
   # ==========================================================================
   notify:
     runs-on: ubuntu-latest
-    needs: [deploy-backend, deploy-frontend, deploy-celery-worker, deploy-celery-beat, deploy-mcp-server, deploy-orchestrator, deploy-discovery-agent, deploy-intelligence-agent]
+    needs: [deploy-backend, deploy-frontend, deploy-celery-worker, deploy-celery-beat, deploy-mcp-server, deploy-orchestrator, deploy-discovery-agent, deploy-intelligence-agent, deploy-chat-titling, deploy-content-agent, deploy-social-agent, deploy-rag-uploader]
     if: always()
 
     steps:
@@ -383,5 +579,9 @@ jobs:
           echo "| Pipeline Orchestrator | ${{ needs.deploy-orchestrator.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Discovery Agent | ${{ needs.deploy-discovery-agent.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Intelligence Agent | ${{ needs.deploy-intelligence-agent.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Chat Titling Worker | ${{ needs.deploy-chat-titling.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Content Agent | ${{ needs.deploy-content-agent.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Social Agent | ${{ needs.deploy-social-agent.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| RAG Uploader | ${{ needs.deploy-rag-uploader.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Commit: \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY

--- a/ai-brand-automator/ai_services/tests/test_views.py
+++ b/ai-brand-automator/ai_services/tests/test_views.py
@@ -497,6 +497,58 @@ class TestChatWithAIPipelineIntegration:
         assert job.input_context["source"] == "chat"
         assert job.input_context["session_id"] == response.data["session_id"]
 
+    @patch("orchestration.tasks.dispatch_job_task")
+    @patch("ai_services.services.GeminiAIService.extract_target_brand")
+    @patch("ai_services.services.GeminiAIService.classify_intent")
+    def test_pipeline_job_excludes_financial_data(
+        self,
+        mock_classify,
+        mock_extract,
+        mock_dispatch,
+        authenticated_client_with_tenant,
+        public_tenant,
+    ):
+        """Financial data NOT in job_context — intelligence agent does its own lookup."""
+        mock_classify.return_value = {"intent": "pipeline", "confidence": 0.9}
+        mock_extract.return_value = {
+            "company_name": "Nike",
+            "sector": "consumer_goods",
+            "base_revenue": 51_000_000_000,
+            "growth_rate": 0.10,
+            "brand_awareness": 95,
+            "profit_margin": 0.12,
+            "customer_loyalty": 82,
+            "market_share": 0.27,
+        }
+
+        response = authenticated_client_with_tenant.post(
+            self.url(),
+            {"message": "Calculate brand equity for Nike"},
+            format="json",
+        )
+
+        from orchestration.models import AnalysisJob
+
+        job = AnalysisJob.objects.get(
+            job_id=response.data["pipeline_job"]["job_id"]
+        )
+        # company_name and sector should be present
+        assert job.input_context["company_name"] == "Nike"
+        assert job.input_context["sector"] == "consumer_goods"
+        # Financial data should NOT be in job_context
+        for key in (
+            "base_revenue",
+            "growth_rate",
+            "brand_awareness",
+            "profit_margin",
+            "customer_loyalty",
+            "market_share",
+        ):
+            assert key not in job.input_context, (
+                f"{key} should not be in job_context — "
+                f"intelligence agent does its own lookup"
+            )
+
 
 @pytest.mark.django_db
 @pytest.mark.unit

--- a/ai-brand-automator/ai_services/views.py
+++ b/ai-brand-automator/ai_services/views.py
@@ -238,6 +238,7 @@ def _collect_attachment_data(attachment_ids, session):
                         att.file_name or "", max_length=255
                     ),
                     "file_type": att.file_type,
+                    "file_size_bytes": att.file_size or 0,
                     "gcs_bucket": att.asset.gcs_bucket,
                     "gcs_path": att.asset.gcs_path,
                 }
@@ -414,16 +415,9 @@ def _process_chat_message(
         if target_brand:
             job_context["company_name"] = target_brand.get("company_name", "")
             job_context["sector"] = target_brand.get("sector", "default")
-            for key in (
-                "base_revenue",
-                "growth_rate",
-                "brand_awareness",
-                "profit_margin",
-                "customer_loyalty",
-                "market_share",
-            ):
-                if key in target_brand:
-                    job_context[key] = target_brand[key]
+            # Financial data (base_revenue, growth_rate, etc.) intentionally NOT
+            # passed — intelligence agent does its own Gemini lookup to ensure
+            # consistent results between chat and pipeline UI flows.
         else:
             company_info = context.get("company", {})
             if company_info:

--- a/ai-brand-automator/onboarding/internal_views.py
+++ b/ai-brand-automator/onboarding/internal_views.py
@@ -52,8 +52,8 @@ class InternalAssetRegisterView(APIView):
 
     POST /api/v1/internal/assets/register/
 
-    Unlike confirm-gcs-upload, this endpoint:
-    - Does NOT trigger the data pipeline (the calling service handles that)
+    This endpoint:
+    - Triggers the data pipeline via Celery (Kafka fallback) after registration
     - Does NOT validate GCS path format strictly
     - Uses X-Service-Token authentication (no JWT required)
 
@@ -164,12 +164,35 @@ class InternalAssetRegisterView(APIView):
             file_name,
         )
 
+        # Trigger the data pipeline (ingestion → curation → indexing)
+        # Uses Celery sync pipeline when Kafka is disabled
+        pipeline_status = asset.pipeline_status
+        if gcs_uri.startswith("gs://"):
+            try:
+                from onboarding.services import get_pipeline_service
+
+                pipeline_service = get_pipeline_service()
+                pipeline_service.publish_asset_event(asset)
+                asset.refresh_from_db()
+                pipeline_status = asset.pipeline_status
+                logger.info(
+                    "Pipeline triggered for asset %s (status=%s)",
+                    asset.id,
+                    pipeline_status,
+                )
+            except Exception as e:
+                logger.warning(
+                    "Pipeline dispatch failed for asset %s: %s",
+                    asset.id,
+                    e,
+                )
+
         return Response(
             {
                 "asset_id": asset.id,
                 "company_id": company.id,
                 "file_name": asset.file_name,
-                "pipeline_status": asset.pipeline_status,
+                "pipeline_status": pipeline_status,
             },
             status=status.HTTP_201_CREATED,
         )

--- a/ai-brand-automator/orchestration/result_handler.py
+++ b/ai-brand-automator/orchestration/result_handler.py
@@ -47,6 +47,18 @@ def handle_pipeline_result(
             logger.warning("handle_pipeline_result: job %s not found", job_id)
             return False
 
+        # Skip if job already in terminal state (idempotent guard)
+        if job.status in (
+            AnalysisJob.Status.COMPLETED,
+            AnalysisJob.Status.FAILED,
+        ):
+            logger.info(
+                "Job %s already in terminal state %s, skipping update",
+                job_id,
+                job.status,
+            )
+            return True
+
         update_fields = ["updated_at"]
 
         # Update progress
@@ -169,21 +181,41 @@ def _save_final_chat_message(job):
     # Build a human-readable summary from result_data
     summary = _build_result_summary(job)
 
-    ChatMessage.objects.create(
+    result_metadata = {
+        "job_id": str(job.job_id),
+        "source": "pipeline_result",
+        "manifest_name": job.manifest.name if job.manifest else None,
+    }
+
+    # Try to update the existing assistant message (created by the chat view)
+    # rather than creating a duplicate.
+    existing = ChatMessage.objects.filter(
         session=session,
         role=ChatMessage.Role.ASSISTANT,
-        content=summary,
-        metadata={
-            "job_id": str(job.job_id),
-            "source": "pipeline_result",
-            "manifest_name": job.manifest.name if job.manifest else None,
-        },
-    )
-    logger.info(
-        "Job %s: final ChatMessage created in session %s",
-        job.job_id,
-        session_id,
-    )
+        metadata__job_id=str(job.job_id),
+    ).first()
+
+    if existing:
+        existing.content = summary
+        existing.metadata = result_metadata
+        existing.save(update_fields=["content", "metadata"])
+        logger.info(
+            "Job %s: updated existing ChatMessage in session %s",
+            job.job_id,
+            session_id,
+        )
+    else:
+        ChatMessage.objects.create(
+            session=session,
+            role=ChatMessage.Role.ASSISTANT,
+            content=summary,
+            metadata=result_metadata,
+        )
+        logger.info(
+            "Job %s: final ChatMessage created in session %s",
+            job.job_id,
+            session_id,
+        )
 
 
 def _build_result_summary(job):

--- a/ai-brand-automator/rag_index/adapters/vertex_ai_adapter.py
+++ b/ai-brand-automator/rag_index/adapters/vertex_ai_adapter.py
@@ -127,6 +127,11 @@ class VertexAIAdapter(VertexAIPort):
 
             from google.cloud import discoveryengine_v1 as discoveryengine
 
+            # Sanitize struct_data: Vertex AI requires all top-level
+            # values in struct_data to be objects, not arrays.
+            if isinstance(document_content, dict):
+                document_content = self._sanitize_for_vertex(document_content)
+
             # Create document with structured data (NO_CONTENT data stores)
             if isinstance(document_content, str):
                 json_str = document_content
@@ -181,6 +186,30 @@ class VertexAIAdapter(VertexAIPort):
                 message=f"Failed to upsert document: {error_message}",
                 document_id=event.file_id,
             )
+
+    @staticmethod
+    def _sanitize_for_vertex(content: dict[str, Any]) -> dict[str, Any]:
+        """Sanitize document content for Vertex AI Discovery Engine.
+
+        Vertex AI auto-infers schema from indexed documents. The Gemini
+        extraction prompt produces variable ``struct_data`` shapes
+        (tables, lists, key_value_pairs) that differ between document
+        types, causing schema-mismatch 400 errors on subsequent upserts.
+
+        Fix: strip the variable-shape fields from ``struct_data``,
+        keeping only ``metadata`` (always a dict) and scalar values.
+        The searchable text lives in ``extracted_text``, so no search
+        quality is lost.
+        """
+        struct_data = content.get("struct_data")
+        if not isinstance(struct_data, dict):
+            return content
+
+        # Remove fields whose shape varies per document
+        for key in ("tables", "lists", "key_value_pairs"):
+            struct_data.pop(key, None)
+
+        return content
 
     async def delete_document(self, event: SyncEvent) -> SyncResult:
         """Delete a document from Vertex AI Search.

--- a/ai-brand-automator/rag_index/tasks/sync_tasks.py
+++ b/ai-brand-automator/rag_index/tasks/sync_tasks.py
@@ -153,7 +153,6 @@ def get_orchestrator():
     if kafka_bootstrap and not mock_mode:
         kafka = KafkaAdapter(
             bootstrap_servers=kafka_bootstrap,
-            mock_mode=mock_mode,
         )
 
     return SyncOrchestrator(

--- a/content-agent-service/app/core/config.py
+++ b/content-agent-service/app/core/config.py
@@ -30,6 +30,7 @@ class Settings(BaseSettings):
     GCS_PROJECT_ID: str = ""
     GCS_BUCKET_NAME: str = ""
     GCS_CREDENTIALS_PATH: str = ""
+    GCS_CREDENTIALS_JSON: str = ""
 
     # Core API (brand persona fetch)
     CORE_API_URL: str = "http://localhost:8001"

--- a/content-agent-service/app/main.py
+++ b/content-agent-service/app/main.py
@@ -63,6 +63,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         project_id=settings.GCS_PROJECT_ID,
         bucket_name=settings.GCS_BUCKET_NAME,
         credentials_path=settings.GCS_CREDENTIALS_PATH,
+        credentials_json=settings.GCS_CREDENTIALS_JSON,
     )
 
     # Initialize Core API client

--- a/content-agent-service/app/services/gcs_client.py
+++ b/content-agent-service/app/services/gcs_client.py
@@ -22,10 +22,12 @@ class GCSClient:
         project_id: str = "",
         bucket_name: str = "",
         credentials_path: str = "",
+        credentials_json: str = "",
     ) -> None:
         self.project_id = project_id
         self.bucket_name = bucket_name
         self.credentials_path = credentials_path
+        self.credentials_json = credentials_json
         self._client: Any = None
         self._stub_mode = not project_id or not bucket_name
 
@@ -40,7 +42,17 @@ class GCSClient:
             try:
                 from google.cloud import storage
 
-                if self.credentials_path:
+                if self.credentials_json:
+                    import json as _json
+
+                    from google.oauth2 import service_account
+
+                    info = _json.loads(self.credentials_json)
+                    creds = service_account.Credentials.from_service_account_info(info)
+                    self._client = storage.Client(
+                        credentials=creds, project=info.get("project_id")
+                    )
+                elif self.credentials_path:
                     self._client = storage.Client.from_service_account_json(
                         self.credentials_path
                     )

--- a/deployment/.env.production.template
+++ b/deployment/.env.production.template
@@ -40,6 +40,9 @@ CELERY_RESULT_BACKEND=${REDIS_URL}
 # Google Gemini API Key
 GOOGLE_API_KEY=your-gemini-api-key
 
+# Tavily API Key (web research for discovery agent)
+TAVILY_API_KEY=your-tavily-api-key
+
 # ==========================================================================
 # Stripe Payments
 # ==========================================================================

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -121,6 +121,7 @@ curl http://localhost:8030/health     # Intelligence Agent
 curl http://localhost:8040/health     # Chat Titling Worker
 curl http://localhost:8050/health     # Content Agent
 curl http://localhost:8060/health     # Social Agent
+curl http://localhost:8070/health     # RAG Uploader Agent
 curl http://localhost:8085/health     # MCP Server
 ```
 
@@ -271,7 +272,7 @@ The workflow at `.github/workflows/deploy-railway.yml` automatically deploys on 
 
 ### Agent Microservices
 
-All 6 agent microservices are standalone FastAPI applications:
+All 7 agent microservices are standalone FastAPI applications:
 
 | Service | Container Name | Port | Redis DB | Dockerfile |
 |---------|---------------|------|----------|------------|
@@ -281,6 +282,7 @@ All 6 agent microservices are standalone FastAPI applications:
 | Chat Titling Worker | titling-worker | 8040 | 4 | `../chat-titling-worker/Dockerfile` |
 | Content Agent | content-agent | 8050 | 5 | `../content-agent-service/Dockerfile` |
 | Social Agent | social-agent | 8060 | 6 | `../social-agent-service/Dockerfile` |
+| RAG Uploader Agent | rag-uploader | 8070 | 7 | `../rag-uploader-agent-service/Dockerfile` |
 | MCP Server | mcp-server | 8085 | 0 | `docker/backend/Dockerfile` |
 
 ### Redis Database Allocation
@@ -296,6 +298,7 @@ A single Redis instance is shared across all services, with each using a differe
 | 4 | Chat Titling Worker | `TITLING_REDIS_URL=redis://redis:6379/4` |
 | 5 | Content Agent | `CONTENT_REDIS_URL=redis://redis:6379/5` |
 | 6 | Social Agent | `SOCIAL_REDIS_URL=redis://redis:6379/6` |
+| 7 | RAG Uploader Agent | `UPLOADER_REDIS_URL=redis://redis:6379/7` |
 
 ### Kafka Setup (Optional)
 

--- a/deployment/railway/RAILWAY_ENV_VARIABLES.md
+++ b/deployment/railway/RAILWAY_ENV_VARIABLES.md
@@ -146,3 +146,93 @@ PYTHONUNBUFFERED=1
 SECURE_PROXY_SSL_HEADER=HTTP_X_FORWARDED_PROTO,https
 USE_X_FORWARDED_HOST=true
 USE_X_FORWARDED_PORT=true
+
+# =============================================================================
+# Service-to-Service Authentication (shared secrets)
+# =============================================================================
+# These MUST match across all services that communicate:
+ORCHESTRATOR_SERVICE_TOKEN=<shared-service-token>
+ORCHESTRATOR_CALLBACK_TOKEN=<shared-callback-token>
+WORKER_TOKEN=<shared-worker-token>
+
+# =============================================================================
+# Pipeline Orchestrator (ORCHESTRATOR_ prefix)
+# =============================================================================
+ORCHESTRATOR_SERVICE_TOKEN=<same-as-backend>
+ORCHESTRATOR_CALLBACK_TOKEN=<same-as-backend>
+ORCHESTRATOR_REDIS_URL=<railway-redis-url>/1
+ORCHESTRATOR_KAFKA_BOOTSTRAP_SERVERS=
+ORCHESTRATOR_GOOGLE_API_KEY=<gemini-api-key>
+ORCHESTRATOR_LOG_LEVEL=INFO
+# Agent URLs (Railway internal DNS):
+ORCHESTRATOR_DISCOVERY_AGENT_URL=http://discovery-agent.railway.internal:8020
+ORCHESTRATOR_CONTENT_AGENT_URL=http://content-agent.railway.internal:8050
+ORCHESTRATOR_SOCIAL_AGENT_URL=http://social-agent.railway.internal:8060
+ORCHESTRATOR_INTELLIGENCE_AGENT_URL=http://intelligence-agent.railway.internal:8030
+ORCHESTRATOR_RAG_UPLOADER_AGENT_URL=http://rag-uploader.railway.internal:8070
+
+# =============================================================================
+# Discovery Agent (DISCOVERY_ prefix, Redis DB 2)
+# =============================================================================
+DISCOVERY_REDIS_URL=<railway-redis-url>/2
+DISCOVERY_KAFKA_BOOTSTRAP_SERVERS=
+DISCOVERY_TAVILY_API_KEY=<tavily-api-key>
+DISCOVERY_GOOGLE_API_KEY=<gemini-api-key>
+DISCOVERY_GCS_PROJECT_ID=<gcp-project>
+DISCOVERY_GCS_BUCKET_NAME=<bucket-name>
+DISCOVERY_LOG_LEVEL=INFO
+
+# =============================================================================
+# Intelligence Agent (INTELLIGENCE_ prefix, Redis DB 3)
+# =============================================================================
+INTELLIGENCE_REDIS_URL=<railway-redis-url>/3
+INTELLIGENCE_KAFKA_BOOTSTRAP_SERVERS=
+INTELLIGENCE_GEMINI_API_KEY=<gemini-api-key>
+INTELLIGENCE_GCS_PROJECT_ID=<gcp-project>
+INTELLIGENCE_GCS_BUCKET_NAME=<bucket-name>
+INTELLIGENCE_LOG_LEVEL=INFO
+
+# =============================================================================
+# Chat Titling Worker (TITLING_ prefix, Redis DB 4)
+# =============================================================================
+TITLING_REDIS_URL=<railway-redis-url>/4
+TITLING_KAFKA_BOOTSTRAP_SERVERS=
+TITLING_GOOGLE_API_KEY=<gemini-api-key>
+TITLING_CORE_API_URL=http://backend.railway.internal:8000
+TITLING_WORKER_TOKEN=<same-as-backend-WORKER_TOKEN>
+TITLING_LOG_LEVEL=INFO
+
+# =============================================================================
+# Content Agent (CONTENT_ prefix, Redis DB 5)
+# =============================================================================
+CONTENT_REDIS_URL=<railway-redis-url>/5
+CONTENT_KAFKA_BOOTSTRAP_SERVERS=
+CONTENT_GOOGLE_API_KEY=<gemini-api-key>
+CONTENT_GCS_PROJECT_ID=<gcp-project>
+CONTENT_GCS_BUCKET_NAME=<bucket-name>
+CONTENT_CORE_API_URL=http://backend.railway.internal:8000
+CONTENT_CORE_API_TOKEN=<same-as-ORCHESTRATOR_SERVICE_TOKEN>
+CONTENT_LOG_LEVEL=INFO
+
+# =============================================================================
+# Social Agent (SOCIAL_ prefix, Redis DB 6)
+# =============================================================================
+SOCIAL_REDIS_URL=<railway-redis-url>/6
+SOCIAL_KAFKA_BOOTSTRAP_SERVERS=
+SOCIAL_GOOGLE_API_KEY=<gemini-api-key>
+SOCIAL_CORE_API_URL=http://backend.railway.internal:8000
+SOCIAL_CORE_API_TOKEN=<same-as-ORCHESTRATOR_SERVICE_TOKEN>
+SOCIAL_MCP_SERVER_URL=http://mcp-server.railway.internal:8085/sse
+SOCIAL_LOG_LEVEL=INFO
+
+# =============================================================================
+# RAG Uploader Agent (UPLOADER_ prefix, Redis DB 7)
+# =============================================================================
+UPLOADER_REDIS_URL=<railway-redis-url>/7
+UPLOADER_KAFKA_BOOTSTRAP_SERVERS=
+UPLOADER_GOOGLE_API_KEY=<gemini-api-key>
+UPLOADER_GCS_PROJECT_ID=<gcp-project>
+UPLOADER_GCS_BUCKET_NAME=<bucket-name>
+UPLOADER_CORE_API_URL=http://backend.railway.internal:8000
+UPLOADER_CORE_API_TOKEN=<same-as-ORCHESTRATOR_SERVICE_TOKEN>
+UPLOADER_LOG_LEVEL=INFO

--- a/deployment/scripts/railway-setup.py
+++ b/deployment/scripts/railway-setup.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""
+Railway Setup Script — Creates and configures all missing services.
+
+Usage:
+    python deployment/scripts/railway-setup.py
+
+This script:
+1. Adds missing env vars to the backend service
+2. Creates 10 missing services (celery-worker, celery-beat, mcp-server,
+   orchestrator, discovery-agent, intelligence-agent, chat-titling-worker,
+   content-agent, social-agent, rag-uploader)
+3. Configures each service with the correct Dockerfile path, root dir,
+   start command, and health check
+4. Sets environment variables for each service
+"""
+
+import json
+import subprocess
+import sys
+import time
+
+# ─── Constants ──────────────────────────────────────────────────────────────
+
+PROJECT_ID = "aa532d23-9787-4e12-abdd-995b1e80cd2a"
+ENV_ID = "d78f43db-b019-46e2-b56f-0fd30b8f77c9"
+
+# Read token from Railway config
+with open("/Users/naveenhanuman/.railway/config.json") as f:
+    config = json.load(f)
+TOKEN = config["user"]["token"]
+
+GRAPHQL_URL = "https://backboard.railway.app/graphql/v2"
+
+# Redis base URL (internal)
+REDIS_BASE = "redis://default:stByFAnjnFfyjBquClceRkDpocLRHrnD@redis.railway.internal:6379"
+
+# Shared secrets
+SERVICE_TOKEN = "Q5Gwa0oiDWcDEXyP7jLmepM8TwIXKBlj5TLTfaOJA3o"
+CALLBACK_TOKEN = "JcvbEPOKQz9gv8WR43yIEcapoh0rf2PaqZGpaAIRrRM"
+WORKER_TOKEN = "yBVV1W8PWGYfKj3WvwrBoofCbWNW0MkMRPkEZKUfboU"
+
+# Google API Key (from backend env)
+GOOGLE_API_KEY = "AIzaSyAyyFMj47QoOUrIU0jIP4WSMC8IWPlc144"
+GCS_PROJECT_ID = "brandsol-project"
+GCS_BUCKET_NAME = "onboarding-brandsol-customer-bucket-1"
+
+# Existing service IDs
+BACKEND_SERVICE_ID = "9422b6c8-da15-4f68-ace4-6ab6f3512037"
+
+
+# ─── Service Definitions ─────────────────────────────────────────────────
+
+SERVICES = [
+    {
+        "name": "celery-worker",
+        "root_dir": "ai-brand-automator",
+        "dockerfile": "Dockerfile",
+        "start_command": "/app/entrypoint-worker.sh celery -A brand_automator worker -l info --concurrency=2 -Q celery,high_priority,low_priority,orchestration",
+        "health_check": None,
+        "env_vars": {
+            "DJANGO_SETTINGS_MODULE": "brand_automator.settings",
+            "PYTHONUNBUFFERED": "1",
+        },
+        "needs_backend_vars": True,
+    },
+    {
+        "name": "celery-beat",
+        "root_dir": "ai-brand-automator",
+        "dockerfile": "Dockerfile",
+        "start_command": "/app/entrypoint-worker.sh celery -A brand_automator beat -l info --scheduler django_celery_beat.schedulers:DatabaseScheduler",
+        "health_check": None,
+        "env_vars": {
+            "DJANGO_SETTINGS_MODULE": "brand_automator.settings",
+            "PYTHONUNBUFFERED": "1",
+        },
+        "needs_backend_vars": True,
+    },
+    {
+        "name": "mcp-server",
+        "root_dir": "ai-brand-automator",
+        "dockerfile": "Dockerfile",
+        "start_command": "/app/entrypoint-worker.sh python run_mcp_server.py --transport sse --port 8085 --host 0.0.0.0",
+        "health_check": "/health",
+        "env_vars": {
+            "PORT": "8085",
+            "DJANGO_SETTINGS_MODULE": "brand_automator.settings",
+            "PYTHONUNBUFFERED": "1",
+        },
+        "needs_backend_vars": True,
+    },
+    {
+        "name": "orchestrator",
+        "root_dir": "pipeline-orchestrator-svc",
+        "dockerfile": "Dockerfile",
+        "start_command": None,
+        "health_check": "/health",
+        "env_vars": {
+            "ORCHESTRATOR_SERVICE_TOKEN": SERVICE_TOKEN,
+            "ORCHESTRATOR_CALLBACK_TOKEN": CALLBACK_TOKEN,
+            "ORCHESTRATOR_REDIS_URL": f"{REDIS_BASE}/1",
+            "ORCHESTRATOR_KAFKA_BOOTSTRAP_SERVERS": "",
+            "ORCHESTRATOR_GOOGLE_API_KEY": GOOGLE_API_KEY,
+            "ORCHESTRATOR_LOG_LEVEL": "INFO",
+            "ORCHESTRATOR_HOST": "0.0.0.0",
+            "ORCHESTRATOR_PORT": "8010",
+            "ORCHESTRATOR_DISCOVERY_AGENT_URL": "http://discovery-agent.railway.internal:8020",
+            "ORCHESTRATOR_CONTENT_AGENT_URL": "http://content-agent.railway.internal:8050",
+            "ORCHESTRATOR_SOCIAL_AGENT_URL": "http://social-agent.railway.internal:8060",
+            "ORCHESTRATOR_INTELLIGENCE_AGENT_URL": "http://intelligence-agent.railway.internal:8030",
+            "ORCHESTRATOR_RAG_UPLOADER_AGENT_URL": "http://rag-uploader.railway.internal:8070",
+            "ORCHESTRATOR_VERTEX_AI_PROJECT_ID": GCS_PROJECT_ID,
+            "PORT": "8010",
+        },
+        "needs_backend_vars": False,
+    },
+    {
+        "name": "discovery-agent",
+        "root_dir": "discovery-agent-svc",
+        "dockerfile": "Dockerfile",
+        "start_command": None,
+        "health_check": "/health",
+        "env_vars": {
+            "DISCOVERY_REDIS_URL": f"{REDIS_BASE}/2",
+            "DISCOVERY_KAFKA_BOOTSTRAP_SERVERS": "",
+            "DISCOVERY_TAVILY_API_KEY": "",
+            "DISCOVERY_GOOGLE_API_KEY": GOOGLE_API_KEY,
+            "DISCOVERY_GCS_PROJECT_ID": GCS_PROJECT_ID,
+            "DISCOVERY_GCS_BUCKET_NAME": GCS_BUCKET_NAME,
+            "DISCOVERY_LOG_LEVEL": "INFO",
+            "PORT": "8020",
+        },
+        "needs_backend_vars": False,
+    },
+    {
+        "name": "intelligence-agent",
+        "root_dir": "intelligence-agent-svc",
+        "dockerfile": "Dockerfile",
+        "start_command": None,
+        "health_check": "/health",
+        "env_vars": {
+            "INTELLIGENCE_REDIS_URL": f"{REDIS_BASE}/3",
+            "INTELLIGENCE_KAFKA_BOOTSTRAP_SERVERS": "",
+            "INTELLIGENCE_GEMINI_API_KEY": GOOGLE_API_KEY,
+            "INTELLIGENCE_GCS_PROJECT_ID": GCS_PROJECT_ID,
+            "INTELLIGENCE_GCS_BUCKET_NAME": GCS_BUCKET_NAME,
+            "INTELLIGENCE_LOG_LEVEL": "INFO",
+            "PORT": "8030",
+        },
+        "needs_backend_vars": False,
+    },
+    {
+        "name": "chat-titling-worker",
+        "root_dir": "chat-titling-worker",
+        "dockerfile": "Dockerfile",
+        "start_command": None,
+        "health_check": "/health",
+        "env_vars": {
+            "TITLING_REDIS_URL": f"{REDIS_BASE}/4",
+            "TITLING_KAFKA_BOOTSTRAP_SERVERS": "",
+            "TITLING_GOOGLE_API_KEY": GOOGLE_API_KEY,
+            "TITLING_CORE_API_URL": "http://Prevision-WS.railway.internal:8000",
+            "TITLING_WORKER_TOKEN": WORKER_TOKEN,
+            "TITLING_LOG_LEVEL": "INFO",
+            "PORT": "8040",
+        },
+        "needs_backend_vars": False,
+    },
+    {
+        "name": "content-agent",
+        "root_dir": "content-agent-service",
+        "dockerfile": "Dockerfile",
+        "start_command": None,
+        "health_check": "/health",
+        "env_vars": {
+            "CONTENT_REDIS_URL": f"{REDIS_BASE}/5",
+            "CONTENT_KAFKA_BOOTSTRAP_SERVERS": "",
+            "CONTENT_GOOGLE_API_KEY": GOOGLE_API_KEY,
+            "CONTENT_GCS_PROJECT_ID": GCS_PROJECT_ID,
+            "CONTENT_GCS_BUCKET_NAME": GCS_BUCKET_NAME,
+            "CONTENT_CORE_API_URL": "http://Prevision-WS.railway.internal:8000",
+            "CONTENT_CORE_API_TOKEN": SERVICE_TOKEN,
+            "CONTENT_LOG_LEVEL": "INFO",
+            "PORT": "8050",
+        },
+        "needs_backend_vars": False,
+    },
+    {
+        "name": "social-agent",
+        "root_dir": "social-agent-service",
+        "dockerfile": "Dockerfile",
+        "start_command": None,
+        "health_check": "/health",
+        "env_vars": {
+            "SOCIAL_REDIS_URL": f"{REDIS_BASE}/6",
+            "SOCIAL_KAFKA_BOOTSTRAP_SERVERS": "",
+            "SOCIAL_GOOGLE_API_KEY": GOOGLE_API_KEY,
+            "SOCIAL_CORE_API_URL": "http://Prevision-WS.railway.internal:8000",
+            "SOCIAL_CORE_API_TOKEN": SERVICE_TOKEN,
+            "SOCIAL_MCP_SERVER_URL": "http://mcp-server.railway.internal:8085/sse",
+            "SOCIAL_LOG_LEVEL": "INFO",
+            "PORT": "8060",
+        },
+        "needs_backend_vars": False,
+    },
+    {
+        "name": "rag-uploader",
+        "root_dir": "rag-uploader-agent-service",
+        "dockerfile": "Dockerfile",
+        "start_command": None,
+        "health_check": "/health",
+        "env_vars": {
+            "UPLOADER_REDIS_URL": f"{REDIS_BASE}/7",
+            "UPLOADER_KAFKA_BOOTSTRAP_SERVERS": "",
+            "UPLOADER_GOOGLE_API_KEY": GOOGLE_API_KEY,
+            "UPLOADER_GCS_PROJECT_ID": GCS_PROJECT_ID,
+            "UPLOADER_GCS_BUCKET_NAME": GCS_BUCKET_NAME,
+            "UPLOADER_CORE_API_URL": "http://Prevision-WS.railway.internal:8000",
+            "UPLOADER_CORE_API_TOKEN": SERVICE_TOKEN,
+            "UPLOADER_LOG_LEVEL": "INFO",
+            "PORT": "8070",
+        },
+        "needs_backend_vars": False,
+    },
+]
+
+
+def gql(query: str) -> dict:
+    """Execute a GraphQL query against the Railway API."""
+    import urllib.request
+
+    req = urllib.request.Request(
+        GRAPHQL_URL,
+        data=json.dumps({"query": query}).encode(),
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {TOKEN}",
+        },
+    )
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read())
+
+
+def create_service(name: str) -> str:
+    """Create a new service and return its ID."""
+    result = gql(
+        f'mutation {{ serviceCreate(input: {{ name: "{name}", projectId: "{PROJECT_ID}" }}) {{ id name }} }}'
+    )
+    if "errors" in result:
+        print(f"  ERROR creating {name}: {result['errors']}")
+        return None
+    svc = result["data"]["serviceCreate"]
+    print(f"  Created service: {svc['name']} (ID: {svc['id']})")
+    return svc["id"]
+
+
+def update_service_instance(
+    service_id: str,
+    root_dir: str = None,
+    dockerfile: str = None,
+    start_command: str = None,
+    health_check: str = None,
+):
+    """Update service instance configuration."""
+    parts = []
+    if root_dir:
+        parts.append(f'rootDirectory: "{root_dir}"')
+    if dockerfile:
+        parts.append(f'dockerfilePath: "{dockerfile}"')
+    if start_command:
+        # Escape quotes in command
+        escaped = start_command.replace('"', '\\"')
+        parts.append(f'startCommand: "{escaped}"')
+    if health_check:
+        parts.append(f'healthcheckPath: "{health_check}"')
+        parts.append("healthcheckTimeout: 300")
+
+    if not parts:
+        return
+
+    input_str = ", ".join(parts)
+    result = gql(
+        f'mutation {{ serviceInstanceUpdate(serviceId: "{service_id}", environmentId: "{ENV_ID}", input: {{ {input_str} }}) }}'
+    )
+    if "errors" in result:
+        print(f"  ERROR updating config: {result['errors']}")
+    else:
+        print(f"  Updated config: {input_str[:80]}...")
+
+
+def set_variables(service_id: str, variables: dict):
+    """Set environment variables for a service."""
+    # Build the variables JSON
+    vars_json = json.dumps(variables).replace('"', '\\"')
+    result = gql(
+        f'mutation {{ variableCollectionUpsert(input: {{ projectId: "{PROJECT_ID}", environmentId: "{ENV_ID}", serviceId: "{service_id}", variables: {json.dumps(variables)} }}) }}'
+    )
+    if "errors" in result:
+        # Try alternative approach
+        print(f"  Trying alternative variable set method...")
+        for key, value in variables.items():
+            val_escaped = value.replace('"', '\\"').replace("\n", "\\n")
+            r = gql(
+                f'mutation {{ variableUpsert(input: {{ projectId: "{PROJECT_ID}", environmentId: "{ENV_ID}", serviceId: "{service_id}", name: "{key}", value: "{val_escaped}" }}) }}'
+            )
+            if "errors" in r:
+                print(f"    ERROR setting {key}: {r['errors'][0]['message']}")
+            else:
+                pass  # silent success
+        print(f"  Set {len(variables)} variables individually")
+    else:
+        print(f"  Set {len(variables)} variables")
+
+
+def get_existing_services() -> dict:
+    """Get map of existing service names to IDs."""
+    result = gql(
+        f'query {{ project(id: "{PROJECT_ID}") {{ services {{ edges {{ node {{ id name }} }} }} }} }}'
+    )
+    services = {}
+    for edge in result["data"]["project"]["services"]["edges"]:
+        node = edge["node"]
+        services[node["name"]] = node["id"]
+    return services
+
+
+def main():
+    print("=" * 60)
+    print("Railway Setup — AI Brand Automator")
+    print("=" * 60)
+
+    # Step 1: Get existing services
+    print("\n[1/4] Checking existing services...")
+    existing = get_existing_services()
+    print(f"  Found {len(existing)} services: {', '.join(existing.keys())}")
+
+    # Step 2: Add missing env vars to backend
+    print("\n[2/4] Adding missing env vars to backend...")
+    backend_new_vars = {
+        "ORCHESTRATOR_URL": "http://orchestrator.railway.internal:8010",
+        "ORCHESTRATOR_SERVICE_TOKEN": SERVICE_TOKEN,
+        "ORCHESTRATOR_CALLBACK_TOKEN": CALLBACK_TOKEN,
+        "WORKER_TOKEN": WORKER_TOKEN,
+        "DJANGO_SETTINGS_MODULE": "brand_automator.settings",
+        "PYTHONUNBUFFERED": "1",
+        "PORT": "8000",
+        "REDIS_URL": f"{REDIS_BASE}/0",
+        "SECURE_PROXY_SSL_HEADER": "HTTP_X_FORWARDED_PROTO,https",
+        "USE_X_FORWARDED_HOST": "true",
+        "USE_X_FORWARDED_PORT": "true",
+        "KONG_ENABLED": "false",
+        "GCS_AUTO_PROVISION": "true",
+        "ONBOARDING_KAFKA_ENABLED": "false",
+        "KAFKA_CONSUMERS_ENABLED": "false",
+        "ORCHESTRATION_KAFKA_ENABLED": "false",
+    }
+    set_variables(BACKEND_SERVICE_ID, backend_new_vars)
+
+    # Step 3: Create missing services
+    print("\n[3/4] Creating missing services...")
+    created = {}
+    for svc_def in SERVICES:
+        name = svc_def["name"]
+        if name in existing:
+            print(f"  {name}: already exists (ID: {existing[name]})")
+            created[name] = existing[name]
+        else:
+            print(f"  Creating {name}...")
+            svc_id = create_service(name)
+            if svc_id:
+                created[name] = svc_id
+                time.sleep(0.5)  # Rate limit
+
+    # Step 4: Configure each service
+    print("\n[4/4] Configuring services...")
+    for svc_def in SERVICES:
+        name = svc_def["name"]
+        svc_id = created.get(name)
+        if not svc_id:
+            print(f"  SKIP {name}: no service ID")
+            continue
+
+        print(f"\n  Configuring {name}...")
+
+        # Update instance config
+        update_service_instance(
+            svc_id,
+            root_dir=svc_def["root_dir"],
+            dockerfile=svc_def["dockerfile"],
+            start_command=svc_def.get("start_command"),
+            health_check=svc_def.get("health_check"),
+        )
+        time.sleep(0.3)
+
+        # Set env vars
+        set_variables(svc_id, svc_def["env_vars"])
+        time.sleep(0.3)
+
+    print("\n" + "=" * 60)
+    print("Setup complete!")
+    print("=" * 60)
+    print("\nService IDs for reference:")
+    for name, sid in sorted(created.items()):
+        print(f"  {name}: {sid}")
+    print(f"\nBackend: {BACKEND_SERVICE_ID}")
+    print(f"\nNext steps:")
+    print(f"  1. Deploy each service using: railway up --service <name>")
+    print(f"  2. Run health checks against deployed URLs")
+    print(f"\nNote: Services that need_backend_vars=True share the")
+    print(f"  same DATABASE_URL, SECRET_KEY, etc. from the backend.")
+    print(f"  These are inherited from Railway's shared variables")
+    print(f"  or need to be copied manually from the backend service.")
+
+
+if __name__ == "__main__":
+    main()

--- a/intelligence-agent-svc/app/cache/redis_manager.py
+++ b/intelligence-agent-svc/app/cache/redis_manager.py
@@ -130,6 +130,34 @@ class RedisManager:
         except Exception as exc:
             logger.warning("Redis error in set_cached_result: %s", exc)
 
+    # --- Company Data Cache ---
+
+    async def get_company_data(self, company_name: str) -> Optional[dict[str, Any]]:
+        """Get cached Gemini company data lookup result."""
+        try:
+            r = await self._get_redis()
+            key = f"intel:company:{company_name.lower().strip()}"
+            data = await r.get(key)
+            if data is not None:
+                logger.debug("Company data cache HIT for: %s", company_name)
+                return json.loads(data)
+            return None
+        except Exception as exc:
+            logger.warning("Redis error in get_company_data: %s", exc)
+            return None
+
+    async def set_company_data(
+        self, company_name: str, data: dict[str, Any]
+    ) -> None:
+        """Cache company data with 4-hour TTL."""
+        try:
+            r = await self._get_redis()
+            key = f"intel:company:{company_name.lower().strip()}"
+            await r.set(key, json.dumps(data), ex=RESULT_CACHE_TTL)
+            logger.debug("Company data cache SET for: %s", company_name)
+        except Exception as exc:
+            logger.warning("Redis error in set_company_data: %s", exc)
+
     # --- Rate Limiting ---
 
     async def check_rate_limit(self, tenant_id: str, limit: int = 10) -> bool:

--- a/intelligence-agent-svc/app/logic/iso_engine/bsi_calculator.py
+++ b/intelligence-agent-svc/app/logic/iso_engine/bsi_calculator.py
@@ -10,7 +10,6 @@ When data for a pillar is missing, the ProxyEngine redistributes
 weights across available pillars (normalized to sum to 1.0).
 """
 
-import hashlib
 import logging
 from typing import Any
 
@@ -26,12 +25,6 @@ DEFAULT_WEIGHTS: dict[str, float] = {
     "legal": 0.25,
 }
 
-# Stub scores when real data is unavailable
-STUB_SCORES: dict[str, float] = {
-    "financial": 65.0,
-    "behavioral": 60.0,
-    "legal": 70.0,
-}
 
 
 class BSICalculator:
@@ -88,12 +81,27 @@ class BSICalculator:
                 effective_weights,
             )
         elif len(available_pillars) == 0:
-            # No data at all — use stub scores with default weights
-            effective_weights = base_weights
-            available_pillars = list(DEFAULT_WEIGHTS.keys())
-            pillar_data = {name: {} for name in available_pillars}
-            data_completeness = 0.0
-            logger.warning("BSI: No pillar data available, using stub scores")
+            # No data at all — return zero score with clear error
+            logger.warning(
+                "BSI: No pillar data available. Cannot calculate Brand "
+                "Strength Index without financial, behavioral, or legal data."
+            )
+            return BSIResult(
+                score=0,
+                pillars=[
+                    PillarScore(
+                        name=name,
+                        weight=round(base_weights[name], 4),
+                        score=0.0,
+                        rationale=(
+                            f"{name.title()} data not available. "
+                            f"Provide {name} metrics for an accurate BSI."
+                        ),
+                    )
+                    for name in DEFAULT_WEIGHTS
+                ],
+                data_completeness=0.0,
+            )
         else:
             effective_weights = base_weights
 
@@ -138,9 +146,9 @@ class BSICalculator:
         data: dict[str, Any] | None,
         brand_seed: str = "",
     ) -> float:
-        """Score a single pillar (0–100)."""
+        """Score a single pillar (0–100). Returns 0 when no data."""
         if not data:
-            return self._seeded_stub_score(pillar_name, brand_seed)
+            return 0.0
 
         # Check if data contains a pre-computed score
         if "score" in data:
@@ -158,23 +166,7 @@ class BSICalculator:
         if pillar_name == "legal":
             return self._score_legal(data)
 
-        return self._seeded_stub_score(pillar_name, brand_seed)
-
-    @staticmethod
-    def _seeded_stub_score(pillar_name: str, brand_seed: str) -> float:
-        """Return a deterministic stub score seeded by brand name.
-
-        Different brands get different stub scores (±15 around the base),
-        avoiding identical BSI results when real data is unavailable.
-        """
-        base = STUB_SCORES.get(pillar_name, 50.0)
-        if not brand_seed:
-            return base
-        seed_str = f"{brand_seed}:{pillar_name}"
-        h = int(hashlib.md5(seed_str.encode()).hexdigest()[:8], 16)
-        # Map hash to offset between -15 and +15
-        offset = (h % 3001) / 100.0 - 15.0
-        return max(10.0, min(95.0, base + offset))
+        return 0.0
 
     @staticmethod
     def _score_financial(data: dict[str, Any]) -> float:
@@ -270,8 +262,8 @@ class BSICalculator:
         """Build rationale string for a pillar score."""
         if not data:
             return (
-                f"{pillar_name.title()} pillar scored"
-                " using stub defaults (no data provided)."
+                f"{pillar_name.title()} data not available. "
+                f"Provide {pillar_name} metrics for an accurate score."
             )
         metrics = ", ".join(f"{k}={v}" for k, v in data.items() if k != "score")
         return (

--- a/intelligence-agent-svc/app/logic/iso_engine/royalty_relief.py
+++ b/intelligence-agent-svc/app/logic/iso_engine/royalty_relief.py
@@ -38,30 +38,8 @@ SECTOR_ROYALTY_RATES: dict[str, float] = {
     "default": 0.04,
 }
 
-# Default growth rate for stub revenue estimation
+# Default growth rate when base revenue exists but growth rate is missing
 DEFAULT_GROWTH_RATE = 0.05
-
-# Sector-specific stub base revenues (used when no real data is available).
-# Avoids returning identical valuations for all brands.
-SECTOR_STUB_REVENUES: dict[str, float] = {
-    "technology": 15_000_000.0,
-    "software": 12_000_000.0,
-    "consumer_goods": 25_000_000.0,
-    "retail": 30_000_000.0,
-    "financial_services": 50_000_000.0,
-    "healthcare": 20_000_000.0,
-    "pharmaceuticals": 35_000_000.0,
-    "automotive": 80_000_000.0,
-    "aerospace": 60_000_000.0,
-    "defense": 70_000_000.0,
-    "industrial": 40_000_000.0,
-    "electric_vehicles": 50_000_000.0,
-    "energy": 100_000_000.0,
-    "telecommunications": 45_000_000.0,
-    "luxury": 18_000_000.0,
-    "media": 8_000_000.0,
-    "default": 10_000_000.0,
-}
 
 
 class RoyaltyReliefEngine:
@@ -229,34 +207,16 @@ class RoyaltyReliefEngine:
             logger.info("Extracted revenue from discovery text: $%.0f", extracted)
             return revenues
 
-        # 5. Stub fallback — use sector-specific base and brand name seed
-        #    for variation so different brands produce different valuations
-        sector_lower = sector.lower().strip()
-        stub_base = SECTOR_STUB_REVENUES.get(
-            sector_lower, SECTOR_STUB_REVENUES["default"]
-        )
-
-        # Use company name hash to add deterministic per-brand variation
-        # (±20% around the sector base), so "Acme" and "Zenith" differ
-        company_name = input_context.get("company_name", "")
-        if company_name:
-            import hashlib
-
-            name_hash = int(hashlib.md5(company_name.encode()).hexdigest()[:8], 16)
-            # Map to a multiplier between 0.80 and 1.20
-            variation = 0.80 + (name_hash % 4001) / 10000.0
-            stub_base *= variation
-
-        growth = float(input_context.get("growth_rate", DEFAULT_GROWTH_RATE))
-        revenues = [stub_base * (1 + growth) ** t for t in range(horizon_years)]
+        # 5. No revenue data available — return empty list so the caller
+        #    can detect this and return a proper error to the user.
+        company_name = input_context.get("company_name", "unknown")
         logger.warning(
-            "No revenue data found — using stub projection "
-            "(sector=%s, base=$%.0fM, company=%s)",
-            sector_lower,
-            stub_base / 1e6,
-            company_name or "unknown",
+            "No revenue data found for '%s' (sector=%s). "
+            "Cannot perform brand valuation without financial data.",
+            company_name,
+            sector,
         )
-        return revenues
+        return []
 
     @staticmethod
     def select_royalty_rate(

--- a/intelligence-agent-svc/app/services/intelligence_executor.py
+++ b/intelligence-agent-svc/app/services/intelligence_executor.py
@@ -175,6 +175,70 @@ class IntelligenceExecutor:
                 ctx_market_share,
             )
 
+        # 1c. Gemini fallback — look up company data if input_context is empty
+        if financial_data is None and not input_context.get("base_revenue"):
+            company_name = input_context.get(
+                "company_name"
+            ) or self._extract_company_name(request.input_prompt)
+            if company_name and self.gemini_client:
+                logger.info(
+                    "No financial data in context — looking up '%s' via Gemini",
+                    company_name,
+                )
+                # Check Redis cache first for consistent results across flows
+                gemini_data = None
+                if self.redis_manager:
+                    gemini_data = await self.redis_manager.get_company_data(
+                        company_name
+                    )
+                    if gemini_data:
+                        logger.info(
+                            "Company data cache HIT for '%s'", company_name
+                        )
+                if gemini_data is None:
+                    gemini_data = self._lookup_company_data(company_name)
+                    # Cache the result for consistent results across flows
+                    if gemini_data and self.redis_manager:
+                        await self.redis_manager.set_company_data(
+                            company_name, gemini_data
+                        )
+                if gemini_data:
+                    for key in (
+                        "company_name",
+                        "sector",
+                        "base_revenue",
+                        "growth_rate",
+                        "brand_awareness",
+                        "profit_margin",
+                        "customer_loyalty",
+                        "market_share",
+                    ):
+                        if key in gemini_data and key not in input_context:
+                            input_context[key] = gemini_data[key]
+                    # Re-derive financial_data from enriched context
+                    if input_context.get("base_revenue"):
+                        growth = float(input_context.get("growth_rate", 0.05))
+                        margin = float(
+                            input_context.get("profit_margin", 0.10)
+                        )
+                        financial_data = {
+                            "revenue_growth": growth,
+                            "profit_margin": margin,
+                        }
+                        ctx_market_share = input_context.get("market_share")
+                        if ctx_market_share is not None:
+                            financial_data["market_share"] = float(
+                                ctx_market_share
+                            )
+                    # Refresh sector from Gemini data
+                    sector = str(input_context.get("sector", sector))
+                    logger.info(
+                        "Enriched context from Gemini: sector=%s, "
+                        "base_revenue=%s",
+                        sector,
+                        input_context.get("base_revenue"),
+                    )
+
         # 2. Determine calculation strategy
         data_manifest = {
             "financial_data": financial_data,
@@ -192,6 +256,35 @@ class IntelligenceExecutor:
         projected_revenues = self.royalty_engine.estimate_revenues_from_context(
             previous_outputs, input_context, horizon_years, sector=sector
         )
+
+        # 4b. Abort if no revenue data — cannot produce a valid valuation
+        if not projected_revenues:
+            company = input_context.get("company_name", "the requested brand")
+            logger.warning(
+                "ISO valuation aborted for tenant %s: no revenue data for '%s'",
+                tenant_id,
+                company,
+            )
+            return ExecuteResponse(
+                findings=[
+                    f"Unable to calculate brand equity for '{company}'.",
+                    "No revenue or financial data could be determined.",
+                    f"Sector: {sector}.",
+                ],
+                recommendations=[
+                    "Provide the company's annual revenue in the request "
+                    "(e.g., 'Calculate brand equity for Nike with $51B revenue').",
+                    "Try a well-known publicly traded company whose financials "
+                    "are available (e.g., Apple, Nike, Tesla).",
+                    "Upload financial statements to enable accurate valuation.",
+                ],
+                analysis_type="iso_valuation",
+                rationale=(
+                    f"Brand equity valuation requires revenue data. "
+                    f"No financial data was found for '{company}' from "
+                    f"AI lookup, user input, or discovery research."
+                ),
+            )
 
         # 5. Calculate BSI
         behavioral_data = self._extract_behavioral_data(previous_outputs)
@@ -405,6 +498,213 @@ class IntelligenceExecutor:
         """Clean up resources."""
         if self.redis_manager:
             await self.redis_manager.close()
+
+    # -----------------------------------------------------------------------
+    # Gemini company data lookup
+    # -----------------------------------------------------------------------
+
+    # Stop words — common words that are NOT company names.
+    _STOP_WORDS = frozenset(
+        {
+            "the",
+            "a",
+            "an",
+            "my",
+            "our",
+            "this",
+            "that",
+            "i",
+            "we",
+            "can",
+            "you",
+            "please",
+            "brand",
+            "equity",
+            "value",
+        }
+    )
+
+    @staticmethod
+    def _extract_company_name(input_prompt: str) -> str | None:
+        """Extract the company/brand name from a user prompt via regex."""
+        import re
+
+        patterns = [
+            r"(?:brand equity|brand valuation|brand value|brand strength)"
+            r"(?:\s+(?:for|of|for the))?\s+(?:the\s+)?"
+            r"([A-Z][A-Za-z0-9\s&'.-]+?)(?:\s+brand)?[?.!,]?\s*$",
+            r"(?:calculate|analyze|analyse|evaluate|assess)"
+            r"(?:\s+(?:the\s+)?brand\s+(?:equity|value|valuation|"
+            r"strength)\s+(?:for|of))?\s+(?:the\s+)?"
+            r"([A-Z][A-Za-z0-9\s&'.-]+?)(?:\s+brand)?[?.!,]?\s*$",
+            r"(?:for|of)\s+(?:the\s+)?"
+            r"([A-Z][A-Za-z0-9\s&'.-]+?)(?:\s+brand)[?.!,]?\s*$",
+            r"([A-Z][A-Za-z0-9&'.-]+?)(?:'s)\s+"
+            r"(?:brand\s+)?(?:equity|value|valuation|strength)",
+        ]
+        for pattern in patterns:
+            match = re.search(pattern, input_prompt, re.IGNORECASE)
+            if match:
+                name = match.group(1).strip().rstrip(".,!?")
+                if (
+                    len(name) > 1
+                    and name.lower()
+                    not in IntelligenceExecutor._STOP_WORDS
+                ):
+                    return name
+        return None
+
+    def _lookup_company_data(self, company_name: str) -> dict[str, Any] | None:
+        """Look up real financial data for a company via Gemini AI.
+
+        Returns a dict with company_name, sector, base_revenue, growth_rate,
+        brand_awareness, profit_margin, customer_loyalty, market_share — or
+        None if the data cannot be determined.
+        """
+        import json as _json
+
+        try:
+            if self.gemini_client is None:
+                return None
+
+            model = self.gemini_client.GenerativeModel(settings.GEMINI_MODEL)
+
+            prompt = (
+                f'Look up the real, publicly available financial data '
+                f'for "{company_name}". Provide the data as a JSON '
+                f'object with ONLY these keys:\n'
+                f'  "company_name": the official company name (string)\n'
+                f'  "sector": one of: technology, software, '
+                f'consumer_goods, retail, automotive, '
+                f'aerospace, defense, industrial, '
+                f'electric_vehicles, '
+                f'financial_services, media, healthcare, '
+                f'pharmaceuticals, luxury, energy, '
+                f'telecommunications (string)\n'
+                f'  "base_revenue": most recent annual revenue in USD '
+                f'(integer, e.g. 51000000000 for $51B)\n'
+                f'  "growth_rate": year-over-year revenue growth rate '
+                f'as a decimal (e.g. 0.10 for 10%)\n'
+                f'  "brand_awareness": estimated global brand awareness '
+                f'score from 0 to 100 (integer)\n'
+                f'  "profit_margin": net profit margin as a decimal '
+                f'(e.g. 0.15 for 15%)\n'
+                f'  "customer_loyalty": estimated customer loyalty/'
+                f'retention score from 0 to 100 (integer, based on '
+                f'repeat purchase rates, NPS, brand switching costs)\n'
+                f'  "market_share": estimated market share in primary '
+                f'market as a decimal (e.g. 0.25 for 25%)\n\n'
+                f'IMPORTANT: Use real data from public filings and '
+                f'reports. If the company is private or you cannot '
+                f'determine its financials, respond with exactly: '
+                f'NOT_FOUND\n\n'
+                f'Respond with ONLY the JSON object (or NOT_FOUND). '
+                f'No markdown fences, no explanation.'
+            )
+
+            response = model.generate_content(prompt)
+            text = response.text.strip()
+
+            if "NOT_FOUND" in text.upper():
+                logger.info(
+                    "Gemini: company '%s' not found or private",
+                    company_name,
+                )
+                return None
+
+            # Strip markdown fences if present
+            if text.startswith("```"):
+                text = text.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
+
+            data = _json.loads(text)
+
+            # Validate required fields
+            required = {
+                "company_name",
+                "sector",
+                "base_revenue",
+                "growth_rate",
+                "brand_awareness",
+                "profit_margin",
+            }
+            if not required.issubset(data.keys()):
+                logger.warning(
+                    "Gemini response missing fields for %s: %s",
+                    company_name,
+                    required - data.keys(),
+                )
+                return None
+
+            # Coerce and validate types
+            data["base_revenue"] = int(float(data["base_revenue"]))
+            data["growth_rate"] = float(data["growth_rate"])
+            data["brand_awareness"] = int(float(data["brand_awareness"]))
+            data["profit_margin"] = float(data["profit_margin"])
+
+            if "customer_loyalty" in data and data["customer_loyalty"] is not None:
+                data["customer_loyalty"] = int(float(data["customer_loyalty"]))
+            if "market_share" in data and data["market_share"] is not None:
+                data["market_share"] = float(data["market_share"])
+
+            if data["base_revenue"] <= 0:
+                logger.warning(
+                    "Gemini returned non-positive revenue for %s",
+                    company_name,
+                )
+                return None
+
+            # Validate the returned company matches the request
+            input_clean = (
+                company_name.lower().replace(".", "").replace(",", "").strip()
+            )
+            result_clean = (
+                data["company_name"]
+                .lower()
+                .replace(".", "")
+                .replace(",", "")
+                .strip()
+            )
+            result_words = result_clean.split()
+            input_words = input_clean.split()
+
+            match_found = (
+                input_clean in result_clean
+                or result_clean in input_clean
+                or any(w in result_clean for w in input_words if len(w) > 2)
+                or any(
+                    rw.startswith(input_clean[:4])
+                    for rw in result_words
+                    if len(input_clean) >= 4
+                )
+                or result_clean.startswith(input_clean[:4])
+            )
+
+            if not match_found:
+                logger.warning(
+                    "Gemini returned mismatched company: asked for "
+                    "'%s', got '%s' — rejecting",
+                    company_name,
+                    data["company_name"],
+                )
+                return None
+
+            logger.info(
+                "Gemini provided data for %s: sector=%s, revenue=$%s, "
+                "awareness=%s",
+                company_name,
+                data.get("sector"),
+                f"{data.get('base_revenue', 0):,}",
+                data.get("brand_awareness"),
+            )
+            return data
+
+        except Exception as e:
+            logger.warning(
+                "Gemini company lookup failed for %s: %s",
+                company_name,
+                e,
+            )
+            return None
 
     # -----------------------------------------------------------------------
     # Helpers

--- a/intelligence-agent-svc/tests/test_bsi_calculator.py
+++ b/intelligence-agent-svc/tests/test_bsi_calculator.py
@@ -24,12 +24,15 @@ class TestBSICalculator:
         assert result.data_completeness == 1.0
         assert len(result.pillars) == 3
 
-    def test_no_data_uses_stubs(self):
-        """When no pillar data provided, use stub scores."""
+    def test_no_data_returns_zero(self):
+        """When no pillar data provided, return score 0 with error rationale."""
         result = self.calc.derive_index()
         assert result.data_completeness == 0.0
-        assert result.score > 0
+        assert result.score == 0
         assert len(result.pillars) == 3
+        for pillar in result.pillars:
+            assert pillar.score == 0.0
+            assert "not available" in pillar.rationale.lower()
 
     def test_missing_financial_pillar(self):
         """Missing financial pillar triggers weight redistribution."""
@@ -122,7 +125,7 @@ class TestBSICalculator:
         assert "revenue_growth" in financial_pillar.rationale
 
     def test_pillar_rationale_without_data(self):
-        """Missing data pillar rationale mentions stubs."""
+        """Missing data pillar rationale explains data is unavailable."""
         result = self.calc.derive_index()
         for pillar in result.pillars:
-            assert "stub" in pillar.rationale.lower()
+            assert "not available" in pillar.rationale.lower()

--- a/intelligence-agent-svc/tests/test_intelligence_executor.py
+++ b/intelligence-agent-svc/tests/test_intelligence_executor.py
@@ -1,6 +1,6 @@
 """Tests for the IntelligenceExecutor orchestration service."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi import HTTPException
@@ -122,15 +122,17 @@ class TestISOValuationFlow:
         assert response.valuation.horizon_years == 5
         assert response.valuation.brand_value_npv > 0
 
-    async def test_valuation_stub_revenues(self):
-        """No revenue data → stub $10M base used."""
+    async def test_valuation_no_revenue_returns_error(self):
+        """No revenue data → returns error response with recommendations."""
         request = ExecuteRequest(
             input_prompt="Calculate brand value",
             config={"method": "royalty_relief"},
         )
         response = await self.executor.execute(request, "tenant-1")
-        assert response.valuation is not None
-        assert response.valuation.brand_value_npv > 0
+        assert response.valuation is None
+        assert response.analysis_type == "iso_valuation"
+        assert any("unable" in f.lower() for f in response.findings)
+        assert len(response.recommendations) > 0
 
     async def test_valuation_includes_bsi(self):
         """Valuation response includes BSI result."""
@@ -203,6 +205,94 @@ class TestRateLimiting:
         )
         response = await executor.execute(request, "tenant-1")
         assert response.analysis_type == "iso_valuation"
+
+
+class TestGeminiLookup:
+    """Verify Gemini company data lookup enriches empty context."""
+
+    def setup_method(self):
+        # Mock Gemini client — genai.GenerativeModel(model).generate_content(prompt)
+        self.mock_genai = MagicMock()
+        mock_model_instance = MagicMock()
+        mock_response = MagicMock()
+        mock_response.text = (
+            '{"company_name": "Nike, Inc.", "sector": "consumer_goods", '
+            '"base_revenue": 51217000000, "growth_rate": 0.10, '
+            '"brand_awareness": 95, "profit_margin": 0.12, '
+            '"customer_loyalty": 82, "market_share": 0.27}'
+        )
+        mock_model_instance.generate_content.return_value = mock_response
+        self.mock_genai.GenerativeModel.return_value = mock_model_instance
+        self.executor = IntelligenceExecutor(
+            royalty_engine=RoyaltyReliefEngine(),
+            bsi_calculator=BSICalculator(proxy_engine=ProxyEngine()),
+            proxy_engine=ProxyEngine(),
+            gap_analyzer=CompetitiveGapAnalyzer(),
+            theme_analyzer=ThemeAnalyzer(),
+            gemini_client=self.mock_genai,
+        )
+
+    async def test_gemini_enriches_empty_context(self):
+        """No revenue in context + Gemini succeeds → real valuation."""
+        request = ExecuteRequest(
+            input_prompt="Calculate brand equity for Nike",
+            config={"method": "royalty_relief"},
+        )
+        response = await self.executor.execute(request, "tenant-1")
+        assert response.analysis_type == "iso_valuation"
+        assert response.valuation is not None
+        assert response.valuation.brand_value_npv > 0
+        assert response.methodology == "royalty_relief"
+
+    async def test_gemini_failure_returns_error(self):
+        """Gemini returns NOT_FOUND → error response."""
+        mock_model = MagicMock()
+        mock_response = MagicMock()
+        mock_response.text = "NOT_FOUND"
+        mock_model.generate_content.return_value = mock_response
+        self.mock_genai.GenerativeModel.return_value = mock_model
+
+        request = ExecuteRequest(
+            input_prompt="Calculate brand equity for UnknownStartup",
+            config={"method": "royalty_relief"},
+        )
+        response = await self.executor.execute(request, "tenant-1")
+        assert response.analysis_type == "iso_valuation"
+        assert response.valuation is None
+        assert any("unable" in f.lower() for f in response.findings)
+
+    async def test_gemini_called_when_only_company_name_in_context(self):
+        """company_name in context but no base_revenue → Gemini lookup triggered."""
+        request = ExecuteRequest(
+            input_prompt="Calculate brand equity for Nike",
+            input_context={
+                "company_name": "Nike",
+                "sector": "consumer_goods",
+            },
+            config={"method": "royalty_relief"},
+        )
+        response = await self.executor.execute(request, "tenant-1")
+        assert response.analysis_type == "iso_valuation"
+        assert response.valuation is not None
+        assert response.valuation.brand_value_npv > 0
+        # Gemini SHOULD have been called since base_revenue is absent
+        self.mock_genai.GenerativeModel.assert_called_once()
+
+    async def test_gemini_skipped_when_revenue_present(self):
+        """Revenue in context → no Gemini call."""
+        request = ExecuteRequest(
+            input_prompt="Calculate brand equity for Nike",
+            input_context={
+                "sector": "consumer_goods",
+                "base_revenue": 51_000_000_000,
+            },
+            config={"method": "royalty_relief"},
+        )
+        response = await self.executor.execute(request, "tenant-1")
+        assert response.valuation is not None
+        assert response.valuation.brand_value_npv > 0
+        # Gemini should NOT have been called
+        self.mock_genai.GenerativeModel.assert_not_called()
 
 
 class TestCaching:

--- a/intelligence-agent-svc/tests/test_routes.py
+++ b/intelligence-agent-svc/tests/test_routes.py
@@ -52,7 +52,11 @@ class TestISOCalcEndpoint:
         )
         assert response.status_code == 200
         data = response.json()
-        assert data["methodology"] == "royalty_relief"
+        # Route defaults to ISO valuation even without explicit method
+        assert data["analysis_type"] == "iso_valuation"
+        # No revenue data → error response with actionable recommendations
+        assert any("unable" in f.lower() for f in data["findings"])
+        assert len(data["recommendations"]) > 0
 
     async def test_iso_calc_no_tenant_header_uses_default(self, client):
         """Missing X-Tenant-ID header should use default."""

--- a/intelligence-agent-svc/tests/test_royalty_relief.py
+++ b/intelligence-agent-svc/tests/test_royalty_relief.py
@@ -154,15 +154,14 @@ class TestRevenueEstimation:
         assert len(revenues) == 3
         assert revenues[0] == 2_000_000.0
 
-    def test_stub_fallback(self):
-        """When no data available, use stub $10M base."""
+    def test_no_data_returns_empty(self):
+        """When no data available, return empty list (error signal)."""
         revenues = self.engine.estimate_revenues_from_context(
             previous_outputs={},
             input_context={},
             horizon_years=5,
         )
-        assert len(revenues) == 5
-        assert revenues[0] == 10_000_000.0
+        assert revenues == []
 
 
 class TestRoyaltyRateSelection:

--- a/pipeline-orchestrator-svc/app/core/config.py
+++ b/pipeline-orchestrator-svc/app/core/config.py
@@ -41,6 +41,9 @@ class Settings(BaseSettings):
     VERTEX_AI_LOCATION: str = "global"
     VERTEX_AI_DATA_STORE_ID: str = "prevision-rag-dev"
 
+    # GCP credentials (service account JSON, for GCS + Vertex AI)
+    GCS_CREDENTIALS_JSON: str = ""
+
     # Gemini (answer synthesis)
     GOOGLE_API_KEY: str = ""
     GEMINI_MODEL: str = "gemini-2.0-flash"
@@ -49,6 +52,13 @@ class Settings(BaseSettings):
     # RAG query cache
     RAG_QUERY_CACHE_TTL: int = 3600
     RAG_SESSION_FILES_TTL: int = 86400
+
+    # Agent service URLs (override for Railway/cloud deployment)
+    DISCOVERY_AGENT_URL: str = "http://discovery-agent-svc:8020"
+    CONTENT_AGENT_URL: str = "http://content-agent-svc:8050"
+    SOCIAL_AGENT_URL: str = "http://social-agent-svc:8060"
+    INTELLIGENCE_AGENT_URL: str = "http://intelligence-agent-svc:8030"
+    RAG_UPLOADER_AGENT_URL: str = "http://rag-uploader-agent-svc:8070"
 
 
 settings = Settings()

--- a/pipeline-orchestrator-svc/app/factory/graph_builder.py
+++ b/pipeline-orchestrator-svc/app/factory/graph_builder.py
@@ -12,11 +12,22 @@ from typing import Any
 
 from langgraph.graph import END, StateGraph
 
+from app.core.config import settings
 from app.factory.node_registry import resolve_handler
 from app.nodes.external_wrapper import ExternalWrapper
 from app.state.schema import AgentState
 
 logger = logging.getLogger(__name__)
+
+# Docker Compose service name → settings attribute mapping.
+# Used to translate hardcoded manifest URLs to environment-configured URLs.
+_SERVICE_URL_MAP: dict[str, str] = {
+    "discovery-agent-svc:8020": settings.DISCOVERY_AGENT_URL,
+    "intelligence-agent-svc:8030": settings.INTELLIGENCE_AGENT_URL,
+    "content-agent-svc:8050": settings.CONTENT_AGENT_URL,
+    "social-agent-svc:8060": settings.SOCIAL_AGENT_URL,
+    "rag-uploader-agent-svc:8070": settings.RAG_UPLOADER_AGENT_URL,
+}
 
 
 class GraphBuildError(Exception):
@@ -125,6 +136,7 @@ class GraphBuilder:
                     raise GraphBuildError(
                         f"External node '{node_id}' missing 'url' field"
                     )
+                url = GraphBuilder._translate_url(url)
                 wrapper = ExternalWrapper(
                     url=url, node_id=node_id, config=merged_config
                 )
@@ -160,6 +172,28 @@ class GraphBuilder:
             terminal_nodes,
         )
         return compiled
+
+    @staticmethod
+    def _translate_url(url: str) -> str:
+        """Translate Docker Compose service URLs to environment-configured URLs.
+
+        Manifest nodes may contain hardcoded Docker Compose hostnames
+        (e.g. http://discovery-agent-svc:8020/v1/search). On Railway or
+        other cloud deployments the internal DNS differs. This method
+        replaces the host:port prefix with the value from settings,
+        preserving the URL path.
+        """
+        for compose_host, settings_base in _SERVICE_URL_MAP.items():
+            prefix = f"http://{compose_host}"
+            if url.startswith(prefix):
+                path = url[len(prefix):]  # e.g. "/v1/search"
+                translated = f"{settings_base}{path}"
+                if translated != url:
+                    logger.debug(
+                        "Translated URL: %s → %s", url, translated
+                    )
+                return translated
+        return url
 
     @staticmethod
     def _topological_sort(

--- a/pipeline-orchestrator-svc/app/nodes/external_wrapper.py
+++ b/pipeline-orchestrator-svc/app/nodes/external_wrapper.py
@@ -57,17 +57,25 @@ class ExternalWrapper(BaseNode):
 
         except httpx.HTTPError as exc:
             logger.warning(
-                "External service %s unreachable for node %s: %s. Using stub data.",
+                "External service %s unreachable for node %s: %s",
                 self.url,
                 self.node_id,
                 str(exc),
             )
             result = {
-                "status": "stub",
-                "message": f"External service {self.url} not available",
-                "findings": [f"Stub data: {self.url} was unreachable."],
+                "error": True,
+                "status": "service_unavailable",
+                "message": (
+                    f"The {self.node_id} service is currently unavailable. "
+                    f"Could not connect to {self.url}."
+                ),
+                "findings": [
+                    f"The {self.node_id} service could not be reached. "
+                    f"This pipeline step was skipped."
+                ],
                 "recommendations": [
-                    "Deploy the agent service and re-run the pipeline."
+                    f"The {self.node_id} service may be down or misconfigured. "
+                    f"Please try again later or contact support."
                 ],
             }
 

--- a/pipeline-orchestrator-svc/app/nodes/internal/pipeline_composer.py
+++ b/pipeline-orchestrator-svc/app/nodes/internal/pipeline_composer.py
@@ -38,7 +38,7 @@ NODE_CATALOG: list[dict[str, Any]] = [
     {
         "id": "web_research",
         "type": "external",
-        "url": "http://discovery-agent-svc:8020/v1/search",
+        "url": f"{settings.DISCOVERY_AGENT_URL}/v1/search",
         "description": (
             "Web research: searches the internet via Tavily for current "
             "data, statistics, trends, competitor info. Use when the "
@@ -51,7 +51,7 @@ NODE_CATALOG: list[dict[str, Any]] = [
     {
         "id": "blog_author",
         "type": "external",
-        "url": "http://content-agent-svc:8050/v1/execute",
+        "url": f"{settings.CONTENT_AGENT_URL}/v1/execute",
         "description": (
             "Blog author: writes SEO-optimized blog posts in markdown. "
             "Needs research input from either web_research or "
@@ -64,7 +64,7 @@ NODE_CATALOG: list[dict[str, Any]] = [
     {
         "id": "social_promoter",
         "type": "external",
-        "url": "http://social-agent-svc:8060/v1/execute",
+        "url": f"{settings.SOCIAL_AGENT_URL}/v1/execute",
         "description": (
             "Social media promoter: adapts content for social platforms "
             "and publishes or schedules posts. Use when the prompt "
@@ -77,7 +77,7 @@ NODE_CATALOG: list[dict[str, Any]] = [
     {
         "id": "valuation_logic",
         "type": "external",
-        "url": "http://intelligence-agent-svc:8030/v1/iso-calc",
+        "url": f"{settings.INTELLIGENCE_AGENT_URL}/v1/iso-calc",
         "description": (
             "ISO 10668 brand valuation using Royalty Relief NPV. Use "
             "when the prompt asks about brand valuation, brand equity, "
@@ -89,7 +89,7 @@ NODE_CATALOG: list[dict[str, Any]] = [
     {
         "id": "gap_analyzer",
         "type": "external",
-        "url": "http://intelligence-agent-svc:8030/v1/analyze",
+        "url": f"{settings.INTELLIGENCE_AGENT_URL}/v1/analyze",
         "description": (
             "Competitive gap analysis. Use when the prompt mentions "
             "competitor analysis, audit, competitive gaps, or market "
@@ -101,7 +101,7 @@ NODE_CATALOG: list[dict[str, Any]] = [
     {
         "id": "rag_uploader",
         "type": "external",
-        "url": "http://rag-uploader-agent-svc:8070/v1/execute",
+        "url": f"{settings.RAG_UPLOADER_AGENT_URL}/v1/execute",
         "description": (
             "RAG archivist: persists documents and files to the tenant's "
             "long-term Vertex AI knowledge base. Use when the user wants "

--- a/pipeline-orchestrator-svc/app/nodes/tools/vertex_search_tool.py
+++ b/pipeline-orchestrator-svc/app/nodes/tools/vertex_search_tool.py
@@ -39,7 +39,25 @@ class VertexSearchTool:
     def _get_client(self) -> discoveryengine.SearchServiceClient:
         """Lazy-init the Discovery Engine search client."""
         if self._client is None:
-            self._client = discoveryengine.SearchServiceClient()
+            if settings.GCS_CREDENTIALS_JSON:
+                try:
+                    import json as _json
+
+                    from google.oauth2 import service_account as _sa
+
+                    info = _json.loads(settings.GCS_CREDENTIALS_JSON)
+                    creds = _sa.Credentials.from_service_account_info(info)
+                    self._client = discoveryengine.SearchServiceClient(
+                        credentials=creds
+                    )
+                except Exception:
+                    logger.warning(
+                        "Failed to parse GCS_CREDENTIALS_JSON for Vertex AI, "
+                        "falling back to ADC"
+                    )
+                    self._client = discoveryengine.SearchServiceClient()
+            else:
+                self._client = discoveryengine.SearchServiceClient()
         return self._client
 
     def _get_data_store_path(

--- a/pipeline-orchestrator-svc/app/services/gcs_reader.py
+++ b/pipeline-orchestrator-svc/app/services/gcs_reader.py
@@ -1,14 +1,30 @@
 """Async GCS file reader for downloading chat attachments."""
 
 import asyncio
+import json
 import logging
 from concurrent.futures import ThreadPoolExecutor
 
 from google.cloud import storage
+from google.oauth2 import service_account
+
+from app.core.config import settings
 
 logger = logging.getLogger(__name__)
 
 _executor = ThreadPoolExecutor(max_workers=4)
+
+
+def _build_storage_client() -> storage.Client:
+    """Build a GCS client using service account JSON from config, or ADC."""
+    if settings.GCS_CREDENTIALS_JSON:
+        try:
+            info = json.loads(settings.GCS_CREDENTIALS_JSON)
+            credentials = service_account.Credentials.from_service_account_info(info)
+            return storage.Client(credentials=credentials, project=info.get("project_id"))
+        except Exception:
+            logger.warning("Failed to parse GCS_CREDENTIALS_JSON, falling back to ADC")
+    return storage.Client()
 
 
 async def download_from_gcs(
@@ -32,7 +48,7 @@ async def download_from_gcs(
 
 def _download_sync(bucket_name: str, blob_path: str) -> tuple[str, bytes]:
     """Synchronous GCS download."""
-    client = storage.Client()
+    client = _build_storage_client()
     bucket = client.bucket(bucket_name)
     blob = bucket.blob(blob_path)
     content = blob.download_as_bytes()

--- a/pipeline-orchestrator-svc/tests/test_external_wrapper.py
+++ b/pipeline-orchestrator-svc/tests/test_external_wrapper.py
@@ -60,7 +60,7 @@ class TestExternalWrapper:
         assert request.headers["X-Tenant-ID"] == "1"
 
     async def test_fallback_on_connection_error(self, httpx_mock):
-        """On HTTP error, returns stub data instead of raising."""
+        """On HTTP error, returns error data instead of raising."""
         import httpx
 
         httpx_mock.add_exception(
@@ -76,10 +76,11 @@ class TestExternalWrapper:
 
         outputs = result.get("node_outputs", {})
         assert "gap_analyzer" in outputs
-        assert outputs["gap_analyzer"]["status"] == "stub"
+        assert outputs["gap_analyzer"]["status"] == "service_unavailable"
+        assert outputs["gap_analyzer"]["error"] is True
 
     async def test_fallback_on_500_error(self, httpx_mock):
-        """On 5xx response, returns stub data."""
+        """On 5xx response, returns error data."""
         httpx_mock.add_response(
             url="http://discovery-agent-svc:8020/v1/search",
             method="POST",
@@ -94,4 +95,5 @@ class TestExternalWrapper:
 
         outputs = result.get("node_outputs", {})
         assert "web_research" in outputs
-        assert outputs["web_research"]["status"] == "stub"
+        assert outputs["web_research"]["status"] == "service_unavailable"
+        assert outputs["web_research"]["error"] is True

--- a/rag-uploader-agent-service/app/core/config.py
+++ b/rag-uploader-agent-service/app/core/config.py
@@ -30,6 +30,7 @@ class Settings(BaseSettings):
     GCS_PROJECT_ID: str = ""
     GCS_BUCKET_NAME: str = ""
     GCS_CREDENTIALS_PATH: str = ""
+    GCS_CREDENTIALS_JSON: str = ""
 
     # Core API (Django backend) for BrandAsset registration
     CORE_API_URL: str = "http://localhost:8001"

--- a/rag-uploader-agent-service/app/logic/context_parser.py
+++ b/rag-uploader-agent-service/app/logic/context_parser.py
@@ -37,7 +37,7 @@ _MIME_MAP: dict[str, str] = {
     ".zip": "application/zip",
 }
 
-_GCS_URI_PATTERN = re.compile(r"gs://[a-zA-Z0-9._\-]+/\S+")
+_GCS_URI_PATTERN = re.compile(r"gs://[a-zA-Z0-9._\-]+/[^\s`'\")\],;]+")
 
 
 def extract_gcs_uris(data: Any) -> list[str]:

--- a/rag-uploader-agent-service/app/logic/file_resolver.py
+++ b/rag-uploader-agent-service/app/logic/file_resolver.py
@@ -89,6 +89,11 @@ class FileResolver:
                 try:
                     bucket, path = parse_gcs_uri(blog_uri)
                     file_name = path.rsplit("/", 1)[-1] if "/" in path else path
+                    # Compute file size from blog_content if available
+                    blog_content = blog_output.get("blog_content", "")
+                    file_size = (
+                        len(blog_content.encode("utf-8")) if blog_content else 0
+                    )
                     files.append(
                         ResolvedFile(
                             gcs_uri=blog_uri,
@@ -96,7 +101,7 @@ class FileResolver:
                             path=path,
                             file_name=file_name,
                             file_type=infer_mime_type(file_name),
-                            file_size_bytes=0,
+                            file_size_bytes=file_size,
                             source="blog_author",
                         )
                     )

--- a/rag-uploader-agent-service/app/main.py
+++ b/rag-uploader-agent-service/app/main.py
@@ -68,6 +68,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         project_id=settings.GCS_PROJECT_ID,
         bucket_name=settings.GCS_BUCKET_NAME,
         credentials_path=settings.GCS_CREDENTIALS_PATH,
+        credentials_json=settings.GCS_CREDENTIALS_JSON,
     )
 
     # Initialize Core API client (for BrandAsset registration)

--- a/rag-uploader-agent-service/app/services/gcs_client.py
+++ b/rag-uploader-agent-service/app/services/gcs_client.py
@@ -23,10 +23,12 @@ class GCSClient:
         project_id: str = "",
         bucket_name: str = "",
         credentials_path: str = "",
+        credentials_json: str = "",
     ) -> None:
         self.project_id = project_id
         self.bucket_name = bucket_name
         self.credentials_path = credentials_path
+        self.credentials_json = credentials_json
         self._client: Any = None
         self._stub_mode = not project_id or not bucket_name
 
@@ -45,7 +47,17 @@ class GCSClient:
             try:
                 from google.cloud import storage
 
-                if self.credentials_path:
+                if self.credentials_json:
+                    import json as _json
+
+                    from google.oauth2 import service_account
+
+                    info = _json.loads(self.credentials_json)
+                    creds = service_account.Credentials.from_service_account_info(info)
+                    self._client = storage.Client(
+                        credentials=creds, project=info.get("project_id")
+                    )
+                elif self.credentials_path:
                     self._client = storage.Client.from_service_account_json(
                         self.credentials_path
                     )


### PR DESCRIPTION
## Summary
- Stop passing financial data from chat flow to intelligence agent — only `company_name` and `sector` are sent so both chat and pipeline UI flows use the intelligence agent's own Gemini lookup
- Add Redis caching for Gemini company data lookups (4h TTL) to eliminate non-deterministic results between flows
- Add Gemini company data lookup with validation, error handling, and abort logic when no revenue data is available
- Update CI/CD deploy workflow, orchestrator, content agent, RAG uploader with deployment and GCS config fixes

## Test plan
- [x] Backend tests pass (39/39 views tests including new `test_pipeline_job_excludes_financial_data`)
- [x] Intelligence agent tests pass (16/16 including new Gemini lookup tests)
- [ ] After merge: trigger "Calculate brand equity for Nike" from both chat and pipeline UI — results should be identical
- [ ] Verify Redis caching works: second request within 4h should show "Company data cache HIT" in intelligence agent logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)