### PR TITLE
fix: CAA 'list' object has no attribute 'get' error

### DIFF
--- a/campaign-architecture-agent-svc/app/logic/human_escalation.py
+++ b/campaign-architecture-agent-svc/app/logic/human_escalation.py
@@ -39,6 +39,8 @@ class HumanEscalation:
 
         # Budget sanity
         blueprint = result.get("blueprint", {})
+        if not isinstance(blueprint, dict):
+            blueprint = {}
         daily_budget = blueprint.get("daily_budget", 0)
         if daily_budget > 0:
             if daily_budget < settings.MIN_DAILY_BUDGET:
@@ -62,6 +64,8 @@ class HumanEscalation:
 
         # KPI realism check
         kpi_targets = result.get("kpi_targets", {})
+        if not isinstance(kpi_targets, dict):
+            kpi_targets = {}
         if kpi_targets and benchmarks:
             bm = benchmarks.get("benchmarks", {})
             per_funnel = kpi_targets.get("targets", {})

--- a/campaign-architecture-agent-svc/app/services/anthropic_client.py
+++ b/campaign-architecture-agent-svc/app/services/anthropic_client.py
@@ -9,6 +9,17 @@ from app.core.config import settings
 logger = logging.getLogger(__name__)
 
 
+def _ensure_dict(value: Any) -> dict[str, Any]:
+    """Ensure parsed JSON is a dict, not a list or scalar."""
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, list) and len(value) == 1 and isinstance(value[0], dict):
+        return value[0]
+    if isinstance(value, list):
+        return {"items": value}
+    return {"raw_response": value}
+
+
 class AnthropicClient:
     """Wrapper around anthropic.AsyncAnthropic."""
 
@@ -37,14 +48,16 @@ class AnthropicClient:
                 response.usage.input_tokens,
                 response.usage.output_tokens,
             )
-            return json.loads(text)
+            parsed = json.loads(text)
+            return _ensure_dict(parsed)
         except json.JSONDecodeError:
             logger.warning("Claude returned non-JSON, attempting extraction")
             text = response.content[0].text
             start = text.find("{")
             end = text.rfind("}") + 1
             if start >= 0 and end > start:
-                return json.loads(text[start:end])
+                parsed = json.loads(text[start:end])
+                return _ensure_dict(parsed)
             return {"raw_response": text}
         except Exception as exc:
             logger.error("Claude API error: %s", exc)

--- a/campaign-architecture-agent-svc/app/services/caa_analyzer.py
+++ b/campaign-architecture-agent-svc/app/services/caa_analyzer.py
@@ -202,10 +202,17 @@ class CAAAnalyzer:
                 logger.error("Claude call 1 failed: %s", exc)
                 call1_result = {}
 
-        # Plan guardrails on call 1 output
+        # Plan guardrails on call 1 output — defensive type checks
+        # Claude may return unexpected types (list vs dict)
         funnel_map = call1_result.get("funnel_map", {})
+        if not isinstance(funnel_map, dict):
+            funnel_map = {}
         targeting_specs = call1_result.get("targeting_specs", [])
+        if not isinstance(targeting_specs, list):
+            targeting_specs = [targeting_specs] if targeting_specs else []
         kpi_targets = call1_result.get("kpi_targets", {})
+        if not isinstance(kpi_targets, dict):
+            kpi_targets = {}
 
         guardrail_warnings = []
         budget_alloc = self._plan_guards.check_budget_allocation(funnel_map)
@@ -262,6 +269,8 @@ class CAAAnalyzer:
         logger.info("Phase 4: Validation")
 
         blueprint = call2_result.get("blueprint", {})
+        if not isinstance(blueprint, dict):
+            blueprint = {}
         meta_check = self._output_guards.check_meta_api_schema(blueprint)
         budget_cap_check = self._output_guards.check_budget_cap(blueprint)
 
@@ -270,6 +279,8 @@ class CAAAnalyzer:
 
         # Test sample size guard
         test_plan = call2_result.get("test_plan", {})
+        if not isinstance(test_plan, dict):
+            test_plan = {}
         test_check = self._plan_guards.check_test_sample_size(test_plan, budget)
         if not test_check["valid"]:
             guardrail_warnings.extend(test_check.get("issues", []))

--- a/campaign-architecture-agent-svc/app/services/context_loader.py
+++ b/campaign-architecture-agent-svc/app/services/context_loader.py
@@ -170,7 +170,12 @@ class CAAContextLoader:
                 )
             if resp.status_code == 200:
                 logger.info("%s context loaded for tenant %s", label, tenant_id)
-                return resp.json()
+                data = resp.json()
+                # Ensure context is always a dict (some endpoints may
+                # return a list; take first element if so)
+                if isinstance(data, list):
+                    return data[0] if data and isinstance(data[0], dict) else None
+                return data
             elif resp.status_code == 404:
                 logger.info("No %s data for tenant %s", label, tenant_id)
                 return None


### PR DESCRIPTION
## Summary
- Fixes `AttributeError: 'list' object has no attribute 'get'` in CAA analyzer when Claude returns non-dict JSON
- Added `_ensure_dict()` helper to `anthropic_client.py` to normalize LLM responses
- Added `isinstance` guards in `caa_analyzer.py`, `human_escalation.py`, and `context_loader.py`

## Root Cause
Railway logs showed: Claude returned non-JSON markdown, the fallback extraction parsed it into a structure where `funnel_map` was a list, then `guardrails.check_budget_allocation()` called `.get()` on the list.

## Test plan
- [x] All 46 CAA tests pass
- [ ] Deploy to Railway and verify campaign architecture pipeline completes without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)