### PR TITLE
fix: display CGA creative assets in ResultDashboard

### DIFF
--- a/ai-brand-automator-frontend/src/components/pipelines/ResultDashboard.tsx
+++ b/ai-brand-automator-frontend/src/components/pipelines/ResultDashboard.tsx
@@ -7121,11 +7121,16 @@ export default function ResultDashboard({
     resultData.targeting_specs != null;
 
   // ── Detect creative generation data ───────────────────────────
+  // CGA large payloads live inside node_results.creative_generation
+  // (manager node only promotes lightweight stats to top-level)
+  const cgaNodeData = (resultData.node_results as Record<string, Record<string, unknown>> | undefined)?.creative_generation;
   const hasCreativeGeneration =
+    cgaNodeData?.creative_package != null ||
+    cgaNodeData?.ad_units != null ||
+    cgaNodeData?.copy_variants != null ||
+    cgaNodeData?.generated_images != null ||
     resultData.creative_package != null ||
-    resultData.ad_units != null ||
-    resultData.copy_variants != null ||
-    resultData.generated_images != null;
+    resultData.ad_units != null;
 
   // ── Extract well-known keys ──────────────────────────────────────
   const summary = resultData.summary as string | undefined;
@@ -7634,22 +7639,22 @@ export default function ResultDashboard({
 
       {hasCreativeGeneration && (
         <CreativeGenerationSection
-          creativePackage={resultData.creative_package as CGACreativePackage | undefined}
-          adSetPackages={resultData.ad_set_packages as CGAAdSetPackage[] | undefined}
-          adUnits={resultData.ad_units as CGACreativeUnit[] | undefined}
-          generatedImages={resultData.generated_images as CGAGeneratedImage[] | undefined}
-          hooks={resultData.hooks as CGAHookVariant[] | undefined}
-          copyVariants={resultData.copy_variants as CGACopySet[] | undefined}
-          ctas={resultData.ctas as CGACTASet[] | undefined}
-          complianceResults={resultData.compliance_results as CGAComplianceResult[] | undefined}
-          totalImagesGenerated={resultData.total_images_generated as number | undefined}
-          imageGenCostUsd={resultData.image_gen_cost_usd as number | undefined}
-          compliancePassRate={resultData.compliance_pass_rate as number | undefined}
-          creativeQualityScore={resultData.creative_quality_score as number | undefined}
-          confidenceScore={((resultData.confidence_scores as Record<string, number> | undefined)?.creative_generation ?? resultData.confidence_score) as number | undefined}
-          imageGenFailed={resultData.image_gen_failed as boolean | undefined}
-          findings={findings}
-          recommendations={recommendations}
+          creativePackage={(cgaNodeData?.creative_package ?? resultData.creative_package) as CGACreativePackage | undefined}
+          adSetPackages={(cgaNodeData?.ad_set_packages ?? resultData.ad_set_packages) as CGAAdSetPackage[] | undefined}
+          adUnits={(cgaNodeData?.ad_units ?? resultData.ad_units) as CGACreativeUnit[] | undefined}
+          generatedImages={(cgaNodeData?.generated_images ?? resultData.generated_images) as CGAGeneratedImage[] | undefined}
+          hooks={(cgaNodeData?.hooks ?? resultData.hooks) as CGAHookVariant[] | undefined}
+          copyVariants={(cgaNodeData?.copy_variants ?? resultData.copy_variants) as CGACopySet[] | undefined}
+          ctas={(cgaNodeData?.ctas ?? resultData.ctas) as CGACTASet[] | undefined}
+          complianceResults={(cgaNodeData?.compliance_results ?? resultData.compliance_results) as CGAComplianceResult[] | undefined}
+          totalImagesGenerated={(cgaNodeData?.total_images_generated ?? resultData.total_images_generated) as number | undefined}
+          imageGenCostUsd={(cgaNodeData?.image_gen_cost_usd ?? resultData.image_gen_cost_usd) as number | undefined}
+          compliancePassRate={(cgaNodeData?.compliance_pass_rate ?? resultData.compliance_pass_rate) as number | undefined}
+          creativeQualityScore={(cgaNodeData?.creative_quality_score ?? resultData.creative_quality_score) as number | undefined}
+          confidenceScore={((resultData.confidence_scores as Record<string, number> | undefined)?.creative_generation ?? (cgaNodeData?.confidence_score ?? resultData.confidence_score)) as number | undefined}
+          imageGenFailed={(cgaNodeData?.image_gen_failed ?? resultData.image_gen_failed) as boolean | undefined}
+          findings={(cgaNodeData?.findings as string[] | undefined) ?? findings}
+          recommendations={(cgaNodeData?.recommendations as string[] | undefined) ?? recommendations}
         />
       )}
 

--- a/creative-generation-agent-svc/app/logic/creative_context_loader.py
+++ b/creative-generation-agent-svc/app/logic/creative_context_loader.py
@@ -81,11 +81,15 @@ class CreativeContextLoader:
 
         for ad_set in ad_sets:
             brief: dict[str, Any] = {
-                "ad_set_name": ad_set.get("name", ""),
-                "persona": ad_set.get("persona", ad_set.get("targeting", {}).get("persona", "")),
-                "funnel_stage": ad_set.get(
-                    "funnel_stage", ad_set.get("stage", "")
-                ),
+                # Prefer CAA-style keys, fall back to blueprint-style keys
+                "ad_set_name": ad_set.get("ad_set_name") or ad_set.get("name", ""),
+                "persona": ad_set.get("persona")
+                or ad_set.get("persona_name")
+                or ad_set.get("targeting", {}).get("persona")
+                or ad_set.get("targeting", {}).get("persona_name", ""),
+                "funnel_stage": ad_set.get("funnel_stage")
+                or ad_set.get("stage")
+                or ad_set.get("funnel_stage_name", ""),
                 "messaging_theme": ad_set.get("messaging_theme", ""),
                 "variant_count": ad_set.get("variant_count", 3),
                 "placements": ad_set.get("placements", []),
@@ -110,23 +114,17 @@ class CreativeContextLoader:
             archetype_raw = bpv_context.get("archetype", "")
             # Normalize archetype to a string for prompt embedding
             if isinstance(archetype_raw, dict):
-                archetype_raw = archetype_raw.get(
-                    "primary", archetype_raw
-                )
+                archetype_raw = archetype_raw.get("primary", archetype_raw)
                 if isinstance(archetype_raw, dict):
                     archetype_raw = archetype_raw.get("name", "")
             visual["archetype"] = archetype_raw
-            visual["mood"] = bpv_context.get(
-                "tone_spectrum", {}
-            ).get("primary_mood", str(archetype_raw))
-            visual["aaker_dimensions"] = bpv_context.get(
-                "aaker_dimensions", {}
+            visual["mood"] = bpv_context.get("tone_spectrum", {}).get(
+                "primary_mood", str(archetype_raw)
             )
+            visual["aaker_dimensions"] = bpv_context.get("aaker_dimensions", {})
 
         if company_context:
-            visual["color_palette_desc"] = company_context.get(
-                "color_palette_desc", ""
-            )
+            visual["color_palette_desc"] = company_context.get("color_palette_desc", "")
             visual["logo_url"] = company_context.get("logo_url", "")
             visual["industry"] = company_context.get("industry", "")
 
@@ -156,13 +154,9 @@ class CreativeContextLoader:
                 bpa_context.get("unique_value_proposition", ""),
             ),
             "key_benefit": bpa_context.get("key_benefit", ""),
-            "positioning_statement": bpa_context.get(
-                "positioning_statement", ""
-            ),
+            "positioning_statement": bpa_context.get("positioning_statement", ""),
             "differentiators": bpa_context.get("differentiators", []),
-            "competitive_advantage": bpa_context.get(
-                "competitive_advantage", ""
-            ),
+            "competitive_advantage": bpa_context.get("competitive_advantage", ""),
         }
 
     def _extract_name_tagline(
@@ -185,24 +179,16 @@ class CreativeContextLoader:
             "tagline_variants": nta_context.get("taglines", []),
         }
 
-    def _extract_story_arcs(
-        self, bsa_context: dict[str, Any] | None
-    ) -> dict[str, Any]:
+    def _extract_story_arcs(self, bsa_context: dict[str, Any] | None) -> dict[str, Any]:
         """Extract brand story arcs from BSA output."""
         if not bsa_context:
             return {}
         return {
             "origin_story": bsa_context.get("origin_story", {}),
-            "mission": bsa_context.get("mission_vision", {}).get(
-                "mission", {}
-            ),
-            "vision": bsa_context.get("mission_vision", {}).get(
-                "vision", {}
-            ),
+            "mission": bsa_context.get("mission_vision", {}).get("mission", {}),
+            "vision": bsa_context.get("mission_vision", {}).get("vision", {}),
             "pitches": bsa_context.get("pitches", {}),
-            "channel_narratives": bsa_context.get(
-                "channel_narratives", {}
-            ),
+            "channel_narratives": bsa_context.get("channel_narratives", {}),
         }
 
     def _extract_audience_personas(

--- a/creative-generation-agent-svc/app/services/anthropic_client.py
+++ b/creative-generation-agent-svc/app/services/anthropic_client.py
@@ -56,14 +56,18 @@ class AnthropicClient:
             start = text.find("{")
             end = text.rfind("}") + 1
             if start >= 0 and end > start:
-                parsed = json.loads(text[start:end])
-                result = _ensure_dict(parsed)
-                logger.info(
-                    "Extracted JSON keys: %s (type=%s)",
-                    list(result.keys())[:10],
-                    type(parsed).__name__,
-                )
-                return result
+                try:
+                    parsed = json.loads(text[start:end])
+                    result = _ensure_dict(parsed)
+                    logger.info(
+                        "Extracted JSON keys: %s (type=%s)",
+                        list(result.keys())[:10],
+                        type(parsed).__name__,
+                    )
+                    return result
+                except (json.JSONDecodeError, ValueError):
+                    logger.warning("JSON extraction parse failed, returning raw")
+                    return {"raw_response": text}
             logger.warning("No JSON object found in response")
             return {"raw_response": text}
         except Exception as exc:

--- a/creative-generation-agent-svc/tests/test_cga_analyzer.py
+++ b/creative-generation-agent-svc/tests/test_cga_analyzer.py
@@ -40,6 +40,30 @@ class TestCAContextUnwrapping:
         assert len(ctx["creative_briefs"]) == 1
         assert ctx["creative_briefs"][0]["ad_set_name"] == "fleet-tofu"
 
+    def test_creative_briefs_caa_style_keys(self):
+        """CAA-style keys (ad_set_name, persona_name) should be preferred."""
+        loader = CreativeContextLoader()
+        caa = {
+            "creative_briefs": [
+                {
+                    "ad_set_name": "fleet-managers-tofu",
+                    "persona_name": "Fleet Manager",
+                    "funnel_stage": "tofu",
+                },
+            ],
+        }
+        ctx = loader.build_context(
+            caa_context=caa,
+            wf1_context=None,
+            bpa_context=None,
+            bpv_context=None,
+            nta_context=None,
+            bsa_context=None,
+            company_context=None,
+        )
+        assert ctx["creative_briefs"][0]["ad_set_name"] == "fleet-managers-tofu"
+        assert ctx["creative_briefs"][0]["persona"] == "Fleet Manager"
+
     def test_creative_briefs_from_top_level_ad_sets(self):
         """Top-level ad_sets (no blueprint wrapper) should also work."""
         loader = CreativeContextLoader()


### PR DESCRIPTION
## Summary
- **Frontend**: Read CGA data from `node_results.creative_generation` where manager node stores full payloads (creative_package, ad_units, hooks, copy_variants, etc.) — only lightweight stats are promoted to top-level
- **CGA backend**: Prefer CAA-style keys (`ad_set_name`, `persona_name`) with fallback to blueprint-style keys
- **CGA backend**: Wrap JSON extraction parse in try/except for fail-safe behavior

## Test plan
- [ ] `npx tsc --noEmit` — passes
- [ ] `pytest tests/test_cga_analyzer.py` — 12 tests pass
- [ ] Run CGA workflow → creative assets (gallery, copy, compliance, ad units) visible in dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)