### PR TITLE
fix: add NEXT_PUBLIC_BRAND_EQUITY_API_URL to frontend Dockerfile

### DIFF
--- a/ai-brand-automator-frontend/Dockerfile
+++ b/ai-brand-automator-frontend/Dockerfile
@@ -7,6 +7,8 @@ WORKDIR /app
 # Build arguments for Next.js public env vars (needed at build time)
 ARG NEXT_PUBLIC_API_URL
 ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
+ARG NEXT_PUBLIC_BRAND_EQUITY_API_URL
+ENV NEXT_PUBLIC_BRAND_EQUITY_API_URL=$NEXT_PUBLIC_BRAND_EQUITY_API_URL
 
 # Install dependencies
 COPY package*.json ./


### PR DESCRIPTION
The /brand-equity page shows 'not configured' on Railway because the env var wasn't passed as a Docker build ARG. This adds it alongside NEXT_PUBLIC_API_URL.