### PR TITLE
Fix brand naming service issues and add NTA to WF2 chain

### DIFF
--- a/ai-brand-automator/orchestration/management/commands/seed_manifests.py
+++ b/ai-brand-automator/orchestration/management/commands/seed_manifests.py
@@ -1002,11 +1002,12 @@ class Command(BaseCommand):
             "name": "Brand Strategy & Positioning",
             "description": (
                 "Full WF2 brand strategy pipeline: positioning, architecture, "
-                "and personality & values. Generates positioning statements, "
-                "value proposition canvas, perceptual maps, brand hierarchy "
-                "tree, naming conventions, Aaker 5D personality profile, "
-                "archetype selection, values hierarchy, and voice matrix. "
-                "Requires completed WF1 Brand Discovery pipeline."
+                "personality & values, and naming & tagline. Generates "
+                "positioning statements, value proposition canvas, perceptual "
+                "maps, brand hierarchy tree, Aaker 5D personality profile, "
+                "archetype selection, values hierarchy, voice matrix, brand "
+                "name candidates with availability checking, taglines, and "
+                "naming brief. Requires completed WF1 Brand Discovery pipeline."
             ),
             "manifest_data": {
                 "nodes": [
@@ -1050,6 +1051,16 @@ class Command(BaseCommand):
                         },
                     },
                     {
+                        "id": "brand_naming",
+                        "type": "external",
+                        "url": ("http://brand-naming-agent-svc" ":8034/v1/execute"),
+                        "config": {
+                            "require_wf1_context": True,
+                            "require_bpa_context": True,
+                            "require_bpv_context": True,
+                        },
+                    },
+                    {
                         "id": "manager",
                         "type": "internal",
                         "handler": "ManagerNode",
@@ -1059,7 +1070,8 @@ class Command(BaseCommand):
                     ["intent_router", "brand_positioning"],
                     ["brand_positioning", "brand_architecture"],
                     ["brand_architecture", "brand_personality"],
-                    ["brand_personality", "manager"],
+                    ["brand_personality", "brand_naming"],
+                    ["brand_naming", "manager"],
                 ],
                 "global_config": {
                     "model": "claude-sonnet-4-20250514",

--- a/ai-brand-automator/orchestration/serializers.py
+++ b/ai-brand-automator/orchestration/serializers.py
@@ -134,6 +134,8 @@ class PipelineManifestSerializer(serializers.ModelSerializer):
         "https://brand-architecture-agent-svc",
         "http://brand-personality-agent-svc",
         "https://brand-personality-agent-svc",
+        "http://brand-naming-agent-svc",
+        "https://brand-naming-agent-svc",
     )
 
     def _validate_external_url(self, node_id, url):


### PR DESCRIPTION
## Summary
- Add `brand-naming-agent-svc` to `ALLOWED_URL_PREFIXES` in orchestration serializers (fixes 400 SSRF validation error)
- Append brand naming agent (NTA) as the 4th agent in the `brand-strategy-positioning` pipeline: BPA → BAA → BPV → **NTA** → Manager
- Update pipeline description to reflect the full 4-agent chain

## Test plan
- [ ] `seed_manifests` creates/updates `brand-strategy-positioning` with 4 external nodes
- [ ] Brand naming workflow no longer returns 400 SSRF error
- [ ] Brand Strategy & Positioning pipeline runs all 4 agents in sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)