### PR TITLE
fix: competitor analysis pipeline — missing results + chat trigger

### DIFF
--- a/ai-brand-automator/ai_services/tests/test_views.py
+++ b/ai-brand-automator/ai_services/tests/test_views.py
@@ -600,6 +600,59 @@ class TestChatWithAIPipelineIntegration:
         ), "Brand valuation job should use iso-brand-equity manifest"
         assert job.manifest.pipeline_id == "iso-brand-equity"
 
+    @patch("orchestration.tasks.dispatch_job_task")
+    @patch("ai_services.services.GeminiAIService.extract_target_brand")
+    @patch("ai_services.services.GeminiAIService.classify_intent")
+    def test_competitor_analysis_uses_audit_manifest(
+        self,
+        mock_classify,
+        mock_extract,
+        mock_dispatch,
+        authenticated_client_with_tenant,
+        public_tenant,
+    ):
+        """Competitor analysis from chat uses competitor-audit manifest."""
+        from orchestration.models import PipelineManifest
+
+        PipelineManifest.objects.create(
+            pipeline_id="competitor-audit",
+            name="Competitor Audit",
+            manifest_data={
+                "nodes": [
+                    {"id": "competitor_research", "type": "external"},
+                    {"id": "gap_analyzer", "type": "external"},
+                    {"id": "manager", "type": "internal"},
+                ],
+                "edges": [
+                    ["competitor_research", "gap_analyzer"],
+                    ["gap_analyzer", "manager"],
+                ],
+            },
+            version=1,
+            is_active=True,
+            tenant=public_tenant,
+        )
+
+        mock_classify.return_value = {
+            "intent": "pipeline",
+            "confidence": 0.9,
+        }
+        mock_extract.return_value = None  # No brand valuation
+
+        response = authenticated_client_with_tenant.post(
+            self.url(),
+            {"message": "Analyze competitor landscape for Nike"},
+            format="json",
+        )
+
+        from orchestration.models import AnalysisJob
+
+        job = AnalysisJob.objects.get(job_id=response.data["pipeline_job"]["job_id"])
+        assert (
+            job.manifest is not None
+        ), "Competitor analysis should use competitor-audit manifest"
+        assert job.manifest.pipeline_id == "competitor-audit"
+
 
 @pytest.mark.django_db
 @pytest.mark.unit

--- a/ai-brand-automator/ai_services/tests/test_views.py
+++ b/ai-brand-automator/ai_services/tests/test_views.py
@@ -550,7 +550,7 @@ class TestChatWithAIPipelineIntegration:
     @patch("orchestration.tasks.dispatch_job_task")
     @patch("ai_services.services.GeminiAIService.extract_target_brand")
     @patch("ai_services.services.GeminiAIService.classify_intent")
-    def test_brand_valuation_uses_iso_manifest(
+    def test_chat_pipeline_uses_auto_detect(
         self,
         mock_classify,
         mock_extract,
@@ -558,29 +558,11 @@ class TestChatWithAIPipelineIntegration:
         authenticated_client_with_tenant,
         public_tenant,
     ):
-        """Brand valuation from chat should use the iso-brand-equity manifest."""
-        from orchestration.models import PipelineManifest
-
-        PipelineManifest.objects.create(
-            pipeline_id="iso-brand-equity",
-            name="ISO Brand Equity",
-            manifest_data={
-                "nodes": [
-                    {"id": "web_research", "type": "external"},
-                    {"id": "valuation_logic", "type": "external"},
-                    {"id": "manager", "type": "internal"},
-                ],
-                "edges": [
-                    ["web_research", "valuation_logic"],
-                    ["valuation_logic", "manager"],
-                ],
-            },
-            version=1,
-            is_active=True,
-            tenant=public_tenant,
-        )
-
-        mock_classify.return_value = {"intent": "pipeline", "confidence": 0.9}
+        """Chat pipelines always use auto-detect (no manifest)."""
+        mock_classify.return_value = {
+            "intent": "pipeline",
+            "confidence": 0.9,
+        }
         mock_extract.return_value = {
             "company_name": "Nike",
             "sector": "consumer_goods",
@@ -596,62 +578,8 @@ class TestChatWithAIPipelineIntegration:
 
         job = AnalysisJob.objects.get(job_id=response.data["pipeline_job"]["job_id"])
         assert (
-            job.manifest is not None
-        ), "Brand valuation job should use iso-brand-equity manifest"
-        assert job.manifest.pipeline_id == "iso-brand-equity"
-
-    @patch("orchestration.tasks.dispatch_job_task")
-    @patch("ai_services.services.GeminiAIService.extract_target_brand")
-    @patch("ai_services.services.GeminiAIService.classify_intent")
-    def test_competitor_analysis_uses_audit_manifest(
-        self,
-        mock_classify,
-        mock_extract,
-        mock_dispatch,
-        authenticated_client_with_tenant,
-        public_tenant,
-    ):
-        """Competitor analysis from chat uses competitor-audit manifest."""
-        from orchestration.models import PipelineManifest
-
-        PipelineManifest.objects.create(
-            pipeline_id="competitor-audit",
-            name="Competitor Audit",
-            manifest_data={
-                "nodes": [
-                    {"id": "competitor_research", "type": "external"},
-                    {"id": "gap_analyzer", "type": "external"},
-                    {"id": "manager", "type": "internal"},
-                ],
-                "edges": [
-                    ["competitor_research", "gap_analyzer"],
-                    ["gap_analyzer", "manager"],
-                ],
-            },
-            version=1,
-            is_active=True,
-            tenant=public_tenant,
-        )
-
-        mock_classify.return_value = {
-            "intent": "pipeline",
-            "confidence": 0.9,
-        }
-        mock_extract.return_value = None  # No brand valuation
-
-        response = authenticated_client_with_tenant.post(
-            self.url(),
-            {"message": "Analyze competitor landscape for Nike"},
-            format="json",
-        )
-
-        from orchestration.models import AnalysisJob
-
-        job = AnalysisJob.objects.get(job_id=response.data["pipeline_job"]["job_id"])
-        assert (
-            job.manifest is not None
-        ), "Competitor analysis should use competitor-audit manifest"
-        assert job.manifest.pipeline_id == "competitor-audit"
+            job.manifest is None
+        ), "Chat jobs should use auto-detect, not a fixed manifest"
 
 
 @pytest.mark.django_db

--- a/ai-brand-automator/ai_services/views.py
+++ b/ai-brand-automator/ai_services/views.py
@@ -246,43 +246,6 @@ def _collect_attachment_data(attachment_ids, session):
     return data
 
 
-_COMPETITOR_KEYWORDS = (
-    "competitor",
-    "competitive",
-    "gap analysis",
-    "market comparison",
-    "audit",
-)
-
-
-def _lookup_manifest(pipeline_id, tenant):
-    """Look up an active manifest, preferring tenant-specific over global."""
-    from orchestration.models import PipelineManifest
-
-    qs = PipelineManifest.objects.filter(
-        pipeline_id=pipeline_id, is_active=True
-    ).order_by("-version")
-    return (qs.filter(tenant=tenant).first() if tenant else None) or qs.filter(
-        tenant__isnull=True
-    ).first()
-
-
-def _resolve_chat_manifest(message, target_brand, tenant):
-    """Resolve the pipeline manifest for a chat-triggered job.
-
-    Brand valuation requests use iso-brand-equity; competitor analysis
-    requests use competitor-audit. Returns None for auto-detect.
-    """
-    if target_brand:
-        return _lookup_manifest("iso-brand-equity", tenant)
-
-    msg_lower = message.lower()
-    if any(kw in msg_lower for kw in _COMPETITOR_KEYWORDS):
-        return _lookup_manifest("competitor-audit", tenant)
-
-    return None
-
-
 def _process_chat_message(
     request, session, message, tenant, is_new_session, serializer
 ):
@@ -464,13 +427,11 @@ def _process_chat_message(
                 job_context["brand_voice"] = company_info.get("brand_voice", "")
                 job_context["core_problem"] = company_info.get("core_problem", "")
 
-        # Attach the correct manifest so chat uses the same pipeline
-        # graph as the pipeline UI for known pipeline types.
-        manifest = _resolve_chat_manifest(message, target_brand, tenant)
-
+        # Chat always uses auto-detect (no manifest). The orchestrator's
+        # PipelineComposer dynamically selects and orders agent nodes
+        # based on the prompt via Gemini function-calling.
         job = AnalysisJob.objects.create(
             tenant=tenant,
-            manifest=manifest,
             input_prompt=message,
             input_context=job_context,
             created_by=request.user,

--- a/ai-brand-automator/ai_services/views.py
+++ b/ai-brand-automator/ai_services/views.py
@@ -246,6 +246,43 @@ def _collect_attachment_data(attachment_ids, session):
     return data
 
 
+_COMPETITOR_KEYWORDS = (
+    "competitor",
+    "competitive",
+    "gap analysis",
+    "market comparison",
+    "audit",
+)
+
+
+def _lookup_manifest(pipeline_id, tenant):
+    """Look up an active manifest, preferring tenant-specific over global."""
+    from orchestration.models import PipelineManifest
+
+    qs = PipelineManifest.objects.filter(
+        pipeline_id=pipeline_id, is_active=True
+    ).order_by("-version")
+    return (qs.filter(tenant=tenant).first() if tenant else None) or qs.filter(
+        tenant__isnull=True
+    ).first()
+
+
+def _resolve_chat_manifest(message, target_brand, tenant):
+    """Resolve the pipeline manifest for a chat-triggered job.
+
+    Brand valuation requests use iso-brand-equity; competitor analysis
+    requests use competitor-audit. Returns None for auto-detect.
+    """
+    if target_brand:
+        return _lookup_manifest("iso-brand-equity", tenant)
+
+    msg_lower = message.lower()
+    if any(kw in msg_lower for kw in _COMPETITOR_KEYWORDS):
+        return _lookup_manifest("competitor-audit", tenant)
+
+    return None
+
+
 def _process_chat_message(
     request, session, message, tenant, is_new_session, serializer
 ):
@@ -362,7 +399,7 @@ def _process_chat_message(
 
     if intent_result["intent"] == "pipeline":
         # Lazy imports to avoid circular dependency with orchestration app
-        from orchestration.models import AnalysisJob, PipelineManifest
+        from orchestration.models import AnalysisJob
         from orchestration.tasks import dispatch_job_task
 
         target_brand = GeminiAIService.extract_target_brand(message)
@@ -427,20 +464,9 @@ def _process_chat_message(
                 job_context["brand_voice"] = company_info.get("brand_voice", "")
                 job_context["core_problem"] = company_info.get("core_problem", "")
 
-        # Use the same manifest as pipeline UI for brand valuation
-        # so both flows execute the same graph (including web_research).
-        # extract_target_brand() only returns non-None for brand valuation
-        # patterns (brand equity/valuation/value/strength), so this won't
-        # match broader analysis prompts.
-        manifest = None
-        if target_brand:
-            _mf_qs = PipelineManifest.objects.filter(
-                pipeline_id="iso-brand-equity", is_active=True
-            ).order_by("-version")
-            # Prefer tenant-specific manifest, fall back to global
-            manifest = (
-                _mf_qs.filter(tenant=tenant).first() if tenant else None
-            ) or _mf_qs.filter(tenant__isnull=True).first()
+        # Attach the correct manifest so chat uses the same pipeline
+        # graph as the pipeline UI for known pipeline types.
+        manifest = _resolve_chat_manifest(message, target_brand, tenant)
 
         job = AnalysisJob.objects.create(
             tenant=tenant,

--- a/ai-brand-automator/orchestration/management/commands/seed_manifests.py
+++ b/ai-brand-automator/orchestration/management/commands/seed_manifests.py
@@ -93,15 +93,15 @@ class Command(BaseCommand):
                         "handler": "StrategyNode",
                     },
                     {
-                        "id": "report_generator",
+                        "id": "manager",
                         "type": "internal",
-                        "handler": "ReportNode",
+                        "handler": "ManagerNode",
                     },
                 ],
                 "edges": [
                     ["intent_router", "market_research"],
                     ["market_research", "brand_strategist"],
-                    ["brand_strategist", "report_generator"],
+                    ["brand_strategist", "manager"],
                 ],
                 "global_config": {
                     "model": "gemini-2.0-flash",
@@ -140,15 +140,15 @@ class Command(BaseCommand):
                         },
                     },
                     {
-                        "id": "report_generator",
+                        "id": "manager",
                         "type": "internal",
-                        "handler": "ReportNode",
+                        "handler": "ManagerNode",
                     },
                 ],
                 "edges": [
                     ["intent_router", "competitor_research"],
                     ["competitor_research", "gap_analyzer"],
-                    ["gap_analyzer", "report_generator"],
+                    ["gap_analyzer", "manager"],
                 ],
                 "global_config": {
                     "model": "gemini-2.0-flash",

--- a/ai-brand-automator/orchestration/result_handler.py
+++ b/ai-brand-automator/orchestration/result_handler.py
@@ -234,6 +234,10 @@ def _build_result_summary(job):
     if social_output or blog_output:
         return _build_content_social_summary(blog_output, social_output)
 
+    gap_output = node_results.get("gap_analyzer", {})
+    if gap_output and gap_output.get("analysis_type") == "competitive_gap":
+        return _build_gap_analysis_summary(gap_output)
+
     if "summary" in result:
         return result["summary"]
 
@@ -307,4 +311,30 @@ def _build_content_social_summary(blog_output, social_output):
     if not parts:
         return "Content pipeline completed successfully."
 
+    return "\n".join(parts)
+
+
+def _build_gap_analysis_summary(gap_output):
+    """Build a summary for competitive gap analysis results."""
+    gap_data = gap_output.get("gap_analysis", {})
+    strengths = len(gap_data.get("strengths", []))
+    gaps = len(gap_data.get("gaps", []))
+    opps = len(gap_data.get("market_opportunities", []))
+
+    parts = ["**Competitor Audit completed.**"]
+    if strengths or gaps:
+        parts.append(
+            f"Identified {strengths} competitive "
+            f"strength(s) and {gaps} market gap(s)."
+        )
+    if opps:
+        parts.append(f"{opps} market opportunity(ies) recommended.")
+
+    findings = gap_output.get("findings", [])
+    if findings:
+        parts.append("")
+        for f in findings[:3]:
+            parts.append(f"- {f}")
+
+    parts.append("\nView the full results in the pipeline card above.")
     return "\n".join(parts)

--- a/tests/integration/phase1_contracts/test_intelligence_contract.py
+++ b/tests/integration/phase1_contracts/test_intelligence_contract.py
@@ -21,7 +21,20 @@ class TestIntelligenceContract:
     ):
         """POST /v1/iso-calc returns valuation and BSI objects."""
         payload = make_agent_payload(
+            input_prompt="Calculate brand equity for TestCorp",
             config={"method": "royalty_relief", "horizon_years": 5},
+        )
+        # Provide financial data so valuation works without Gemini
+        payload["input_context"].update(
+            {
+                "company_name": "TestCorp",
+                "sector": "technology",
+                "base_revenue": 1_000_000_000,
+                "growth_rate": 0.08,
+                "profit_margin": 0.15,
+                "brand_awareness": 70,
+                "market_share": 0.10,
+            }
         )
         resp = await http_client.post(
             f"{INTELLIGENCE_URL}/v1/iso-calc",
@@ -53,7 +66,9 @@ class TestIntelligenceContract:
         assert isinstance(bsi["score"], int)
         assert 0 <= bsi["score"] <= 100
 
-    async def test_analyze_returns_gap_analysis(self, http_client, tenant_headers):
+    async def test_analyze_returns_gap_analysis(
+        self, http_client, tenant_headers
+    ):
         """POST /v1/analyze returns findings and recommendations."""
         payload = make_agent_payload(
             config={"analysis_type": "competitive_gap"},
@@ -84,10 +99,23 @@ class TestIntelligenceContract:
         assert "recommendations" in data
         assert len(data["findings"]) > 0
 
-    async def test_execute_routes_by_config_method(self, http_client, tenant_headers):
-        """config.method='royalty_relief' triggers ISO valuation path."""
+    async def test_execute_routes_by_config_method(
+        self, http_client, tenant_headers
+    ):
+        """royalty_relief config triggers ISO valuation path."""
         payload = make_agent_payload(
+            input_prompt="Calculate brand equity for TestCorp",
             config={"method": "royalty_relief"},
+        )
+        payload["input_context"].update(
+            {
+                "company_name": "TestCorp",
+                "sector": "technology",
+                "base_revenue": 1_000_000_000,
+                "growth_rate": 0.08,
+                "profit_margin": 0.15,
+                "brand_awareness": 70,
+            }
         )
         resp = await http_client.post(
             f"{INTELLIGENCE_URL}/v1/execute",
@@ -102,8 +130,10 @@ class TestIntelligenceContract:
             or data.get("methodology") == "royalty_relief"
         )
 
-    async def test_execute_routes_by_analysis_type(self, http_client, tenant_headers):
-        """config.analysis_type='competitive_gap' triggers gap analysis."""
+    async def test_execute_routes_by_analysis_type(
+        self, http_client, tenant_headers
+    ):
+        """competitive_gap config triggers gap analysis."""
         payload = make_agent_payload(
             config={"analysis_type": "competitive_gap"},
         )
@@ -116,10 +146,23 @@ class TestIntelligenceContract:
         data = resp.json()
         assert "findings" in data
 
-    async def test_bsi_schema_has_pillars(self, http_client, tenant_headers):
-        """BSI pillars are a list of {name, weight, score, rationale}."""
+    async def test_bsi_schema_has_pillars(
+        self, http_client, tenant_headers
+    ):
+        """BSI pillars: list of {name, weight, score, rationale}."""
         payload = make_agent_payload(
+            input_prompt="Calculate brand equity for TestCorp",
             config={"method": "royalty_relief"},
+        )
+        payload["input_context"].update(
+            {
+                "company_name": "TestCorp",
+                "sector": "technology",
+                "base_revenue": 1_000_000_000,
+                "growth_rate": 0.08,
+                "profit_margin": 0.15,
+                "brand_awareness": 70,
+            }
         )
         resp = await http_client.post(
             f"{INTELLIGENCE_URL}/v1/iso-calc",
@@ -147,7 +190,18 @@ class TestIntelligenceContract:
     async def test_valuation_schema_has_npv(self, http_client, tenant_headers):
         """Valuation object has brand_value_npv as positive float."""
         payload = make_agent_payload(
+            input_prompt="Calculate brand equity for TestCorp",
             config={"method": "royalty_relief", "horizon_years": 5},
+        )
+        payload["input_context"].update(
+            {
+                "company_name": "TestCorp",
+                "sector": "technology",
+                "base_revenue": 1_000_000_000,
+                "growth_rate": 0.08,
+                "profit_margin": 0.15,
+                "brand_awareness": 70,
+            }
         )
         resp = await http_client.post(
             f"{INTELLIGENCE_URL}/v1/iso-calc",

--- a/tests/integration/phase2_domain/test_bsi_scoring.py
+++ b/tests/integration/phase2_domain/test_bsi_scoring.py
@@ -117,8 +117,10 @@ class TestBSIScoring:
         total_weight = sum(p["weight"] for p in bsi["pillars"])
         assert total_weight == pytest.approx(1.0, abs=0.01)
 
-    async def test_no_data_uses_stubs(self, http_client, tenant_headers):
-        """No pillar data -> stub scores, completeness=0.0."""
+    async def test_no_data_returns_zero_score(
+        self, http_client, tenant_headers
+    ):
+        """No pillar data -> score=0, completeness=0.0."""
         payload = make_agent_payload(
             input_prompt="BSI test: no pillar data stubs",
             config={"method": "royalty_relief"},
@@ -136,8 +138,10 @@ class TestBSIScoring:
         bsi = data["bsi"]
 
         assert bsi["data_completeness"] == 0.0
-        assert bsi["score"] > 0  # Stub scores produce non-zero BSI
-        assert bsi["score"] <= 100
+        # No pillar data available → BSI score is 0
+        assert bsi["score"] == 0
+        # All 3 pillars listed with rationale
+        assert len(bsi["pillars"]) == 3
 
     async def test_bsi_score_clamped_0_100(self, http_client, tenant_headers):
         """Extreme inputs never produce score outside 0-100."""

--- a/tests/integration/phase2_domain/test_golden_path.py
+++ b/tests/integration/phase2_domain/test_golden_path.py
@@ -66,6 +66,17 @@ class TestGoldenPath:
             manifest=ISO_BRAND_EQUITY_MANIFEST,
             callback_url="http://host.docker.internal:9998/callback",
         )
+        # Provide financial data so valuation works without Gemini
+        payload["input_context"].update(
+            {
+                "company_name": "TestCorp",
+                "sector": "technology",
+                "base_revenue": 1_000_000_000,
+                "growth_rate": 0.08,
+                "profit_margin": 0.15,
+                "brand_awareness": 70,
+            }
+        )
         resp = await http_client.post(
             f"{ORCHESTRATOR_URL}/v1/jobs/dispatch",
             json=payload,

--- a/tests/integration/phase2_domain/test_npv_benchmarks.py
+++ b/tests/integration/phase2_domain/test_npv_benchmarks.py
@@ -34,6 +34,9 @@ class TestNPVBenchmarks:
           PV(TV) = 4,100,000 / 1.10^5 = 2,545,777.45
 
         Total NPV = 1,137,236.01 + 2,545,777.45 = 3,683,013.46
+
+        Note: brand_awareness=50 ensures BSI >= 40, avoiding the
+        10% royalty rate discount applied to weak brands (BSI < 40).
         """
         payload = make_agent_payload(
             input_prompt="NPV benchmark: 5-year flat $10M technology",
@@ -51,6 +54,7 @@ class TestNPVBenchmarks:
                 10_000_000,
             ],
             "sector": "technology",
+            "brand_awareness": 50,
         }
 
         resp = await http_client.post(
@@ -70,8 +74,10 @@ class TestNPVBenchmarks:
         assert val["horizon_years"] == 5
         assert len(val["annual_royalties"]) == 5
 
-    async def test_npv_empty_revenues_uses_stub(self, http_client, tenant_headers):
-        """Empty revenue list -> engine uses stub $10M projection."""
+    async def test_npv_empty_revenues_returns_error(
+        self, http_client, tenant_headers
+    ):
+        """Empty revenue list with no fallback data -> error response."""
         payload = make_agent_payload(
             input_prompt="NPV benchmark: empty revenues fallback",
             config={"method": "royalty_relief"},
@@ -86,10 +92,10 @@ class TestNPVBenchmarks:
         )
         assert resp.status_code == 200
         data = resp.json()
-        val = data["valuation"]
-        # Empty list falls through to stub $10M projection
-        assert val["brand_value_npv"] > 0
-        assert val["horizon_years"] >= 1
+        # No revenue data → executor returns error (no valuation)
+        assert data.get("valuation") is None
+        assert "findings" in data
+        assert len(data["findings"]) > 0
 
     async def test_npv_single_year(self, http_client, tenant_headers):
         """One year explicit + terminal value.
@@ -106,6 +112,7 @@ class TestNPVBenchmarks:
         payload["input_context"] = {
             "projected_revenues": [10_000_000],
             "sector": "technology",
+            "brand_awareness": 50,
         }
         resp = await http_client.post(
             f"{INTELLIGENCE_URL}/v1/iso-calc",
@@ -132,6 +139,7 @@ class TestNPVBenchmarks:
         payload["input_context"] = {
             "projected_revenues": revenues,
             "sector": "technology",
+            "brand_awareness": 50,
         }
         resp = await http_client.post(
             f"{INTELLIGENCE_URL}/v1/iso-calc",
@@ -163,6 +171,7 @@ class TestNPVBenchmarks:
             payload["input_context"] = {
                 "projected_revenues": [10_000_000],
                 "sector": sector,
+                "brand_awareness": 50,
             }
             resp = await http_client.post(
                 f"{INTELLIGENCE_URL}/v1/iso-calc",


### PR DESCRIPTION
## Summary

Fixes two issues with the competitor analysis pipeline:

1. **Pipeline UI shows no results** — `competitor-audit` and `brand-analysis` manifests terminated with `ReportNode` instead of `ManagerNode`. Only `ManagerNode` sets `result_data` in pipeline state, so results were empty.
2. **Gap analysis chat summary** — Added `_build_gap_analysis_summary()` to generate meaningful chat messages when a gap analysis pipeline completes.

Additionally fixes integration test failures:
- Phase 1 contract tests: Added financial data to ISO valuation payloads so tests work in CI stub mode (no Gemini API key).
- Phase 2 domain tests: Added `brand_awareness` to NPV benchmark payloads to avoid BSI-based royalty rate adjustment (BSI < 40 → 10% rate discount). Updated empty-revenue and no-data BSI tests to match actual executor behavior.

## Changes

### Manifest fixes (`seed_manifests.py`)
- `competitor-audit`: Replaced `report_generator`/`ReportNode` with `manager`/`ManagerNode` as terminal node
- `brand-analysis`: Same fix — replaced `ReportNode` with `ManagerNode`

### Chat flow (`views.py`)
- Chat pipelines use **pure auto-detect** (no manifest). The orchestrator's `PipelineComposer` dynamically selects and orders agent nodes via Gemini function-calling.
- Removed all manifest-attachment code from chat — both brand valuation and competitor analysis go through the dynamic pipeline.

### Result handler (`result_handler.py`)
- Added gap analysis detection in `_build_result_summary()` for `gap_analyzer` node output
- Added `_build_gap_analysis_summary()` helper for competitive gap analysis results

### Integration tests
- `test_chat_pipeline_uses_auto_detect` — verifies chat jobs have `manifest=None`
- Phase 1: Added `base_revenue`, `growth_rate`, `profit_margin`, `brand_awareness` to ISO valuation test payloads
- Phase 2: Added `brand_awareness=50` to NPV/rate tests; updated `test_npv_empty_revenues_returns_error` and `test_no_data_returns_zero_score` assertions

## Test plan

- [x] `cd ai-brand-automator && pytest ai_services/tests/test_views.py -v` — 40/40 pass
- [x] `cd ai-brand-automator && pytest -v` — all backend tests pass
- [x] CI: backend-tests, orchestrator-tests, discovery-agent-tests, intelligence-agent-tests pass
- [ ] CI: integration-tests (phase1 + phase2 domain tests)
- [ ] After deploy: `seed_manifests` runs via entrypoint.sh, re-seeds updated manifests
- [ ] Pipeline UI: "Competitor Audit" shows findings/recommendations
- [ ] Chat: competitor analysis triggers via PipelineComposer dynamic routing

🤖 Generated with [Claude Code](https://claude.com/claude-code)