### PR TITLE
fix: show actual error in pipeline findings when service unreachable

### DIFF
--- a/campaign-architecture-agent-svc/app/services/anthropic_client.py
+++ b/campaign-architecture-agent-svc/app/services/anthropic_client.py
@@ -65,8 +65,6 @@ class AnthropicClient:
                 )
                 return result
             logger.warning("No JSON object found in response")
-                return _ensure_dict(parsed)
-
             return {"raw_response": text}
         except Exception as exc:
             logger.error("Claude API error: %s", exc)

--- a/pipeline-orchestrator-svc/app/nodes/external_wrapper.py
+++ b/pipeline-orchestrator-svc/app/nodes/external_wrapper.py
@@ -78,16 +78,18 @@ class ExternalWrapper(BaseNode):
                 str(exc),
                 type(exc).__name__,
             )
+            error_detail = f"{type(exc).__name__}: {exc}"
             result = {
                 "error": True,
                 "status": "service_unavailable",
                 "message": (
                     f"The {self.node_id} service is currently unavailable. "
-                    f"Could not connect to {self.url}."
+                    f"Could not connect to {self.url}. "
+                    f"Error: {error_detail}"
                 ),
                 "findings": [
-                    f"The {self.node_id} service could not be reached. "
-                    f"This pipeline step was skipped."
+                    f"The {self.node_id} service could not be reached at "
+                    f"{self.url}. Error: {error_detail}"
                 ],
                 "recommendations": [
                     f"The {self.node_id} service may be down or misconfigured. "


### PR DESCRIPTION
## Summary
- When ExternalWrapper can't reach a service, the findings now include the exact URL and error type (e.g., `ConnectError`, `ConnectTimeout`, `NameResolutionError`)
- This makes the root cause visible directly in the dashboard results, eliminating the need to dig through Railway application logs

## Test plan
- [x] All 301 orchestrator tests pass
- [ ] Merge, deploy, re-run pipeline — the KEY FINDINGS will now show the actual error and URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)