### PR TITLE
fix: Connect dashboard KPI cards to real data sources

### DIFF
--- a/ai-brand-automator-frontend/src/components/dashboard/OverviewCards.tsx
+++ b/ai-brand-automator-frontend/src/components/dashboard/OverviewCards.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { FileText, Zap, GitBranch, MessageSquare } from 'lucide-react';
 import { apiClient } from '@/lib/api';
 
 interface CardData {
@@ -8,6 +9,16 @@ interface CardData {
   value: string;
   change: string;
   changeType: 'positive' | 'neutral' | 'negative';
+  icon: React.ReactNode;
+}
+
+/** Extract count from a DRF paginated response or plain array. */
+function extractCount(data: unknown): number {
+  if (Array.isArray(data)) return data.length;
+  if (data && typeof data === 'object' && 'count' in data) {
+    return (data as { count: number }).count;
+  }
+  return 0;
 }
 
 export function OverviewCards() {
@@ -17,24 +28,28 @@ export function OverviewCards() {
       value: '0',
       change: 'Loading...',
       changeType: 'neutral' as const,
+      icon: <FileText className="h-5 w-5 text-brand-electric" />,
     },
     {
       title: 'AI Interactions',
       value: '0',
       change: 'Loading...',
       changeType: 'neutral' as const,
+      icon: <Zap className="h-5 w-5 text-brand-mint" />,
     },
     {
-      title: 'Companies',
+      title: 'Workflows Run',
       value: '0',
-      change: 'Active',
+      change: 'Loading...',
       changeType: 'neutral' as const,
+      icon: <GitBranch className="h-5 w-5 text-purple-400" />,
     },
     {
       title: 'Chat Sessions',
       value: '0',
-      change: 'Total',
+      change: 'Loading...',
       changeType: 'neutral' as const,
+      icon: <MessageSquare className="h-5 w-5 text-amber-400" />,
     },
   ]);
   const [loading, setLoading] = useState(true);
@@ -42,50 +57,53 @@ export function OverviewCards() {
   useEffect(() => {
     const fetchDashboardData = async () => {
       try {
-        // Fetch assets count
-        const assetsResponse = await apiClient.get('/assets/');
-        const assetsData = await assetsResponse.json();
-        const assetsCount = Array.isArray(assetsData) ? assetsData.length : 0;
+        const [assetsRes, aiRes, jobsRes, chatRes] = await Promise.all([
+          apiClient.get('/assets/'),
+          apiClient.get('/ai/generations/'),
+          apiClient.get('/orchestration/jobs/?status=completed'),
+          apiClient.get('/ai/chat-sessions/'),
+        ]);
 
-        // Fetch AI generations count
-        const aiResponse = await apiClient.get('/ai/generations/');
-        const aiData = await aiResponse.json();
-        const aiCount = Array.isArray(aiData) ? aiData.length : 0;
+        const [assetsData, aiData, jobsData, chatData] = await Promise.all([
+          assetsRes.json(),
+          aiRes.json(),
+          jobsRes.json(),
+          chatRes.json(),
+        ]);
 
-        // Fetch companies count
-        const companiesResponse = await apiClient.get('/companies/');
-        const companiesData = await companiesResponse.json();
-        const companiesCount = Array.isArray(companiesData) ? companiesData.length : 0;
-
-        // Fetch chat sessions count
-        const chatResponse = await apiClient.get('/ai/chat-sessions/');
-        const chatData = await chatResponse.json();
-        const chatCount = Array.isArray(chatData) ? chatData.length : 0;
+        const assetsCount = extractCount(assetsData);
+        const aiCount = extractCount(aiData);
+        const jobsCount = extractCount(jobsData);
+        const chatCount = extractCount(chatData);
 
         setCards([
           {
             title: 'Total Assets',
-            value: assetsCount.toString(),
-            change: `${assetsCount} files`,
-            changeType: 'neutral',
+            value: assetsCount.toLocaleString(),
+            change: `${assetsCount} files uploaded`,
+            changeType: assetsCount > 0 ? 'positive' : 'neutral',
+            icon: <FileText className="h-5 w-5 text-brand-electric" />,
           },
           {
             title: 'AI Interactions',
-            value: aiCount.toString(),
-            change: `${aiCount} total`,
+            value: aiCount.toLocaleString(),
+            change: `${aiCount} generations`,
             changeType: aiCount > 0 ? 'positive' : 'neutral',
+            icon: <Zap className="h-5 w-5 text-brand-mint" />,
           },
           {
-            title: 'Companies',
-            value: companiesCount.toString(),
-            change: 'Active',
-            changeType: 'neutral',
+            title: 'Workflows Run',
+            value: jobsCount.toLocaleString(),
+            change: `${jobsCount} completed`,
+            changeType: jobsCount > 0 ? 'positive' : 'neutral',
+            icon: <GitBranch className="h-5 w-5 text-purple-400" />,
           },
           {
             title: 'Chat Sessions',
-            value: chatCount.toString(),
+            value: chatCount.toLocaleString(),
             change: `${chatCount} sessions`,
             changeType: chatCount > 0 ? 'positive' : 'neutral',
+            icon: <MessageSquare className="h-5 w-5 text-amber-400" />,
           },
         ]);
         setLoading(false);
@@ -115,7 +133,10 @@ export function OverviewCards() {
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
       {cards.map((card, index) => (
         <div key={index} className="dashboard-card">
-          <h3 className="font-heading text-sm font-medium text-brand-silver/70">{card.title}</h3>
+          <div className="flex items-center justify-between">
+            <h3 className="font-heading text-sm font-medium text-brand-silver/70">{card.title}</h3>
+            {card.icon}
+          </div>
           <div className="mt-2 flex items-baseline">
             <p className="text-2xl font-heading font-semibold text-white">{card.value}</p>
             <p

--- a/ai-brand-automator-frontend/src/components/dashboard/OverviewCards.tsx
+++ b/ai-brand-automator-frontend/src/components/dashboard/OverviewCards.tsx
@@ -4,13 +4,39 @@ import { useState, useEffect } from 'react';
 import { FileText, Zap, GitBranch, MessageSquare } from 'lucide-react';
 import { apiClient } from '@/lib/api';
 
-interface CardData {
+interface CardConfig {
   title: string;
-  value: string;
-  change: string;
-  changeType: 'positive' | 'neutral' | 'negative';
   icon: React.ReactNode;
+  endpoint: string;
+  formatChange: (count: number) => string;
 }
+
+const CARD_CONFIGS: CardConfig[] = [
+  {
+    title: 'Total Assets',
+    icon: <FileText className="h-5 w-5 text-brand-electric" />,
+    endpoint: '/assets/',
+    formatChange: (n) => `${n} files uploaded`,
+  },
+  {
+    title: 'AI Interactions',
+    icon: <Zap className="h-5 w-5 text-brand-mint" />,
+    endpoint: '/ai/generations/',
+    formatChange: (n) => `${n} generations`,
+  },
+  {
+    title: 'Workflows Run',
+    icon: <GitBranch className="h-5 w-5 text-purple-400" />,
+    endpoint: '/orchestration/jobs/?status=completed',
+    formatChange: (n) => `${n} completed`,
+  },
+  {
+    title: 'Chat Sessions',
+    icon: <MessageSquare className="h-5 w-5 text-amber-400" />,
+    endpoint: '/ai/chat-sessions/',
+    formatChange: (n) => `${n} sessions`,
+  },
+];
 
 /** Extract count from a DRF paginated response or plain array. */
 function extractCount(data: unknown): number {
@@ -21,91 +47,38 @@ function extractCount(data: unknown): number {
   return 0;
 }
 
+interface CardState {
+  value: string;
+  change: string;
+  changeType: 'positive' | 'neutral' | 'negative';
+}
+
 export function OverviewCards() {
-  const [cards, setCards] = useState<CardData[]>([
-    {
-      title: 'Total Assets',
+  const [cardStates, setCardStates] = useState<CardState[]>(
+    CARD_CONFIGS.map(() => ({
       value: '0',
       change: 'Loading...',
       changeType: 'neutral' as const,
-      icon: <FileText className="h-5 w-5 text-brand-electric" />,
-    },
-    {
-      title: 'AI Interactions',
-      value: '0',
-      change: 'Loading...',
-      changeType: 'neutral' as const,
-      icon: <Zap className="h-5 w-5 text-brand-mint" />,
-    },
-    {
-      title: 'Workflows Run',
-      value: '0',
-      change: 'Loading...',
-      changeType: 'neutral' as const,
-      icon: <GitBranch className="h-5 w-5 text-purple-400" />,
-    },
-    {
-      title: 'Chat Sessions',
-      value: '0',
-      change: 'Loading...',
-      changeType: 'neutral' as const,
-      icon: <MessageSquare className="h-5 w-5 text-amber-400" />,
-    },
-  ]);
+    }))
+  );
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const fetchDashboardData = async () => {
       try {
-        const [assetsRes, aiRes, jobsRes, chatRes] = await Promise.all([
-          apiClient.get('/assets/'),
-          apiClient.get('/ai/generations/'),
-          apiClient.get('/orchestration/jobs/?status=completed'),
-          apiClient.get('/ai/chat-sessions/'),
-        ]);
+        const responses = await Promise.all(
+          CARD_CONFIGS.map((cfg) => apiClient.get(cfg.endpoint))
+        );
+        const dataList = await Promise.all(responses.map((r) => r.json()));
+        const counts = dataList.map(extractCount);
 
-        const [assetsData, aiData, jobsData, chatData] = await Promise.all([
-          assetsRes.json(),
-          aiRes.json(),
-          jobsRes.json(),
-          chatRes.json(),
-        ]);
-
-        const assetsCount = extractCount(assetsData);
-        const aiCount = extractCount(aiData);
-        const jobsCount = extractCount(jobsData);
-        const chatCount = extractCount(chatData);
-
-        setCards([
-          {
-            title: 'Total Assets',
-            value: assetsCount.toLocaleString(),
-            change: `${assetsCount} files uploaded`,
-            changeType: assetsCount > 0 ? 'positive' : 'neutral',
-            icon: <FileText className="h-5 w-5 text-brand-electric" />,
-          },
-          {
-            title: 'AI Interactions',
-            value: aiCount.toLocaleString(),
-            change: `${aiCount} generations`,
-            changeType: aiCount > 0 ? 'positive' : 'neutral',
-            icon: <Zap className="h-5 w-5 text-brand-mint" />,
-          },
-          {
-            title: 'Workflows Run',
-            value: jobsCount.toLocaleString(),
-            change: `${jobsCount} completed`,
-            changeType: jobsCount > 0 ? 'positive' : 'neutral',
-            icon: <GitBranch className="h-5 w-5 text-purple-400" />,
-          },
-          {
-            title: 'Chat Sessions',
-            value: chatCount.toLocaleString(),
-            change: `${chatCount} sessions`,
-            changeType: chatCount > 0 ? 'positive' : 'neutral',
-            icon: <MessageSquare className="h-5 w-5 text-amber-400" />,
-          },
-        ]);
+        setCardStates(
+          counts.map((count, i) => ({
+            value: count.toLocaleString(),
+            change: CARD_CONFIGS[i].formatChange(count),
+            changeType: count > 0 ? ('positive' as const) : ('neutral' as const),
+          }))
+        );
         setLoading(false);
       } catch (error) {
         console.error('Error fetching dashboard data:', error);
@@ -119,8 +92,8 @@ export function OverviewCards() {
   if (loading) {
     return (
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-        {[1, 2, 3, 4].map((i) => (
-          <div key={i} className="dashboard-card animate-pulse">
+        {CARD_CONFIGS.map((cfg) => (
+          <div key={cfg.title} className="dashboard-card animate-pulse">
             <div className="h-4 bg-white/10 rounded w-1/2 mb-4"></div>
             <div className="h-8 bg-white/10 rounded w-3/4"></div>
           </div>
@@ -131,26 +104,29 @@ export function OverviewCards() {
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-      {cards.map((card, index) => (
-        <div key={index} className="dashboard-card">
-          <div className="flex items-center justify-between">
-            <h3 className="font-heading text-sm font-medium text-brand-silver/70">{card.title}</h3>
-            {card.icon}
+      {CARD_CONFIGS.map((cfg, index) => {
+        const state = cardStates[index];
+        return (
+          <div key={cfg.title} className="dashboard-card">
+            <div className="flex items-center justify-between">
+              <h3 className="font-heading text-sm font-medium text-brand-silver/70">{cfg.title}</h3>
+              {cfg.icon}
+            </div>
+            <div className="mt-2 flex items-baseline">
+              <p className="text-2xl font-heading font-semibold text-white">{state.value}</p>
+              <p
+                className={`ml-2 text-sm ${
+                  state.changeType === 'positive'
+                    ? 'text-brand-mint'
+                    : 'text-brand-silver/70'
+                }`}
+              >
+                {state.change}
+              </p>
+            </div>
           </div>
-          <div className="mt-2 flex items-baseline">
-            <p className="text-2xl font-heading font-semibold text-white">{card.value}</p>
-            <p
-              className={`ml-2 text-sm ${
-                card.changeType === 'positive'
-                  ? 'text-brand-mint'
-                  : 'text-brand-silver/70'
-              }`}
-            >
-              {card.change}
-            </p>
-          </div>
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 }

--- a/ai-brand-automator/orchestration/views.py
+++ b/ai-brand-automator/orchestration/views.py
@@ -71,6 +71,8 @@ class AnalysisJobViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):
         Callback action bypasses tenant filtering — it is a
         service-to-service call authenticated via token, not
         per-tenant middleware.
+
+        Supports ``?status=`` query-param filtering (e.g. ``?status=completed``).
         """
         qs = AnalysisJob.objects.select_related("manifest", "created_by")
         if self.action == "callback":
@@ -78,6 +80,12 @@ class AnalysisJobViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):
         tenant = getattr(self.request, "tenant", None)
         if tenant:
             qs = qs.filter(Q(tenant=tenant) | Q(tenant__isnull=True))
+
+        # Optional status filter
+        status = self.request.query_params.get("status")
+        if status and status in AnalysisJob.Status.values:
+            qs = qs.filter(status=status)
+
         return qs
 
     def get_serializer_class(self):


### PR DESCRIPTION
## Summary
- **Fix pagination bug**: `extractCount()` handles both DRF paginated `{count, results}` responses and plain arrays — all 4 KPIs were showing "0" because `Array.isArray()` returns false for paginated objects
- **Replace "Companies" KPI** (always 1 per tenant, not useful) with **"Workflows Run"** using `/orchestration/jobs/?status=completed`
- **Add icons** (lucide-react) and positive/neutral change indicators to each card
- **Parallel fetching** via `Promise.all()` instead of sequential API calls

## Test plan
- [ ] Dashboard loads with correct counts for Total Assets, AI Interactions, Workflows Run, Chat Sessions
- [ ] Cards show "0" gracefully when no data exists
- [ ] Loading skeleton displays while data is fetching
- [ ] Icons render correctly next to card titles

🤖 Generated with [Claude Code](https://claude.com/claude-code)