### PR TITLE
feat: enable real image display in CGA creative gallery

### DIFF
--- a/ai-brand-automator-frontend/src/components/pipelines/ResultDashboard.tsx
+++ b/ai-brand-automator-frontend/src/components/pipelines/ResultDashboard.tsx
@@ -6338,13 +6338,17 @@ function CreativeGenerationSection({
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
                 {allImages.map((img, i) => (
                   <div key={i} className="bg-white/5 rounded-lg border border-white/10 overflow-hidden">
-                    {img.gcs_url ? (
-                      <div className="h-40 bg-gradient-to-br from-brand-electric/10 to-violet-500/10 flex items-center justify-center">
-                        <span className="text-xs text-brand-silver/40">{img.aspect_ratio ?? '1:1'}</span>
+                    {img.gcs_url && (img.gcs_url.startsWith('data:') || img.gcs_url.startsWith('http')) ? (
+                      <div className="h-40 bg-black/20 flex items-center justify-center overflow-hidden">
+                        <img
+                          src={img.gcs_url}
+                          alt={`${img.ad_set_name} ${img.aspect_ratio}`}
+                          className="h-full w-full object-cover"
+                        />
                       </div>
                     ) : (
-                      <div className="h-40 bg-white/5 flex items-center justify-center">
-                        <span className="text-xs text-brand-silver/30">Placeholder</span>
+                      <div className="h-40 bg-gradient-to-br from-brand-electric/10 to-violet-500/10 flex items-center justify-center">
+                        <span className="text-xs text-brand-silver/40">{img.gcs_url ? 'GCS' : 'Placeholder'} · {img.aspect_ratio ?? '1:1'}</span>
                       </div>
                     )}
                     <div className="p-2 space-y-1">

--- a/creative-generation-agent-svc/app/services/gcs_client.py
+++ b/creative-generation-agent-svc/app/services/gcs_client.py
@@ -1,6 +1,7 @@
 """GCS client for creative asset persistence."""
 
 import asyncio
+import base64
 import json
 import logging
 from datetime import datetime, timezone
@@ -71,7 +72,10 @@ class GCSClient:
     ) -> str:
         """Upload image bytes to GCS. Returns GCS URI or empty string."""
         if not self._ensure_client():
-            logger.info("GCS not configured, skipping image upload")
+            logger.info("GCS not configured, returning data URI")
+            if image_data and len(image_data) > 8:
+                b64 = base64.b64encode(image_data).decode("ascii")
+                return f"data:{content_type};base64,{b64}"
             return ""
         try:
             path = f"cga/{tenant_id}/{job_id}/images/{filename}"
@@ -114,9 +118,7 @@ class GCSClient:
             logger.warning("GCS package upload failed: %s", exc)
             return ""
 
-    async def download_package(
-        self, package_path: str
-    ) -> dict[str, Any] | None:
+    async def download_package(self, package_path: str) -> dict[str, Any] | None:
         """Download a creative package from GCS."""
         if not self._ensure_client():
             return None


### PR DESCRIPTION
## Summary
- **GCS client**: Return base64 data URIs when GCS is not configured, so Nano Banana 2 generated images are embedded in the response instead of being discarded
- **Frontend gallery**: Render actual `<img>` tags for data URIs and HTTP URLs instead of placeholder gradient divs
- **Railway**: `CGA_GOOGLE_API_KEY` has been set — Nano Banana 2 (Gemini) image generation is now active

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] Run CGA workflow → real AI-generated images visible in Creative Gallery tab
- [ ] Images render as inline base64 when GCS is not configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)