### PR TITLE
fix: remove stray line crashing CAA service on startup

### DIFF
--- a/campaign-architecture-agent-svc/app/services/anthropic_client.py
+++ b/campaign-architecture-agent-svc/app/services/anthropic_client.py
@@ -65,8 +65,6 @@ class AnthropicClient:
                 )
                 return result
             logger.warning("No JSON object found in response")
-                return _ensure_dict(parsed)
-
             return {"raw_response": text}
         except Exception as exc:
             logger.error("Claude API error: %s", exc)


### PR DESCRIPTION
## Summary
- PR #254 still left a stray `return _ensure_dict(parsed)` on line 68 with wrong indentation
- This causes `IndentationError` on startup, failing the health check
- Removes the duplicate line — verified with `py_compile`

## Test plan
- [x] `py_compile` passes
- [ ] Merge and verify CAA health check passes on Railway

🤖 Generated with [Claude Code](https://claude.com/claude-code)