### PR TITLE
fix: add brand-naming-agent-svc to ALLOWED_URL_PREFIXES

### DIFF
--- a/ai-brand-automator/orchestration/serializers.py
+++ b/ai-brand-automator/orchestration/serializers.py
@@ -134,6 +134,8 @@ class PipelineManifestSerializer(serializers.ModelSerializer):
         "https://brand-architecture-agent-svc",
         "http://brand-personality-agent-svc",
         "https://brand-personality-agent-svc",
+        "http://brand-naming-agent-svc",
+        "https://brand-naming-agent-svc",
     )
 
     def _validate_external_url(self, node_id, url):


### PR DESCRIPTION
Adds http/https prefixes for brand-naming-agent-svc to the SSRF allowlist so the brand-strategy-naming manifest passes validation.