### PR TITLE
fix: Resolve stale lock state causing false Read-only on workflow switch

### DIFF
--- a/ai-brand-automator-frontend/src/app/dashboard/workflows/page.tsx
+++ b/ai-brand-automator-frontend/src/app/dashboard/workflows/page.tsx
@@ -144,6 +144,8 @@ function WorkflowsPageInner() {
   const [error, setError] = useState<string | null>(null);
   const [lockInfo, setLockInfo] = useState<LockInfo | null>(null);
   const lockHeartbeatRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const selectedIdRef = useRef<string | null>(null);
+  const lockInfoRef = useRef<LockInfo | null>(null);
 
   // Execution tracking
   const [activeJobId, setActiveJobId] = useState<string | null>(null);
@@ -165,6 +167,10 @@ function WorkflowsPageInner() {
 
   const isTemplatePreview = selectedTemplateId !== null;
   const isReadonly = isTemplatePreview || (lockInfo?.locked === true && !lockInfo?.is_mine);
+
+  // Keep refs in sync for cleanup on unmount (avoids stale closure)
+  selectedIdRef.current = selectedId;
+  lockInfoRef.current = lockInfo;
 
   // Derive current node data from store (always fresh with latest progress)
   const selectedNodeData = useMemo(() => {
@@ -441,6 +447,7 @@ function WorkflowsPageInner() {
       releaseLock(selectedId).catch(() => {});
     }
     setSelectedId(workflowId);
+    setLockInfo(null);
     // Clear template preview when selecting a workflow
     setSelectedTemplateId(null);
     setSelectedTemplateName(null);
@@ -755,11 +762,10 @@ function WorkflowsPageInner() {
 
   useEffect(() => {
     return () => {
-      if (selectedId && lockInfo?.is_mine) {
-        releaseLock(selectedId).catch(() => {});
+      if (selectedIdRef.current && lockInfoRef.current?.is_mine) {
+        releaseLock(selectedIdRef.current).catch(() => {});
       }
     };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   if (!hasMounted) {

--- a/ai-brand-automator-frontend/src/app/dashboard/workflows/page.tsx
+++ b/ai-brand-automator-frontend/src/app/dashboard/workflows/page.tsx
@@ -442,8 +442,9 @@ function WorkflowsPageInner() {
   // ── Actions ──
 
   const handleSelect = useCallback((workflowId: string) => {
-    // Release lock on previous workflow
-    if (selectedId && lockInfo?.is_mine) {
+    // Always attempt lock release on previous workflow — even if lockInfo
+    // hasn't resolved yet. releaseLock tolerates 403 (not holder) gracefully.
+    if (selectedId) {
       releaseLock(selectedId).catch(() => {});
     }
     setSelectedId(workflowId);
@@ -456,7 +457,7 @@ function WorkflowsPageInner() {
     setWsProgress({});
     setWsQuickStatus(null);
     setSelectedNodeId(null);
-  }, [selectedId, lockInfo?.is_mine]);
+  }, [selectedId]);
 
   const handleSelectTemplate = useCallback((templateId: string) => {
     // Find template in the list (typed as PipelineManifest with manifest_data)
@@ -466,8 +467,8 @@ function WorkflowsPageInner() {
       return;
     }
 
-    // Clear workflow selection
-    if (selectedId && lockInfo?.is_mine) {
+    // Clear workflow selection — always attempt lock release
+    if (selectedId) {
       releaseLock(selectedId).catch(() => {});
     }
     setSelectedId(null);
@@ -487,7 +488,7 @@ function WorkflowsPageInner() {
       tmpl.manifest_data as unknown as ManifestGraphData,
     );
     store.dispatch({ type: 'LOAD', nodes, edges });
-  }, [templates, selectedId, lockInfo?.is_mine, store]);
+  }, [templates, selectedId, store]);
 
   const handleCreateNew = useCallback(async () => {
     const name = window.prompt('Workflow name:', `Untitled Workflow ${workflows.length + 1}`);
@@ -766,7 +767,7 @@ function WorkflowsPageInner() {
         releaseLock(selectedIdRef.current).catch(() => {});
       }
     };
-  }, []);
+  }, [releaseLock]);
 
   if (!hasMounted) {
     return (


### PR DESCRIPTION
## Summary
- **Reset `lockInfo` to null in `handleSelect`** — prevents the previous workflow's lock state from being applied to the newly selected workflow during the async fetch gap, which caused a false "Read-only: locked by another user" banner
- **Fix stale closure in unmount cleanup** — the `useEffect([], [])` cleanup captured `selectedId=null` and `lockInfo=null` from the initial render, so locks were never released when navigating away or closing the tab. Replaced with refs (`selectedIdRef`, `lockInfoRef`) that always reflect current values

## Root cause
When switching workflows, `handleSelect` called `setSelectedId(newId)` but did not reset `lockInfo`. The `fetchDetail` useEffect is async, so between the state change and the API response, `isReadonly` evaluated against the *previous* workflow's lock state — showing the read-only banner on the newly selected workflow.

## Test plan
- [ ] Select a workflow, save it (acquires lock), then select a different workflow — no "Read-only" banner
- [ ] Open workflows page, select workflow, navigate away, come back — lock was properly released
- [ ] Two users editing different workflows — correct lock behavior maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)