### PR TITLE
fix: ad-publishing-agent initialization + Railway deployment

### DIFF
--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -39,6 +39,7 @@ jobs:
       brand-story-changed: ${{ steps.changes.outputs.brand-story }}
       campaign-architecture-changed: ${{ steps.changes.outputs.campaign-architecture }}
       creative-generation-changed: ${{ steps.changes.outputs.creative-generation }}
+      ad-publishing-changed: ${{ steps.changes.outputs.ad-publishing }}
       audience-persona-changed: ${{ steps.changes.outputs.audience-persona }}
       trend-cultural-changed: ${{ steps.changes.outputs.trend-cultural }}
       voc-agent-changed: ${{ steps.changes.outputs.voc-agent }}
@@ -74,6 +75,7 @@ jobs:
             echo "brand-story=true" >> "$GITHUB_OUTPUT"
             echo "campaign-architecture=true" >> "$GITHUB_OUTPUT"
             echo "creative-generation=true" >> "$GITHUB_OUTPUT"
+            echo "ad-publishing=true" >> "$GITHUB_OUTPUT"
             echo "audience-persona=true" >> "$GITHUB_OUTPUT"
             echo "trend-cultural=true" >> "$GITHUB_OUTPUT"
             echo "voc-agent=true" >> "$GITHUB_OUTPUT"
@@ -211,6 +213,13 @@ jobs:
             echo "creative-generation=true" >> "$GITHUB_OUTPUT"
           else
             echo "creative-generation=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Check if ad-publishing-agent-svc changed
+          if git diff --name-only HEAD~1 | grep -qE '^ad-publishing-agent-svc/'; then
+            echo "ad-publishing=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ad-publishing=false" >> "$GITHUB_OUTPUT"
           fi
 
           # Check if audience-persona-agent-svc changed
@@ -1055,6 +1064,45 @@ jobs:
           fi
 
   # ==========================================================================
+  # Deploy Ad Publishing Agent to Railway
+  # ==========================================================================
+  deploy-ad-publishing-agent:
+    runs-on: ubuntu-latest
+    needs: [pre-deploy-checks]
+    if: always() && (needs.pre-deploy-checks.outputs.ad-publishing-changed == 'true' || github.event_name == 'workflow_dispatch')
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy Ad Publishing Agent
+        run: |
+          if [ -n "${{ secrets.RAILWAY_AD_PUBLISHING_SERVICE }}" ]; then
+            railway up --service ${{ secrets.RAILWAY_AD_PUBLISHING_SERVICE }} --detach
+          else
+            echo "RAILWAY_AD_PUBLISHING_SERVICE not set, skipping ad-publishing deployment"
+          fi
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+
+      - name: Wait for deployment
+        run: |
+          echo "Waiting for ad-publishing-agent deployment to complete..."
+          sleep 30
+
+      - name: Health check
+        run: |
+          ADPUB_URL="${{ secrets.RAILWAY_AD_PUBLISHING_URL }}"
+          if [ -n "$ADPUB_URL" ]; then
+            curl -f "${ADPUB_URL}/health" || echo "Health check failed - deployment may still be in progress"
+          else
+            echo "RAILWAY_AD_PUBLISHING_URL not set, skipping health check"
+          fi
+
+  # ==========================================================================
   # Deploy Audience Persona Agent to Railway
   # ==========================================================================
   deploy-audience-persona-agent:
@@ -1176,7 +1224,7 @@ jobs:
   # ==========================================================================
   notify:
     runs-on: ubuntu-latest
-    needs: [deploy-backend, deploy-frontend, deploy-celery-worker, deploy-celery-beat, deploy-mcp-server, deploy-orchestrator, deploy-discovery-agent, deploy-intelligence-agent, deploy-chat-titling, deploy-content-agent, deploy-social-agent, deploy-rag-uploader, deploy-odoo-mcp-server, deploy-odoo-worker-agent, deploy-market-research-agent, deploy-competitor-intel-agent, deploy-brand-positioning-agent, deploy-brand-architecture-agent, deploy-brand-personality-agent, deploy-brand-story-agent, deploy-campaign-architecture-agent, deploy-creative-generation-agent, deploy-audience-persona-agent, deploy-trend-cultural-agent, deploy-voc-agent]
+    needs: [deploy-backend, deploy-frontend, deploy-celery-worker, deploy-celery-beat, deploy-mcp-server, deploy-orchestrator, deploy-discovery-agent, deploy-intelligence-agent, deploy-chat-titling, deploy-content-agent, deploy-social-agent, deploy-rag-uploader, deploy-odoo-mcp-server, deploy-odoo-worker-agent, deploy-market-research-agent, deploy-competitor-intel-agent, deploy-brand-positioning-agent, deploy-brand-architecture-agent, deploy-brand-personality-agent, deploy-brand-story-agent, deploy-campaign-architecture-agent, deploy-creative-generation-agent, deploy-ad-publishing-agent, deploy-audience-persona-agent, deploy-trend-cultural-agent, deploy-voc-agent]
     if: always()
 
     steps:
@@ -1208,6 +1256,7 @@ jobs:
           echo "| Brand Story Agent | ${{ needs.deploy-brand-story-agent.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Campaign Architecture Agent | ${{ needs.deploy-campaign-architecture-agent.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Creative Generation Agent | ${{ needs.deploy-creative-generation-agent.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Ad Publishing Agent | ${{ needs.deploy-ad-publishing-agent.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Audience Persona Agent | ${{ needs.deploy-audience-persona-agent.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Trend Cultural Agent | ${{ needs.deploy-trend-cultural-agent.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| VoC Agent | ${{ needs.deploy-voc-agent.result }} |" >> $GITHUB_STEP_SUMMARY

--- a/ad-publishing-agent-svc/app/main.py
+++ b/ad-publishing-agent-svc/app/main.py
@@ -14,8 +14,17 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.api import routes
+from app.cache.redis_manager import RedisManager
 from app.core.config import settings
 from app.core.logging_config import setup_logging
+from app.messaging.event_emitter import EventEmitter
+from app.messaging.kafka_producer import AuditProducer, TraceProducer
+from app.services.adpub_analyzer import AdPubAnalyzer
+from app.services.adpub_executor import AdPubExecutor
+from app.services.approval_manager import ApprovalManager
+from app.services.context_loader import AdPubContextLoader
+from app.services.meta_api_client import MetaApiClient
+from app.services.targeting_translator import TargetingTranslator
 
 logger = logging.getLogger(__name__)
 
@@ -31,22 +40,90 @@ async def lifespan(app: FastAPI):
         settings.META_ADS_SANDBOX_MODE,
     )
 
-    # Dependencies will be initialized here in later phases:
     # 1. Redis (DB 23)
-    # 2. Kafka producers (trace, audit, event)
+    redis_manager = RedisManager()
+    await redis_manager.connect()
+
+    # 2. Kafka producers
+    trace_producer = TraceProducer(settings.KAFKA_BOOTSTRAP_SERVERS)
+    await trace_producer.start()
+    audit_producer = AuditProducer(settings.KAFKA_BOOTSTRAP_SERVERS)
+    await audit_producer.start()
+
     # 3. Anthropic client (Claude Sonnet 4 for targeting translation)
-    # 4. Meta API client (facebook-business SDK)
-    # 5. GCS client (read creative package images)
+    anthropic_client = None
+    if settings.ANTHROPIC_API_KEY:
+        try:
+            import anthropic
+
+            anthropic_client = anthropic.AsyncAnthropic(
+                api_key=settings.ANTHROPIC_API_KEY
+            )
+            logger.info(
+                "Anthropic client initialized (model: %s)",
+                settings.ANTHROPIC_MODEL,
+            )
+        except Exception as exc:
+            logger.warning("Anthropic client init failed: %s", exc)
+
+    # 4. LLM wrapper + targeting translator
+    from app.services.anthropic_client import AnthropicClient
+
+    llm_wrapper = AnthropicClient(anthropic_client) if anthropic_client else None
+    targeting_translator = TargetingTranslator(llm_client=llm_wrapper)
+
+    # 5. Meta API client
+    meta_client = MetaApiClient(
+        api_version=settings.META_API_VERSION,
+        sandbox_mode=settings.META_ADS_SANDBOX_MODE,
+    )
+
     # 6. Event emitter
+    event_emitter = EventEmitter(audit_producer)
+
     # 7. Context loader
+    context_loader = AdPubContextLoader()
+
     # 8. Approval manager
+    approval_manager = ApprovalManager(
+        redis_manager=redis_manager,
+        expiry_seconds=settings.APPROVAL_EXPIRY_SECONDS,
+    )
+
     # 9. Analyzer (7-phase publishing engine)
+    analyzer = AdPubAnalyzer(
+        meta_client=meta_client,
+        targeting_translator=targeting_translator,
+        event_emitter=event_emitter,
+    )
+
     # 10. Executor
+    executor = AdPubExecutor(
+        analyzer=analyzer,
+        approval_manager=approval_manager,
+        context_loader=context_loader,
+        redis_manager=redis_manager,
+        trace_producer=trace_producer,
+        audit_producer=audit_producer,
+        event_emitter=event_emitter,
+        daily_spend_cap_usd=settings.DAILY_SPEND_CAP_USD,
+        min_audience_size=settings.MIN_AUDIENCE_SIZE,
+        max_campaign_budget_usd=settings.MAX_CAMPAIGN_BUDGET_USD,
+    )
+
+    # Store in app state for route access
+    app.state.executor = executor
+    app.state.approval_manager = approval_manager
+    app.state.redis_manager = redis_manager
 
     logger.info("Ad Publishing Agent service ready")
 
     yield
 
+    # Teardown
+    await trace_producer.stop()
+    await audit_producer.stop()
+    await redis_manager.close()
     logger.info("Ad Publishing Agent service stopped")
 
 

--- a/ad-publishing-agent-svc/railway.json
+++ b/ad-publishing-agent-svc/railway.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile"
+  },
+  "deploy": {
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 5,
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 300
+  }
+}


### PR DESCRIPTION
## Summary
- Wire up full DI chain in `ad-publishing-agent-svc` lifespan — Redis, Anthropic, Meta API client, targeting translator, approval manager, analyzer, and executor were never instantiated, causing all `/v1/execute` calls to return stub "not fully initialized" responses
- Add `railway.json` and `deploy-railway.yml` job for Railway deployment
- Railway Redis only supports 16 DBs (0–15), so production uses DB 15 with `adpub:` key prefix (DB 23 remains for local Docker)

## Test plan
- [x] All 57 ad-publishing-agent tests pass locally
- [x] Service deployed and healthy on Railway (`/health` returns 200)
- [x] Redis connected (DB 15), Anthropic initialized, Kafka in stub mode
- [x] Executor fully initialized — no more stub responses

🤖 Generated with [Claude Code](https://claude.ai/claude-code)