### PR TITLE
fix: prevent campaign name text overflow in CAA overview

### DIFF
--- a/ai-brand-automator-frontend/src/components/pipelines/ResultDashboard.tsx
+++ b/ai-brand-automator-frontend/src/components/pipelines/ResultDashboard.tsx
@@ -6161,7 +6161,7 @@ function CampaignArchitectureSection({
               {blueprint.campaign_name && (
                 <div className="p-3 rounded-lg bg-white/5">
                   <div className="text-xs text-brand-silver/60 mb-1">Campaign</div>
-                  <div className="text-sm text-white font-medium">{blueprint.campaign_name}</div>
+                  <div className="text-sm text-white font-medium break-all">{blueprint.campaign_name}</div>
                 </div>
               )}
               {blueprint.campaign_objective && (


### PR DESCRIPTION
## Summary
- Adds `break-all` to the campaign name div in the CAA Overview tab so long names with underscores (e.g. `Pomodoro_Productivity_Launch_2024`) wrap within the card

## Test plan
- [ ] Verify campaign name wraps correctly in the Overview tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)