### PR TITLE
fix: strip markdown from blog content before saving as scheduled post

### DIFF
--- a/ai-brand-automator/automation/internal_views.py
+++ b/ai-brand-automator/automation/internal_views.py
@@ -203,12 +203,15 @@ class InternalPublishView(APIView):
                 status=status.HTTP_404_NOT_FOUND,
             )
 
+        # Strip markdown — social platforms render plain text, not markdown
+        from automation.utils import strip_markdown
+
         # Create ContentCalendar entry
         calendar_entry = ContentCalendar.objects.create(
             tenant_id=tenant_id,
             user=profiles[0].user,
-            title=title,
-            content=content_text,
+            title=strip_markdown(title),
+            content=strip_markdown(content_text),
             media_urls=media_urls or [],
             platforms=[p.platform for p in profiles],
             scheduled_date=timezone.now(),

--- a/ai-brand-automator/automation/internal_views.py
+++ b/ai-brand-automator/automation/internal_views.py
@@ -206,12 +206,15 @@ class InternalPublishView(APIView):
         # Strip markdown — social platforms render plain text, not markdown
         from automation.utils import strip_markdown
 
+        clean_title = strip_markdown(title)
+        clean_content = strip_markdown(content_text)
+
         # Create ContentCalendar entry
         calendar_entry = ContentCalendar.objects.create(
             tenant_id=tenant_id,
             user=profiles[0].user,
-            title=strip_markdown(title),
-            content=strip_markdown(content_text),
+            title=clean_title,
+            content=clean_content,
             media_urls=media_urls or [],
             platforms=[p.platform for p in profiles],
             scheduled_date=timezone.now(),
@@ -236,8 +239,8 @@ class InternalPublishView(APIView):
         for profile in profiles:
             result, error = publish_to_platform(
                 profile=profile,
-                content_text=content_text,
-                content_title=title,
+                content_text=clean_content,
+                content_title=clean_title,
                 media_urls=media_urls,
                 log_prefix=f"[social-agent][job:{job_id}]",
             )

--- a/ai-brand-automator/automation/mcp_server.py
+++ b/ai-brand-automator/automation/mcp_server.py
@@ -1716,11 +1716,14 @@ def _execute_tool_sync(name: str, arguments: dict) -> dict[str, Any]:
         # Optional tenant context for multi-tenant pipeline usage
         tenant_id = arguments.get("tenant_id")
 
+        # Strip markdown from content — social platforms render plain text
+        from automation.utils import strip_markdown
+
         # Create content
         create_kwargs = {
             "user": user,
-            "title": arguments["title"],
-            "content": arguments["content"],
+            "title": strip_markdown(arguments["title"]),
+            "content": strip_markdown(arguments["content"]),
             "platforms": platforms,
             "scheduled_date": scheduled_date,
             "media_urls": arguments.get("media_urls", []),

--- a/ai-brand-automator/automation/tests/test_utils.py
+++ b/ai-brand-automator/automation/tests/test_utils.py
@@ -1,0 +1,113 @@
+"""Unit tests for automation.utils.strip_markdown."""
+
+import pytest
+
+from automation.utils import strip_markdown
+
+
+@pytest.mark.unit
+class TestStripMarkdown:
+    """Tests for strip_markdown()."""
+
+    def test_empty_and_none(self):
+        assert strip_markdown("") == ""
+        assert strip_markdown(None) is None
+
+    def test_plain_text_unchanged(self):
+        assert strip_markdown("Hello world") == "Hello world"
+
+    def test_headers(self):
+        assert strip_markdown("# Title") == "Title"
+        assert strip_markdown("## Subtitle") == "Subtitle"
+        assert strip_markdown("###### Deep") == "Deep"
+
+    def test_bold(self):
+        assert strip_markdown("This is **bold** text") == "This is bold text"
+        assert strip_markdown("This is __bold__ text") == "This is bold text"
+
+    def test_italic(self):
+        assert strip_markdown("This is *italic* text") == "This is italic text"
+
+    def test_bold_italic(self):
+        assert strip_markdown("***both***") == "both"
+
+    def test_strikethrough(self):
+        assert strip_markdown("~~removed~~") == "removed"
+
+    def test_links(self):
+        assert strip_markdown("[Click](https://example.com)") == "Click"
+
+    def test_link_with_parentheses_in_url(self):
+        """Handles Wikipedia-style URLs with parentheses."""
+        md = "[Function](https://en.wikipedia.org/wiki/Function_(mathematics))"
+        result = strip_markdown(md)
+        assert result == "Function"
+
+    def test_images(self):
+        assert strip_markdown("![Alt text](image.png)") == "Alt text"
+
+    def test_inline_code(self):
+        assert strip_markdown("Use `code` here") == "Use code here"
+
+    def test_inline_code_protected_from_emphasis(self):
+        """Inline code like `__init__` should not be mangled by underscore stripping."""
+        result = strip_markdown("Call `__init__` method")
+        assert "__init__" in result
+
+    def test_fenced_code_block(self):
+        md = "Before\n```python\nprint('hi')\n```\nAfter"
+        result = strip_markdown(md)
+        assert "print" not in result
+        assert "Before" in result
+        assert "After" in result
+
+    def test_blockquotes(self):
+        assert strip_markdown("> Quoted text") == "Quoted text"
+
+    def test_horizontal_rules(self):
+        assert strip_markdown("Above\n---\nBelow").strip() == "Above\n\nBelow"
+        assert strip_markdown("Above\n***\nBelow").strip() == "Above\n\nBelow"
+
+    def test_unordered_list(self):
+        md = "- Item one\n- Item two"
+        result = strip_markdown(md)
+        assert result == "Item one\nItem two"
+
+    def test_ordered_list(self):
+        md = "1. First\n2. Second"
+        result = strip_markdown(md)
+        assert result == "First\nSecond"
+
+    def test_html_tags(self):
+        assert strip_markdown("Hello <b>world</b>") == "Hello world"
+
+    def test_multiple_blank_lines_collapsed(self):
+        md = "A\n\n\n\n\nB"
+        result = strip_markdown(md)
+        assert result == "A\n\nB"
+
+    def test_full_blog_post(self):
+        """Representative blog content from the content agent."""
+        blog = (
+            "# Building Your Brand\n\n"
+            "**Brand identity** is crucial for [success](https://example.com).\n\n"
+            "## Key Points\n\n"
+            "- Be authentic\n"
+            "- Be consistent\n"
+            "- Use *visual storytelling*\n\n"
+            "> Great brands tell stories.\n\n"
+            "---\n\n"
+            "Follow us for more tips!"
+        )
+        result = strip_markdown(blog)
+        assert "# " not in result
+        assert "**" not in result
+        assert "[success]" not in result
+        assert "- " not in result
+        assert "> " not in result
+        assert "---" not in result
+        assert "Building Your Brand" in result
+        assert "Brand identity" in result
+        assert "Be authentic" in result
+        assert "visual storytelling" in result
+        assert "Follow us for more tips!" in result

--- a/ai-brand-automator/automation/utils.py
+++ b/ai-brand-automator/automation/utils.py
@@ -4,6 +4,27 @@ Utility functions for the automation app.
 
 import re
 
+# Pre-compiled patterns for strip_markdown (used on every scheduled post).
+_CODE_BLOCK = re.compile(r"```[\s\S]*?```")
+_INLINE_CODE = re.compile(r"`([^`]+)`")
+_IMAGE = re.compile(r"!\[([^\]]*)\]\((?:[^()]*|\([^()]*\))*\)")
+# Link pattern handles one level of nested parentheses in URLs
+# (e.g. Wikipedia: https://en.wikipedia.org/wiki/Function_(mathematics)).
+_LINK = re.compile(r"\[([^\]]+)\]\((?:[^()]*|\([^()]*\))*\)")
+_HEADER = re.compile(r"^#{1,6}\s+", re.MULTILINE)
+_BOLD_STAR = re.compile(r"\*{1,3}([^*]+)\*{1,3}")
+_BOLD_UNDER = re.compile(r"(?<!\w)_{1,3}([^_]+)_{1,3}(?!\w)")
+_STRIKE = re.compile(r"~~([^~]+)~~")
+_BLOCKQUOTE = re.compile(r"^>\s?", re.MULTILINE)
+_HR = re.compile(r"^[-*_]{3,}\s*$", re.MULTILINE)
+_UL = re.compile(r"^[\s]*[-*+]\s+", re.MULTILINE)
+_OL = re.compile(r"^[\s]*\d+\.\s+", re.MULTILINE)
+_HTML = re.compile(r"<[^>]+>")
+_BLANK_LINES = re.compile(r"\n{3,}")
+
+# Placeholder for inline code spans during processing.
+_CODE_PLACEHOLDER = "\x00CODE{}\x00"
+
 
 def strip_markdown(text: str) -> str:
     """Convert markdown-formatted text to clean plain text for social posts.
@@ -12,6 +33,9 @@ def strip_markdown(text: str) -> str:
     blockquotes, horizontal rules, and list markers while preserving
     the actual content and paragraph structure.
 
+    Inline code spans (e.g. ``__init__``) are protected from the
+    emphasis-stripping pass so their contents are not mangled.
+
     Used when blog content (authored in markdown) is saved as a
     scheduled social post — social platforms render plain text, not
     markdown, so ``# My Title`` should become ``My Title``.
@@ -19,32 +43,47 @@ def strip_markdown(text: str) -> str:
     if not text:
         return text
 
-    # Remove code blocks (``` ... ```)
-    result = re.sub(r"```[\s\S]*?```", "", text)
-    # Remove inline code (`code`)
-    result = re.sub(r"`([^`]+)`", r"\1", result)
-    # Remove images ![alt](url)
-    result = re.sub(r"!\[([^\]]*)\]\([^)]+\)", r"\1", result)
+    # Remove fenced code blocks (``` ... ```)
+    result = _CODE_BLOCK.sub("", text)
+
+    # Protect inline code spans from emphasis stripping: replace them
+    # with numbered placeholders, then restore after bold/italic removal.
+    code_spans: list[str] = []
+
+    def _save_code(m: re.Match) -> str:
+        code_spans.append(m.group(1))
+        return _CODE_PLACEHOLDER.format(len(code_spans) - 1)
+
+    result = _INLINE_CODE.sub(_save_code, result)
+
+    # Remove images ![alt](url) → alt text
+    result = _IMAGE.sub(r"\1", result)
     # Convert links [text](url) → text
-    result = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", result)
+    result = _LINK.sub(r"\1", result)
     # Remove headers (# ... ######)
-    result = re.sub(r"^#{1,6}\s+", "", result, flags=re.MULTILINE)
-    # Remove bold/italic markers (**, __, *, _)
-    result = re.sub(r"\*{1,3}([^*]+)\*{1,3}", r"\1", result)
-    result = re.sub(r"_{1,3}([^_]+)_{1,3}", r"\1", result)
+    result = _HEADER.sub("", result)
+    # Remove bold/italic markers (**, *, ___)
+    result = _BOLD_STAR.sub(r"\1", result)
+    # Underscore emphasis: require word boundaries so identifiers like
+    # __init__ are not treated as bold markers.
+    result = _BOLD_UNDER.sub(r"\1", result)
     # Remove strikethrough (~~text~~)
-    result = re.sub(r"~~([^~]+)~~", r"\1", result)
+    result = _STRIKE.sub(r"\1", result)
     # Remove blockquotes (> ...)
-    result = re.sub(r"^>\s?", "", result, flags=re.MULTILINE)
+    result = _BLOCKQUOTE.sub("", result)
     # Remove horizontal rules (---, ***, ___)
-    result = re.sub(r"^[-*_]{3,}\s*$", "", result, flags=re.MULTILINE)
+    result = _HR.sub("", result)
     # Remove unordered list markers (- , * , + )
-    result = re.sub(r"^[\s]*[-*+]\s+", "", result, flags=re.MULTILINE)
+    result = _UL.sub("", result)
     # Remove ordered list markers (1. , 2. , etc.)
-    result = re.sub(r"^[\s]*\d+\.\s+", "", result, flags=re.MULTILINE)
+    result = _OL.sub("", result)
     # Remove HTML tags
-    result = re.sub(r"<[^>]+>", "", result)
+    result = _HTML.sub("", result)
     # Collapse multiple blank lines into at most two newlines
-    result = re.sub(r"\n{3,}", "\n\n", result)
+    result = _BLANK_LINES.sub("\n\n", result)
+
+    # Restore inline code spans (now safe from emphasis stripping)
+    for idx, span in enumerate(code_spans):
+        result = result.replace(_CODE_PLACEHOLDER.format(idx), span)
 
     return result.strip()

--- a/ai-brand-automator/automation/utils.py
+++ b/ai-brand-automator/automation/utils.py
@@ -1,0 +1,50 @@
+"""
+Utility functions for the automation app.
+"""
+
+import re
+
+
+def strip_markdown(text: str) -> str:
+    """Convert markdown-formatted text to clean plain text for social posts.
+
+    Removes headers, bold/italic markers, links, images, code blocks,
+    blockquotes, horizontal rules, and list markers while preserving
+    the actual content and paragraph structure.
+
+    Used when blog content (authored in markdown) is saved as a
+    scheduled social post — social platforms render plain text, not
+    markdown, so ``# My Title`` should become ``My Title``.
+    """
+    if not text:
+        return text
+
+    # Remove code blocks (``` ... ```)
+    result = re.sub(r"```[\s\S]*?```", "", text)
+    # Remove inline code (`code`)
+    result = re.sub(r"`([^`]+)`", r"\1", result)
+    # Remove images ![alt](url)
+    result = re.sub(r"!\[([^\]]*)\]\([^)]+\)", r"\1", result)
+    # Convert links [text](url) → text
+    result = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", result)
+    # Remove headers (# ... ######)
+    result = re.sub(r"^#{1,6}\s+", "", result, flags=re.MULTILINE)
+    # Remove bold/italic markers (**, __, *, _)
+    result = re.sub(r"\*{1,3}([^*]+)\*{1,3}", r"\1", result)
+    result = re.sub(r"_{1,3}([^_]+)_{1,3}", r"\1", result)
+    # Remove strikethrough (~~text~~)
+    result = re.sub(r"~~([^~]+)~~", r"\1", result)
+    # Remove blockquotes (> ...)
+    result = re.sub(r"^>\s?", "", result, flags=re.MULTILINE)
+    # Remove horizontal rules (---, ***, ___)
+    result = re.sub(r"^[-*_]{3,}\s*$", "", result, flags=re.MULTILINE)
+    # Remove unordered list markers (- , * , + )
+    result = re.sub(r"^[\s]*[-*+]\s+", "", result, flags=re.MULTILINE)
+    # Remove ordered list markers (1. , 2. , etc.)
+    result = re.sub(r"^[\s]*\d+\.\s+", "", result, flags=re.MULTILINE)
+    # Remove HTML tags
+    result = re.sub(r"<[^>]+>", "", result)
+    # Collapse multiple blank lines into at most two newlines
+    result = re.sub(r"\n{3,}", "\n\n", result)
+
+    return result.strip()


### PR DESCRIPTION
## Summary

Blog content authored by the content-agent-service is in Markdown format (headers, bold, links, lists, etc.). Social platforms render plain text, so markdown formatting like `# Title` and `**bold**` appeared as raw symbols in scheduled/published posts.

## Changes

| File | Change |
|------|--------|
| `ai-brand-automator/automation/utils.py` | **NEW** — `strip_markdown()` utility that removes headers, bold/italic, links, images, code blocks, blockquotes, list markers, and HTML tags |
| `ai-brand-automator/automation/mcp_server.py` | Apply `strip_markdown()` to title and content in `create_scheduled_content` handler |
| `ai-brand-automator/automation/internal_views.py` | Apply `strip_markdown()` to title and content in `InternalPublishView.post()` |

## Before / After

**Before:** `# Building Your Brand\n\n**Brand identity** is crucial for [success](https://example.com).`

**After:** `Building Your Brand\n\nBrand identity is crucial for success.`

## Test plan

- [x] Unit tested strip_markdown() with headers, bold, italic, links, images, lists, blockquotes, code, HTML
- [x] Backend lint passes (black + flake8)
- [x] Docker deployed and verified
- [ ] After merge: Railway auto-deploys, verify new pipeline posts have clean formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)