### PR TITLE
fix: replace LangGraph astream with direct sequential node execution

### DIFF
--- a/pipeline-orchestrator-svc/app/services/job_executor.py
+++ b/pipeline-orchestrator-svc/app/services/job_executor.py
@@ -4,17 +4,25 @@ Job executor — central orchestration service.
 Ties together graph building, node execution, progress callbacks,
 cancel checking, and result reporting. This is the core runtime
 engine of the pipeline orchestrator.
+
+Uses **direct sequential execution** instead of LangGraph's ainvoke /
+astream.  This ensures per-node progress callbacks fire reliably across
+all deployment targets (local Docker, Railway, etc.) by giving the
+executor full control over the call → callback loop.
 """
 
 import copy
 import logging
+from collections import defaultdict, deque
 from datetime import datetime, timezone
 from typing import Any
 
 from app.api.schemas import DispatchRequest
 from app.core.config import settings
 from app.core.redis_client import get_redis
-from app.factory.graph_builder import GraphBuilder, GraphBuildError
+from app.factory.graph_builder import GraphBuilder
+from app.factory.node_registry import resolve_handler
+from app.nodes.external_wrapper import ExternalWrapper
 from app.services.callback_client import CallbackClient
 from app.state.schema import AgentState
 
@@ -40,16 +48,17 @@ class JobExecutor:
         1. Build initial AgentState from the dispatch request
         2. Send "running" callback + initial progress
         3. If no manifest → run intent routing (PipelineComposer)
-        4. Build LangGraph from manifest
-        5. Stream graph execution via ``astream(stream_mode="updates")``
-        6. After each node completes: mark done → mark next running → callback
-        7. Check cancel flag between nodes
-        8. Send completed / failed callback at the end
+        4. Resolve node handlers (internal / external)
+        5. Execute nodes sequentially with per-node progress callbacks
+        6. Check cancel flag between nodes
+        7. Send completed / failed callback at the end
 
-        Uses ``astream`` instead of ``ainvoke`` so that per-node progress
-        callbacks are sent from the executor loop (which works reliably
-        across all deployment targets) rather than depending solely on
-        TrackedNode wrappers inside the graph.
+        Uses **direct sequential execution** — the executor calls each
+        node handler in topological order and sends progress callbacks
+        between every step.  This bypasses LangGraph's ``ainvoke`` /
+        ``astream`` execution engine entirely, ensuring per-node
+        progress is visible on all deployment targets (local Docker,
+        Railway, etc.).
         """
         job_id = request.job_id
         callback_url = request.callback_url
@@ -116,31 +125,53 @@ class JobExecutor:
                     callback_url, copy.deepcopy(state["progress"])
                 )
 
-            # Build the LangGraph without callback_client — the executor's
-            # astream loop handles per-node progress callbacks directly, so
-            # TrackedNode wrappers are not needed (and would cause duplicate
-            # or out-of-order progress events).
-            logger.info(
-                "Job %s: building graph with %d nodes (streaming mode)",
-                job_id,
-                len(manifest_data.get("nodes", [])),
-            )
-            try:
-                compiled_graph = GraphBuilder.build(manifest_data, callback_client=None)
-            except (GraphBuildError, ValueError) as exc:
-                logger.error("Graph build failed for job %s: %s", job_id, exc)
-                await self.callback.send_failed(
-                    callback_url,
-                    error_message=f"Graph build error: {exc}",
-                    progress=state["progress"],
-                )
-                return
-
-            # Execute the graph node by node
+            # ── Resolve node handlers ──
+            # Build handlers directly without using LangGraph's execution
+            # engine.  This gives the executor full control over the
+            # call → callback → cancel loop so per-node progress fires
+            # reliably on every deployment target.
             nodes = manifest_data.get("nodes", [])
-            node_ids = [n["id"] for n in nodes]
+            global_config = manifest_data.get("global_config", {})
 
-            # Check cancel flag before starting execution
+            node_ids: list[str] = []
+            handlers: dict[str, Any] = {}
+
+            # Topological sort to honour edges
+            sorted_ids = self._topological_sort(
+                manifest_data.get("nodes", []),
+                manifest_data.get("edges", []),
+            )
+
+            for node_def in nodes:
+                nid = node_def["id"]
+                node_ids.append(nid)
+                node_type = node_def.get("type", "internal")
+                merged_config = {**global_config, **node_def.get("config", {})}
+
+                if node_type == "internal":
+                    handler_name = node_def.get("handler")
+                    if not handler_name:
+                        raise ValueError(f"Internal node '{nid}' missing 'handler'")
+                    handler_cls = resolve_handler(handler_name)
+                    handlers[nid] = handler_cls(config=merged_config)
+                elif node_type == "external":
+                    url = node_def.get("url", "")
+                    url = GraphBuilder._translate_url(url)
+                    handlers[nid] = ExternalWrapper(
+                        url=url, node_id=nid, config=merged_config
+                    )
+                else:
+                    raise ValueError(f"Unknown node type '{node_type}' for '{nid}'")
+
+            logger.info(
+                "Job %s: executing %d nodes sequentially: %s " "(callback_url=%s)",
+                job_id,
+                len(sorted_ids),
+                " → ".join(sorted_ids),
+                callback_url[:80] if callback_url else "<empty>",
+            )
+
+            # ── Check cancel before starting ──
             if await self._is_cancelled(job_id):
                 logger.info("Job %s cancelled before execution", job_id)
                 await self.callback.send_failed(
@@ -150,134 +181,131 @@ class JobExecutor:
                 )
                 return
 
-            # Mark the first node as running so the UI shows immediate
-            # activity instead of all-pending during the first node's work.
-            if node_ids:
-                state["progress"][node_ids[0]] = {
-                    "status": "running",
-                    "started_at": self._now_iso(),
-                }
-                await self.callback.send_progress(
-                    callback_url, copy.deepcopy(state["progress"])
-                )
+            # ── Sequential execution loop ──
+            result_data = None
 
-            # Stream the compiled graph for per-node progress.
-            # Using astream(stream_mode="updates") yields {node_id: output}
-            # as each node completes, and the executor sends progress
-            # callbacks directly from this loop.  The graph is built
-            # without callback_client so TrackedNode is not used —
-            # this avoids duplicate/out-of-order progress events.
-            logger.info(
-                "Job %s: streaming graph with %d nodes: %s " "(callback_url=%s)",
-                job_id,
-                len(node_ids),
-                " → ".join(node_ids),
-                callback_url[:80] if callback_url else "<empty>",
-            )
             try:
-                result_data = None
-                accumulated_outputs: dict[str, Any] = dict(
-                    state.get("node_outputs", {})
-                )
+                for idx, nid in enumerate(sorted_ids):
+                    handler = handlers.get(nid)
+                    if handler is None:
+                        logger.error("Job %s: no handler for node %s", job_id, nid)
+                        continue
 
-                async for chunk in compiled_graph.astream(
-                    state,
-                    config={
-                        "configurable": {
-                            "thread_id": (
-                                f"{state.get('tenant_id', 'default')}" f":{job_id}"
-                            )
-                        }
-                    },
-                    stream_mode="updates",
-                ):
-                    for completed_node_id, node_output in chunk.items():
-                        # Skip LangGraph internal markers (__start__, etc.)
-                        if completed_node_id.startswith("__"):
-                            continue
+                    # Mark node as running
+                    started_at = self._now_iso()
+                    state["progress"][nid] = {
+                        "status": "running",
+                        "started_at": started_at,
+                    }
+                    await self.callback.send_progress(
+                        callback_url, copy.deepcopy(state["progress"])
+                    )
 
-                        logger.info(
-                            "Job %s: node %s completed (streamed)",
+                    logger.info(
+                        "Job %s: node %s starting (%d/%d)",
+                        job_id,
+                        nid,
+                        idx + 1,
+                        len(sorted_ids),
+                    )
+
+                    # Execute the handler
+                    try:
+                        node_result = await handler(state)
+                    except Exception as exc:
+                        logger.error(
+                            "Job %s: node %s failed: %s",
                             job_id,
-                            completed_node_id,
+                            nid,
+                            exc,
+                            exc_info=True,
                         )
-
-                        # Accumulate result_data and node_outputs
-                        if isinstance(node_output, dict):
-                            if "result_data" in node_output:
-                                result_data = node_output["result_data"]
-                            if "node_outputs" in node_output:
-                                accumulated_outputs.update(node_output["node_outputs"])
-                                # Persist back so state reflects all
-                                # streamed outputs after the loop.
-                                state["node_outputs"] = accumulated_outputs
-
-                        # Mark completed node as done, preserving
-                        # started_at if it was set when running.
-                        existing = state["progress"].get(completed_node_id, {})
-                        done_entry: dict[str, Any] = {
-                            "status": "done",
+                        # Mark this node as failed
+                        state["progress"][nid] = {
+                            "status": "failed",
+                            "started_at": started_at,
                             "completed_at": self._now_iso(),
                         }
-                        if "started_at" in existing:
-                            done_entry["started_at"] = existing["started_at"]
-                        state["progress"][completed_node_id] = done_entry
-
-                        # Check cancel before transitioning the next
-                        # node — avoids briefly showing a node as
-                        # "running" when the job is about to stop.
-                        if await self._is_cancelled(job_id):
-                            logger.info(
-                                "Job %s cancelled after node %s",
-                                job_id,
-                                completed_node_id,
-                            )
-                            await self.callback.send_progress(
-                                callback_url,
-                                copy.deepcopy(state["progress"]),
-                            )
-                            await self.callback.send_failed(
-                                callback_url,
-                                error_message="Job cancelled by user",
-                                progress=state["progress"],
-                            )
-                            return
-
-                        # Mark the next pending node as running
-                        for nid in node_ids:
+                        # Mark remaining pending nodes as failed
+                        for remaining_id in sorted_ids[idx + 1 :]:
                             if (
-                                nid != completed_node_id
-                                and state["progress"].get(nid, {}).get("status")
+                                state["progress"].get(remaining_id, {}).get("status")
                                 == "pending"
                             ):
-                                state["progress"][nid] = {
-                                    "status": "running",
-                                    "started_at": self._now_iso(),
+                                state["progress"][remaining_id] = {
+                                    "status": "failed",
+                                    "completed_at": self._now_iso(),
                                 }
-                                break
+                        await self.callback.send_failed(
+                            callback_url,
+                            error_message=f"Node {nid} failed: {exc}",
+                            progress=state["progress"],
+                        )
+                        return
 
-                        # Send per-node progress callback (deepcopy
-                        # to snapshot the mutable progress dict)
+                    # Merge node result into state
+                    if isinstance(node_result, dict):
+                        if "node_outputs" in node_result:
+                            state["node_outputs"].update(node_result["node_outputs"])
+                        if "result_data" in node_result:
+                            result_data = node_result["result_data"]
+
+                    # Mark node as done
+                    state["progress"][nid] = {
+                        "status": "done",
+                        "started_at": started_at,
+                        "completed_at": self._now_iso(),
+                    }
+
+                    logger.info(
+                        "Job %s: node %s completed (%d/%d)",
+                        job_id,
+                        nid,
+                        idx + 1,
+                        len(sorted_ids),
+                    )
+
+                    # Check cancel before the next node
+                    if await self._is_cancelled(job_id):
+                        logger.info(
+                            "Job %s cancelled after node %s",
+                            job_id,
+                            nid,
+                        )
+                        # Mark remaining pending nodes
+                        for remaining_id in sorted_ids[idx + 1 :]:
+                            if (
+                                state["progress"].get(remaining_id, {}).get("status")
+                                == "pending"
+                            ):
+                                state["progress"][remaining_id] = {
+                                    "status": "failed",
+                                    "completed_at": self._now_iso(),
+                                }
                         await self.callback.send_progress(
                             callback_url,
                             copy.deepcopy(state["progress"]),
                         )
+                        await self.callback.send_failed(
+                            callback_url,
+                            error_message="Job cancelled by user",
+                            progress=state["progress"],
+                        )
+                        return
+
+                    # Send per-node progress callback
+                    await self.callback.send_progress(
+                        callback_url,
+                        copy.deepcopy(state["progress"]),
+                    )
 
             except Exception as exc:
                 logger.error(
-                    "Graph execution failed for job %s: %s",
+                    "Execution loop failed for job %s: %s",
                     job_id,
                     exc,
                     exc_info=True,
                 )
-                # Mark remaining running/pending nodes as failed
-                for nid in node_ids:
-                    status = state["progress"].get(nid, {}).get("status")
-                    if status in ("running", "pending"):
-                        state["progress"][nid] = {
-                            "status": "failed",
-                            "completed_at": self._now_iso(),
-                        }
                 await self.callback.send_failed(
                     callback_url,
                     error_message=str(exc)[:10000],
@@ -287,7 +315,7 @@ class JobExecutor:
 
             # Ensure all nodes are marked done in final progress
             final_progress = state["progress"]
-            for nid in node_ids:
+            for nid in sorted_ids:
                 if final_progress.get(nid, {}).get("status") not in (
                     "done",
                     "failed",
@@ -466,6 +494,51 @@ class JobExecutor:
             }
 
         return None
+
+    @staticmethod
+    def _topological_sort(
+        nodes: list[dict[str, Any]],
+        edges: list[list[str]],
+    ) -> list[str]:
+        """Return node IDs in topological (execution) order.
+
+        Uses Kahn's algorithm.  Falls back to the original node list
+        order if the graph has no edges (single-node or edge-free).
+
+        Raises ValueError if the graph contains a cycle.
+        """
+        node_ids = [n["id"] for n in nodes]
+        if not edges:
+            return node_ids
+
+        in_degree: dict[str, int] = {nid: 0 for nid in node_ids}
+        adjacency: dict[str, list[str]] = defaultdict(list)
+
+        for edge in edges:
+            if len(edge) != 2:
+                continue
+            src, dst = edge[0], edge[1]
+            if src in in_degree and dst in in_degree:
+                adjacency[src].append(dst)
+                in_degree[dst] += 1
+
+        queue: deque[str] = deque(nid for nid in node_ids if in_degree[nid] == 0)
+        sorted_ids: list[str] = []
+
+        while queue:
+            nid = queue.popleft()
+            sorted_ids.append(nid)
+            for neighbour in adjacency.get(nid, []):
+                in_degree[neighbour] -= 1
+                if in_degree[neighbour] == 0:
+                    queue.append(neighbour)
+
+        if len(sorted_ids) != len(node_ids):
+            visited = set(sorted_ids)
+            cyclic = [n for n in node_ids if n not in visited]
+            raise ValueError(f"Manifest contains a cycle involving: {cyclic}")
+
+        return sorted_ids
 
     async def _is_cancelled(self, job_id: str) -> bool:
         """Check if a cancel flag is set in Redis for this job."""

--- a/pipeline-orchestrator-svc/app/services/job_executor.py
+++ b/pipeline-orchestrator-svc/app/services/job_executor.py
@@ -133,35 +133,63 @@ class JobExecutor:
             nodes = manifest_data.get("nodes", [])
             global_config = manifest_data.get("global_config", {})
 
-            node_ids: list[str] = []
+            if not nodes:
+                logger.error("Job %s: manifest contains no nodes", job_id)
+                await self.callback.send_failed(
+                    callback_url,
+                    error_message="Manifest contains no nodes",
+                    progress=state["progress"],
+                )
+                return
+
             handlers: dict[str, Any] = {}
 
-            # Topological sort to honour edges
-            sorted_ids = self._topological_sort(
-                manifest_data.get("nodes", []),
-                manifest_data.get("edges", []),
-            )
+            # Topological sort + handler resolution.  If this fails
+            # (e.g. unknown handler, invalid node type, cycle in edges)
+            # we fail fast but still return the already-initialised
+            # per-node progress so the UI can show pending nodes.
+            try:
+                sorted_ids = self._topological_sort(
+                    manifest_data.get("nodes", []),
+                    manifest_data.get("edges", []),
+                )
 
-            for node_def in nodes:
-                nid = node_def["id"]
-                node_ids.append(nid)
-                node_type = node_def.get("type", "internal")
-                merged_config = {**global_config, **node_def.get("config", {})}
+                for node_def in nodes:
+                    nid = node_def["id"]
+                    node_type = node_def.get("type", "internal")
+                    merged_config = {
+                        **global_config,
+                        **node_def.get("config", {}),
+                    }
 
-                if node_type == "internal":
-                    handler_name = node_def.get("handler")
-                    if not handler_name:
-                        raise ValueError(f"Internal node '{nid}' missing 'handler'")
-                    handler_cls = resolve_handler(handler_name)
-                    handlers[nid] = handler_cls(config=merged_config)
-                elif node_type == "external":
-                    url = node_def.get("url", "")
-                    url = GraphBuilder._translate_url(url)
-                    handlers[nid] = ExternalWrapper(
-                        url=url, node_id=nid, config=merged_config
-                    )
-                else:
-                    raise ValueError(f"Unknown node type '{node_type}' for '{nid}'")
+                    if node_type == "internal":
+                        handler_name = node_def.get("handler")
+                        if not handler_name:
+                            raise ValueError(f"Internal node '{nid}' missing 'handler'")
+                        handler_cls = resolve_handler(handler_name)
+                        handlers[nid] = handler_cls(config=merged_config)
+                    elif node_type == "external":
+                        url = node_def.get("url", "")
+                        if not url:
+                            raise ValueError(f"External node '{nid}' missing 'url'")
+                        url = GraphBuilder._translate_url(url)
+                        handlers[nid] = ExternalWrapper(
+                            url=url, node_id=nid, config=merged_config
+                        )
+                    else:
+                        raise ValueError(f"Unknown node type '{node_type}' for '{nid}'")
+            except Exception as exc:
+                logger.exception(
+                    "Job %s: manifest/handler resolution failed: %s",
+                    job_id,
+                    exc,
+                )
+                await self.callback.send_failed(
+                    callback_url,
+                    error_message=(f"Manifest or handler resolution error: {exc}"),
+                    progress=state["progress"],
+                )
+                return
 
             logger.info(
                 "Job %s: executing %d nodes sequentially: %s " "(callback_url=%s)",
@@ -181,15 +209,36 @@ class JobExecutor:
                 )
                 return
 
+            # ── Validate handler coverage ──
+            missing_handlers = [nid for nid in sorted_ids if handlers.get(nid) is None]
+            if missing_handlers:
+                logger.error(
+                    "Job %s: missing handlers for node(s): %s",
+                    job_id,
+                    ", ".join(missing_handlers),
+                )
+                now_iso = self._now_iso()
+                for missing_id in missing_handlers:
+                    state["progress"][missing_id] = {
+                        "status": "failed",
+                        "completed_at": now_iso,
+                    }
+                await self.callback.send_failed(
+                    callback_url,
+                    error_message=(
+                        "Execution aborted due to missing handlers "
+                        "for node(s): " + ", ".join(missing_handlers)
+                    ),
+                    progress=state["progress"],
+                )
+                return
+
             # ── Sequential execution loop ──
             result_data = None
 
             try:
                 for idx, nid in enumerate(sorted_ids):
-                    handler = handlers.get(nid)
-                    if handler is None:
-                        logger.error("Job %s: no handler for node %s", job_id, nid)
-                        continue
+                    handler = handlers[nid]
 
                     # Mark node as running
                     started_at = self._now_iso()
@@ -514,13 +563,21 @@ class JobExecutor:
         in_degree: dict[str, int] = {nid: 0 for nid in node_ids}
         adjacency: dict[str, list[str]] = defaultdict(list)
 
-        for edge in edges:
+        node_id_set = set(node_ids)
+        for i, edge in enumerate(edges):
             if len(edge) != 2:
-                continue
+                raise ValueError(
+                    f"Edge at index {i} is malformed (expected 2 "
+                    f"elements, got {len(edge)}): {edge}"
+                )
             src, dst = edge[0], edge[1]
-            if src in in_degree and dst in in_degree:
-                adjacency[src].append(dst)
-                in_degree[dst] += 1
+            unknown = [n for n in (src, dst) if n not in node_id_set]
+            if unknown:
+                raise ValueError(
+                    f"Edge [{src}, {dst}] references unknown " f"node(s): {unknown}"
+                )
+            adjacency[src].append(dst)
+            in_degree[dst] += 1
 
         queue: deque[str] = deque(nid for nid in node_ids if in_degree[nid] == 0)
         sorted_ids: list[str] = []

--- a/pipeline-orchestrator-svc/tests/test_job_executor.py
+++ b/pipeline-orchestrator-svc/tests/test_job_executor.py
@@ -1,6 +1,6 @@
 """Tests for the job executor — end-to-end pipeline execution."""
 
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import AsyncMock, patch
 
 from app.api.schemas import (
     AvailableManifest,
@@ -13,6 +13,12 @@ from app.services.job_executor import JobExecutor
 
 # Use a sentinel to distinguish "no manifest" from "explicit None"
 _UNSET = object()
+
+
+def _stub_handler_factory(return_value=None):
+    """Return a mock resolve_handler that returns async stub handlers."""
+    async_handler = AsyncMock(return_value=return_value or {"node_outputs": {}})
+    return lambda name: (lambda config=None: async_handler)
 
 
 def _make_request(manifest=_UNSET, available_manifests=None, job_id="test-job-123"):
@@ -62,8 +68,12 @@ class TestJobExecutor:
         executor.callback.send_progress.return_value = True
         executor.callback.send_completed.return_value = True
 
-        request = _make_request()
-        await executor.execute(request)
+        with patch(
+            "app.services.job_executor.resolve_handler",
+            side_effect=_stub_handler_factory(),
+        ):
+            request = _make_request()
+            await executor.execute(request)
 
         # Verify "running" was sent
         executor.callback.send_running.assert_called_once()
@@ -109,8 +119,12 @@ class TestJobExecutor:
         executor.callback.send_progress.return_value = True
         executor.callback.send_failed.return_value = True
 
-        request = _make_request()
-        await executor.execute(request)
+        with patch(
+            "app.services.job_executor.resolve_handler",
+            side_effect=_stub_handler_factory(),
+        ):
+            request = _make_request()
+            await executor.execute(request)
 
         # Verify "failed" was sent with cancel message
         executor.callback.send_failed.assert_called()
@@ -158,8 +172,12 @@ class TestJobExecutor:
         executor.callback.send_progress.return_value = True
         executor.callback.send_completed.return_value = True
 
-        request = _make_request()
-        await executor.execute(request)
+        with patch(
+            "app.services.job_executor.resolve_handler",
+            side_effect=_stub_handler_factory(),
+        ):
+            request = _make_request()
+            await executor.execute(request)
 
         # Completed callback must include progress for all nodes
         executor.callback.send_completed.assert_called_once()
@@ -199,8 +217,12 @@ class TestJobExecutor:
         executor.callback.send_progress.return_value = True
         executor.callback.send_completed.return_value = True
 
-        request = _make_request()
-        await executor.execute(request)
+        with patch(
+            "app.services.job_executor.resolve_handler",
+            side_effect=_stub_handler_factory(),
+        ):
+            request = _make_request()
+            await executor.execute(request)
 
         # Should still complete (Redis failure is non-fatal for cancel check)
         executor.callback.send_completed.assert_called_once()
@@ -236,10 +258,16 @@ class TestJobExecutor:
         executor.callback.send_completed.return_value = True
         executor.callback.send_resolved_manifest.return_value = True
 
-        with patch(
-            "app.nodes.internal.pipeline_composer.PipelineComposer.compose",
-            new_callable=AsyncMock,
-            return_value={"_composed_manifest": composed_manifest},
+        with (
+            patch(
+                "app.nodes.internal.pipeline_composer.PipelineComposer.compose",
+                new_callable=AsyncMock,
+                return_value={"_composed_manifest": composed_manifest},
+            ),
+            patch(
+                "app.services.job_executor.resolve_handler",
+                side_effect=_stub_handler_factory(),
+            ),
         ):
             request = _make_request(manifest=None)
             await executor.execute(request)
@@ -281,23 +309,31 @@ class TestJobExecutor:
         executor.callback.send_progress.return_value = True
         executor.callback.send_completed.return_value = True
 
-        with patch(
-            "app.nodes.internal.pipeline_composer.PipelineComposer.compose",
-            new_callable=AsyncMock,
-            return_value={"_composed_manifest": composed_manifest},
+        with (
+            patch(
+                "app.nodes.internal.pipeline_composer.PipelineComposer.compose",
+                new_callable=AsyncMock,
+                return_value={"_composed_manifest": composed_manifest},
+            ),
+            patch(
+                "app.services.job_executor.resolve_handler",
+                side_effect=_stub_handler_factory(),
+            ),
         ):
             request = _make_request(manifest=None)
             await executor.execute(request)
 
         # send_progress should be called multiple times:
-        # 1. composer running, 2. composer done, 3. pending nodes before stream,
+        # 1. composer running, 2. composer done, 3. pending nodes,
         # 4. first node running, 5+ per-node done callbacks
         progress_calls = executor.callback.send_progress.call_args_list
         # Find the call that includes pending nodes (after composer done)
         found_pending = False
-        for call in progress_calls:
+        for progress_call in progress_calls:
             progress = (
-                call.args[1] if len(call.args) > 1 else call.kwargs.get("progress", {})
+                progress_call.args[1]
+                if len(progress_call.args) > 1
+                else progress_call.kwargs.get("progress", {})
             )
             if isinstance(progress, dict):
                 discovery_status = progress.get("discovery", {}).get("status")
@@ -343,10 +379,16 @@ class TestJobExecutor:
             )
         ]
 
-        with patch(
-            "app.nodes.internal.pipeline_composer.PipelineComposer.compose",
-            new_callable=AsyncMock,
-            return_value={"resolved_manifest_id": "blog-authoring"},
+        with (
+            patch(
+                "app.nodes.internal.pipeline_composer.PipelineComposer.compose",
+                new_callable=AsyncMock,
+                return_value={"resolved_manifest_id": "blog-authoring"},
+            ),
+            patch(
+                "app.services.job_executor.resolve_handler",
+                side_effect=_stub_handler_factory(),
+            ),
         ):
             request = _make_request(manifest=None, available_manifests=available)
             await executor.execute(request)
@@ -355,23 +397,29 @@ class TestJobExecutor:
         executor.callback.send_resolved_manifest.assert_called_once()
 
     @patch("app.services.job_executor.get_redis", new_callable=AsyncMock)
-    async def test_streaming_sends_per_node_progress(self, mock_get_redis):
-        """astream sends a progress callback after each node completes,
-        with the completed node marked 'done' and next pending node
-        marked 'running'.  Uses a stub compiled_graph to prove the
-        executor calls astream(stream_mode='updates') and processes
-        the yielded chunks."""
+    async def test_sequential_sends_per_node_progress(self, mock_get_redis):
+        """Direct sequential execution sends a progress callback after
+        each node completes, with the completed node marked 'done'
+        and the next node marked 'running'."""
         mock_redis = AsyncMock()
         mock_redis.get.return_value = None  # not cancelled
         mock_get_redis.return_value = mock_redis
 
-        # Build a fake compiled graph whose astream yields per-node chunks
-        async def _fake_astream(state, *, config=None, stream_mode=None):
-            yield {"strategy": {"node_outputs": {"brand_strategist": {"ok": True}}}}
-            yield {"report": {"node_outputs": {"report_generator": {"ok": True}}}}
+        # Stub handlers that return quickly
+        mock_strategy = AsyncMock(
+            return_value={"node_outputs": {"strategy": {"ok": True}}}
+        )
+        mock_report = AsyncMock(return_value={"node_outputs": {"report": {"ok": True}}})
 
-        mock_compiled = MagicMock()
-        mock_compiled.astream = _fake_astream
+        def _mock_resolve(name):
+            handler_map = {
+                "StrategyNode": lambda config=None: mock_strategy,
+                "ReportNode": lambda config=None: mock_report,
+            }
+            factory = handler_map.get(name)
+            if factory:
+                return factory
+            raise ValueError(f"Unknown handler: {name}")
 
         executor = JobExecutor()
         executor.callback = AsyncMock()
@@ -380,8 +428,8 @@ class TestJobExecutor:
         executor.callback.send_completed.return_value = True
 
         with patch(
-            "app.services.job_executor.GraphBuilder.build",
-            return_value=mock_compiled,
+            "app.services.job_executor.resolve_handler",
+            side_effect=_mock_resolve,
         ):
             request = _make_request()
             await executor.execute(request)
@@ -397,27 +445,30 @@ class TestJobExecutor:
                     found_strategy_done = True
                 if progress.get("report", {}).get("status") == "done":
                     found_report_done = True
-        assert found_strategy_done, "strategy node should be marked done via stream"
-        assert found_report_done, "report node should be marked done via stream"
+        assert found_strategy_done, "strategy node should be marked done"
+        assert found_report_done, "report node should be marked done"
 
         # Verify completed was sent
         executor.callback.send_completed.assert_called_once()
 
     @patch("app.services.job_executor.get_redis", new_callable=AsyncMock)
-    async def test_streaming_marks_first_node_running(self, mock_get_redis):
-        """Before streaming starts, the first node is marked 'running'
-        so the UI shows immediate activity.  Uses a stub compiled_graph
-        to prove the executor calls astream(stream_mode='updates')."""
+    async def test_sequential_marks_first_node_running(self, mock_get_redis):
+        """Before executing each node, the executor marks it 'running'
+        so the UI shows immediate activity."""
         mock_redis = AsyncMock()
         mock_redis.get.return_value = None
         mock_get_redis.return_value = mock_redis
 
-        async def _fake_astream(state, *, config=None, stream_mode=None):
-            yield {"strategy": {"node_outputs": {"brand_strategist": {"ok": True}}}}
-            yield {"report": {"node_outputs": {"report_generator": {"ok": True}}}}
+        mock_strategy = AsyncMock(
+            return_value={"node_outputs": {"strategy": {"ok": True}}}
+        )
+        mock_report = AsyncMock(return_value={"node_outputs": {"report": {"ok": True}}})
 
-        mock_compiled = MagicMock()
-        mock_compiled.astream = _fake_astream
+        def _mock_resolve(name):
+            return {
+                "StrategyNode": lambda config=None: mock_strategy,
+                "ReportNode": lambda config=None: mock_report,
+            }[name]
 
         executor = JobExecutor()
         executor.callback = AsyncMock()
@@ -426,8 +477,8 @@ class TestJobExecutor:
         executor.callback.send_completed.return_value = True
 
         with patch(
-            "app.services.job_executor.GraphBuilder.build",
-            return_value=mock_compiled,
+            "app.services.job_executor.resolve_handler",
+            side_effect=_mock_resolve,
         ):
             request = _make_request()
             await executor.execute(request)
@@ -445,23 +496,20 @@ class TestJobExecutor:
                     break
         assert (
             found_first_running
-        ), "First node should be marked running before streaming"
+        ), "First node should be marked running before execution"
 
     @patch("app.services.job_executor.get_redis", new_callable=AsyncMock)
-    async def test_graph_built_without_callback_client(self, mock_get_redis):
-        """GraphBuilder.build is called with callback_client=None
-        so that TrackedNode wrappers are not applied (the executor
-        handles progress via the astream loop)."""
+    async def test_no_langgraph_build_used(self, mock_get_redis):
+        """The executor resolves handlers directly and does NOT call
+        GraphBuilder.build — execution is fully sequential."""
         mock_redis = AsyncMock()
         mock_redis.get.return_value = None
         mock_get_redis.return_value = mock_redis
 
-        async def _fake_astream(state, *, config=None, stream_mode=None):
-            yield {"strategy": {"node_outputs": {}}}
-            yield {"report": {"node_outputs": {}}}
+        mock_handler = AsyncMock(return_value={"node_outputs": {}})
 
-        mock_compiled = MagicMock()
-        mock_compiled.astream = _fake_astream
+        def _mock_resolve(name):
+            return lambda config=None: mock_handler
 
         executor = JobExecutor()
         executor.callback = AsyncMock()
@@ -469,17 +517,20 @@ class TestJobExecutor:
         executor.callback.send_progress.return_value = True
         executor.callback.send_completed.return_value = True
 
-        with patch(
-            "app.services.job_executor.GraphBuilder.build",
-            return_value=mock_compiled,
-        ) as mock_build:
+        with (
+            patch(
+                "app.services.job_executor.resolve_handler",
+                side_effect=_mock_resolve,
+            ),
+            patch(
+                "app.services.job_executor.GraphBuilder.build",
+            ) as mock_build,
+        ):
             request = _make_request()
             await executor.execute(request)
 
-        # Verify GraphBuilder.build was called with callback_client=None
-        mock_build.assert_called_once()
-        _, build_kwargs = mock_build.call_args
-        assert build_kwargs.get("callback_client") is None
+        # GraphBuilder.build should NOT be called
+        mock_build.assert_not_called()
 
     @patch("app.services.job_executor.get_redis", new_callable=AsyncMock)
     async def test_done_preserves_started_at(self, mock_get_redis):
@@ -489,12 +540,10 @@ class TestJobExecutor:
         mock_redis.get.return_value = None
         mock_get_redis.return_value = mock_redis
 
-        async def _fake_astream(state, *, config=None, stream_mode=None):
-            yield {"strategy": {"node_outputs": {}}}
-            yield {"report": {"node_outputs": {}}}
+        mock_handler = AsyncMock(return_value={"node_outputs": {}})
 
-        mock_compiled = MagicMock()
-        mock_compiled.astream = _fake_astream
+        def _mock_resolve(name):
+            return lambda config=None: mock_handler
 
         executor = JobExecutor()
         executor.callback = AsyncMock()
@@ -503,8 +552,8 @@ class TestJobExecutor:
         executor.callback.send_completed.return_value = True
 
         with patch(
-            "app.services.job_executor.GraphBuilder.build",
-            return_value=mock_compiled,
+            "app.services.job_executor.resolve_handler",
+            side_effect=_mock_resolve,
         ):
             request = _make_request()
             await executor.execute(request)
@@ -527,12 +576,16 @@ class TestJobExecutor:
         mock_redis.get.side_effect = [None, "1"]
         mock_get_redis.return_value = mock_redis
 
-        async def _fake_astream(state, *, config=None, stream_mode=None):
-            yield {"strategy": {"node_outputs": {}}}
-            yield {"report": {"node_outputs": {}}}
+        mock_strategy = AsyncMock(
+            return_value={"node_outputs": {"strategy": {"ok": True}}}
+        )
+        mock_report = AsyncMock(return_value={"node_outputs": {"report": {"ok": True}}})
 
-        mock_compiled = MagicMock()
-        mock_compiled.astream = _fake_astream
+        def _mock_resolve(name):
+            return {
+                "StrategyNode": lambda config=None: mock_strategy,
+                "ReportNode": lambda config=None: mock_report,
+            }[name]
 
         executor = JobExecutor()
         executor.callback = AsyncMock()
@@ -541,8 +594,8 @@ class TestJobExecutor:
         executor.callback.send_failed.return_value = True
 
         with patch(
-            "app.services.job_executor.GraphBuilder.build",
-            return_value=mock_compiled,
+            "app.services.job_executor.resolve_handler",
+            side_effect=_mock_resolve,
         ):
             request = _make_request()
             await executor.execute(request)

--- a/pipeline-orchestrator-svc/tests/test_job_executor.py
+++ b/pipeline-orchestrator-svc/tests/test_job_executor.py
@@ -136,7 +136,8 @@ class TestJobExecutor:
 
     @patch("app.services.job_executor.get_redis", new_callable=AsyncMock)
     async def test_invalid_manifest_sends_failed(self, mock_get_redis):
-        """Invalid manifest (unknown handler) → graph build error → failed callback."""
+        """Invalid manifest (unknown handler) → resolution error → failed callback
+        with per-node progress preserved."""
         mock_redis = AsyncMock()
         mock_redis.get.return_value = None
         mock_get_redis.return_value = mock_redis
@@ -151,13 +152,116 @@ class TestJobExecutor:
         executor = JobExecutor()
         executor.callback = AsyncMock()
         executor.callback.send_running.return_value = True
+        executor.callback.send_progress.return_value = True
         executor.callback.send_failed.return_value = True
 
         request = _make_request(manifest=bad_manifest)
         await executor.execute(request)
 
-        # Verify "failed" was sent
+        # Verify "failed" was sent with progress (not empty dict)
         executor.callback.send_failed.assert_called()
+        call_kwargs = executor.callback.send_failed.call_args.kwargs
+        progress = call_kwargs.get("progress", {})
+        assert "bad" in progress, "progress should contain the node from the manifest"
+
+    @patch("app.services.job_executor.get_redis", new_callable=AsyncMock)
+    async def test_empty_manifest_nodes_sends_failed(self, mock_get_redis):
+        """Manifest with zero nodes → send_failed (not false-success)."""
+        mock_redis = AsyncMock()
+        mock_redis.get.return_value = None
+        mock_get_redis.return_value = mock_redis
+
+        empty_manifest = ManifestData(nodes=[], edges=[])
+
+        executor = JobExecutor()
+        executor.callback = AsyncMock()
+        executor.callback.send_running.return_value = True
+        executor.callback.send_failed.return_value = True
+
+        request = _make_request(manifest=empty_manifest)
+        await executor.execute(request)
+
+        executor.callback.send_failed.assert_called()
+        call_kwargs = executor.callback.send_failed.call_args.kwargs
+        assert "no nodes" in call_kwargs.get("error_message", "").lower()
+
+    @patch("app.services.job_executor.get_redis", new_callable=AsyncMock)
+    async def test_external_node_missing_url_sends_failed(self, mock_get_redis):
+        """External node without a url → resolution error → failed with progress."""
+        mock_redis = AsyncMock()
+        mock_redis.get.return_value = None
+        mock_get_redis.return_value = mock_redis
+
+        bad_manifest = ManifestData(
+            nodes=[
+                ManifestNode(id="ext", type="external", url=""),
+            ],
+            edges=[],
+        )
+
+        executor = JobExecutor()
+        executor.callback = AsyncMock()
+        executor.callback.send_running.return_value = True
+        executor.callback.send_failed.return_value = True
+
+        request = _make_request(manifest=bad_manifest)
+        await executor.execute(request)
+
+        executor.callback.send_failed.assert_called()
+        call_kwargs = executor.callback.send_failed.call_args.kwargs
+        assert "url" in call_kwargs.get("error_message", "").lower()
+
+    @patch("app.services.job_executor.get_redis", new_callable=AsyncMock)
+    async def test_malformed_edge_raises_error(self, mock_get_redis):
+        """Manifest with a malformed edge (not 2-element) → failed."""
+        mock_redis = AsyncMock()
+        mock_redis.get.return_value = None
+        mock_get_redis.return_value = mock_redis
+
+        bad_manifest = ManifestData(
+            nodes=[
+                ManifestNode(id="a", type="internal", handler="StrategyNode"),
+            ],
+            edges=[["a"]],  # malformed
+        )
+
+        executor = JobExecutor()
+        executor.callback = AsyncMock()
+        executor.callback.send_running.return_value = True
+        executor.callback.send_failed.return_value = True
+
+        request = _make_request(manifest=bad_manifest)
+        await executor.execute(request)
+
+        executor.callback.send_failed.assert_called()
+        call_kwargs = executor.callback.send_failed.call_args.kwargs
+        assert "malformed" in call_kwargs.get("error_message", "").lower()
+
+    @patch("app.services.job_executor.get_redis", new_callable=AsyncMock)
+    async def test_edge_unknown_node_raises_error(self, mock_get_redis):
+        """Manifest with an edge referencing an unknown node → failed."""
+        mock_redis = AsyncMock()
+        mock_redis.get.return_value = None
+        mock_get_redis.return_value = mock_redis
+
+        bad_manifest = ManifestData(
+            nodes=[
+                ManifestNode(id="a", type="internal", handler="StrategyNode"),
+            ],
+            edges=[["a", "nonexistent"]],
+        )
+
+        executor = JobExecutor()
+        executor.callback = AsyncMock()
+        executor.callback.send_running.return_value = True
+        executor.callback.send_failed.return_value = True
+
+        request = _make_request(manifest=bad_manifest)
+        await executor.execute(request)
+
+        executor.callback.send_failed.assert_called()
+        call_kwargs = executor.callback.send_failed.call_args.kwargs
+        assert "unknown" in call_kwargs.get("error_message", "").lower()
 
     @patch("app.services.job_executor.get_redis", new_callable=AsyncMock)
     async def test_completed_includes_progress_for_all_nodes(self, mock_get_redis):
@@ -190,7 +294,8 @@ class TestJobExecutor:
             assert progress[node_id]["status"] == "done"
 
     def test_general_chat_inline_manifest(self):
-        """Inline fallback manifest for general-chat when no Django manifest available."""
+        """Inline fallback manifest for general-chat
+        when no Django manifest available."""
         request = _make_request(manifest=None, available_manifests=[])
         result = JobExecutor._find_resolved_manifest(request, "general-chat")
         assert result is not None
@@ -614,3 +719,42 @@ class TestJobExecutor:
                 assert (
                     report_status != "running"
                 ), "report should not be marked running after cancel"
+
+
+class TestTopologicalSort:
+    """Unit tests for JobExecutor._topological_sort validation."""
+
+    def test_valid_linear_graph(self):
+        nodes = [{"id": "a"}, {"id": "b"}, {"id": "c"}]
+        edges = [["a", "b"], ["b", "c"]]
+        result = JobExecutor._topological_sort(nodes, edges)
+        assert result == ["a", "b", "c"]
+
+    def test_no_edges_preserves_order(self):
+        nodes = [{"id": "x"}, {"id": "y"}]
+        result = JobExecutor._topological_sort(nodes, [])
+        assert result == ["x", "y"]
+
+    def test_cycle_raises_value_error(self):
+        import pytest
+
+        nodes = [{"id": "a"}, {"id": "b"}]
+        edges = [["a", "b"], ["b", "a"]]
+        with pytest.raises(ValueError, match="cycle"):
+            JobExecutor._topological_sort(nodes, edges)
+
+    def test_malformed_edge_raises_value_error(self):
+        import pytest
+
+        nodes = [{"id": "a"}, {"id": "b"}]
+        edges = [["a"]]  # only 1 element
+        with pytest.raises(ValueError, match="malformed"):
+            JobExecutor._topological_sort(nodes, edges)
+
+    def test_unknown_node_in_edge_raises_value_error(self):
+        import pytest
+
+        nodes = [{"id": "a"}]
+        edges = [["a", "ghost"]]
+        with pytest.raises(ValueError, match="unknown"):
+            JobExecutor._topological_sort(nodes, edges)


### PR DESCRIPTION
The astream/TrackedNode approaches both failed to produce per-node progress callbacks on Railway, despite working locally.  Root cause: LangGraph's execution engine does not reliably invoke async callable nodes or yield per-node astream chunks in all deployment targets.

This commit replaces the LangGraph execution engine with direct sequential execution:

- Executor resolves node handlers directly (resolve_handler + ExternalWrapper) without building a compiled LangGraph
- Iterates nodes in topological order with a simple for-loop
- Sends running/done progress callbacks between each node
- Checks cancel flag between nodes
- Fully controls the call → callback → cancel loop

This approach is deployment-agnostic — no dependency on LangGraph's ainvoke, astream, or TrackedNode wrappers.

All 187 orchestrator tests pass.