### PR TITLE
fix: Analytics extraction data structure mismatch and pipeline coverage

### DIFF
--- a/ai-brand-automator/analytics/extractors/__init__.py
+++ b/ai-brand-automator/analytics/extractors/__init__.py
@@ -4,14 +4,77 @@ from analytics.extractors.brand_analysis import BrandAnalysisExtractor
 from analytics.extractors.content_social import ContentSocialExtractor
 
 # Pipeline ID → Extractor mapping
+# Covers all pipeline IDs from seed_manifests.py
 PIPELINE_EXTRACTORS = {
+    # Brand discovery pipelines (all 5 agents)
     "brand-discovery-complete": BrandDiscoveryExtractor(),
     "brand-discovery-full": BrandDiscoveryExtractor(),
+    # Brand equity / valuation
     "iso-brand-equity": BrandEquityExtractor(),
+    # Brand analysis / competitor audit
     "brand-analysis": BrandAnalysisExtractor(),
     "competitor-audit": BrandAnalysisExtractor(),
+    # Individual agent pipelines (extract what they produce)
+    "voice-of-customer": BrandDiscoveryExtractor(),
+    "audience-persona": BrandDiscoveryExtractor(),
+    "audience-persona-discovery": BrandDiscoveryExtractor(),
+    "trend-cultural-insights": BrandDiscoveryExtractor(),
+    "competitor-intelligence": BrandAnalysisExtractor(),
+    "market-research": BrandDiscoveryExtractor(),
+    "market-research-competitor-intel": BrandAnalysisExtractor(),
+    "market-research-report": BrandDiscoveryExtractor(),
+    # Content / social pipelines
     "blog-authoring": ContentSocialExtractor(),
     "content-social-publish": ContentSocialExtractor(),
     "social-promotion": ContentSocialExtractor(),
+    "social-post": ContentSocialExtractor(),
+    "rag-blog-social": ContentSocialExtractor(),
+    "rag-blog-authoring": ContentSocialExtractor(),
+    "content-strategy": ContentSocialExtractor(),
     "default-full-pipeline": ContentSocialExtractor(),
+    # General chat — uses brand discovery extractor to grab any
+    # agent results that were composed dynamically
+    "general-chat": BrandDiscoveryExtractor(),
 }
+
+
+def detect_extractor_from_result(result_data: dict):
+    """Detect the best extractor based on result_data content.
+
+    Used as fallback when pipeline_id is unknown (chat-mode Tier 1).
+    """
+    if not result_data:
+        return None
+
+    node_results = result_data.get("node_results", {})
+
+    # Check for discovery agent outputs
+    has_voc = bool(
+        node_results.get("voice_of_customer") or result_data.get("voc_health_score")
+    )
+    has_cia = bool(
+        node_results.get("competitor_intelligence")
+        or result_data.get("competitors_analyzed")
+    )
+    has_apa = bool(node_results.get("audience_persona") or result_data.get("personas"))
+    has_tcia = bool(
+        node_results.get("trend_cultural") or result_data.get("scored_trends")
+    )
+
+    if has_voc or has_cia or has_apa or has_tcia:
+        return BrandDiscoveryExtractor()
+
+    # Check for content/social outputs
+    has_blog = bool(node_results.get("blog_author") or result_data.get("blog_content"))
+    has_social = bool(
+        node_results.get("social_promoter") or result_data.get("platforms_posted")
+    )
+
+    if has_blog or has_social:
+        return ContentSocialExtractor()
+
+    # Check for brand equity outputs
+    if result_data.get("brand_equity") or result_data.get("valuation"):
+        return BrandEquityExtractor()
+
+    return None

--- a/ai-brand-automator/analytics/extractors/brand_analysis.py
+++ b/ai-brand-automator/analytics/extractors/brand_analysis.py
@@ -4,18 +4,29 @@ from analytics.extractors.base import BaseExtractor
 class BrandAnalysisExtractor(BaseExtractor):
     """Extracts metrics from brand-analysis and competitor-audit pipelines.
 
-    Reuses CIA + VoC extraction logic from the brand discovery extractor.
+    Reuses CIA + VoC extraction logic.
+    Data lives under result_data["node_results"][<node_id>].
     """
 
     def extract(self, job) -> list:
         result = job.result_data or {}
+        node_results = result.get("node_results", {})
         metrics = []
 
-        # CIA metrics
-        cia = result.get("competitor_intelligence", {})
+        # CIA metrics — node_id: "competitor_intelligence"
+        cia = node_results.get("competitor_intelligence", {})
+        if not cia:
+            cia = result.get("competitor_intelligence", {})
         if cia:
             competitors = cia.get("competitors_analyzed", [])
-            if isinstance(competitors, list):
+            if not competitors:
+                raw = cia.get("competitors", [])
+                if isinstance(raw, list):
+                    competitors = [
+                        c.get("name", "") for c in raw if isinstance(c, dict)
+                    ]
+                    competitors = [n for n in competitors if n]
+            if isinstance(competitors, list) and competitors:
                 metrics.append(
                     self._make_metric(
                         job,
@@ -27,10 +38,12 @@ class BrandAnalysisExtractor(BaseExtractor):
                     )
                 )
 
-        # VoC metrics (if present in brand-analysis results)
-        voc = result.get("voc_analysis", {})
+        # VoC metrics — node_id: "voice_of_customer"
+        voc = node_results.get("voice_of_customer", {})
+        if not voc:
+            voc = result.get("voice_of_customer", {})
         if voc:
-            health_score = self._safe_get(voc, "health_score")
+            health_score = self._safe_get(voc, "voc_health_score")
             if health_score:
                 metrics.append(
                     self._make_metric(
@@ -42,20 +55,21 @@ class BrandAnalysisExtractor(BaseExtractor):
                     )
                 )
 
-            nps_data = voc.get("nps", {})
-            nps_score = self._safe_get(
-                nps_data, "current_nps", "nps_score", default=None
-            )
-            if nps_score is not None:
-                metrics.append(
-                    self._make_metric(
-                        job,
-                        "nps",
-                        float(nps_score),
-                        "customer_voice",
-                        unit="score",
-                        agent_source="voc-agent",
-                    )
+            nps_data = voc.get("nps_analysis", {})
+            if isinstance(nps_data, dict):
+                nps_score = self._safe_get(
+                    nps_data, "current_nps", "nps_score", default=None
                 )
+                if nps_score is not None:
+                    metrics.append(
+                        self._make_metric(
+                            job,
+                            "nps",
+                            float(nps_score),
+                            "customer_voice",
+                            unit="score",
+                            agent_source="voc-agent",
+                        )
+                    )
 
         return metrics

--- a/ai-brand-automator/analytics/extractors/brand_discovery.py
+++ b/ai-brand-automator/analytics/extractors/brand_discovery.py
@@ -5,29 +5,39 @@ class BrandDiscoveryExtractor(BaseExtractor):
     """Extracts metrics from brand-discovery pipelines.
 
     Covers VoC, TCIA, APA, and CIA agent outputs.
+    Data lives under result_data["node_results"][<node_id>].
     """
 
     def extract(self, job) -> list:
         result = job.result_data or {}
+        node_results = result.get("node_results", {})
         metrics = []
 
-        # VoC metrics
-        voc = result.get("voc_analysis", {})
+        # VoC metrics — node_id: "voice_of_customer"
+        voc = node_results.get("voice_of_customer", {})
+        if not voc:
+            voc = result.get("voice_of_customer", {})
         if voc:
             metrics.extend(self._extract_voc(job, voc))
 
-        # TCIA metrics
-        tcia = result.get("trend_cultural_analysis", {})
+        # TCIA metrics — node_id: "trend_cultural"
+        tcia = node_results.get("trend_cultural", {})
+        if not tcia:
+            tcia = result.get("trend_cultural", {})
         if tcia:
             metrics.extend(self._extract_tcia(job, tcia))
 
-        # APA metrics
-        apa = result.get("audience_persona_analysis", {})
+        # APA metrics — node_id: "audience_persona"
+        apa = node_results.get("audience_persona", {})
+        if not apa:
+            apa = result.get("audience_persona", {})
         if apa:
             metrics.extend(self._extract_apa(job, apa))
 
-        # CIA metrics
-        cia = result.get("competitor_intelligence", {})
+        # CIA metrics — node_id: "competitor_intelligence"
+        cia = node_results.get("competitor_intelligence", {})
+        if not cia:
+            cia = result.get("competitor_intelligence", {})
         if cia:
             metrics.extend(self._extract_cia(job, cia))
 
@@ -36,7 +46,8 @@ class BrandDiscoveryExtractor(BaseExtractor):
     def _extract_voc(self, job, voc: dict) -> list:
         metrics = []
 
-        health_score = self._safe_get(voc, "health_score")
+        # VoC health score — top-level key in service response
+        health_score = self._safe_get(voc, "voc_health_score")
         if health_score:
             metrics.append(
                 self._make_metric(
@@ -48,11 +59,17 @@ class BrandDiscoveryExtractor(BaseExtractor):
                 )
             )
 
-        # Sentiment percentages
-        sentiment = voc.get("sentiment_distribution", {})
-        if sentiment:
-            pos = self._safe_get(sentiment, "positive", default=0)
-            neg = self._safe_get(sentiment, "negative", default=0)
+        # Sentiment percentages — voc.sentiment.overall_sentiment
+        sentiment = voc.get("sentiment", {})
+        overall = sentiment.get("overall_sentiment", {}) if sentiment else {}
+        if overall:
+            pos = self._safe_get(overall, "positive", default=0)
+            neg = self._safe_get(overall, "negative", default=0)
+            # Convert from 0-1 ratio to percentage if needed
+            if isinstance(pos, (int, float)) and pos <= 1.0:
+                pos = pos * 100
+            if isinstance(neg, (int, float)) and neg <= 1.0:
+                neg = neg * 100
             metrics.append(
                 self._make_metric(
                     job,
@@ -74,24 +91,35 @@ class BrandDiscoveryExtractor(BaseExtractor):
                 )
             )
 
-        # NPS — actual structure: nps.current_nps.nps_score
-        nps_data = voc.get("nps", {})
-        nps_score = self._safe_get(nps_data, "current_nps", "nps_score", default=None)
-        if nps_score is not None:
-            metrics.append(
-                self._make_metric(
-                    job,
-                    "nps",
-                    float(nps_score),
-                    "customer_voice",
-                    unit="score",
-                    agent_source="voc-agent",
-                )
+        # NPS — voc.nps_analysis.current_nps.nps_score
+        nps_data = voc.get("nps_analysis", {})
+        if isinstance(nps_data, dict):
+            nps_score = self._safe_get(
+                nps_data, "current_nps", "nps_score", default=None
             )
+            # Also check proxy NPS
+            if nps_score is None:
+                nps_score = self._safe_get(
+                    nps_data, "proxy_nps", "nps_score", default=None
+                )
+            if nps_score is not None:
+                metrics.append(
+                    self._make_metric(
+                        job,
+                        "nps",
+                        float(nps_score),
+                        "customer_voice",
+                        unit="score",
+                        agent_source="voc-agent",
+                    )
+                )
 
-        # Pain points count
-        pain_points = voc.get("pain_points", [])
-        if isinstance(pain_points, list):
+        # Pain points count — voc.pain_point_priority_matrix.pain_points
+        pain_matrix = voc.get("pain_point_priority_matrix", {})
+        pain_points = (
+            pain_matrix.get("pain_points", []) if isinstance(pain_matrix, dict) else []
+        )
+        if isinstance(pain_points, list) and pain_points:
             metrics.append(
                 self._make_metric(
                     job,
@@ -103,14 +131,18 @@ class BrandDiscoveryExtractor(BaseExtractor):
                 )
             )
 
-        # Data coverage
-        coverage = self._safe_get(voc, "data_coverage_pct", default=None)
+        # Data coverage — voc.data_coverage_score
+        coverage = self._safe_get(voc, "data_coverage_score", default=None)
         if coverage is not None:
+            # Convert 0-1 to percentage
+            cov_val = float(coverage)
+            if cov_val <= 1.0:
+                cov_val = cov_val * 100
             metrics.append(
                 self._make_metric(
                     job,
                     "data_coverage_pct",
-                    float(coverage),
+                    cov_val,
                     "customer_voice",
                     unit="percent",
                     agent_source="voc-agent",
@@ -121,8 +153,14 @@ class BrandDiscoveryExtractor(BaseExtractor):
 
     def _extract_tcia(self, job, tcia: dict) -> list:
         metrics = []
-        trends = tcia.get("trends", [])
-        if isinstance(trends, list):
+        # scored_trends is a list of trend objects
+        trends = tcia.get("scored_trends", [])
+        if not trends:
+            # Fallback: check trend_report for trends
+            report = tcia.get("trend_report", {})
+            if isinstance(report, dict):
+                trends = report.get("trend_scorecard", [])
+        if isinstance(trends, list) and trends:
             metrics.append(
                 self._make_metric(
                     job,
@@ -138,7 +176,7 @@ class BrandDiscoveryExtractor(BaseExtractor):
     def _extract_apa(self, job, apa: dict) -> list:
         metrics = []
         personas = apa.get("personas", [])
-        if isinstance(personas, list):
+        if isinstance(personas, list) and personas:
             metrics.append(
                 self._make_metric(
                     job,
@@ -153,9 +191,14 @@ class BrandDiscoveryExtractor(BaseExtractor):
 
     def _extract_cia(self, job, cia: dict) -> list:
         metrics = []
-        # Actual CIA result has competitors_analyzed as a list
         competitors = cia.get("competitors_analyzed", [])
-        if isinstance(competitors, list):
+        if not competitors:
+            # Fallback: competitors list with dicts
+            raw = cia.get("competitors", [])
+            if isinstance(raw, list):
+                competitors = [c.get("name", "") for c in raw if isinstance(c, dict)]
+                competitors = [n for n in competitors if n]
+        if isinstance(competitors, list) and competitors:
             metrics.append(
                 self._make_metric(
                     job,

--- a/ai-brand-automator/analytics/extractors/brand_equity.py
+++ b/ai-brand-automator/analytics/extractors/brand_equity.py
@@ -2,17 +2,29 @@ from analytics.extractors.base import BaseExtractor
 
 
 class BrandEquityExtractor(BaseExtractor):
-    """Extracts metrics from iso-brand-equity pipeline."""
+    """Extracts metrics from iso-brand-equity pipeline.
+
+    Data may be at top level or under node_results.
+    """
 
     def extract(self, job) -> list:
         result = job.result_data or {}
+        node_results = result.get("node_results", {})
         metrics = []
 
-        # Brand equity scores (ISO 10668 dimensions)
+        # Try multiple paths for brand equity data
         equity = result.get("brand_equity", {})
         if not equity:
-            # Try alternate key structure
             equity = result.get("valuation", {}).get("brand_equity", {})
+        if not equity:
+            # Check under node_results (intelligence node)
+            intel = node_results.get("intelligence", {})
+            if not intel:
+                intel = node_results.get("brand_equity_calculator", {})
+            if intel:
+                equity = intel.get("brand_equity", {})
+                if not equity:
+                    equity = intel.get("valuation", {}).get("brand_equity", {})
 
         awareness = self._safe_get(equity, "awareness", default=None)
         if awareness is not None:
@@ -50,10 +62,20 @@ class BrandEquityExtractor(BaseExtractor):
                 )
             )
 
-        # Brand value NPV
+        # Brand value NPV — check multiple paths
         npv = self._safe_get(result, "brand_value", "npv", default=None)
         if npv is None:
             npv = self._safe_get(result, "valuation", "brand_value_npv", default=None)
+        if npv is None and node_results:
+            intel = node_results.get(
+                "intelligence", node_results.get("brand_equity_calculator", {})
+            )
+            if isinstance(intel, dict):
+                npv = self._safe_get(intel, "brand_value", "npv", default=None)
+                if npv is None:
+                    npv = self._safe_get(
+                        intel, "valuation", "brand_value_npv", default=None
+                    )
         if npv is not None:
             metrics.append(
                 self._make_metric(

--- a/ai-brand-automator/analytics/extractors/content_social.py
+++ b/ai-brand-automator/analytics/extractors/content_social.py
@@ -2,40 +2,73 @@ from analytics.extractors.base import BaseExtractor
 
 
 class ContentSocialExtractor(BaseExtractor):
-    """Extracts metrics from content and social publishing pipelines."""
+    """Extracts metrics from content and social publishing pipelines.
+
+    Data lives under result_data["node_results"][<node_id>].
+    """
 
     def extract(self, job) -> list:
         result = job.result_data or {}
+        node_results = result.get("node_results", {})
         metrics = []
 
-        # Content agent: word count
-        content = result.get("content", {})
+        # Content agent: word count — node_id: "blog_author"
+        content = node_results.get("blog_author", {})
+        if not content:
+            content = result.get("content", {})
         if not content:
             content = result.get("blog_content", {})
 
         if content:
-            body = content.get("body", "") or content.get("content", "")
+            # blog_content is a string, word_count may be a field
+            body = ""
+            if isinstance(content, str):
+                body = content
+            elif isinstance(content, dict):
+                body = (
+                    content.get("blog_content", "")
+                    or content.get("body", "")
+                    or content.get("content", "")
+                )
+                # Also check direct word_count field
+                wc = content.get("word_count")
+                if wc and isinstance(wc, (int, float)) and wc > 0:
+                    metrics.append(
+                        self._make_metric(
+                            job,
+                            "word_count",
+                            float(wc),
+                            "content",
+                            unit="count",
+                            agent_source="content-agent",
+                        )
+                    )
+                    body = ""  # Skip manual count
+
             if isinstance(body, str) and body.strip():
                 word_count = len(body.split())
-                metrics.append(
-                    self._make_metric(
-                        job,
-                        "word_count",
-                        float(word_count),
-                        "content",
-                        unit="count",
-                        agent_source="content-agent",
+                if word_count > 0:
+                    metrics.append(
+                        self._make_metric(
+                            job,
+                            "word_count",
+                            float(word_count),
+                            "content",
+                            unit="count",
+                            agent_source="content-agent",
+                        )
                     )
-                )
 
-        # Social agent: platforms posted
-        social = result.get("social", {})
+        # Social agent: platforms posted — node_id: "social_promoter"
+        social = node_results.get("social_promoter", {})
+        if not social:
+            social = result.get("social", {})
         if not social:
             social = result.get("social_promotion", {})
 
-        if social:
+        if social and isinstance(social, dict):
             platforms = social.get("platforms_posted", [])
-            if isinstance(platforms, list):
+            if isinstance(platforms, list) and platforms:
                 metrics.append(
                     self._make_metric(
                         job,
@@ -46,7 +79,7 @@ class ContentSocialExtractor(BaseExtractor):
                         agent_source="social-agent",
                     )
                 )
-            elif isinstance(platforms, int):
+            elif isinstance(platforms, int) and platforms > 0:
                 metrics.append(
                     self._make_metric(
                         job,

--- a/ai-brand-automator/analytics/tasks.py
+++ b/ai-brand-automator/analytics/tasks.py
@@ -19,7 +19,7 @@ def extract_metrics_task(self, job_id: int):
     """
     from orchestration.models import AnalysisJob
     from analytics.brand_affinity import BrandAffinityVerifier
-    from analytics.extractors import PIPELINE_EXTRACTORS
+    from analytics.extractors import PIPELINE_EXTRACTORS, detect_extractor_from_result
     from analytics.kafka_events import emit_analytics_event
     from analytics.models import MetricDefinition, MetricSnapshot
     from analytics.rollups import update_rollups
@@ -62,10 +62,19 @@ def extract_metrics_task(self, job_id: int):
 
     # IG-04: pipeline_id mapped to an extractor
     pipeline_id = _resolve_pipeline_id(job)
-    if pipeline_id not in PIPELINE_EXTRACTORS:
-        logger.debug("No extractor for pipeline %s (job %s)", pipeline_id, job_id)
-        cache.set(redis_key, "unmapped", 86400)
-        return
+    extractor = PIPELINE_EXTRACTORS.get(pipeline_id)
+    if not extractor:
+        # Fallback: detect extractor from result_data content (chat-mode)
+        extractor = detect_extractor_from_result(job.result_data)
+        if not extractor:
+            logger.debug("No extractor for pipeline %s (job %s)", pipeline_id, job_id)
+            cache.set(redis_key, "unmapped", 86400)
+            return
+        logger.info(
+            "Using content-detected extractor for pipeline %s (job %s)",
+            pipeline_id,
+            job_id,
+        )
 
     # IG-05: tenant exists
     if not job.tenant:
@@ -112,7 +121,6 @@ def extract_metrics_task(self, job_id: int):
         return
 
     # Extract metrics
-    extractor = PIPELINE_EXTRACTORS[pipeline_id]
     try:
         metrics = extractor.extract(job)
     except Exception as e:


### PR DESCRIPTION
## Summary
- **Extractors now read from `node_results.<node_id>`** — matches actual orchestrator output structure instead of fabricated keys
- **PIPELINE_EXTRACTORS expanded from 9 to 22 entries** — covers all pipeline IDs from `seed_manifests.py`
- **Content-based fallback detection** for chat-mode (Tier 1 dynamic composition) where `pipeline_id` resolves to `"unknown"`

## Root Cause
Analytics data wasn't appearing because:
1. Extractors read wrong data paths (e.g., `voc_analysis.health_score` instead of `node_results.voice_of_customer.voc_health_score`)
2. Many pipeline IDs (`voice-of-customer`, `audience-persona`, `trend-cultural-insights`, etc.) were not mapped to extractors
3. Chat-mode workflows with dynamically composed pipelines had no fallback

## Key Path Corrections
| Field | Before (wrong) | After (correct) |
|-------|----------------|-----------------|
| VoC health | `voc_analysis.health_score` | `node_results.voice_of_customer.voc_health_score` |
| Sentiment | `.sentiment_distribution.positive` | `.sentiment.overall_sentiment.positive` |
| NPS | `.nps.current_nps.nps_score` | `.nps_analysis.current_nps.nps_score` |
| Pain points | `.pain_points` | `.pain_point_priority_matrix.pain_points` |
| Coverage | `.data_coverage_pct` | `.data_coverage_score` |
| Trends | `trend_cultural_analysis.trends` | `node_results.trend_cultural.scored_trends` |

## Test plan
- [ ] Run a brand discovery workflow and verify MetricSnapshot rows are created
- [ ] Check analytics dashboard shows KPI cards with data
- [ ] Run backfill_analytics to populate historical data
- [ ] Verify chat-mode workflows also extract metrics via fallback detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)