### PR TITLE
fix: use astream for per-node progress callbacks in job executor

### DIFF
--- a/pipeline-orchestrator-svc/app/services/job_executor.py
+++ b/pipeline-orchestrator-svc/app/services/job_executor.py
@@ -6,6 +6,7 @@ cancel checking, and result reporting. This is the core runtime
 engine of the pipeline orchestrator.
 """
 
+import copy
 import logging
 from datetime import datetime, timezone
 from typing import Any
@@ -38,12 +39,17 @@ class JobExecutor:
 
         1. Build initial AgentState from the dispatch request
         2. Send "running" callback + initial progress
-        3. If no manifest → run intent routing
+        3. If no manifest → run intent routing (PipelineComposer)
         4. Build LangGraph from manifest
-        5. Execute nodes sequentially via graph
-        6. Check cancel flag between nodes
-        7. Send progress callbacks after each node
+        5. Stream graph execution via ``astream(stream_mode="updates")``
+        6. After each node completes: mark done → mark next running → callback
+        7. Check cancel flag between nodes
         8. Send completed / failed callback at the end
+
+        Uses ``astream`` instead of ``ainvoke`` so that per-node progress
+        callbacks are sent from the executor loop (which works reliably
+        across all deployment targets) rather than depending solely on
+        TrackedNode wrappers inside the graph.
         """
         job_id = request.job_id
         callback_url = request.callback_url
@@ -106,7 +112,9 @@ class JobExecutor:
                 )
 
                 # Send progress with all pending nodes visible to the UI
-                await self.callback.send_progress(callback_url, state["progress"])
+                await self.callback.send_progress(
+                    callback_url, copy.deepcopy(state["progress"])
+                )
 
             # Build the LangGraph (with per-node progress tracking)
             logger.info(
@@ -142,23 +150,104 @@ class JobExecutor:
                 )
                 return
 
-            # Invoke the compiled graph
+            # Mark the first node as running so the UI shows immediate
+            # activity instead of all-pending during the first node's work.
+            if node_ids:
+                state["progress"][node_ids[0]] = {
+                    "status": "running",
+                    "started_at": self._now_iso(),
+                }
+                await self.callback.send_progress(
+                    callback_url, copy.deepcopy(state["progress"])
+                )
+
+            # Stream the compiled graph for per-node progress.
+            # Using astream(stream_mode="updates") yields {node_id: output}
+            # as each node completes, allowing the executor to send progress
+            # callbacks directly — bypassing TrackedNode which is unreliable
+            # on certain cloud runtimes (Railway).
             logger.info(
-                "Job %s: invoking graph with %d nodes: %s " "(callback_url=%s)",
+                "Job %s: streaming graph with %d nodes: %s " "(callback_url=%s)",
                 job_id,
                 len(node_ids),
                 " → ".join(node_ids),
                 callback_url[:80] if callback_url else "<empty>",
             )
             try:
-                result_state = await compiled_graph.ainvoke(
+                result_data = None
+                accumulated_outputs: dict[str, Any] = dict(
+                    state.get("node_outputs", {})
+                )
+
+                async for chunk in compiled_graph.astream(
                     state,
                     config={
                         "configurable": {
-                            "thread_id": f"{state.get('tenant_id', 'default')}:{job_id}"
+                            "thread_id": (
+                                f"{state.get('tenant_id', 'default')}" f":{job_id}"
+                            )
                         }
                     },
-                )
+                    stream_mode="updates",
+                ):
+                    for completed_node_id, node_output in chunk.items():
+                        # Skip LangGraph internal markers (__start__, etc.)
+                        if completed_node_id.startswith("__"):
+                            continue
+
+                        logger.info(
+                            "Job %s: node %s completed (streamed)",
+                            job_id,
+                            completed_node_id,
+                        )
+
+                        # Accumulate result_data and node_outputs
+                        if isinstance(node_output, dict):
+                            if "result_data" in node_output:
+                                result_data = node_output["result_data"]
+                            if "node_outputs" in node_output:
+                                accumulated_outputs.update(node_output["node_outputs"])
+
+                        # Mark completed node as done
+                        state["progress"][completed_node_id] = {
+                            "status": "done",
+                            "completed_at": self._now_iso(),
+                        }
+
+                        # Mark the next pending node as running
+                        for nid in node_ids:
+                            if (
+                                nid != completed_node_id
+                                and state["progress"].get(nid, {}).get("status")
+                                == "pending"
+                            ):
+                                state["progress"][nid] = {
+                                    "status": "running",
+                                    "started_at": self._now_iso(),
+                                }
+                                break
+
+                        # Send per-node progress callback (deepcopy
+                        # to snapshot the mutable progress dict)
+                        await self.callback.send_progress(
+                            callback_url,
+                            copy.deepcopy(state["progress"]),
+                        )
+
+                        # Check cancel between nodes
+                        if await self._is_cancelled(job_id):
+                            logger.info(
+                                "Job %s cancelled after node %s",
+                                job_id,
+                                completed_node_id,
+                            )
+                            await self.callback.send_failed(
+                                callback_url,
+                                error_message="Job cancelled by user",
+                                progress=state["progress"],
+                            )
+                            return
+
             except Exception as exc:
                 logger.error(
                     "Graph execution failed for job %s: %s",
@@ -166,9 +255,10 @@ class JobExecutor:
                     exc,
                     exc_info=True,
                 )
-                # Mark remaining running nodes as failed
+                # Mark remaining running/pending nodes as failed
                 for nid in node_ids:
-                    if state["progress"].get(nid, {}).get("status") == "running":
+                    status = state["progress"].get(nid, {}).get("status")
+                    if status in ("running", "pending"):
                         state["progress"][nid] = {
                             "status": "failed",
                             "completed_at": self._now_iso(),
@@ -180,21 +270,25 @@ class JobExecutor:
                 )
                 return
 
-            # Update progress with completed status for all nodes
-            final_progress = result_state.get("progress", state["progress"])
+            # Ensure all nodes are marked done in final progress
+            final_progress = state["progress"]
             for nid in node_ids:
-                if final_progress.get(nid, {}).get("status") not in ("done", "failed"):
+                if final_progress.get(nid, {}).get("status") not in (
+                    "done",
+                    "failed",
+                ):
                     final_progress[nid] = {
                         "status": "done",
                         "completed_at": self._now_iso(),
                     }
 
-            # Extract result_data from the final state
-            result_data = result_state.get("result_data") or {
-                "summary": "Pipeline completed successfully.",
-                "findings": ["Analysis completed."],
-                "recommendations": [],
-            }
+            # Use accumulated result_data or fall back to default
+            if result_data is None:
+                result_data = {
+                    "summary": "Pipeline completed successfully.",
+                    "findings": ["Analysis completed."],
+                    "recommendations": [],
+                }
 
             # Check for cancel one last time
             if await self._is_cancelled(job_id):
@@ -288,7 +382,9 @@ class JobExecutor:
             "status": "running",
             "started_at": self._now_iso(),
         }
-        await self.callback.send_progress(request.callback_url, state["progress"])
+        await self.callback.send_progress(
+            request.callback_url, copy.deepcopy(state["progress"])
+        )
 
         composer = PipelineComposer()
         result = await composer.compose(state)
@@ -308,7 +404,9 @@ class JobExecutor:
                 "completed_at": self._now_iso(),
             }
             # Send progress update (no manifest_id to resolve in DB)
-            await self.callback.send_progress(request.callback_url, state["progress"])
+            await self.callback.send_progress(
+                request.callback_url, copy.deepcopy(state["progress"])
+            )
         else:
             state["resolved_manifest_id"] = result.get("resolved_manifest_id")
             state["progress"]["pipeline_composer"] = {

--- a/pipeline-orchestrator-svc/app/services/job_executor.py
+++ b/pipeline-orchestrator-svc/app/services/job_executor.py
@@ -116,17 +116,17 @@ class JobExecutor:
                     callback_url, copy.deepcopy(state["progress"])
                 )
 
-            # Build the LangGraph (with per-node progress tracking)
+            # Build the LangGraph without callback_client — the executor's
+            # astream loop handles per-node progress callbacks directly, so
+            # TrackedNode wrappers are not needed (and would cause duplicate
+            # or out-of-order progress events).
             logger.info(
-                "Job %s: building graph with %d nodes, callback_client=%s",
+                "Job %s: building graph with %d nodes (streaming mode)",
                 job_id,
                 len(manifest_data.get("nodes", [])),
-                "yes" if self.callback else "no",
             )
             try:
-                compiled_graph = GraphBuilder.build(
-                    manifest_data, callback_client=self.callback
-                )
+                compiled_graph = GraphBuilder.build(manifest_data, callback_client=None)
             except (GraphBuildError, ValueError) as exc:
                 logger.error("Graph build failed for job %s: %s", job_id, exc)
                 await self.callback.send_failed(
@@ -163,9 +163,10 @@ class JobExecutor:
 
             # Stream the compiled graph for per-node progress.
             # Using astream(stream_mode="updates") yields {node_id: output}
-            # as each node completes, allowing the executor to send progress
-            # callbacks directly — bypassing TrackedNode which is unreliable
-            # on certain cloud runtimes (Railway).
+            # as each node completes, and the executor sends progress
+            # callbacks directly from this loop.  The graph is built
+            # without callback_client so TrackedNode is not used —
+            # this avoids duplicate/out-of-order progress events.
             logger.info(
                 "Job %s: streaming graph with %d nodes: %s " "(callback_url=%s)",
                 job_id,
@@ -207,12 +208,40 @@ class JobExecutor:
                                 result_data = node_output["result_data"]
                             if "node_outputs" in node_output:
                                 accumulated_outputs.update(node_output["node_outputs"])
+                                # Persist back so state reflects all
+                                # streamed outputs after the loop.
+                                state["node_outputs"] = accumulated_outputs
 
-                        # Mark completed node as done
-                        state["progress"][completed_node_id] = {
+                        # Mark completed node as done, preserving
+                        # started_at if it was set when running.
+                        existing = state["progress"].get(completed_node_id, {})
+                        done_entry: dict[str, Any] = {
                             "status": "done",
                             "completed_at": self._now_iso(),
                         }
+                        if "started_at" in existing:
+                            done_entry["started_at"] = existing["started_at"]
+                        state["progress"][completed_node_id] = done_entry
+
+                        # Check cancel before transitioning the next
+                        # node — avoids briefly showing a node as
+                        # "running" when the job is about to stop.
+                        if await self._is_cancelled(job_id):
+                            logger.info(
+                                "Job %s cancelled after node %s",
+                                job_id,
+                                completed_node_id,
+                            )
+                            await self.callback.send_progress(
+                                callback_url,
+                                copy.deepcopy(state["progress"]),
+                            )
+                            await self.callback.send_failed(
+                                callback_url,
+                                error_message="Job cancelled by user",
+                                progress=state["progress"],
+                            )
+                            return
 
                         # Mark the next pending node as running
                         for nid in node_ids:
@@ -233,20 +262,6 @@ class JobExecutor:
                             callback_url,
                             copy.deepcopy(state["progress"]),
                         )
-
-                        # Check cancel between nodes
-                        if await self._is_cancelled(job_id):
-                            logger.info(
-                                "Job %s cancelled after node %s",
-                                job_id,
-                                completed_node_id,
-                            )
-                            await self.callback.send_failed(
-                                callback_url,
-                                error_message="Job cancelled by user",
-                                progress=state["progress"],
-                            )
-                            return
 
             except Exception as exc:
                 logger.error(

--- a/pipeline-orchestrator-svc/tests/test_job_executor.py
+++ b/pipeline-orchestrator-svc/tests/test_job_executor.py
@@ -1,6 +1,6 @@
 """Tests for the job executor — end-to-end pipeline execution."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 from app.api.schemas import (
     AvailableManifest,
@@ -358,10 +358,20 @@ class TestJobExecutor:
     async def test_streaming_sends_per_node_progress(self, mock_get_redis):
         """astream sends a progress callback after each node completes,
         with the completed node marked 'done' and next pending node
-        marked 'running'."""
+        marked 'running'.  Uses a stub compiled_graph to prove the
+        executor calls astream(stream_mode='updates') and processes
+        the yielded chunks."""
         mock_redis = AsyncMock()
         mock_redis.get.return_value = None  # not cancelled
         mock_get_redis.return_value = mock_redis
+
+        # Build a fake compiled graph whose astream yields per-node chunks
+        async def _fake_astream(state, *, config=None, stream_mode=None):
+            yield {"strategy": {"node_outputs": {"brand_strategist": {"ok": True}}}}
+            yield {"report": {"node_outputs": {"report_generator": {"ok": True}}}}
+
+        mock_compiled = MagicMock()
+        mock_compiled.astream = _fake_astream
 
         executor = JobExecutor()
         executor.callback = AsyncMock()
@@ -369,20 +379,19 @@ class TestJobExecutor:
         executor.callback.send_progress.return_value = True
         executor.callback.send_completed.return_value = True
 
-        request = _make_request()
-        await executor.execute(request)
+        with patch(
+            "app.services.job_executor.GraphBuilder.build",
+            return_value=mock_compiled,
+        ):
+            request = _make_request()
+            await executor.execute(request)
 
         # Verify progress callbacks include per-node done statuses.
-        # The manifest has nodes: strategy → report. We expect progress
-        # calls that show strategy=done → report=running, then
-        # report=done.
         progress_calls = executor.callback.send_progress.call_args_list
         found_strategy_done = False
         found_report_done = False
-        for call in progress_calls:
-            progress = (
-                call.args[1] if len(call.args) > 1 else call.kwargs.get("progress", {})
-            )
+        for c in progress_calls:
+            progress = c.args[1] if len(c.args) > 1 else c.kwargs.get("progress", {})
             if isinstance(progress, dict):
                 if progress.get("strategy", {}).get("status") == "done":
                     found_strategy_done = True
@@ -391,13 +400,24 @@ class TestJobExecutor:
         assert found_strategy_done, "strategy node should be marked done via stream"
         assert found_report_done, "report node should be marked done via stream"
 
+        # Verify completed was sent
+        executor.callback.send_completed.assert_called_once()
+
     @patch("app.services.job_executor.get_redis", new_callable=AsyncMock)
     async def test_streaming_marks_first_node_running(self, mock_get_redis):
         """Before streaming starts, the first node is marked 'running'
-        so the UI shows immediate activity."""
+        so the UI shows immediate activity.  Uses a stub compiled_graph
+        to prove the executor calls astream(stream_mode='updates')."""
         mock_redis = AsyncMock()
         mock_redis.get.return_value = None
         mock_get_redis.return_value = mock_redis
+
+        async def _fake_astream(state, *, config=None, stream_mode=None):
+            yield {"strategy": {"node_outputs": {"brand_strategist": {"ok": True}}}}
+            yield {"report": {"node_outputs": {"report_generator": {"ok": True}}}}
+
+        mock_compiled = MagicMock()
+        mock_compiled.astream = _fake_astream
 
         executor = JobExecutor()
         executor.callback = AsyncMock()
@@ -405,16 +425,18 @@ class TestJobExecutor:
         executor.callback.send_progress.return_value = True
         executor.callback.send_completed.return_value = True
 
-        request = _make_request()
-        await executor.execute(request)
+        with patch(
+            "app.services.job_executor.GraphBuilder.build",
+            return_value=mock_compiled,
+        ):
+            request = _make_request()
+            await executor.execute(request)
 
         # Find a progress call where strategy=running before it's done
         progress_calls = executor.callback.send_progress.call_args_list
         found_first_running = False
-        for call in progress_calls:
-            progress = (
-                call.args[1] if len(call.args) > 1 else call.kwargs.get("progress", {})
-            )
+        for c in progress_calls:
+            progress = c.args[1] if len(c.args) > 1 else c.kwargs.get("progress", {})
             if isinstance(progress, dict):
                 strategy_status = progress.get("strategy", {}).get("status")
                 report_status = progress.get("report", {}).get("status")
@@ -424,3 +446,118 @@ class TestJobExecutor:
         assert (
             found_first_running
         ), "First node should be marked running before streaming"
+
+    @patch("app.services.job_executor.get_redis", new_callable=AsyncMock)
+    async def test_graph_built_without_callback_client(self, mock_get_redis):
+        """GraphBuilder.build is called with callback_client=None
+        so that TrackedNode wrappers are not applied (the executor
+        handles progress via the astream loop)."""
+        mock_redis = AsyncMock()
+        mock_redis.get.return_value = None
+        mock_get_redis.return_value = mock_redis
+
+        async def _fake_astream(state, *, config=None, stream_mode=None):
+            yield {"strategy": {"node_outputs": {}}}
+            yield {"report": {"node_outputs": {}}}
+
+        mock_compiled = MagicMock()
+        mock_compiled.astream = _fake_astream
+
+        executor = JobExecutor()
+        executor.callback = AsyncMock()
+        executor.callback.send_running.return_value = True
+        executor.callback.send_progress.return_value = True
+        executor.callback.send_completed.return_value = True
+
+        with patch(
+            "app.services.job_executor.GraphBuilder.build",
+            return_value=mock_compiled,
+        ) as mock_build:
+            request = _make_request()
+            await executor.execute(request)
+
+        # Verify GraphBuilder.build was called with callback_client=None
+        mock_build.assert_called_once()
+        _, build_kwargs = mock_build.call_args
+        assert build_kwargs.get("callback_client") is None
+
+    @patch("app.services.job_executor.get_redis", new_callable=AsyncMock)
+    async def test_done_preserves_started_at(self, mock_get_redis):
+        """When a node transitions from running → done, the started_at
+        timestamp set during the running phase is preserved."""
+        mock_redis = AsyncMock()
+        mock_redis.get.return_value = None
+        mock_get_redis.return_value = mock_redis
+
+        async def _fake_astream(state, *, config=None, stream_mode=None):
+            yield {"strategy": {"node_outputs": {}}}
+            yield {"report": {"node_outputs": {}}}
+
+        mock_compiled = MagicMock()
+        mock_compiled.astream = _fake_astream
+
+        executor = JobExecutor()
+        executor.callback = AsyncMock()
+        executor.callback.send_running.return_value = True
+        executor.callback.send_progress.return_value = True
+        executor.callback.send_completed.return_value = True
+
+        with patch(
+            "app.services.job_executor.GraphBuilder.build",
+            return_value=mock_compiled,
+        ):
+            request = _make_request()
+            await executor.execute(request)
+
+        # Completed callback's progress should have started_at for strategy
+        call_kwargs = executor.callback.send_completed.call_args.kwargs
+        progress = call_kwargs.get("progress", {})
+        assert (
+            "started_at" in progress["strategy"]
+        ), "strategy should preserve started_at from running phase"
+        assert progress["strategy"]["status"] == "done"
+
+    @patch("app.services.job_executor.get_redis", new_callable=AsyncMock)
+    async def test_cancel_before_marking_next_running(self, mock_get_redis):
+        """Cancel flag between nodes should NOT mark the next node as
+        running — the job should stop immediately after the done callback."""
+        mock_redis = AsyncMock()
+        # 1st call: pre-execution cancel check → not cancelled
+        # 2nd call: after strategy node completes → cancelled
+        mock_redis.get.side_effect = [None, "1"]
+        mock_get_redis.return_value = mock_redis
+
+        async def _fake_astream(state, *, config=None, stream_mode=None):
+            yield {"strategy": {"node_outputs": {}}}
+            yield {"report": {"node_outputs": {}}}
+
+        mock_compiled = MagicMock()
+        mock_compiled.astream = _fake_astream
+
+        executor = JobExecutor()
+        executor.callback = AsyncMock()
+        executor.callback.send_running.return_value = True
+        executor.callback.send_progress.return_value = True
+        executor.callback.send_failed.return_value = True
+
+        with patch(
+            "app.services.job_executor.GraphBuilder.build",
+            return_value=mock_compiled,
+        ):
+            request = _make_request()
+            await executor.execute(request)
+
+        # Should have ended with a failed/cancelled callback
+        executor.callback.send_failed.assert_called()
+        cancel_call = executor.callback.send_failed.call_args
+        error_msg = cancel_call.kwargs.get("error_message", "")
+        assert "cancel" in error_msg.lower()
+
+        # report should NOT have been marked as running in any progress call
+        for c in executor.callback.send_progress.call_args_list:
+            progress = c.args[1] if len(c.args) > 1 else c.kwargs.get("progress", {})
+            if isinstance(progress, dict):
+                report_status = progress.get("report", {}).get("status")
+                assert (
+                    report_status != "running"
+                ), "report should not be marked running after cancel"

--- a/pipeline-orchestrator-svc/tests/test_job_executor.py
+++ b/pipeline-orchestrator-svc/tests/test_job_executor.py
@@ -261,7 +261,7 @@ class TestJobExecutor:
     @patch("app.services.job_executor.get_redis", new_callable=AsyncMock)
     async def test_composed_manifest_sends_pending_nodes_progress(self, mock_get_redis):
         """After intent routing resolves nodes, send_progress is called
-        with all new nodes as 'pending' before ainvoke() starts."""
+        with all new nodes as 'pending' before streaming starts."""
         mock_redis = AsyncMock()
         mock_redis.get.return_value = None
         mock_get_redis.return_value = mock_redis
@@ -290,7 +290,8 @@ class TestJobExecutor:
             await executor.execute(request)
 
         # send_progress should be called multiple times:
-        # 1. composer running, 2. composer done, 3. pending nodes before ainvoke
+        # 1. composer running, 2. composer done, 3. pending nodes before stream,
+        # 4. first node running, 5+ per-node done callbacks
         progress_calls = executor.callback.send_progress.call_args_list
         # Find the call that includes pending nodes (after composer done)
         found_pending = False
@@ -306,7 +307,7 @@ class TestJobExecutor:
                     break
         assert (
             found_pending
-        ), "send_progress must be called with pending nodes before ainvoke"
+        ), "send_progress must be called with pending nodes before streaming"
 
     @patch("app.services.job_executor.get_redis", new_callable=AsyncMock)
     async def test_composer_fallback_resolves_manifest_id(self, mock_get_redis):
@@ -352,3 +353,74 @@ class TestJobExecutor:
 
         executor.callback.send_completed.assert_called_once()
         executor.callback.send_resolved_manifest.assert_called_once()
+
+    @patch("app.services.job_executor.get_redis", new_callable=AsyncMock)
+    async def test_streaming_sends_per_node_progress(self, mock_get_redis):
+        """astream sends a progress callback after each node completes,
+        with the completed node marked 'done' and next pending node
+        marked 'running'."""
+        mock_redis = AsyncMock()
+        mock_redis.get.return_value = None  # not cancelled
+        mock_get_redis.return_value = mock_redis
+
+        executor = JobExecutor()
+        executor.callback = AsyncMock()
+        executor.callback.send_running.return_value = True
+        executor.callback.send_progress.return_value = True
+        executor.callback.send_completed.return_value = True
+
+        request = _make_request()
+        await executor.execute(request)
+
+        # Verify progress callbacks include per-node done statuses.
+        # The manifest has nodes: strategy → report. We expect progress
+        # calls that show strategy=done → report=running, then
+        # report=done.
+        progress_calls = executor.callback.send_progress.call_args_list
+        found_strategy_done = False
+        found_report_done = False
+        for call in progress_calls:
+            progress = (
+                call.args[1] if len(call.args) > 1 else call.kwargs.get("progress", {})
+            )
+            if isinstance(progress, dict):
+                if progress.get("strategy", {}).get("status") == "done":
+                    found_strategy_done = True
+                if progress.get("report", {}).get("status") == "done":
+                    found_report_done = True
+        assert found_strategy_done, "strategy node should be marked done via stream"
+        assert found_report_done, "report node should be marked done via stream"
+
+    @patch("app.services.job_executor.get_redis", new_callable=AsyncMock)
+    async def test_streaming_marks_first_node_running(self, mock_get_redis):
+        """Before streaming starts, the first node is marked 'running'
+        so the UI shows immediate activity."""
+        mock_redis = AsyncMock()
+        mock_redis.get.return_value = None
+        mock_get_redis.return_value = mock_redis
+
+        executor = JobExecutor()
+        executor.callback = AsyncMock()
+        executor.callback.send_running.return_value = True
+        executor.callback.send_progress.return_value = True
+        executor.callback.send_completed.return_value = True
+
+        request = _make_request()
+        await executor.execute(request)
+
+        # Find a progress call where strategy=running before it's done
+        progress_calls = executor.callback.send_progress.call_args_list
+        found_first_running = False
+        for call in progress_calls:
+            progress = (
+                call.args[1] if len(call.args) > 1 else call.kwargs.get("progress", {})
+            )
+            if isinstance(progress, dict):
+                strategy_status = progress.get("strategy", {}).get("status")
+                report_status = progress.get("report", {}).get("status")
+                if strategy_status == "running" and report_status == "pending":
+                    found_first_running = True
+                    break
+        assert (
+            found_first_running
+        ), "First node should be marked running before streaming"


### PR DESCRIPTION
Replace compiled_graph.ainvoke() with compiled_graph.astream(stream_mode='updates') so that the executor sends per-node progress callbacks directly from its streaming loop. This bypasses TrackedNode wrappers which are unreliable on Railway deployments.

Changes:
- job_executor.py: Stream graph with astream, mark first node running immediately, send done/running callbacks after each node completes, cancel check between nodes
- Use copy.deepcopy on progress dicts to prevent mutable reference issues in callbacks
- test_job_executor.py: Add test_streaming_sends_per_node_progress and test_streaming_marks_first_node_running, update comments for astream terminology
- Delete temporary _debug_graph.py diagnostic file