### PR TITLE
fix: pipeline progress callbacks silently failing on Railway

### DIFF
--- a/ai-brand-automator-frontend/src/components/chat/MessageBubble.tsx
+++ b/ai-brand-automator-frontend/src/components/chat/MessageBubble.tsx
@@ -45,7 +45,7 @@ function PipelineInlineCard({ jobId }: { jobId: string }) {
         <div className="p-3">
           <ThoughtTrace
             progress={quickStatus?.progress ?? job.progress}
-            jobStatus={job.status}
+            jobStatus={quickStatus?.status ?? job.status}
             lastThought={quickStatus?.last_thought}
             progressPercent={quickStatus?.progress_percent}
           />

--- a/ai-brand-automator/orchestration/services.py
+++ b/ai-brand-automator/orchestration/services.py
@@ -214,7 +214,7 @@ class OrchestratorDispatcher:
         base_url = config(
             "CALLBACK_BASE_URL",
             default=config("BACKEND_URL", default="http://localhost:8001"),
-        )
+        ).rstrip("/")
         if "localhost" in base_url or "127.0.0.1" in base_url:
             logger.warning(
                 "Callback base URL is '%s' — pipeline callbacks will "

--- a/ai-brand-automator/orchestration/services.py
+++ b/ai-brand-automator/orchestration/services.py
@@ -204,6 +204,26 @@ class OrchestratorDispatcher:
         }
 
     def _build_callback_url(self, job):
-        """Build the callback URL for this job."""
-        base_url = config("BACKEND_URL", default="http://localhost:8001")
-        return f"{base_url}/api/v1/orchestration/jobs/{job.job_id}/callback/"
+        """Build the callback URL for this job.
+
+        Prefers ``CALLBACK_BASE_URL`` (should be a private/internal URL
+        reachable by the orchestrator, e.g.
+        ``http://Prevision-WS.railway.internal:8000``).
+        Falls back to ``BACKEND_URL`` if ``CALLBACK_BASE_URL`` is not set.
+        """
+        base_url = config(
+            "CALLBACK_BASE_URL",
+            default=config("BACKEND_URL", default="http://localhost:8001"),
+        )
+        if "localhost" in base_url or "127.0.0.1" in base_url:
+            logger.warning(
+                "Callback base URL is '%s' — pipeline callbacks will "
+                "fail if the orchestrator runs on a different host. "
+                "Set CALLBACK_BASE_URL to the internal service URL "
+                "(e.g. http://backend:8001 or "
+                "http://<service>.railway.internal:<port>).",
+                base_url,
+            )
+        callback_url = f"{base_url}/api/v1/orchestration/jobs/{job.job_id}/callback/"
+        logger.info("Callback URL for job %s: %s", job.job_id, callback_url)
+        return callback_url

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -95,6 +95,7 @@ services:
       - ORCHESTRATOR_CALLBACK_TOKEN=${ORCHESTRATOR_CALLBACK_TOKEN:-dev-callback-token}
       - ORCHESTRATOR_TIMEOUT=${ORCHESTRATOR_TIMEOUT:-30}
       - BACKEND_URL=${BACKEND_URL:-http://backend:8001}
+      - CALLBACK_BASE_URL=${CALLBACK_BASE_URL:-http://backend:8001}
       # Orchestration Kafka integration
       - ORCHESTRATION_KAFKA_ENABLED=${ORCHESTRATION_KAFKA_ENABLED:-false}
       # Chat titling worker integration
@@ -198,6 +199,7 @@ services:
       - ORCHESTRATOR_CALLBACK_TOKEN=${ORCHESTRATOR_CALLBACK_TOKEN:-dev-callback-token}
       - ORCHESTRATOR_TIMEOUT=${ORCHESTRATOR_TIMEOUT:-30}
       - BACKEND_URL=${BACKEND_URL:-http://backend:8001}
+      - CALLBACK_BASE_URL=${CALLBACK_BASE_URL:-http://backend:8001}
       # Orchestration Kafka integration
       - ORCHESTRATION_KAFKA_ENABLED=${ORCHESTRATION_KAFKA_ENABLED:-false}
       - KAFKA_BOOTSTRAP_SERVERS=${KAFKA_BOOTSTRAP_SERVERS:-}

--- a/deployment/scripts/railway-setup.py
+++ b/deployment/scripts/railway-setup.py
@@ -88,6 +88,7 @@ SERVICES = [
             "DJANGO_SETTINGS_MODULE": "brand_automator.settings",
             "PYTHONUNBUFFERED": "1",
             "BACKEND_URL": BACKEND_INTERNAL_URL,
+            "CALLBACK_BASE_URL": BACKEND_INTERNAL_URL,
             "ORCHESTRATOR_URL": "http://orchestrator.railway.internal:8010",
             "ORCHESTRATOR_SERVICE_TOKEN": SERVICE_TOKEN,
             "ORCHESTRATOR_CALLBACK_TOKEN": CALLBACK_TOKEN,

--- a/deployment/scripts/railway-setup.py
+++ b/deployment/scripts/railway-setup.py
@@ -66,6 +66,15 @@ SERVICES = [
         "env_vars": {
             "DJANGO_SETTINGS_MODULE": "brand_automator.settings",
             "PYTHONUNBUFFERED": "1",
+            "BACKEND_URL": BACKEND_INTERNAL_URL,
+            # CALLBACK_BASE_URL: internal URL the orchestrator uses to call
+            # back with per-node progress.  Must NOT be a public/HTTPS URL
+            # because cloud load balancers drop idle connections and cause
+            # silent callback failures.
+            "CALLBACK_BASE_URL": BACKEND_INTERNAL_URL,
+            "ORCHESTRATOR_URL": "http://orchestrator.railway.internal:8010",
+            "ORCHESTRATOR_SERVICE_TOKEN": SERVICE_TOKEN,
+            "ORCHESTRATOR_CALLBACK_TOKEN": CALLBACK_TOKEN,
         },
         "needs_backend_vars": True,
     },
@@ -78,6 +87,10 @@ SERVICES = [
         "env_vars": {
             "DJANGO_SETTINGS_MODULE": "brand_automator.settings",
             "PYTHONUNBUFFERED": "1",
+            "BACKEND_URL": BACKEND_INTERNAL_URL,
+            "ORCHESTRATOR_URL": "http://orchestrator.railway.internal:8010",
+            "ORCHESTRATOR_SERVICE_TOKEN": SERVICE_TOKEN,
+            "ORCHESTRATOR_CALLBACK_TOKEN": CALLBACK_TOKEN,
         },
         "needs_backend_vars": True,
     },

--- a/pipeline-orchestrator-svc/app/nodes/tracked.py
+++ b/pipeline-orchestrator-svc/app/nodes/tracked.py
@@ -63,16 +63,8 @@ class TrackedNode:
             "started_at": started_at,
         }
 
-        # Send running callback (non-fatal; awaited to ensure delivery)
-        if callback_url:
-            await self.callback_client.send_progress(
-                callback_url, progress
-            )
-        else:
-            logger.warning(
-                "[TrackedNode] Node %s has NO callback_url — skipping progress",
-                self.node_id,
-            )
+        # Send running callback (non-fatal — must never break execution)
+        await self._safe_send_progress(callback_url, progress)
 
         # Emit Kafka trace (best-effort)
         await self._emit_trace(job_id, "started")
@@ -81,19 +73,14 @@ class TrackedNode:
         try:
             result = await self.inner(state)
         except Exception:
-            logger.exception(
-                "[TrackedNode] Node %s FAILED", self.node_id
-            )
+            logger.exception("[TrackedNode] Node %s FAILED", self.node_id)
             # Mark as failed
             progress[self.node_id] = {
                 "status": "failed",
                 "started_at": started_at,
                 "completed_at": _now_iso(),
             }
-            if callback_url:
-                await self.callback_client.send_progress(
-                    callback_url, progress
-                )
+            await self._safe_send_progress(callback_url, progress)
             await self._emit_trace(job_id, "failed")
             raise
 
@@ -104,15 +91,10 @@ class TrackedNode:
             "completed_at": _now_iso(),
         }
 
-        logger.info(
-            "[TrackedNode] Node %s DONE (job=%s)", self.node_id, job_id
-        )
+        logger.info("[TrackedNode] Node %s DONE (job=%s)", self.node_id, job_id)
 
         # Send done callback
-        if callback_url:
-            await self.callback_client.send_progress(
-                callback_url, progress
-            )
+        await self._safe_send_progress(callback_url, progress)
 
         # Emit Kafka trace
         await self._emit_trace(job_id, "completed")
@@ -120,6 +102,27 @@ class TrackedNode:
         # Merge progress into the node result
         result["progress"] = progress
         return result
+
+    async def _safe_send_progress(self, callback_url: str, progress: dict) -> None:
+        """Send a progress callback without ever raising."""
+        if not callback_url:
+            logger.warning(
+                "[TrackedNode] Node %s has NO callback_url — skipping",
+                self.node_id,
+            )
+            return
+        try:
+            ok = await self.callback_client.send_progress(callback_url, progress)
+            if not ok:
+                logger.warning(
+                    "[TrackedNode] Progress callback returned False " "for node %s",
+                    self.node_id,
+                )
+        except Exception:
+            logger.exception(
+                "[TrackedNode] Unexpected error sending progress " "for node %s",
+                self.node_id,
+            )
 
     async def _emit_trace(self, job_id: str, status: str) -> None:
         """Emit a Kafka trace event (best-effort, no-op if unavailable)."""

--- a/pipeline-orchestrator-svc/app/services/callback_client.py
+++ b/pipeline-orchestrator-svc/app/services/callback_client.py
@@ -3,8 +3,12 @@ Callback client — sends progress and result callbacks to core-api-service.
 
 Uses HTTP PATCH to the callback_url with X-Callback-Token authentication.
 Matches the contract in ai-brand-automator/orchestration/views.py callback endpoint.
+
+Retries once on connection errors (stale connections from cloud load balancers)
+using a fresh httpx client on the retry attempt.
 """
 
+import asyncio
 import logging
 from typing import Any, Optional
 
@@ -12,30 +16,24 @@ import httpx
 
 logger = logging.getLogger(__name__)
 
+# Max retries for transient connection errors (stale connections, resets)
+_MAX_RETRIES = 2
+_RETRY_DELAY = 0.5  # seconds
+
 
 class CallbackClient:
     """HTTP client for sending job progress/results to core-api-service.
 
-    Uses a reusable httpx.AsyncClient to avoid connection pool overhead
-    from creating a new client per request.
+    Creates a fresh httpx.AsyncClient per request to avoid stale connection
+    issues when callbacks route through cloud load balancers (Railway, etc.).
     """
 
     def __init__(self, callback_token: str, timeout: float = 30.0):
         self.callback_token = callback_token
         self.timeout = timeout
-        self._client: httpx.AsyncClient | None = None
-
-    async def _get_client(self) -> httpx.AsyncClient:
-        """Return a reusable AsyncClient, creating one if needed."""
-        if self._client is None or self._client.is_closed:
-            self._client = httpx.AsyncClient(timeout=self.timeout)
-        return self._client
 
     async def close(self) -> None:
-        """Close the underlying HTTP client. Call on shutdown."""
-        if self._client is not None and not self._client.is_closed:
-            await self._client.aclose()
-            self._client = None
+        """No-op — clients are created per-request now."""
 
     def _headers(self) -> dict[str, str]:
         return {
@@ -47,34 +45,56 @@ class CallbackClient:
         """
         Send a PATCH request to the callback URL.
 
+        Retries once on connection/transport errors using a fresh client.
         Returns True on success, False on failure (non-fatal).
         """
-        try:
-            client = await self._get_client()
-            response = await client.patch(
-                callback_url,
-                json=payload,
-                headers=self._headers(),
-            )
-            response.raise_for_status()
-            label = payload.get("status") or next(
-                (k for k in ("resolved_manifest_id", "progress") if k in payload),
-                "unknown",
-            )
-            logger.info(
-                "Callback sent to %s: %s (HTTP %d)",
-                callback_url,
-                label,
-                response.status_code,
-            )
-            return True
-        except httpx.HTTPError as exc:
-            logger.error(
-                "Callback failed for %s: %s",
-                callback_url,
-                str(exc),
-            )
-            return False
+        label = payload.get("status") or next(
+            (k for k in ("resolved_manifest_id", "progress") if k in payload),
+            "unknown",
+        )
+
+        for attempt in range(_MAX_RETRIES):
+            try:
+                async with httpx.AsyncClient(timeout=self.timeout) as client:
+                    response = await client.patch(
+                        callback_url,
+                        json=payload,
+                        headers=self._headers(),
+                    )
+                    response.raise_for_status()
+
+                logger.info(
+                    "Callback sent: %s (HTTP %d, attempt %d)",
+                    label,
+                    response.status_code,
+                    attempt + 1,
+                )
+                return True
+
+            except Exception as exc:
+                is_last = attempt >= _MAX_RETRIES - 1
+                if is_last:
+                    logger.error(
+                        "Callback failed after %d attempts for %s [%s]: %s (%s)",
+                        _MAX_RETRIES,
+                        callback_url,
+                        label,
+                        exc,
+                        type(exc).__name__,
+                    )
+                    return False
+
+                logger.warning(
+                    "Callback attempt %d failed for %s [%s]: %s (%s) — retrying",
+                    attempt + 1,
+                    callback_url,
+                    label,
+                    exc,
+                    type(exc).__name__,
+                )
+                await asyncio.sleep(_RETRY_DELAY)
+
+        return False
 
     async def send_progress(
         self,

--- a/pipeline-orchestrator-svc/app/services/callback_client.py
+++ b/pipeline-orchestrator-svc/app/services/callback_client.py
@@ -45,7 +45,8 @@ class CallbackClient:
         """
         Send a PATCH request to the callback URL.
 
-        Retries once on connection/transport errors using a fresh client.
+        Retries on transport-level errors (connection resets, timeouts) and
+        5xx responses.  Does NOT retry on 4xx (deterministic client errors).
         Returns True on success, False on failure (non-fatal).
         """
         label = payload.get("status") or next(
@@ -71,11 +72,40 @@ class CallbackClient:
                 )
                 return True
 
-            except Exception as exc:
-                is_last = attempt >= _MAX_RETRIES - 1
-                if is_last:
+            except httpx.HTTPStatusError as exc:
+                # 4xx → non-retryable (bad request, auth, etc.)
+                if exc.response.status_code < 500:
                     logger.error(
-                        "Callback failed after %d attempts for %s [%s]: %s (%s)",
+                        "Callback rejected (HTTP %d) for %s [%s]: %s",
+                        exc.response.status_code,
+                        callback_url,
+                        label,
+                        exc,
+                    )
+                    return False
+                # 5xx → retryable
+                if attempt >= _MAX_RETRIES - 1:
+                    logger.error(
+                        "Callback failed after %d attempts for %s " "[%s]: HTTP %d",
+                        _MAX_RETRIES,
+                        callback_url,
+                        label,
+                        exc.response.status_code,
+                    )
+                    return False
+                logger.warning(
+                    "Callback attempt %d got HTTP %d for %s [%s] " "— retrying",
+                    attempt + 1,
+                    exc.response.status_code,
+                    callback_url,
+                    label,
+                )
+
+            except Exception as exc:
+                # Transport errors (connection reset, timeout, DNS, etc.)
+                if attempt >= _MAX_RETRIES - 1:
+                    logger.error(
+                        "Callback failed after %d attempts for %s " "[%s]: %s (%s)",
                         _MAX_RETRIES,
                         callback_url,
                         label,
@@ -83,16 +113,16 @@ class CallbackClient:
                         type(exc).__name__,
                     )
                     return False
-
                 logger.warning(
-                    "Callback attempt %d failed for %s [%s]: %s (%s) — retrying",
+                    "Callback attempt %d failed for %s [%s]: %s (%s) " "— retrying",
                     attempt + 1,
                     callback_url,
                     label,
                     exc,
                     type(exc).__name__,
                 )
-                await asyncio.sleep(_RETRY_DELAY)
+
+            await asyncio.sleep(_RETRY_DELAY)
 
         return False
 

--- a/pipeline-orchestrator-svc/app/services/job_executor.py
+++ b/pipeline-orchestrator-svc/app/services/job_executor.py
@@ -91,15 +91,30 @@ class JobExecutor:
                         return
 
                 # Initialize progress for the resolved manifest's nodes
+                node_ids_added = []
                 for node in manifest_data.get("nodes", []):
                     nid = node["id"]
                     if nid not in state["progress"]:
                         state["progress"][nid] = {"status": "pending"}
+                        node_ids_added.append(nid)
+
+                logger.info(
+                    "Job %s: added %d pending nodes: %s",
+                    job_id,
+                    len(node_ids_added),
+                    ", ".join(node_ids_added),
+                )
 
                 # Send progress with all pending nodes visible to the UI
                 await self.callback.send_progress(callback_url, state["progress"])
 
             # Build the LangGraph (with per-node progress tracking)
+            logger.info(
+                "Job %s: building graph with %d nodes, callback_client=%s",
+                job_id,
+                len(manifest_data.get("nodes", [])),
+                "yes" if self.callback else "no",
+            )
             try:
                 compiled_graph = GraphBuilder.build(
                     manifest_data, callback_client=self.callback
@@ -128,9 +143,13 @@ class JobExecutor:
                 return
 
             # Invoke the compiled graph
-            # LangGraph executes nodes in dependency order.
-            # Per-node progress is reported via the progress dict
-            # updated as the graph transitions state.
+            logger.info(
+                "Job %s: invoking graph with %d nodes: %s " "(callback_url=%s)",
+                job_id,
+                len(node_ids),
+                " → ".join(node_ids),
+                callback_url[:80] if callback_url else "<empty>",
+            )
             try:
                 result_state = await compiled_graph.ainvoke(
                     state,

--- a/pipeline-orchestrator-svc/tests/test_callback_client.py
+++ b/pipeline-orchestrator-svc/tests/test_callback_client.py
@@ -98,7 +98,9 @@ class TestCallbackClient:
         assert body["resolved_manifest_id"] == "brand-analysis"
         assert "progress" in body
 
-    async def test_returns_false_on_http_error(self, httpx_mock):
+    async def test_returns_false_on_5xx(self, httpx_mock):
+        # 5xx is retried, so provide responses for both attempts
+        httpx_mock.add_response(url=CALLBACK_URL, method="PATCH", status_code=500)
         httpx_mock.add_response(url=CALLBACK_URL, method="PATCH", status_code=500)
 
         client = CallbackClient(callback_token=TOKEN)
@@ -108,10 +110,16 @@ class TestCallbackClient:
         )
 
         assert result is False
+        assert len(httpx_mock.get_requests()) == 2
 
     async def test_returns_false_on_connection_error(self, httpx_mock):
         import httpx
 
+        # Transport errors are retried, so provide exceptions for both attempts
+        httpx_mock.add_exception(
+            httpx.ConnectError("Connection refused"),
+            url=CALLBACK_URL,
+        )
         httpx_mock.add_exception(
             httpx.ConnectError("Connection refused"),
             url=CALLBACK_URL,
@@ -124,6 +132,53 @@ class TestCallbackClient:
         )
 
         assert result is False
+        assert len(httpx_mock.get_requests()) == 2
+
+    async def test_retries_transport_error_then_succeeds(self, httpx_mock):
+        """Transport error on first attempt, success on retry."""
+        import httpx
+
+        httpx_mock.add_exception(
+            httpx.ConnectError("Connection reset"),
+            url=CALLBACK_URL,
+        )
+        httpx_mock.add_response(url=CALLBACK_URL, method="PATCH", json={})
+
+        client = CallbackClient(callback_token=TOKEN)
+        result = await client.send_progress(
+            CALLBACK_URL,
+            progress={"n1": {"status": "running"}},
+        )
+
+        assert result is True
+        assert len(httpx_mock.get_requests()) == 2
+
+    async def test_retries_5xx_then_succeeds(self, httpx_mock):
+        """5xx on first attempt, success on retry."""
+        httpx_mock.add_response(url=CALLBACK_URL, method="PATCH", status_code=502)
+        httpx_mock.add_response(url=CALLBACK_URL, method="PATCH", json={})
+
+        client = CallbackClient(callback_token=TOKEN)
+        result = await client.send_progress(
+            CALLBACK_URL,
+            progress={"n1": {"status": "running"}},
+        )
+
+        assert result is True
+        assert len(httpx_mock.get_requests()) == 2
+
+    async def test_no_retry_on_4xx(self, httpx_mock):
+        """4xx errors are deterministic and must NOT be retried."""
+        httpx_mock.add_response(url=CALLBACK_URL, method="PATCH", status_code=403)
+
+        client = CallbackClient(callback_token=TOKEN)
+        result = await client.send_progress(
+            CALLBACK_URL,
+            progress={"n1": {"status": "running"}},
+        )
+
+        assert result is False
+        assert len(httpx_mock.get_requests()) == 1
 
     async def test_error_message_truncated_to_10000(self, httpx_mock):
         httpx_mock.add_response(url=CALLBACK_URL, method="PATCH", json={})


### PR DESCRIPTION
## Summary

- Pipeline progress (per-agent status list) was not showing in chat on Railway — only the progress bar appeared with no agent detail. Docker worked fine.
- Root cause: callback URL used Railway's **public HTTPS URL** which routes through the edge proxy/load balancer, causing stale connection failures on per-node TrackedNode callbacks
- The first 3 callbacks (job started, composer running/done) succeeded because they happened close together, but subsequent callbacks during graph execution silently failed due to dropped connections

## Changes

- **`CALLBACK_BASE_URL` env var** — new env var for internal URL routing (`http://Prevision-WS.railway.internal:8000`), avoiding the public load balancer entirely
- **CallbackClient rewrite** — creates a fresh `httpx.AsyncClient` per request instead of reusing a persistent connection pool; adds retry logic (2 attempts, 0.5s delay) and catches all `Exception` types (not just `httpx.HTTPError`)
- **TrackedNode `_safe_send_progress`** — wraps callback sends so they never raise and break pipeline execution
- **Diagnostic logging** — added to job executor (node count, callback_url, graph build status)
- **ThoughtTrace fix** — `jobStatus` prop now uses real-time `quickStatus?.status` instead of stale initial job status
- **docker-compose** — passes `CALLBACK_BASE_URL` to backend and celery-worker
- **railway-setup.py** — adds `CALLBACK_BASE_URL` and other missing env vars to celery-worker/celery-beat

## Test plan
- [x] Orchestrator tests pass (179/179)
- [x] Backend orchestration tests pass (123/123)
- [x] Frontend builds cleanly
- [x] `CALLBACK_BASE_URL` set on Railway celery-worker via CLI
- [ ] Verify on Railway: trigger chat pipeline, confirm agent list + real-time progress appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)