### PR TITLE
fix: pipeline progress observability + quick-status fallback

### DIFF
--- a/ai-brand-automator/orchestration/result_handler.py
+++ b/ai-brand-automator/orchestration/result_handler.py
@@ -185,7 +185,12 @@ def _update_redis_cache(job):
             job.status,
         )
     except Exception as exc:
-        logger.warning("Redis cache update failed for job %s: %s", job.job_id, exc)
+        logger.warning(
+            "Redis cache update failed for job %s: %s",
+            job.job_id,
+            exc,
+            exc_info=True,
+        )
 
 
 def _save_final_chat_message(job):

--- a/ai-brand-automator/orchestration/result_handler.py
+++ b/ai-brand-automator/orchestration/result_handler.py
@@ -176,8 +176,18 @@ def _update_redis_cache(job):
         elif job.status == AnalysisJob.Status.FAILED:
             cache_data["error_message"] = job.error_message
         cache.set(cache_key, cache_data, timeout=3600)
-    except Exception:
-        pass  # Cache failures must not break result processing
+        logger.info(
+            "Redis cache updated for job %s: current_node=%s, "
+            "progress_percent=%d%%, status=%s",
+            job.job_id,
+            current_node,
+            percent,
+            job.status,
+        )
+    except Exception as exc:
+        logger.warning(
+            "Redis cache update failed for job %s: %s", job.job_id, exc
+        )
 
 
 def _save_final_chat_message(job):

--- a/ai-brand-automator/orchestration/result_handler.py
+++ b/ai-brand-automator/orchestration/result_handler.py
@@ -185,9 +185,7 @@ def _update_redis_cache(job):
             job.status,
         )
     except Exception as exc:
-        logger.warning(
-            "Redis cache update failed for job %s: %s", job.job_id, exc
-        )
+        logger.warning("Redis cache update failed for job %s: %s", job.job_id, exc)
 
 
 def _save_final_chat_message(job):

--- a/ai-brand-automator/orchestration/views.py
+++ b/ai-brand-automator/orchestration/views.py
@@ -164,10 +164,19 @@ class AnalysisJobViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):
         # Fall back to DB
         job = self.get_object()
         progress = job.progress or {}
+        # Derive current_node from progress dict (same logic as cache)
+        current_node = next(
+            (
+                nid
+                for nid, info in progress.items()
+                if isinstance(info, dict) and info.get("status") == "running"
+            ),
+            None,
+        )
         data = {
             "status": job.status,
             "progress": progress,
-            "current_node": None,
+            "current_node": current_node,
             "progress_percent": self._calc_percent(progress),
             "last_thought": None,
         }

--- a/pipeline-orchestrator-svc/app/nodes/tracked.py
+++ b/pipeline-orchestrator-svc/app/nodes/tracked.py
@@ -63,15 +63,10 @@ class TrackedNode:
             "started_at": started_at,
         }
 
-        # Send running callback (non-blocking, non-fatal)
+        # Send running callback (non-fatal; awaited to ensure delivery)
         if callback_url:
-            ok = await self.callback_client.send_progress(
+            await self.callback_client.send_progress(
                 callback_url, progress
-            )
-            logger.info(
-                "[TrackedNode] Node %s → running callback sent (ok=%s)",
-                self.node_id,
-                ok,
             )
         else:
             logger.warning(
@@ -85,9 +80,9 @@ class TrackedNode:
         # Execute the actual node
         try:
             result = await self.inner(state)
-        except Exception as exc:
-            logger.error(
-                "[TrackedNode] Node %s FAILED: %s", self.node_id, exc
+        except Exception:
+            logger.exception(
+                "[TrackedNode] Node %s FAILED", self.node_id
             )
             # Mark as failed
             progress[self.node_id] = {
@@ -115,13 +110,8 @@ class TrackedNode:
 
         # Send done callback
         if callback_url:
-            ok = await self.callback_client.send_progress(
+            await self.callback_client.send_progress(
                 callback_url, progress
-            )
-            logger.info(
-                "[TrackedNode] Node %s → done callback sent (ok=%s)",
-                self.node_id,
-                ok,
             )
 
         # Emit Kafka trace

--- a/pipeline-orchestrator-svc/app/nodes/tracked.py
+++ b/pipeline-orchestrator-svc/app/nodes/tracked.py
@@ -48,6 +48,13 @@ class TrackedNode:
         callback_url = state.get("callback_url", "")
         job_id = state.get("job_id", "")
 
+        logger.info(
+            "[TrackedNode] Node %s STARTING (job=%s, callback_url=%s)",
+            self.node_id,
+            job_id,
+            callback_url[:80] if callback_url else "<empty>",
+        )
+
         # Copy progress and mark this node as running
         progress = dict(state.get("progress", {}))
         started_at = _now_iso()
@@ -58,7 +65,19 @@ class TrackedNode:
 
         # Send running callback (non-blocking, non-fatal)
         if callback_url:
-            await self.callback_client.send_progress(callback_url, progress)
+            ok = await self.callback_client.send_progress(
+                callback_url, progress
+            )
+            logger.info(
+                "[TrackedNode] Node %s → running callback sent (ok=%s)",
+                self.node_id,
+                ok,
+            )
+        else:
+            logger.warning(
+                "[TrackedNode] Node %s has NO callback_url — skipping progress",
+                self.node_id,
+            )
 
         # Emit Kafka trace (best-effort)
         await self._emit_trace(job_id, "started")
@@ -66,7 +85,10 @@ class TrackedNode:
         # Execute the actual node
         try:
             result = await self.inner(state)
-        except Exception:
+        except Exception as exc:
+            logger.error(
+                "[TrackedNode] Node %s FAILED: %s", self.node_id, exc
+            )
             # Mark as failed
             progress[self.node_id] = {
                 "status": "failed",
@@ -87,9 +109,20 @@ class TrackedNode:
             "completed_at": _now_iso(),
         }
 
+        logger.info(
+            "[TrackedNode] Node %s DONE (job=%s)", self.node_id, job_id
+        )
+
         # Send done callback
         if callback_url:
-            await self.callback_client.send_progress(callback_url, progress)
+            ok = await self.callback_client.send_progress(
+                callback_url, progress
+            )
+            logger.info(
+                "[TrackedNode] Node %s → done callback sent (ok=%s)",
+                self.node_id,
+                ok,
+            )
 
         # Emit Kafka trace
         await self._emit_trace(job_id, "completed")

--- a/pipeline-orchestrator-svc/app/services/callback_client.py
+++ b/pipeline-orchestrator-svc/app/services/callback_client.py
@@ -57,10 +57,14 @@ class CallbackClient:
                 headers=self._headers(),
             )
             response.raise_for_status()
+            label = payload.get("status") or next(
+                (k for k in ("resolved_manifest_id", "progress") if k in payload),
+                "unknown",
+            )
             logger.info(
                 "Callback sent to %s: %s (HTTP %d)",
                 callback_url,
-                payload.get("status", "progress"),
+                label,
                 response.status_code,
             )
             return True

--- a/pipeline-orchestrator-svc/app/services/callback_client.py
+++ b/pipeline-orchestrator-svc/app/services/callback_client.py
@@ -57,10 +57,11 @@ class CallbackClient:
                 headers=self._headers(),
             )
             response.raise_for_status()
-            logger.debug(
-                "Callback sent to %s: %s",
+            logger.info(
+                "Callback sent to %s: %s (HTTP %d)",
                 callback_url,
                 payload.get("status", "progress"),
+                response.status_code,
             )
             return True
         except httpx.HTTPError as exc:


### PR DESCRIPTION
## Summary
- Add INFO-level logging to `TrackedNode` per-node callbacks (start/done/fail with job_id and callback_url)
- Upgrade `CallbackClient` success logging from DEBUG to INFO with HTTP status code
- Add logging to `_update_redis_cache` to confirm Redis updates and surface failures (was silent `except: pass`)
- Fix `quick-status` DB fallback to derive `current_node` from progress dict (was always `None`)

## Test plan
- [x] 178 orchestrator tests pass
- [x] 123 Django orchestration tests pass (including quick-status caching tests)
- [x] Docker containers rebuilt and verified locally
- [ ] Deploy to Railway and check orchestrator logs for `[TrackedNode]` entries
- [ ] Verify `Redis cache updated` entries appear in backend logs
- [ ] Trigger pipeline from chat and confirm ThoughtTrace shows per-node progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)