### PR TITLE
fix: pipeline progress + social content for brand equity on Railway

### DIFF
--- a/deployment/scripts/railway-setup.py
+++ b/deployment/scripts/railway-setup.py
@@ -337,6 +337,7 @@ def main():
     # Step 2: Add missing env vars to backend
     print("\n[2/4] Adding missing env vars to backend...")
     backend_new_vars = {
+        "BACKEND_URL": "http://Prevision-WS.railway.internal:8000",
         "ORCHESTRATOR_URL": "http://orchestrator.railway.internal:8010",
         "ORCHESTRATOR_SERVICE_TOKEN": SERVICE_TOKEN,
         "ORCHESTRATOR_CALLBACK_TOKEN": CALLBACK_TOKEN,

--- a/deployment/scripts/railway-setup.py
+++ b/deployment/scripts/railway-setup.py
@@ -45,6 +45,11 @@ GOOGLE_API_KEY = "AIzaSyAyyFMj47QoOUrIU0jIP4WSMC8IWPlc144"
 GCS_PROJECT_ID = "brandsol-project"
 GCS_BUCKET_NAME = "onboarding-brandsol-customer-bucket-1"
 
+# Backend service name (used to derive internal Railway hostname)
+BACKEND_SERVICE_NAME = "Prevision-WS"
+BACKEND_PORT = "8000"
+BACKEND_INTERNAL_URL = f"http://{BACKEND_SERVICE_NAME}.railway.internal:{BACKEND_PORT}"
+
 # Existing service IDs
 BACKEND_SERVICE_ID = "9422b6c8-da15-4f68-ace4-6ab6f3512037"
 
@@ -159,7 +164,7 @@ SERVICES = [
             "TITLING_REDIS_URL": f"{REDIS_BASE}/4",
             "TITLING_KAFKA_BOOTSTRAP_SERVERS": "",
             "TITLING_GOOGLE_API_KEY": GOOGLE_API_KEY,
-            "TITLING_CORE_API_URL": "http://Prevision-WS.railway.internal:8000",
+            "TITLING_CORE_API_URL": BACKEND_INTERNAL_URL,
             "TITLING_WORKER_TOKEN": WORKER_TOKEN,
             "TITLING_LOG_LEVEL": "INFO",
             "PORT": "8040",
@@ -178,7 +183,7 @@ SERVICES = [
             "CONTENT_GOOGLE_API_KEY": GOOGLE_API_KEY,
             "CONTENT_GCS_PROJECT_ID": GCS_PROJECT_ID,
             "CONTENT_GCS_BUCKET_NAME": GCS_BUCKET_NAME,
-            "CONTENT_CORE_API_URL": "http://Prevision-WS.railway.internal:8000",
+            "CONTENT_CORE_API_URL": BACKEND_INTERNAL_URL,
             "CONTENT_CORE_API_TOKEN": SERVICE_TOKEN,
             "CONTENT_LOG_LEVEL": "INFO",
             "PORT": "8050",
@@ -195,7 +200,7 @@ SERVICES = [
             "SOCIAL_REDIS_URL": f"{REDIS_BASE}/6",
             "SOCIAL_KAFKA_BOOTSTRAP_SERVERS": "",
             "SOCIAL_GOOGLE_API_KEY": GOOGLE_API_KEY,
-            "SOCIAL_CORE_API_URL": "http://Prevision-WS.railway.internal:8000",
+            "SOCIAL_CORE_API_URL": BACKEND_INTERNAL_URL,
             "SOCIAL_CORE_API_TOKEN": SERVICE_TOKEN,
             "SOCIAL_MCP_SERVER_URL": "http://mcp-server.railway.internal:8085/sse",
             "SOCIAL_LOG_LEVEL": "INFO",
@@ -215,7 +220,7 @@ SERVICES = [
             "UPLOADER_GOOGLE_API_KEY": GOOGLE_API_KEY,
             "UPLOADER_GCS_PROJECT_ID": GCS_PROJECT_ID,
             "UPLOADER_GCS_BUCKET_NAME": GCS_BUCKET_NAME,
-            "UPLOADER_CORE_API_URL": "http://Prevision-WS.railway.internal:8000",
+            "UPLOADER_CORE_API_URL": BACKEND_INTERNAL_URL,
             "UPLOADER_CORE_API_TOKEN": SERVICE_TOKEN,
             "UPLOADER_LOG_LEVEL": "INFO",
             "PORT": "8070",
@@ -337,7 +342,7 @@ def main():
     # Step 2: Add missing env vars to backend
     print("\n[2/4] Adding missing env vars to backend...")
     backend_new_vars = {
-        "BACKEND_URL": "http://Prevision-WS.railway.internal:8000",
+        "BACKEND_URL": BACKEND_INTERNAL_URL,
         "ORCHESTRATOR_URL": "http://orchestrator.railway.internal:8010",
         "ORCHESTRATOR_SERVICE_TOKEN": SERVICE_TOKEN,
         "ORCHESTRATOR_CALLBACK_TOKEN": CALLBACK_TOKEN,

--- a/pipeline-orchestrator-svc/app/services/job_executor.py
+++ b/pipeline-orchestrator-svc/app/services/job_executor.py
@@ -69,9 +69,7 @@ class JobExecutor:
                 else:
                     resolved_id = state.get("resolved_manifest_id")
                     # Look up the full manifest_data from available_manifests
-                    manifest_data = self._find_resolved_manifest(
-                        request, resolved_id
-                    )
+                    manifest_data = self._find_resolved_manifest(request, resolved_id)
                     if manifest_data is None:
                         # No manifest_data available — cannot execute
                         await self.callback.send_completed(
@@ -82,9 +80,7 @@ class JobExecutor:
                                     f"Resolved manifest: {resolved_id}"
                                 ),
                                 "resolved_manifest_id": resolved_id,
-                                "findings": [
-                                    "Auto-detect routing completed."
-                                ],
+                                "findings": ["Auto-detect routing completed."],
                                 "recommendations": [
                                     "Re-run with the resolved manifest "
                                     "for full analysis."
@@ -99,6 +95,9 @@ class JobExecutor:
                     nid = node["id"]
                     if nid not in state["progress"]:
                         state["progress"][nid] = {"status": "pending"}
+
+                # Send progress with all pending nodes visible to the UI
+                await self.callback.send_progress(callback_url, state["progress"])
 
             # Build the LangGraph (with per-node progress tracking)
             try:
@@ -279,34 +278,24 @@ class JobExecutor:
         composed = "_composed_manifest" in result
         if composed:
             state["_composed_manifest"] = result["_composed_manifest"]
-            node_ids = [
-                n["id"] for n in result["_composed_manifest"].get("nodes", [])
-            ]
+            node_ids = [n["id"] for n in result["_composed_manifest"].get("nodes", [])]
             state["progress"]["pipeline_composer"] = {
                 "status": "done",
                 "output": {
                     "composed": True,
                     "pipeline": " → ".join(node_ids),
                 },
-                "started_at": state["progress"]["pipeline_composer"].get(
-                    "started_at"
-                ),
+                "started_at": state["progress"]["pipeline_composer"].get("started_at"),
                 "completed_at": self._now_iso(),
             }
             # Send progress update (no manifest_id to resolve in DB)
-            await self.callback.send_progress(
-                request.callback_url, state["progress"]
-            )
+            await self.callback.send_progress(request.callback_url, state["progress"])
         else:
             state["resolved_manifest_id"] = result.get("resolved_manifest_id")
             state["progress"]["pipeline_composer"] = {
                 "status": "done",
-                "output": {
-                    "resolved_manifest_id": state["resolved_manifest_id"]
-                },
-                "started_at": state["progress"]["pipeline_composer"].get(
-                    "started_at"
-                ),
+                "output": {"resolved_manifest_id": state["resolved_manifest_id"]},
+                "started_at": state["progress"]["pipeline_composer"].get("started_at"),
                 "completed_at": self._now_iso(),
             }
             # Notify the callback about the resolved manifest

--- a/pipeline-orchestrator-svc/tests/test_job_executor.py
+++ b/pipeline-orchestrator-svc/tests/test_job_executor.py
@@ -259,6 +259,56 @@ class TestJobExecutor:
         executor.callback.send_progress.assert_called()
 
     @patch("app.services.job_executor.get_redis", new_callable=AsyncMock)
+    async def test_composed_manifest_sends_pending_nodes_progress(self, mock_get_redis):
+        """After intent routing resolves nodes, send_progress is called
+        with all new nodes as 'pending' before ainvoke() starts."""
+        mock_redis = AsyncMock()
+        mock_redis.get.return_value = None
+        mock_get_redis.return_value = mock_redis
+
+        composed_manifest = {
+            "nodes": [
+                {"id": "discovery", "type": "internal", "handler": "StrategyNode"},
+                {"id": "intelligence", "type": "internal", "handler": "ReportNode"},
+            ],
+            "edges": [["discovery", "intelligence"]],
+            "global_config": {},
+        }
+
+        executor = JobExecutor()
+        executor.callback = AsyncMock()
+        executor.callback.send_running.return_value = True
+        executor.callback.send_progress.return_value = True
+        executor.callback.send_completed.return_value = True
+
+        with patch(
+            "app.nodes.internal.pipeline_composer.PipelineComposer.compose",
+            new_callable=AsyncMock,
+            return_value={"_composed_manifest": composed_manifest},
+        ):
+            request = _make_request(manifest=None)
+            await executor.execute(request)
+
+        # send_progress should be called multiple times:
+        # 1. composer running, 2. composer done, 3. pending nodes before ainvoke
+        progress_calls = executor.callback.send_progress.call_args_list
+        # Find the call that includes pending nodes (after composer done)
+        found_pending = False
+        for call in progress_calls:
+            progress = (
+                call.args[1] if len(call.args) > 1 else call.kwargs.get("progress", {})
+            )
+            if isinstance(progress, dict):
+                discovery_status = progress.get("discovery", {}).get("status")
+                intelligence_status = progress.get("intelligence", {}).get("status")
+                if discovery_status == "pending" and intelligence_status == "pending":
+                    found_pending = True
+                    break
+        assert (
+            found_pending
+        ), "send_progress must be called with pending nodes before ainvoke"
+
+    @patch("app.services.job_executor.get_redis", new_callable=AsyncMock)
     async def test_composer_fallback_resolves_manifest_id(self, mock_get_redis):
         """PipelineComposer keyword fallback → resolves manifest_id."""
         mock_redis = AsyncMock()
@@ -297,9 +347,7 @@ class TestJobExecutor:
             new_callable=AsyncMock,
             return_value={"resolved_manifest_id": "blog-authoring"},
         ):
-            request = _make_request(
-                manifest=None, available_manifests=available
-            )
+            request = _make_request(manifest=None, available_manifests=available)
             await executor.execute(request)
 
         executor.callback.send_completed.assert_called_once()

--- a/social-agent-service/app/logic/platform_adapter.py
+++ b/social-agent-service/app/logic/platform_adapter.py
@@ -110,6 +110,21 @@ class PlatformAdapter:
             "Just write the post itself, ready to publish."
         )
 
+        # Detect whether content is structured analysis data (brand equity
+        # metrics, BSI scores) versus blog/article content, and tailor the
+        # prompt accordingly so Gemini produces contextually accurate posts.
+        is_analysis = _is_analysis_content(content)
+
+        if is_analysis:
+            return self._build_analysis_prompt(
+                platform,
+                content,
+                brand_name,
+                brand_voice,
+                keyword_str,
+                no_options,
+            )
+
         prompts = {
             "linkedin": (
                 f"Write exactly ONE LinkedIn post for {brand_name} based on "
@@ -151,6 +166,74 @@ class PlatformAdapter:
         }
 
         return prompts.get(platform, prompts["linkedin"])
+
+    def _build_analysis_prompt(
+        self,
+        platform: str,
+        content: str,
+        brand_name: str,
+        brand_voice: str,
+        keyword_str: str,
+        no_options: str,
+    ) -> str:
+        """Build prompts tailored for brand equity / analysis data."""
+        limits = {
+            "linkedin": LINKEDIN_MAX_CHARS,
+            "twitter": TWITTER_MAX_CHARS,
+            "facebook": FACEBOOK_MAX_CHARS,
+            "instagram": INSTAGRAM_MAX_CHARS,
+        }
+        char_limit = limits.get(platform, LINKEDIN_MAX_CHARS)
+
+        base_instruction = (
+            f"You are writing a social media post for {brand_name}. "
+            f"Use a {brand_voice} tone.\n\n"
+            "The data below contains brand valuation and strength metrics "
+            "from an ISO 10668 brand equity analysis. Transform these results "
+            "into an engaging social media post that highlights the key "
+            "achievements and business value.\n\n"
+            "Guidelines:\n"
+            "- Lead with a compelling insight or headline number\n"
+            "- Translate financial metrics into business impact language\n"
+            "- Include specific numbers (valuation, BSI score) naturally\n"
+            "- End with a forward-looking call to action\n"
+        )
+
+        platform_specifics = {
+            "linkedin": (
+                f"Write exactly ONE LinkedIn post. "
+                "Structure as: attention-grabbing headline metric, "
+                "then 2-3 sentences explaining what the numbers mean "
+                "for the business, then a call to action. "
+                f"Stay under {char_limit} characters. "
+                f"End with 3-5 hashtags related to: {keyword_str}."
+            ),
+            "twitter": (
+                f"Write exactly ONE tweet under {char_limit} characters. "
+                "Highlight the single most impressive metric with context. "
+                f"Include 1-2 hashtags related to: {keyword_str}."
+            ),
+            "facebook": (
+                f"Write exactly ONE Facebook post under {char_limit} characters. "
+                "Make it conversational — share the results as an exciting "
+                "milestone. Include a question to drive engagement."
+            ),
+            "instagram": (
+                f"Write exactly ONE Instagram caption under {char_limit} "
+                "characters. Start with a strong hook. Use short paragraphs "
+                "and line breaks. End with a CTA. Include 10-15 hashtags "
+                f"related to: {keyword_str}."
+            ),
+        }
+
+        specifics = platform_specifics.get(platform, platform_specifics["linkedin"])
+
+        return (
+            f"{base_instruction}\n"
+            f"{specifics}\n\n"
+            f"{no_options}\n\n"
+            f"Brand analysis results:\n{content}"
+        )
 
     def _stub_adapt(
         self,
@@ -214,6 +297,26 @@ class PlatformAdapter:
             char_count=len(content),
             post_type=post_type,
         )
+
+
+# ── Content-type detection ───────────────────────────────────────────
+
+# Phrases that signal structured brand-equity / analysis output
+_ANALYSIS_MARKERS = (
+    "brand valuation:",
+    "brand strength index",
+    "royalty rate:",
+    "forecast horizon:",
+    "key findings:",
+    "bsi:",
+    "(iso 10668",
+)
+
+
+def _is_analysis_content(content: str) -> bool:
+    """Return True when *content* looks like structured analysis metrics."""
+    lower = content[:500].lower()
+    return sum(1 for m in _ANALYSIS_MARKERS if m in lower) >= 2
 
 
 # ── Post-processing helpers ──────────────────────────────────────────

--- a/social-agent-service/app/services/social_executor.py
+++ b/social-agent-service/app/services/social_executor.py
@@ -69,16 +69,30 @@ class SocialExecutor:
         if isinstance(seo_meta, str):
             seo_meta = {}
 
+        logger.info(
+            "Job %s: previous_outputs keys=%s, blog_content=%d chars",
+            job_id,
+            list(request.previous_outputs.keys()),
+            len(blog_content),
+        )
+
         if not blog_content:
             # Try to build content from brand equity / intelligence results
             blog_content = _build_content_from_previous_outputs(
                 request.previous_outputs, request.input_prompt
             )
             if blog_content != request.input_prompt:
-                logger.info("Built social content from upstream analysis results")
+                logger.info(
+                    "Job %s: built social content from analysis results "
+                    "(%d chars): %.200s",
+                    job_id,
+                    len(blog_content),
+                    blog_content,
+                )
             else:
                 logger.info(
-                    "No blog_author output — using input_prompt as content"
+                    "Job %s: no analysis data found — using input_prompt " "as content",
+                    job_id,
                 )
 
         # 3. Determine target platforms (intersect with connected profiles)
@@ -502,12 +516,7 @@ def _build_content_from_previous_outputs(
         if "recommendations" in output and isinstance(output["recommendations"], list):
             recommendations.extend(output["recommendations"])
 
-    if (
-        not valuation_data
-        and not bsi_data
-        and not findings
-        and not recommendations
-    ):
+    if not valuation_data and not bsi_data and not findings and not recommendations:
         return fallback
 
     # Compose a structured summary for Gemini to adapt
@@ -603,12 +612,8 @@ def _build_publishable_content(post: SocialPost) -> str:
     platform = (post.platform or "").lower()
 
     # Check if hashtags are already present in the content
-    existing_tags = {
-        tag.lower() for tag in re.findall(r"#\w+", content)
-    }
-    missing = [
-        tag for tag in post.hashtags if tag.lower() not in existing_tags
-    ]
+    existing_tags = {tag.lower() for tag in re.findall(r"#\w+", content)}
+    missing = [tag for tag in post.hashtags if tag.lower() not in existing_tags]
     if not missing:
         return content
 

--- a/social-agent-service/app/services/social_executor.py
+++ b/social-agent-service/app/services/social_executor.py
@@ -82,12 +82,15 @@ class SocialExecutor:
                 request.previous_outputs, request.input_prompt
             )
             if blog_content != request.input_prompt:
+                content_hash = hashlib.sha256(blog_content.encode("utf-8")).hexdigest()[
+                    :8
+                ]
                 logger.info(
                     "Job %s: built social content from analysis results "
-                    "(%d chars): %.200s",
+                    "(len=%d, sha256_prefix=%s)",
                     job_id,
                     len(blog_content),
-                    blog_content,
+                    content_hash,
                 )
             else:
                 logger.info(

--- a/social-agent-service/tests/test_platform_adapter.py
+++ b/social-agent-service/tests/test_platform_adapter.py
@@ -14,6 +14,7 @@ from app.logic.platform_adapter import (
     TWITTER_MAX_CHARS,
     PlatformAdapter,
     _clean_ai_output,
+    _is_analysis_content,
 )
 
 
@@ -223,9 +224,7 @@ class TestAIMode:
         sample_brand_persona: dict[str, Any],
     ):
         mock_model = MagicMock()
-        mock_model.generate_content = MagicMock(
-            side_effect=RuntimeError("API error")
-        )
+        mock_model.generate_content = MagicMock(side_effect=RuntimeError("API error"))
         adapter = PlatformAdapter(gemini_model=mock_model)
 
         seo_meta = {"title": "Tesla", "keywords": ["Tesla"]}
@@ -317,3 +316,85 @@ class TestCleanAIOutput:
         result = _clean_ai_output(text)
         assert "Option" not in result
         assert "Great insights on Tesla!" in result
+
+
+class TestAnalysisContentDetection:
+    """Tests for _is_analysis_content and analysis-aware prompt routing."""
+
+    def test_brand_equity_content_detected(self):
+        content = (
+            "Brand Valuation: $142,154 (ISO 10668 royalty relief)\n"
+            "Royalty Rate: 4.0%\n"
+            "Brand Strength Index (BSI): 72/100"
+        )
+        assert _is_analysis_content(content) is True
+
+    def test_blog_content_not_detected(self):
+        content = (
+            "# How Tesla Is Changing the EV Landscape\n\n"
+            "Tesla continues to push boundaries in sustainable transport. "
+            "Their latest innovations show a commitment to a greener future."
+        )
+        assert _is_analysis_content(content) is False
+
+    def test_single_marker_not_enough(self):
+        content = "Brand Valuation: $50,000 and nothing else relevant."
+        assert _is_analysis_content(content) is False
+
+    def test_findings_and_bsi_detected(self):
+        content = "BSI: 68/100\n\n" "Key Findings:\n" "- Market share increased by 15%"
+        assert _is_analysis_content(content) is True
+
+    def test_empty_content(self):
+        assert _is_analysis_content("") is False
+
+    async def test_ai_uses_analysis_prompt_for_metrics(
+        self,
+        sample_brand_persona: dict,
+    ):
+        """When content is analysis data, Gemini receives the analysis prompt."""
+        mock_model = MagicMock()
+        mock_response = MagicMock()
+        mock_response.text = (
+            "Our brand valuation just hit $142K! "
+            "With a BSI of 72/100, we're stronger than ever. "
+            "#BrandEquity #Growth"
+        )
+        mock_model.generate_content = MagicMock(return_value=mock_response)
+        adapter = PlatformAdapter(gemini_model=mock_model)
+
+        analysis_content = (
+            "Brand Valuation: $142,154 (ISO 10668 royalty relief)\n"
+            "Royalty Rate: 4.0%\n"
+            "Brand Strength Index (BSI): 72/100"
+        )
+        seo_meta = {"keywords": ["brand equity"]}
+        await adapter.adapt(
+            analysis_content, seo_meta, sample_brand_persona, ["linkedin"]
+        )
+
+        prompt = mock_model.generate_content.call_args[0][0]
+        assert "Brand analysis results:" in prompt
+        assert "ISO 10668" in prompt
+        assert "Blog content:" not in prompt
+
+    async def test_ai_uses_blog_prompt_for_articles(
+        self,
+        sample_blog_content: str,
+        sample_brand_persona: dict,
+    ):
+        """When content is a blog, Gemini receives the blog prompt."""
+        mock_model = MagicMock()
+        mock_response = MagicMock()
+        mock_response.text = "Check out our latest blog on sustainability!"
+        mock_model.generate_content = MagicMock(return_value=mock_response)
+        adapter = PlatformAdapter(gemini_model=mock_model)
+
+        seo_meta = {"keywords": ["sustainability"]}
+        await adapter.adapt(
+            sample_blog_content, seo_meta, sample_brand_persona, ["linkedin"]
+        )
+
+        prompt = mock_model.generate_content.call_args[0][0]
+        assert "Blog content:" in prompt
+        assert "Brand analysis results:" not in prompt


### PR DESCRIPTION
## Summary

Fixes two Railway-specific issues where pipeline progress tracking and social content generation work locally in Docker but fail on Railway.

### Issue 1: Pipeline progress stuck at pipeline_composer
- **Root cause**: `BACKEND_URL` was missing from `railway-setup.py` backend env vars, defaulting to `http://localhost:8001` which is unreachable from the orchestrator container on Railway. Additionally, after intent routing resolved the manifest, the new pending nodes were added to the progress dict but no callback was sent — so the UI didn't know about them until TrackedNode fired during `ainvoke()`.
- **Fix**: Added `BACKEND_URL=http://Prevision-WS.railway.internal:8000` to the Railway setup script. Added a `send_progress()` callback right after adding pending nodes to make them immediately visible in the UI.

### Issue 2: Social post content wrong for brand equity results
- **Root cause**: When the social agent receives brand equity data (valuation, BSI scores, findings) instead of blog content, the Gemini prompt still said "Write a LinkedIn post based on the **blog content** below" — causing Gemini to produce generic content instead of leveraging the specific metrics.
- **Fix**: Added content-type detection (`_is_analysis_content()`) that recognizes structured brand equity data via marker phrases. When detected, uses a specialized `_build_analysis_prompt()` that instructs Gemini to transform ISO 10668 metrics into engaging social posts with specific numbers and business impact language.

### Additional improvements
- Added diagnostic logging to `SocialExecutor.execute()` showing `previous_outputs` keys and extracted content length — helps trace content extraction issues on Railway

## Files changed
- `deployment/scripts/railway-setup.py` — Added `BACKEND_URL` to backend env vars
- `pipeline-orchestrator-svc/app/services/job_executor.py` — Send pending nodes progress before `ainvoke()`
- `social-agent-service/app/logic/platform_adapter.py` — Analysis-aware prompt builder + content detection
- `social-agent-service/app/services/social_executor.py` — Diagnostic logging for content extraction

## Test plan
- [x] `pytest pipeline-orchestrator-svc/tests/ -v` — 178 passed
- [x] `pytest social-agent-service/tests/ -v` — 104 passed
- [ ] Manual: Trigger auto-detect pipeline on Railway → verify nodes transition pending → running → done in real-time
- [ ] Manual: Ask chat to convert brand equity results to LinkedIn post → verify post includes valuation/BSI numbers
- [ ] Verify `BACKEND_URL` is set on Railway backend service (run railway-setup.py or set manually)

🤖 Generated with [Claude Code](https://claude.com/claude-code)