### PR TITLE
chore: trigger frontend rebuild

### DIFF
--- a/ai-brand-automator-frontend/next.config.ts
+++ b/ai-brand-automator-frontend/next.config.ts
@@ -27,3 +27,5 @@ const nextConfig: NextConfig = {
 };
 
 export default nextConfig;
+
+// rebuild trigger


### PR DESCRIPTION
Triggers a frontend rebuild so NEXT_PUBLIC_BRAND_EQUITY_API_URL gets baked into the Next.js bundle at build time.