### PR TITLE
chore: Run analytics backfill on next deployment

### DIFF
--- a/deployment/scripts/start-backend.sh
+++ b/deployment/scripts/start-backend.sh
@@ -68,6 +68,10 @@ python manage.py seed_manifests || echo "Manifest seeding skipped"
 echo "Seeding analytics metric definitions..."
 python manage.py seed_metrics || echo "Metric seeding skipped"
 
+# One-time backfill: extract analytics from existing completed jobs
+echo "Backfilling analytics from existing jobs..."
+python manage.py backfill_analytics || echo "Analytics backfill skipped"
+
 # Start Gunicorn
 echo "Starting Gunicorn server on port ${PORT:-8000}..."
 exec gunicorn brand_automator.wsgi:application \

--- a/deployment/scripts/start-backend.sh
+++ b/deployment/scripts/start-backend.sh
@@ -69,8 +69,13 @@ echo "Seeding analytics metric definitions..."
 python manage.py seed_metrics || echo "Metric seeding skipped"
 
 # One-time backfill: extract analytics from existing completed jobs
-echo "Backfilling analytics from existing jobs..."
-python manage.py backfill_analytics || echo "Analytics backfill skipped"
+# Gated behind env var to avoid running on every deploy/scale-out
+if [ "${RUN_ANALYTICS_BACKFILL}" = "true" ]; then
+    echo "Backfilling analytics from existing jobs..."
+    python manage.py backfill_analytics
+else
+    echo "Skipping analytics backfill (set RUN_ANALYTICS_BACKFILL=true to enable)"
+fi
 
 # Start Gunicorn
 echo "Starting Gunicorn server on port ${PORT:-8000}..."


### PR DESCRIPTION
## Summary
- Adds `python manage.py backfill_analytics` to the startup script
- Extracts analytics metrics from all existing completed jobs
- Idempotent (skips already-processed jobs via Redis keys)
- Should be removed after the first successful deployment

## Why
The analytics extraction pipeline was fixed in PR #235 (data path corrections). Existing completed jobs need to be backfilled to populate the analytics dashboard.

## Test plan
- [ ] Deploy and check Railway logs for backfill output
- [ ] Verify analytics dashboard shows data for Pomodoro brand
- [ ] Remove this line from start-backend.sh after successful run

🤖 Generated with [Claude Code](https://claude.com/claude-code)