### PR TITLE
fix: add .railway.internal to ALLOWED_HOSTS for pipeline callbacks

### DIFF
--- a/ai-brand-automator/brand_automator/settings.py
+++ b/ai-brand-automator/brand_automator/settings.py
@@ -39,14 +39,23 @@ ALLOWED_HOSTS = config(
     cast=lambda v: [s.strip() for s in v.split(",")],
 )
 
-# Railway private networking: allow internal service-to-service hostnames.
-# The pipeline orchestrator sends HTTP callbacks to the backend using the
-# Railway internal URL (e.g. http://Prevision-WS.railway.internal:8000).
-# Without this, Django rejects callbacks with 400 DisallowedHost and
+# Railway private networking: allow the specific internal hostname used for
+# service-to-service callbacks.  The pipeline orchestrator sends HTTP
+# callbacks to the backend using the CALLBACK_BASE_URL (e.g.
+# http://Prevision-WS.railway.internal:8000).  Without adding that hostname
+# to ALLOWED_HOSTS, Django rejects callbacks with 400 DisallowedHost and
 # pipeline progress never reaches the frontend.
 if config("RAILWAY_ENVIRONMENT_NAME", default=""):
-    if ".railway.internal" not in ALLOWED_HOSTS:
-        ALLOWED_HOSTS.append(".railway.internal")
+    from urllib.parse import urlparse as _urlparse
+
+    _cb_host = _urlparse(
+        config(
+            "CALLBACK_BASE_URL",
+            default=config("BACKEND_URL", default=""),
+        )
+    ).hostname
+    if _cb_host and _cb_host not in ALLOWED_HOSTS:
+        ALLOWED_HOSTS.append(_cb_host)
 
 
 # Application definition

--- a/ai-brand-automator/brand_automator/settings.py
+++ b/ai-brand-automator/brand_automator/settings.py
@@ -39,6 +39,15 @@ ALLOWED_HOSTS = config(
     cast=lambda v: [s.strip() for s in v.split(",")],
 )
 
+# Railway private networking: allow internal service-to-service hostnames.
+# The pipeline orchestrator sends HTTP callbacks to the backend using the
+# Railway internal URL (e.g. http://Prevision-WS.railway.internal:8000).
+# Without this, Django rejects callbacks with 400 DisallowedHost and
+# pipeline progress never reaches the frontend.
+if config("RAILWAY_ENVIRONMENT_NAME", default=""):
+    if ".railway.internal" not in ALLOWED_HOSTS:
+        ALLOWED_HOSTS.append(".railway.internal")
+
 
 # Application definition
 

--- a/deployment/scripts/railway-setup.py
+++ b/deployment/scripts/railway-setup.py
@@ -373,6 +373,10 @@ def main():
         "ONBOARDING_KAFKA_ENABLED": "false",
         "KAFKA_CONSUMERS_ENABLED": "false",
         "ORCHESTRATION_KAFKA_ENABLED": "false",
+        # Note: RAILWAY_ENVIRONMENT_NAME is auto-injected by Railway.
+        # settings.py uses it to append .railway.internal to ALLOWED_HOSTS
+        # so pipeline callbacks from the orchestrator are not rejected
+        # with 400 DisallowedHost.
     }
     set_variables(BACKEND_SERVICE_ID, backend_new_vars)
 

--- a/pipeline-orchestrator-svc/app/services/callback_client.py
+++ b/pipeline-orchestrator-svc/app/services/callback_client.py
@@ -75,12 +75,15 @@ class CallbackClient:
             except httpx.HTTPStatusError as exc:
                 # 4xx → non-retryable (bad request, auth, etc.)
                 if exc.response.status_code < 500:
+                    # Log response body for diagnosis (e.g. DisallowedHost)
+                    body = exc.response.text[:500] if exc.response else ""
                     logger.error(
-                        "Callback rejected (HTTP %d) for %s [%s]: %s",
+                        "Callback rejected (HTTP %d) for %s [%s]: %s " "— response: %s",
                         exc.response.status_code,
                         callback_url,
                         label,
                         exc,
+                        body,
                     )
                     return False
                 # 5xx → retryable

--- a/pipeline-orchestrator-svc/app/services/callback_client.py
+++ b/pipeline-orchestrator-svc/app/services/callback_client.py
@@ -75,8 +75,13 @@ class CallbackClient:
             except httpx.HTTPStatusError as exc:
                 # 4xx → non-retryable (bad request, auth, etc.)
                 if exc.response.status_code < 500:
-                    # Log response body for diagnosis (e.g. DisallowedHost)
-                    body = exc.response.text[:500] if exc.response else ""
+                    # Log a capped snippet of the response for diagnosis
+                    # (e.g. DisallowedHost).  Use raw bytes to avoid reading
+                    # an unbounded body via .text.
+                    body = ""
+                    if exc.response is not None:
+                        raw = exc.response.content[:512]
+                        body = raw.decode("utf-8", errors="replace").replace("\n", " ")
                     logger.error(
                         "Callback rejected (HTTP %d) for %s [%s]: %s " "— response: %s",
                         exc.response.status_code,


### PR DESCRIPTION
## Summary

- **Root cause**: Django's `DefaultTenantMiddleware` calls `request.get_host()` which validates the `Host` header against `ALLOWED_HOSTS`. On Railway, the orchestrator sends callbacks to `http://Prevision-WS.railway.internal:8000/...` but `.railway.internal` was not in `ALLOWED_HOSTS`. Django returned **400 DisallowedHost** for every callback, silently dropping all per-node progress updates.
- **Symptom**: The frontend shows "Pipeline Progress" header with an empty agent list — no running/done/failed nodes visible. Feels frozen to the user.
- **Why Docker works**: Docker's `ALLOWED_HOSTS` includes `backend` which matches the Docker service hostname used for callbacks (`http://backend:8001`).

## Changes

| File | Change |
|------|--------|
| `ai-brand-automator/brand_automator/settings.py` | Auto-detect Railway via `RAILWAY_ENVIRONMENT_NAME` (auto-injected by Railway) and append `.railway.internal` to `ALLOWED_HOSTS` |
| `pipeline-orchestrator-svc/app/services/callback_client.py` | Log HTTP response body on 4xx errors for easier future diagnosis |
| `deployment/scripts/railway-setup.py` | Document the `RAILWAY_ENVIRONMENT_NAME` auto-detection mechanism |

## Test plan

- [x] All 182 orchestrator tests pass
- [x] All 123 backend orchestration tests pass
- [x] Verified settings.py auto-detection: without `RAILWAY_ENVIRONMENT_NAME` → no change; with it → `.railway.internal` added
- [x] Black formatting + flake8 pass
- [ ] After merge: verify on Railway that pipeline progress shows agent list in real-time

🤖 Generated with [Claude Code](https://claude.com/claude-code)