### PR TITLE
fix: Add railway.json for APA service build configuration

### DIFF
--- a/audience-persona-agent-svc/railway.json
+++ b/audience-persona-agent-svc/railway.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile"
+  },
+  "deploy": {
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 5,
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 300
+  }
+}


### PR DESCRIPTION
Configures Railway to use DOCKERFILE builder with health check on /health endpoint, matching the pattern of other agent services.