### PR TITLE
fix: unify chat and pipeline UI brand valuation flows

### DIFF
--- a/ai-brand-automator/ai_services/tests/test_views.py
+++ b/ai-brand-automator/ai_services/tests/test_views.py
@@ -549,6 +549,61 @@ class TestChatWithAIPipelineIntegration:
                 f"intelligence agent does its own lookup"
             )
 
+    @patch("orchestration.tasks.dispatch_job_task")
+    @patch("ai_services.services.GeminiAIService.extract_target_brand")
+    @patch("ai_services.services.GeminiAIService.classify_intent")
+    def test_brand_valuation_uses_iso_manifest(
+        self,
+        mock_classify,
+        mock_extract,
+        mock_dispatch,
+        authenticated_client_with_tenant,
+        public_tenant,
+    ):
+        """Brand valuation from chat should use the iso-brand-equity manifest."""
+        from orchestration.models import PipelineManifest
+
+        PipelineManifest.objects.create(
+            pipeline_id="iso-brand-equity",
+            name="ISO Brand Equity",
+            manifest_data={
+                "nodes": [
+                    {"id": "web_research", "type": "external"},
+                    {"id": "valuation_logic", "type": "external"},
+                    {"id": "manager", "type": "internal"},
+                ],
+                "edges": [
+                    ["web_research", "valuation_logic"],
+                    ["valuation_logic", "manager"],
+                ],
+            },
+            version=1,
+            is_active=True,
+            tenant=public_tenant,
+        )
+
+        mock_classify.return_value = {"intent": "pipeline", "confidence": 0.9}
+        mock_extract.return_value = {
+            "company_name": "Nike",
+            "sector": "consumer_goods",
+        }
+
+        response = authenticated_client_with_tenant.post(
+            self.url(),
+            {"message": "Calculate brand equity for Nike"},
+            format="json",
+        )
+
+        from orchestration.models import AnalysisJob
+
+        job = AnalysisJob.objects.get(
+            job_id=response.data["pipeline_job"]["job_id"]
+        )
+        assert job.manifest is not None, (
+            "Brand valuation job should use iso-brand-equity manifest"
+        )
+        assert job.manifest.pipeline_id == "iso-brand-equity"
+
 
 @pytest.mark.django_db
 @pytest.mark.unit

--- a/ai-brand-automator/ai_services/tests/test_views.py
+++ b/ai-brand-automator/ai_services/tests/test_views.py
@@ -529,9 +529,7 @@ class TestChatWithAIPipelineIntegration:
 
         from orchestration.models import AnalysisJob
 
-        job = AnalysisJob.objects.get(
-            job_id=response.data["pipeline_job"]["job_id"]
-        )
+        job = AnalysisJob.objects.get(job_id=response.data["pipeline_job"]["job_id"])
         # company_name and sector should be present
         assert job.input_context["company_name"] == "Nike"
         assert job.input_context["sector"] == "consumer_goods"
@@ -596,12 +594,10 @@ class TestChatWithAIPipelineIntegration:
 
         from orchestration.models import AnalysisJob
 
-        job = AnalysisJob.objects.get(
-            job_id=response.data["pipeline_job"]["job_id"]
-        )
-        assert job.manifest is not None, (
-            "Brand valuation job should use iso-brand-equity manifest"
-        )
+        job = AnalysisJob.objects.get(job_id=response.data["pipeline_job"]["job_id"])
+        assert (
+            job.manifest is not None
+        ), "Brand valuation job should use iso-brand-equity manifest"
         assert job.manifest.pipeline_id == "iso-brand-equity"
 
 

--- a/ai-brand-automator/ai_services/tests/test_views.py
+++ b/ai-brand-automator/ai_services/tests/test_views.py
@@ -508,7 +508,7 @@ class TestChatWithAIPipelineIntegration:
         authenticated_client_with_tenant,
         public_tenant,
     ):
-        """Financial data NOT in job_context — intelligence agent does its own lookup."""
+        """Financial data NOT in job_context — intel agent looks up."""
         mock_classify.return_value = {"intent": "pipeline", "confidence": 0.9}
         mock_extract.return_value = {
             "company_name": "Nike",

--- a/ai-brand-automator/ai_services/views.py
+++ b/ai-brand-automator/ai_services/views.py
@@ -362,7 +362,7 @@ def _process_chat_message(
 
     if intent_result["intent"] == "pipeline":
         # Lazy imports to avoid circular dependency with orchestration app
-        from orchestration.models import AnalysisJob
+        from orchestration.models import AnalysisJob, PipelineManifest
         from orchestration.tasks import dispatch_job_task
 
         target_brand = GeminiAIService.extract_target_brand(message)
@@ -427,8 +427,21 @@ def _process_chat_message(
                 job_context["brand_voice"] = company_info.get("brand_voice", "")
                 job_context["core_problem"] = company_info.get("core_problem", "")
 
+        # Use the same manifest as pipeline UI for brand valuation
+        # so both flows execute the same graph (including web_research).
+        manifest = None
+        if target_brand:
+            manifest = (
+                PipelineManifest.objects.filter(
+                    pipeline_id="iso-brand-equity", is_active=True
+                )
+                .order_by("-version")
+                .first()
+            )
+
         job = AnalysisJob.objects.create(
             tenant=tenant,
+            manifest=manifest,
             input_prompt=message,
             input_context=job_context,
             created_by=request.user,

--- a/ai-brand-automator/ai_services/views.py
+++ b/ai-brand-automator/ai_services/views.py
@@ -429,15 +429,18 @@ def _process_chat_message(
 
         # Use the same manifest as pipeline UI for brand valuation
         # so both flows execute the same graph (including web_research).
+        # extract_target_brand() only returns non-None for brand valuation
+        # patterns (brand equity/valuation/value/strength), so this won't
+        # match broader analysis prompts.
         manifest = None
         if target_brand:
+            _mf_qs = PipelineManifest.objects.filter(
+                pipeline_id="iso-brand-equity", is_active=True
+            ).order_by("-version")
+            # Prefer tenant-specific manifest, fall back to global
             manifest = (
-                PipelineManifest.objects.filter(
-                    pipeline_id="iso-brand-equity", is_active=True
-                )
-                .order_by("-version")
-                .first()
-            )
+                _mf_qs.filter(tenant=tenant).first() if tenant else None
+            ) or _mf_qs.filter(tenant__isnull=True).first()
 
         job = AnalysisJob.objects.create(
             tenant=tenant,

--- a/intelligence-agent-svc/app/cache/redis_manager.py
+++ b/intelligence-agent-svc/app/cache/redis_manager.py
@@ -151,13 +151,11 @@ class RedisManager:
         )
         return n.strip().rstrip(",").strip()
 
-    # --- Company Data Cache ---
-
     async def get_company_data(self, company_name: str) -> Optional[dict[str, Any]]:
         """Get cached Gemini company data lookup result."""
         try:
             r = await self._get_redis()
-            key = f"intel:company:{company_name.lower().strip()}"
+            key = f"intel:company:{self._normalize_company(company_name)}"
             data = await r.get(key)
             if data is not None:
                 logger.debug("Company data cache HIT for: %s", company_name)
@@ -173,7 +171,7 @@ class RedisManager:
         """Cache company data with 4-hour TTL."""
         try:
             r = await self._get_redis()
-            key = f"intel:company:{company_name.lower().strip()}"
+            key = f"intel:company:{self._normalize_company(company_name)}"
             await r.set(key, json.dumps(data), ex=RESULT_CACHE_TTL)
             logger.debug("Company data cache SET for: %s", company_name)
         except Exception as exc:


### PR DESCRIPTION
## Summary

- **Chat flow now uses the same `iso-brand-equity` manifest** as the pipeline UI, ensuring both flows execute the same graph (including `web_research` → `valuation_logic` → `manager`). Previously, chat used auto-detect mode which often skipped `web_research`, producing different BSI/NPV values.
- **Redis cache key normalization fixed** — `_normalize_company()` was defined but not wired into `get_company_data`/`set_company_data`. Now 'NIKE, Inc.', 'Nike Inc', and 'Nike' all map to the same cache key `intel:company:nike`.

## Test plan

- [x] `pytest ai_services/tests/test_views.py -v` — 40/40 pass (new test: `test_brand_valuation_uses_iso_manifest`)
- [x] `pytest intelligence-agent-svc/tests/ -v -m "not integration"` — 99/99 pass
- [ ] After merge: flush Redis `intel:company:*` keys on intelligence agent (DB 3)
- [ ] After merge: test "Calculate brand equity for Nike" from both chat and pipeline UI — results should match

🤖 Generated with [Claude Code](https://claude.com/claude-code)