### PR TITLE
fix: ad-publishing context loading + CGA/CAA format mapping

### DIFF
--- a/ad-publishing-agent-svc/app/core/config.py
+++ b/ad-publishing-agent-svc/app/core/config.py
@@ -44,6 +44,11 @@ class Settings(BaseSettings):
     BACKEND_URL: str = "http://localhost:8001"
     BACKEND_SERVICE_TOKEN: str = "dev-service-token"
 
+    @property
+    def backend_url(self) -> str:
+        """BACKEND_URL with whitespace stripped."""
+        return self.BACKEND_URL.strip().rstrip("/")
+
     # Kafka (optional)
     KAFKA_BOOTSTRAP_SERVERS: str = ""
     KAFKA_CONSUMERS_ENABLED: bool = False

--- a/ad-publishing-agent-svc/app/logic/guardrails.py
+++ b/ad-publishing-agent-svc/app/logic/guardrails.py
@@ -32,14 +32,14 @@ class InputGuardrails:
         for i, pkg in enumerate(packages):
             units = pkg.get("ad_units", [])
             if not units:
-                errors.append(
-                    f"IG-08: Creative package [{i}] has no ad units."
-                )
+                errors.append(f"IG-08: Creative package [{i}] has no ad units.")
             for j, unit in enumerate(units):
-                if not unit.get("image_url"):
-                    errors.append(
-                        f"IG-08: Package [{i}] unit [{j}] missing image_url."
-                    )
+                # CGA uses gcs_url; ad-publishing uses image_url
+                has_image = (
+                    unit.get("image_url") or unit.get("gcs_url") or unit.get("image")
+                )
+                if not has_image:
+                    errors.append(f"IG-08: Package [{i}] unit [{j}] missing image.")
 
         # IG-09: Campaign blueprint validation
         bp = context.get("blueprint", {})
@@ -49,9 +49,7 @@ class InputGuardrails:
                 "Run Campaign Architecture (Agent 3.1) first."
             )
         if not bp.get("funnel_stages"):
-            errors.append(
-                "IG-09: Blueprint has no funnel stages."
-            )
+            errors.append("IG-09: Blueprint has no funnel stages.")
 
         # IG-10: Meta credentials check (only in production mode)
         if not context.get("sandbox_mode", True):
@@ -194,9 +192,7 @@ class OutputGuardrails:
         # OG-03: Campaign status
         campaign_status = published_entities.get("campaign_status", "")
         if campaign_status and campaign_status not in ("ACTIVE", "PAUSED"):
-            errors.append(
-                f"OG-03: Unexpected campaign status: {campaign_status}"
-            )
+            errors.append(f"OG-03: Unexpected campaign status: {campaign_status}")
 
         return {
             "all_valid": len(errors) == 0,

--- a/ad-publishing-agent-svc/app/logic/guardrails.py
+++ b/ad-publishing-agent-svc/app/logic/guardrails.py
@@ -53,18 +53,19 @@ class InputGuardrails:
                 "IG-09: Blueprint has no funnel stages."
             )
 
-        # IG-10: Meta credentials check
-        creds = context.get("meta_credentials", {})
-        if not creds.get("access_token"):
-            errors.append(
-                "IG-10: Meta access_token missing. "
-                "Configure Meta Business Manager credentials."
-            )
-        if not creds.get("ad_account_id"):
-            errors.append(
-                "IG-10: Meta ad_account_id missing. "
-                "Configure Meta Business Manager credentials."
-            )
+        # IG-10: Meta credentials check (only in production mode)
+        if not context.get("sandbox_mode", True):
+            creds = context.get("meta_credentials", {})
+            if not creds.get("access_token"):
+                errors.append(
+                    "IG-10: Meta access_token missing. "
+                    "Configure Meta Business Manager credentials."
+                )
+            if not creds.get("ad_account_id"):
+                errors.append(
+                    "IG-10: Meta ad_account_id missing. "
+                    "Configure Meta Business Manager credentials."
+                )
 
         # IG-11: Daily spend cap pre-check
         total_budget = bp.get("total_budget_usd", 0)

--- a/ad-publishing-agent-svc/app/services/adpub_executor.py
+++ b/ad-publishing-agent-svc/app/services/adpub_executor.py
@@ -65,6 +65,15 @@ class AdPubExecutor:
         """
         start = time.time()
 
+        logger.info(
+            "Execute called: tenant_id=%s, job_id=%s, "
+            "previous_outputs_keys=%s, config_keys=%s",
+            tenant_id,
+            job_id,
+            list(previous_outputs.keys()) if previous_outputs else [],
+            list(config.keys()) if config else [],
+        )
+
         # 1. Load context from previous_outputs (pipeline chaining)
         context = self._context_loader.load(
             previous_outputs=previous_outputs,

--- a/ad-publishing-agent-svc/app/services/adpub_executor.py
+++ b/ad-publishing-agent-svc/app/services/adpub_executor.py
@@ -65,13 +65,18 @@ class AdPubExecutor:
         """
         start = time.time()
 
-        # 1. Load context
+        # 1. Load context from previous_outputs (pipeline chaining)
         context = self._context_loader.load(
             previous_outputs=previous_outputs,
             input_context=input_context,
             tenant_context=tenant_context,
             config=config,
         )
+
+        # 1b. If CAA/CGA data missing, fetch from Django backend
+        #     (standalone execution — agents ran as separate pipelines)
+        if context.get("_needs_caa_fetch") or context.get("_needs_cga_fetch"):
+            context = await self._context_loader.enrich_from_backend(context)
 
         # 2. Input guardrails
         validation_errors = self._context_loader.validate(context)

--- a/ad-publishing-agent-svc/app/services/context_loader.py
+++ b/ad-publishing-agent-svc/app/services/context_loader.py
@@ -253,8 +253,20 @@ class AdPubContextLoader:
     def _extract_blueprint(caa_output: dict[str, Any]) -> dict[str, Any]:
         """Extract blueprint fields from CAA output.
 
-        Handles both direct CAA output and the nested 'blueprint' key
-        returned by the caa-context endpoint.
+        Handles both:
+        - Direct CAA node output (pipeline chaining via previous_outputs)
+        - The caa-context Django endpoint response
+
+        CAA output structure:
+          blueprint:
+            campaign_name, campaign_objective, daily_budget,
+            buying_type, bid_strategy, cbo_enabled,
+            ad_sets: [{name, funnel_stage, targeting, placements, ...}]
+          funnel_map:
+            stages: [{stage, meta_objective, budget_pct}]
+          targeting_specs: [...]
+          placement_budget: {per_ad_set: [...]}
+          special_ad_category: str
         """
         if not caa_output:
             return {
@@ -265,27 +277,92 @@ class AdPubContextLoader:
                 "funnel_stages": [],
                 "placements": [],
                 "special_ad_categories": [],
+                "ad_sets": [],
+                "funnel_map": {},
+                "targeting_specs": [],
+                "placement_budget": {},
+                "raw_blueprint": {},
             }
 
-        # The caa-context endpoint nests under 'blueprint'
+        # The caa-context endpoint nests campaign data under 'blueprint'
         bp = caa_output.get("blueprint", caa_output)
 
-        def _get(key: str, default: Any) -> Any:
-            """Return blueprint value, preserving valid falsy values (0, [])."""
-            if key in bp and bp[key] is not None:
-                return bp[key]
-            if key in caa_output and caa_output[key] is not None:
-                return caa_output[key]
+        def _first(*keys: str, default: Any = None) -> Any:
+            """Return first non-None value found across bp and caa_output."""
+            for src in (bp, caa_output):
+                for key in keys:
+                    if key in src and src[key] is not None:
+                        return src[key]
             return default
 
+        # Campaign name
+        campaign_name = _first("campaign_name", default="")
+
+        # Objective: CAA uses "campaign_objective", normalize
+        objective = _first(
+            "campaign_objective", "objective", default="OUTCOME_AWARENESS"
+        )
+
+        # Budget: CAA uses "daily_budget"; also accept "total_budget_usd"
+        daily_budget = _first("daily_budget", "total_budget_usd", default=0)
+
+        # Duration
+        duration_days = _first("duration_days", default=30)
+
+        # Funnel stages: derive from blueprint.ad_sets or funnel_map.stages
+        ad_sets = _first("ad_sets", default=[])
+        funnel_map = caa_output.get("funnel_map", {})
+        funnel_stages_raw = funnel_map.get("stages", [])
+
+        # Build unified funnel_stages list from ad_sets (preferred) or
+        # funnel_map stages
+        funnel_stages = []
+        if ad_sets:
+            for ad_set in ad_sets:
+                funnel_stages.append(ad_set)
+        elif funnel_stages_raw:
+            funnel_stages = funnel_stages_raw
+        else:
+            # Fallback: check for literal "funnel_stages" key
+            funnel_stages = _first("funnel_stages", default=[])
+
+        # Placements: collect from ad_sets or top-level
+        placements = _first("placements", default=[])
+        if not placements and ad_sets:
+            seen = set()
+            for ad_set in ad_sets:
+                for p in ad_set.get("placements", []):
+                    if p not in seen:
+                        seen.add(p)
+                        placements.append(p)
+
+        # Special ad categories: CAA uses singular "special_ad_category"
+        special_ad_categories = _first("special_ad_categories", default=[])
+        if not special_ad_categories:
+            cat = _first("special_ad_category", default="")
+            if cat:
+                special_ad_categories = [cat]
+
+        # Targeting specs (top-level in caa-context response)
+        targeting_specs = caa_output.get("targeting_specs", [])
+
+        # Placement budget (top-level in caa-context response)
+        placement_budget = caa_output.get("placement_budget", {})
+
         return {
-            "campaign_name": _get("campaign_name", ""),
-            "objective": _get("objective", "OUTCOME_AWARENESS"),
-            "total_budget_usd": _get("total_budget_usd", 0),
-            "duration_days": _get("duration_days", 30),
-            "funnel_stages": _get("funnel_stages", []),
-            "placements": _get("placements", []),
-            "special_ad_categories": _get("special_ad_categories", []),
+            "campaign_name": campaign_name,
+            "objective": objective,
+            "total_budget_usd": daily_budget * duration_days,
+            "daily_budget": daily_budget,
+            "duration_days": duration_days,
+            "funnel_stages": funnel_stages,
+            "placements": placements,
+            "special_ad_categories": special_ad_categories,
+            "ad_sets": ad_sets,
+            "funnel_map": funnel_map,
+            "targeting_specs": targeting_specs,
+            "placement_budget": placement_budget,
+            "raw_blueprint": bp,
         }
 
     @staticmethod

--- a/ad-publishing-agent-svc/app/services/context_loader.py
+++ b/ad-publishing-agent-svc/app/services/context_loader.py
@@ -126,6 +126,15 @@ class AdPubContextLoader:
             logger.warning("No tenant_id — cannot fetch from backend")
             return context
 
+        logger.info(
+            "Enriching from backend: tenant_id=%s, backend_url=%s, "
+            "needs_caa=%s, needs_cga=%s",
+            tenant_id,
+            settings.BACKEND_URL,
+            context.get("_needs_caa_fetch"),
+            context.get("_needs_cga_fetch"),
+        )
+
         headers = {
             "X-Service-Token": settings.BACKEND_SERVICE_TOKEN,
             "X-Tenant-ID": str(tenant_id),
@@ -134,11 +143,12 @@ class AdPubContextLoader:
         async with httpx.AsyncClient(timeout=30) as client:
             # Fetch CAA blueprint if missing
             if context.get("_needs_caa_fetch"):
+                caa_url = (
+                    f"{settings.BACKEND_URL}/api/v1/analytics/caa-context/"
+                )
                 try:
-                    resp = await client.get(
-                        f"{settings.BACKEND_URL}/api/v1/analytics/caa-context/",
-                        headers=headers,
-                    )
+                    logger.info("Fetching CAA context from: %s", caa_url)
+                    resp = await client.get(caa_url, headers=headers)
                     if resp.status_code == 200:
                         caa_data = resp.json()
                         context["blueprint"] = self._extract_blueprint(caa_data)
@@ -148,18 +158,23 @@ class AdPubContextLoader:
                         )
                     else:
                         logger.warning(
-                            "CAA context fetch failed: HTTP %d", resp.status_code
+                            "CAA context fetch failed: HTTP %d — %s",
+                            resp.status_code,
+                            resp.text[:500],
                         )
                 except Exception as exc:
-                    logger.warning("CAA context fetch error: %s", exc)
+                    logger.error(
+                        "CAA context fetch error (url=%s): %s", caa_url, exc
+                    )
 
             # Fetch CGA creative packages if missing
             if context.get("_needs_cga_fetch"):
+                cga_url = (
+                    f"{settings.BACKEND_URL}/api/v1/analytics/cga-context/"
+                )
                 try:
-                    resp = await client.get(
-                        f"{settings.BACKEND_URL}/api/v1/analytics/cga-context/",
-                        headers=headers,
-                    )
+                    logger.info("Fetching CGA context from: %s", cga_url)
+                    resp = await client.get(cga_url, headers=headers)
                     if resp.status_code == 200:
                         cga_data = resp.json()
                         context["creative_packages"] = (
@@ -171,10 +186,14 @@ class AdPubContextLoader:
                         )
                     else:
                         logger.warning(
-                            "CGA context fetch failed: HTTP %d", resp.status_code
+                            "CGA context fetch failed: HTTP %d — %s",
+                            resp.status_code,
+                            resp.text[:500],
                         )
                 except Exception as exc:
-                    logger.warning("CGA context fetch error: %s", exc)
+                    logger.error(
+                        "CGA context fetch error (url=%s): %s", cga_url, exc
+                    )
 
             # Fetch WF1 personas if still empty
             if not context.get("persona_profiles"):

--- a/ad-publishing-agent-svc/app/services/context_loader.py
+++ b/ad-publishing-agent-svc/app/services/context_loader.py
@@ -46,7 +46,7 @@ class AdPubContextLoader:
 
         # 2. Creative packages from CGA (Agent 3.2) — MUST be approved
         cga_output = previous_outputs.get("creative_generation", {})
-        creative_packages = cga_output.get("creative_packages", [])
+        creative_packages = self._extract_creative_packages(cga_output)
         approval_status = cga_output.get("approval_status", "")
 
         # 3. Persona profiles from WF1 APA
@@ -162,11 +162,8 @@ class AdPubContextLoader:
                     )
                     if resp.status_code == 200:
                         cga_data = resp.json()
-                        context["creative_packages"] = cga_data.get(
-                            "creative_packages", []
-                        )
-                        context["creative_approval_status"] = cga_data.get(
-                            "approval_status", ""
+                        context["creative_packages"] = self._extract_creative_packages(
+                            cga_data
                         )
                         logger.info(
                             "CGA packages fetched from backend: %d packages",
@@ -243,6 +240,49 @@ class AdPubContextLoader:
             "special_ad_categories": _get("special_ad_categories", []),
         }
 
+    @staticmethod
+    def _extract_creative_packages(cga_output: dict[str, Any]) -> list[dict]:
+        """Extract creative packages from CGA output.
+
+        CGA stores per-ad-set packages in "ad_set_packages", each with
+        "creative_units" (assembled image+copy+CTA). This method maps
+        them to the ad-publishing expected format: a list of dicts with
+        "ad_set_name" and "ad_units".
+
+        Also handles the already-mapped "creative_packages" key returned
+        by the cga-context Django endpoint.
+        """
+        if not cga_output:
+            return []
+
+        # Already mapped (from cga-context endpoint)
+        creative_packages = cga_output.get("creative_packages", [])
+        if creative_packages:
+            return creative_packages
+
+        # Map from raw CGA output (pipeline chaining)
+        ad_set_packages = cga_output.get("ad_set_packages", [])
+        if ad_set_packages:
+            packages = []
+            for pkg in ad_set_packages:
+                units = pkg.get("creative_units", [])
+                packages.append(
+                    {
+                        "ad_set_name": pkg.get("ad_set_name", ""),
+                        "persona": pkg.get("persona", ""),
+                        "funnel_stage": pkg.get("funnel_stage", ""),
+                        "ad_units": units,
+                    }
+                )
+            return packages
+
+        # Fallback: top-level ad_units
+        ad_units = cga_output.get("ad_units", [])
+        if ad_units:
+            return [{"ad_set_name": "Default", "ad_units": ad_units}]
+
+        return []
+
     def validate(self, context: dict[str, Any]) -> list[str]:
         """Validate that all required prerequisites are present.
 
@@ -277,10 +317,12 @@ class AdPubContextLoader:
             if not ad_units:
                 errors.append(f"Creative package [{i}] has no ad units")
             for j, unit in enumerate(ad_units):
-                if not unit.get("image_url"):
-                    errors.append(
-                        f"Creative package [{i}] ad unit [{j}] " "has no image_url"
-                    )
+                # CGA uses gcs_url; ad-publishing uses image_url
+                has_image = (
+                    unit.get("image_url") or unit.get("gcs_url") or unit.get("image")
+                )
+                if not has_image:
+                    errors.append(f"Creative package [{i}] ad unit [{j}] has no image")
 
         # Meta credentials (only required in production mode)
         if not context.get("sandbox_mode", True):

--- a/ad-publishing-agent-svc/app/services/context_loader.py
+++ b/ad-publishing-agent-svc/app/services/context_loader.py
@@ -141,7 +141,7 @@ class AdPubContextLoader:
             "Enriching from backend: tenant_id=%s, backend_url=%s, "
             "needs_caa=%s, needs_cga=%s",
             tenant_id,
-            settings.BACKEND_URL,
+            settings.backend_url,
             context.get("_needs_caa_fetch"),
             context.get("_needs_cga_fetch"),
         )
@@ -155,7 +155,7 @@ class AdPubContextLoader:
             # Fetch CAA blueprint if missing
             if context.get("_needs_caa_fetch"):
                 caa_url = (
-                    f"{settings.BACKEND_URL}/api/v1/analytics/caa-context/"
+                    f"{settings.backend_url}/api/v1/analytics/caa-context/"
                 )
                 try:
                     logger.info("Fetching CAA context from: %s", caa_url)
@@ -189,7 +189,7 @@ class AdPubContextLoader:
             # Fetch CGA creative packages if missing
             if context.get("_needs_cga_fetch"):
                 cga_url = (
-                    f"{settings.BACKEND_URL}/api/v1/analytics/cga-context/"
+                    f"{settings.backend_url}/api/v1/analytics/cga-context/"
                 )
                 try:
                     logger.info("Fetching CGA context from: %s", cga_url)
@@ -227,7 +227,7 @@ class AdPubContextLoader:
             if not context.get("persona_profiles"):
                 try:
                     resp = await client.get(
-                        f"{settings.BACKEND_URL}/api/v1/analytics/wf1-context/",
+                        f"{settings.backend_url}/api/v1/analytics/wf1-context/",
                         headers=headers,
                     )
                     if resp.status_code == 200:

--- a/ad-publishing-agent-svc/app/services/context_loader.py
+++ b/ad-publishing-agent-svc/app/services/context_loader.py
@@ -7,10 +7,17 @@ and/or Django backend endpoints:
 - APA persona profiles (WF1)
 - Company model (website, industry)
 - Meta credentials (per-tenant)
+
+When running standalone (not chained after CAA/CGA in the same
+pipeline), fetches context from Django analytics endpoints.
 """
 
 import logging
 from typing import Any
+
+import httpx
+
+from app.core.config import settings
 
 logger = logging.getLogger(__name__)
 
@@ -35,17 +42,7 @@ class AdPubContextLoader:
 
         # 1. Campaign blueprint from CAA (Agent 3.1)
         caa_output = previous_outputs.get("campaign_architecture", {})
-        blueprint = {
-            "campaign_name": caa_output.get("campaign_name", ""),
-            "objective": caa_output.get("objective", "OUTCOME_AWARENESS"),
-            "total_budget_usd": caa_output.get("total_budget_usd", 0),
-            "duration_days": caa_output.get("duration_days", 30),
-            "funnel_stages": caa_output.get("funnel_stages", []),
-            "placements": caa_output.get("placements", []),
-            "special_ad_categories": caa_output.get(
-                "special_ad_categories", []
-            ),
-        }
+        blueprint = self._extract_blueprint(caa_output)
 
         # 2. Creative packages from CGA (Agent 3.2) — MUST be approved
         cga_output = previous_outputs.get("creative_generation", {})
@@ -100,18 +97,165 @@ class AdPubContextLoader:
             "company": company,
             "meta_credentials": meta_credentials,
             "sandbox_mode": sandbox_mode,
+            # Store tenant info for backend fallback
+            "_tenant_id": tenant_ctx.get("tenant_id", ""),
+            "_needs_caa_fetch": not caa_output,
+            "_needs_cga_fetch": not cga_output,
         }
 
         logger.info(
             "Context loaded: blueprint=%s, packages=%d, personas=%d, "
-            "sandbox=%s",
+            "sandbox=%s, needs_caa_fetch=%s, needs_cga_fetch=%s",
             blueprint.get("campaign_name", "?"),
             len(creative_packages),
             len(persona_profiles),
             sandbox_mode,
+            not caa_output,
+            not cga_output,
         )
 
         return context
+
+    async def enrich_from_backend(self, context: dict[str, Any]) -> dict[str, Any]:
+        """Fetch missing CAA/CGA context from Django backend.
+
+        Called when previous_outputs didn't contain CAA or CGA data
+        (standalone pipeline execution).
+        """
+        tenant_id = context.get("_tenant_id", "")
+        if not tenant_id:
+            logger.warning("No tenant_id — cannot fetch from backend")
+            return context
+
+        headers = {
+            "X-Service-Token": settings.BACKEND_SERVICE_TOKEN,
+            "X-Tenant-ID": str(tenant_id),
+        }
+
+        async with httpx.AsyncClient(timeout=30) as client:
+            # Fetch CAA blueprint if missing
+            if context.get("_needs_caa_fetch"):
+                try:
+                    resp = await client.get(
+                        f"{settings.BACKEND_URL}/api/v1/analytics/caa-context/",
+                        headers=headers,
+                    )
+                    if resp.status_code == 200:
+                        caa_data = resp.json()
+                        context["blueprint"] = self._extract_blueprint(caa_data)
+                        logger.info(
+                            "CAA blueprint fetched from backend: %s",
+                            context["blueprint"].get("campaign_name", "?"),
+                        )
+                    else:
+                        logger.warning(
+                            "CAA context fetch failed: HTTP %d", resp.status_code
+                        )
+                except Exception as exc:
+                    logger.warning("CAA context fetch error: %s", exc)
+
+            # Fetch CGA creative packages if missing
+            if context.get("_needs_cga_fetch"):
+                try:
+                    resp = await client.get(
+                        f"{settings.BACKEND_URL}/api/v1/analytics/cga-context/",
+                        headers=headers,
+                    )
+                    if resp.status_code == 200:
+                        cga_data = resp.json()
+                        context["creative_packages"] = cga_data.get(
+                            "creative_packages", []
+                        )
+                        context["creative_approval_status"] = cga_data.get(
+                            "approval_status", ""
+                        )
+                        logger.info(
+                            "CGA packages fetched from backend: %d packages",
+                            len(context["creative_packages"]),
+                        )
+                    else:
+                        logger.warning(
+                            "CGA context fetch failed: HTTP %d", resp.status_code
+                        )
+                except Exception as exc:
+                    logger.warning("CGA context fetch error: %s", exc)
+
+            # Fetch WF1 personas if still empty
+            if not context.get("persona_profiles"):
+                try:
+                    resp = await client.get(
+                        f"{settings.BACKEND_URL}/api/v1/analytics/wf1-context/",
+                        headers=headers,
+                    )
+                    if resp.status_code == 200:
+                        wf1_data = resp.json()
+                        personas = wf1_data.get("persona_profiles", [])
+                        if personas:
+                            context["persona_profiles"] = personas
+                            logger.info(
+                                "WF1 personas fetched from backend: %d",
+                                len(personas),
+                            )
+                except Exception as exc:
+                    logger.warning("WF1 context fetch error: %s", exc)
+
+        # Clean up internal flags
+        context.pop("_needs_caa_fetch", None)
+        context.pop("_needs_cga_fetch", None)
+
+        return context
+
+    @staticmethod
+    def _extract_blueprint(caa_output: dict[str, Any]) -> dict[str, Any]:
+        """Extract blueprint fields from CAA output.
+
+        Handles both direct CAA output and the nested 'blueprint' key
+        returned by the caa-context endpoint.
+        """
+        if not caa_output:
+            return {
+                "campaign_name": "",
+                "objective": "OUTCOME_AWARENESS",
+                "total_budget_usd": 0,
+                "duration_days": 30,
+                "funnel_stages": [],
+                "placements": [],
+                "special_ad_categories": [],
+            }
+
+        # The caa-context endpoint nests under 'blueprint'
+        bp = caa_output.get("blueprint", caa_output)
+
+        return {
+            "campaign_name": (
+                bp.get("campaign_name", "")
+                or caa_output.get("campaign_name", "")
+            ),
+            "objective": (
+                bp.get("objective", "")
+                or caa_output.get("objective", "OUTCOME_AWARENESS")
+            ),
+            "total_budget_usd": (
+                bp.get("total_budget_usd", 0)
+                or caa_output.get("total_budget_usd", 0)
+            ),
+            "duration_days": (
+                bp.get("duration_days", 30)
+                or caa_output.get("duration_days", 30)
+            ),
+            "funnel_stages": (
+                bp.get("funnel_stages", [])
+                or caa_output.get("funnel_stages", [])
+            ),
+            "placements": (
+                bp.get("placements", [])
+                or caa_output.get("placements", [])
+            ),
+            "special_ad_categories": (
+                bp.get("special_ad_categories", [])
+                or caa_output.get("special_ad_categories", [])
+            ),
+        }
 
     def validate(self, context: dict[str, Any]) -> list[str]:
         """Validate that all required prerequisites are present.

--- a/ad-publishing-agent-svc/app/services/context_loader.py
+++ b/ad-publishing-agent-svc/app/services/context_loader.py
@@ -120,10 +120,21 @@ class AdPubContextLoader:
 
         Called when previous_outputs didn't contain CAA or CGA data
         (standalone pipeline execution).
+
+        Stores diagnostic messages in context["_backend_diagnostics"]
+        so validation errors can surface them to the user.
         """
+        diagnostics: list[str] = []
         tenant_id = context.get("_tenant_id", "")
+
         if not tenant_id:
-            logger.warning("No tenant_id — cannot fetch from backend")
+            msg = (
+                "Backend enrichment skipped: no tenant_id in tenant_context. "
+                "Ensure the pipeline dispatch includes tenant_context.tenant_id."
+            )
+            logger.warning(msg)
+            diagnostics.append(msg)
+            context["_backend_diagnostics"] = diagnostics
             return context
 
         logger.info(
@@ -152,20 +163,28 @@ class AdPubContextLoader:
                     if resp.status_code == 200:
                         caa_data = resp.json()
                         context["blueprint"] = self._extract_blueprint(caa_data)
+                        bp_name = context["blueprint"].get("campaign_name", "?")
                         logger.info(
-                            "CAA blueprint fetched from backend: %s",
-                            context["blueprint"].get("campaign_name", "?"),
+                            "CAA blueprint fetched from backend: %s", bp_name
+                        )
+                        diagnostics.append(
+                            f"CAA fetch OK: campaign={bp_name}"
                         )
                     else:
-                        logger.warning(
-                            "CAA context fetch failed: HTTP %d — %s",
-                            resp.status_code,
-                            resp.text[:500],
+                        body = resp.text[:300]
+                        msg = (
+                            f"CAA fetch failed: HTTP {resp.status_code} "
+                            f"from {caa_url} (tenant={tenant_id}) — {body}"
                         )
+                        logger.warning(msg)
+                        diagnostics.append(msg)
                 except Exception as exc:
-                    logger.error(
-                        "CAA context fetch error (url=%s): %s", caa_url, exc
+                    msg = (
+                        f"CAA fetch error: {exc} "
+                        f"(url={caa_url}, tenant={tenant_id})"
                     )
+                    logger.error(msg)
+                    diagnostics.append(msg)
 
             # Fetch CGA creative packages if missing
             if context.get("_needs_cga_fetch"):
@@ -180,20 +199,29 @@ class AdPubContextLoader:
                         context["creative_packages"] = (
                             self._extract_creative_packages(cga_data)
                         )
+                        pkg_count = len(context["creative_packages"])
                         logger.info(
                             "CGA packages fetched from backend: %d packages",
-                            len(context["creative_packages"]),
+                            pkg_count,
+                        )
+                        diagnostics.append(
+                            f"CGA fetch OK: {pkg_count} packages"
                         )
                     else:
-                        logger.warning(
-                            "CGA context fetch failed: HTTP %d — %s",
-                            resp.status_code,
-                            resp.text[:500],
+                        body = resp.text[:300]
+                        msg = (
+                            f"CGA fetch failed: HTTP {resp.status_code} "
+                            f"from {cga_url} (tenant={tenant_id}) — {body}"
                         )
+                        logger.warning(msg)
+                        diagnostics.append(msg)
                 except Exception as exc:
-                    logger.error(
-                        "CGA context fetch error (url=%s): %s", cga_url, exc
+                    msg = (
+                        f"CGA fetch error: {exc} "
+                        f"(url={cga_url}, tenant={tenant_id})"
                     )
+                    logger.error(msg)
+                    diagnostics.append(msg)
 
             # Fetch WF1 personas if still empty
             if not context.get("persona_profiles"):
@@ -217,6 +245,7 @@ class AdPubContextLoader:
         # Clean up internal flags
         context.pop("_needs_caa_fetch", None)
         context.pop("_needs_cga_fetch", None)
+        context["_backend_diagnostics"] = diagnostics
 
         return context
 
@@ -306,8 +335,16 @@ class AdPubContextLoader:
         """Validate that all required prerequisites are present.
 
         Returns a list of error messages (empty = valid).
+        Includes backend fetch diagnostics if enrichment was attempted.
         """
         errors = []
+
+        # Surface backend fetch diagnostics so failures are visible
+        diagnostics = context.pop("_backend_diagnostics", [])
+        if diagnostics:
+            errors.append(
+                "Backend enrichment diagnostics: " + " | ".join(diagnostics)
+            )
 
         # Campaign blueprint
         bp = context.get("blueprint", {})

--- a/ad-publishing-agent-svc/app/services/context_loader.py
+++ b/ad-publishing-agent-svc/app/services/context_loader.py
@@ -200,12 +200,22 @@ class AdPubContextLoader:
                             self._extract_creative_packages(cga_data)
                         )
                         pkg_count = len(context["creative_packages"])
+                        cga_job = cga_data.get("cga_job_id", "?")
+                        raw_pkgs = len(cga_data.get("ad_set_packages", []))
+                        raw_units = len(cga_data.get("ad_units", []))
                         logger.info(
-                            "CGA packages fetched from backend: %d packages",
+                            "CGA packages fetched: %d packages "
+                            "(raw: %d ad_set_packages, %d ad_units, "
+                            "job=%s)",
                             pkg_count,
+                            raw_pkgs,
+                            raw_units,
+                            cga_job,
                         )
                         diagnostics.append(
-                            f"CGA fetch OK: {pkg_count} packages"
+                            f"CGA fetch OK: {pkg_count} packages "
+                            f"(job={cga_job}, raw_pkgs={raw_pkgs}, "
+                            f"raw_units={raw_units})"
                         )
                     else:
                         body = resp.text[:300]

--- a/ad-publishing-agent-svc/app/services/context_loader.py
+++ b/ad-publishing-agent-svc/app/services/context_loader.py
@@ -74,8 +74,7 @@ class AdPubContextLoader:
                 or cfg.get("meta_ad_account_id", "")
             ),
             "page_id": (
-                tenant_ctx.get("meta_page_id", "")
-                or cfg.get("meta_page_id", "")
+                tenant_ctx.get("meta_page_id", "") or cfg.get("meta_page_id", "")
             ),
             "business_id": (
                 tenant_ctx.get("meta_business_id", "")
@@ -226,35 +225,22 @@ class AdPubContextLoader:
         # The caa-context endpoint nests under 'blueprint'
         bp = caa_output.get("blueprint", caa_output)
 
+        def _get(key: str, default: Any) -> Any:
+            """Return blueprint value, preserving valid falsy values (0, [])."""
+            if key in bp and bp[key] is not None:
+                return bp[key]
+            if key in caa_output and caa_output[key] is not None:
+                return caa_output[key]
+            return default
+
         return {
-            "campaign_name": (
-                bp.get("campaign_name", "")
-                or caa_output.get("campaign_name", "")
-            ),
-            "objective": (
-                bp.get("objective", "")
-                or caa_output.get("objective", "OUTCOME_AWARENESS")
-            ),
-            "total_budget_usd": (
-                bp.get("total_budget_usd", 0)
-                or caa_output.get("total_budget_usd", 0)
-            ),
-            "duration_days": (
-                bp.get("duration_days", 30)
-                or caa_output.get("duration_days", 30)
-            ),
-            "funnel_stages": (
-                bp.get("funnel_stages", [])
-                or caa_output.get("funnel_stages", [])
-            ),
-            "placements": (
-                bp.get("placements", [])
-                or caa_output.get("placements", [])
-            ),
-            "special_ad_categories": (
-                bp.get("special_ad_categories", [])
-                or caa_output.get("special_ad_categories", [])
-            ),
+            "campaign_name": _get("campaign_name", ""),
+            "objective": _get("objective", "OUTCOME_AWARENESS"),
+            "total_budget_usd": _get("total_budget_usd", 0),
+            "duration_days": _get("duration_days", 30),
+            "funnel_stages": _get("funnel_stages", []),
+            "placements": _get("placements", []),
+            "special_ad_categories": _get("special_ad_categories", []),
         }
 
     def validate(self, context: dict[str, Any]) -> list[str]:
@@ -289,14 +275,11 @@ class AdPubContextLoader:
         for i, pkg in enumerate(packages):
             ad_units = pkg.get("ad_units", [])
             if not ad_units:
-                errors.append(
-                    f"Creative package [{i}] has no ad units"
-                )
+                errors.append(f"Creative package [{i}] has no ad units")
             for j, unit in enumerate(ad_units):
                 if not unit.get("image_url"):
                     errors.append(
-                        f"Creative package [{i}] ad unit [{j}] "
-                        "has no image_url"
+                        f"Creative package [{i}] ad unit [{j}] " "has no image_url"
                     )
 
         # Meta credentials (only required in production mode)

--- a/ad-publishing-agent-svc/app/services/context_loader.py
+++ b/ad-publishing-agent-svc/app/services/context_loader.py
@@ -299,17 +299,18 @@ class AdPubContextLoader:
                         "has no image_url"
                     )
 
-        # Meta credentials
-        creds = context.get("meta_credentials", {})
-        if not creds.get("access_token"):
-            errors.append(
-                "Meta access_token missing: configure Meta Business "
-                "Manager credentials"
-            )
-        if not creds.get("ad_account_id"):
-            errors.append(
-                "Meta ad_account_id missing: configure Meta Business "
-                "Manager credentials"
-            )
+        # Meta credentials (only required in production mode)
+        if not context.get("sandbox_mode", True):
+            creds = context.get("meta_credentials", {})
+            if not creds.get("access_token"):
+                errors.append(
+                    "Meta access_token missing: configure Meta Business "
+                    "Manager credentials"
+                )
+            if not creds.get("ad_account_id"):
+                errors.append(
+                    "Meta ad_account_id missing: configure Meta Business "
+                    "Manager credentials"
+                )
 
         return errors

--- a/ad-publishing-agent-svc/tests/conftest.py
+++ b/ad-publishing-agent-svc/tests/conftest.py
@@ -84,16 +84,26 @@ def mock_anthropic():
 
 @pytest.fixture
 def sample_creative_package():
-    """Sample CGA creative package (previous_outputs)."""
+    """Sample CGA creative package (previous_outputs).
+
+    Uses actual CGA output format: ad_set_packages with creative_units.
+    """
     return {
         "creative_generation": {
-            "creative_packages": [
+            "creative_package": {
+                "campaign_id": "",
+                "brand_name": "TestBrand",
+                "total_images_generated": 1,
+            },
+            "ad_set_packages": [
                 {
                     "ad_set_name": "TOFU - Tech Enthusiasts",
-                    "ad_units": [
+                    "persona": "Tech Enthusiasts",
+                    "funnel_stage": "TOFU",
+                    "creative_units": [
                         {
                             "variant_label": "A",
-                            "image_url": "gs://bucket/img1.jpg",
+                            "gcs_url": "gs://bucket/img1.jpg",
                             "headline": "Discover Innovation",
                             "primary_text": "Transform your workflow today.",
                             "cta": "LEARN_MORE",
@@ -102,7 +112,17 @@ def sample_creative_package():
                     ],
                 }
             ],
-            "approval_status": "approved",
+            "ad_units": [
+                {
+                    "variant_label": "A",
+                    "gcs_url": "gs://bucket/img1.jpg",
+                    "headline": "Discover Innovation",
+                    "primary_text": "Transform your workflow today.",
+                    "cta": "LEARN_MORE",
+                    "link_url": "https://example.com",
+                }
+            ],
+            "confidence_score": 0.85,
         }
     }
 

--- a/ad-publishing-agent-svc/tests/conftest.py
+++ b/ad-publishing-agent-svc/tests/conftest.py
@@ -129,31 +129,71 @@ def sample_creative_package():
 
 @pytest.fixture
 def sample_campaign_blueprint():
-    """Sample CAA campaign blueprint (previous_outputs)."""
+    """Sample CAA campaign blueprint (previous_outputs).
+
+    Uses actual CAA output format: blueprint with ad_sets + funnel_map.
+    """
     return {
         "campaign_architecture": {
-            "campaign_name": "Q2 2026 Brand Awareness",
-            "objective": "OUTCOME_AWARENESS",
-            "total_budget_usd": 1000.0,
-            "duration_days": 30,
-            "funnel_stages": [
-                {
-                    "stage": "TOFU",
-                    "budget_pct": 0.5,
-                    "audiences": [
-                        {
-                            "name": "Tech Enthusiasts",
+            "blueprint": {
+                "campaign_name": "Q2 2026 Brand Awareness",
+                "campaign_objective": "OUTCOME_AWARENESS",
+                "daily_budget": 33.33,
+                "buying_type": "AUCTION",
+                "bid_strategy": "LOWEST_COST",
+                "cbo_enabled": True,
+                "ad_sets": [
+                    {
+                        "name": "TOFU - Tech Enthusiasts",
+                        "funnel_stage": "tofu",
+                        "objective": "OUTCOME_AWARENESS",
+                        "targeting": {
+                            "ad_set_name": "TOFU - Tech Enthusiasts",
+                            "funnel_stage": "tofu",
                             "demographics": {
                                 "age_min": 25,
                                 "age_max": 54,
                                 "genders": ["male", "female"],
-                                "countries": ["US"],
+                                "locations": ["US"],
                             },
                             "interests": ["technology", "software"],
-                        }
-                    ],
-                    "placements": ["FACEBOOK_FEED", "INSTAGRAM_FEED"],
+                            "behaviors": [],
+                            "custom_audiences": [],
+                            "lookalike_audiences": [],
+                            "exclusions": [],
+                            "estimated_audience_size": 500000,
+                        },
+                        "placements": ["facebook_feed", "instagram_feed"],
+                        "daily_budget": 33.33,
+                        "optimization_goal": "REACH",
+                    }
+                ],
+            },
+            "funnel_map": {
+                "stages": [
+                    {
+                        "stage": "tofu",
+                        "meta_objective": "OUTCOME_AWARENESS",
+                        "budget_pct": 50.0,
+                        "description": "Top-of-funnel awareness",
+                    }
+                ]
+            },
+            "targeting_specs": [
+                {
+                    "ad_set_name": "TOFU - Tech Enthusiasts",
+                    "funnel_stage": "tofu",
+                    "demographics": {
+                        "age_min": 25,
+                        "age_max": 54,
+                        "genders": ["male", "female"],
+                        "locations": ["US"],
+                    },
+                    "interests": ["technology", "software"],
+                    "behaviors": [],
                 }
             ],
+            "special_ad_category": "",
+            "confidence_score": 0.85,
         }
     }

--- a/ad-publishing-agent-svc/tests/test_context_loader.py
+++ b/ad-publishing-agent-svc/tests/test_context_loader.py
@@ -26,6 +26,7 @@ class TestLoad:
             config={"meta_ads_sandbox_mode": True},
         )
         assert context["blueprint"]["campaign_name"] == "Q2 2026 Brand Awareness"
+        assert len(context["blueprint"]["funnel_stages"]) == 1
         assert len(context["creative_packages"]) == 1
         assert context["sandbox_mode"] is True
         assert context["_needs_caa_fetch"] is False
@@ -192,66 +193,111 @@ class TestExtractBlueprint:
         assert result["objective"] == "OUTCOME_AWARENESS"
         assert result["total_budget_usd"] == 0
         assert result["duration_days"] == 30
+        assert result["funnel_stages"] == []
 
-    def test_direct_caa_output(self):
+    def test_real_caa_output_format(self):
+        """Actual CAA output: blueprint with campaign_objective + ad_sets."""
         caa = {
-            "campaign_name": "Direct",
+            "blueprint": {
+                "campaign_name": "Q2 Campaign",
+                "campaign_objective": "OUTCOME_TRAFFIC",
+                "daily_budget": 50.0,
+                "ad_sets": [
+                    {
+                        "name": "MOFU - Browsers",
+                        "funnel_stage": "mofu",
+                        "placements": ["facebook_feed"],
+                        "daily_budget": 50.0,
+                    }
+                ],
+            },
+            "funnel_map": {
+                "stages": [
+                    {"stage": "mofu", "meta_objective": "OUTCOME_TRAFFIC"}
+                ]
+            },
+            "special_ad_category": "",
+        }
+        result = AdPubContextLoader._extract_blueprint(caa)
+        assert result["campaign_name"] == "Q2 Campaign"
+        assert result["objective"] == "OUTCOME_TRAFFIC"
+        assert result["daily_budget"] == 50.0
+        assert len(result["funnel_stages"]) == 1
+        assert result["funnel_stages"][0]["funnel_stage"] == "mofu"
+        assert result["placements"] == ["facebook_feed"]
+
+    def test_caa_context_endpoint_response(self):
+        """Response from /api/v1/analytics/caa-context/."""
+        caa = {
+            "blueprint": {
+                "campaign_name": "From Endpoint",
+                "campaign_objective": "OUTCOME_CONVERSIONS",
+                "daily_budget": 100.0,
+                "ad_sets": [
+                    {
+                        "name": "BOFU - Buyers",
+                        "funnel_stage": "bofu",
+                        "placements": ["instagram_feed"],
+                    }
+                ],
+            },
+            "funnel_map": {
+                "stages": [{"stage": "bofu", "budget_pct": 100}]
+            },
+            "special_ad_category": "HOUSING",
+        }
+        result = AdPubContextLoader._extract_blueprint(caa)
+        assert result["campaign_name"] == "From Endpoint"
+        assert result["special_ad_categories"] == ["HOUSING"]
+        assert len(result["funnel_stages"]) == 1
+
+    def test_funnel_map_fallback(self):
+        """When blueprint has no ad_sets, fall back to funnel_map.stages."""
+        caa = {
+            "blueprint": {
+                "campaign_name": "Map Only",
+                "campaign_objective": "OUTCOME_AWARENESS",
+                "daily_budget": 30.0,
+            },
+            "funnel_map": {
+                "stages": [
+                    {"stage": "tofu", "meta_objective": "OUTCOME_AWARENESS"},
+                    {"stage": "mofu", "meta_objective": "OUTCOME_TRAFFIC"},
+                ]
+            },
+        }
+        result = AdPubContextLoader._extract_blueprint(caa)
+        assert len(result["funnel_stages"]) == 2
+
+    def test_preserves_zero_budget(self):
+        """Falsy values like 0 should be preserved, not treated as missing."""
+        caa = {
+            "blueprint": {
+                "campaign_name": "Zero Budget Test",
+                "daily_budget": 0,
+                "ad_sets": [],
+            },
+        }
+        result = AdPubContextLoader._extract_blueprint(caa)
+        assert result["daily_budget"] == 0
+        assert result["funnel_stages"] == []
+
+    def test_legacy_format_backward_compatible(self):
+        """Legacy format with funnel_stages and objective still works."""
+        caa = {
+            "campaign_name": "Legacy",
             "objective": "OUTCOME_TRAFFIC",
             "total_budget_usd": 2000,
             "duration_days": 7,
             "funnel_stages": [{"stage": "MOFU"}],
             "placements": ["FACEBOOK_FEED"],
-            "special_ad_categories": [],
+            "special_ad_categories": ["CREDIT"],
         }
         result = AdPubContextLoader._extract_blueprint(caa)
-        assert result["campaign_name"] == "Direct"
+        assert result["campaign_name"] == "Legacy"
         assert result["objective"] == "OUTCOME_TRAFFIC"
-
-    def test_nested_blueprint_key(self):
-        caa = {
-            "blueprint": {
-                "campaign_name": "Nested",
-                "objective": "OUTCOME_CONVERSIONS",
-                "total_budget_usd": 3000,
-                "duration_days": 14,
-                "funnel_stages": [],
-                "placements": [],
-                "special_ad_categories": ["HOUSING"],
-            }
-        }
-        result = AdPubContextLoader._extract_blueprint(caa)
-        assert result["campaign_name"] == "Nested"
-        assert result["special_ad_categories"] == ["HOUSING"]
-
-    def test_preserves_zero_budget(self):
-        """Falsy values like 0 should be preserved, not treated as missing."""
-        caa = {
-            "campaign_name": "Zero Budget Test",
-            "total_budget_usd": 0,
-            "duration_days": 0,
-            "funnel_stages": [],
-            "placements": [],
-            "special_ad_categories": [],
-        }
-        result = AdPubContextLoader._extract_blueprint(caa)
-        assert result["total_budget_usd"] == 0
-        assert result["duration_days"] == 0
-        assert result["funnel_stages"] == []
-
-    def test_preserves_empty_list(self):
-        """Empty lists should be preserved, not fall through to defaults."""
-        caa = {
-            "blueprint": {
-                "campaign_name": "Test",
-                "funnel_stages": [],
-                "placements": [],
-                "special_ad_categories": [],
-            },
-            "funnel_stages": [{"stage": "TOFU"}],  # outer fallback
-        }
-        result = AdPubContextLoader._extract_blueprint(caa)
-        # Should use blueprint's empty list, NOT fall through to outer
-        assert result["funnel_stages"] == []
+        assert len(result["funnel_stages"]) == 1
+        assert result["special_ad_categories"] == ["CREDIT"]
 
 
 class TestExtractCreativePackages:
@@ -308,7 +354,10 @@ class TestValidate:
 
     def test_valid_context(self):
         context = {
-            "blueprint": {"campaign_name": "X", "funnel_stages": [{}]},
+            "blueprint": {
+                "campaign_name": "X",
+                "funnel_stages": [{"funnel_stage": "tofu"}],
+            },
             "creative_packages": [{"ad_units": [{"image_url": "gs://x"}]}],
             "sandbox_mode": True,
         }
@@ -316,7 +365,10 @@ class TestValidate:
 
     def test_sandbox_skips_credential_check(self):
         context = {
-            "blueprint": {"campaign_name": "X", "funnel_stages": [{}]},
+            "blueprint": {
+                "campaign_name": "X",
+                "funnel_stages": [{"funnel_stage": "tofu"}],
+            },
             "creative_packages": [{"ad_units": [{"image_url": "gs://x"}]}],
             "sandbox_mode": True,
             "meta_credentials": {},
@@ -326,7 +378,10 @@ class TestValidate:
 
     def test_production_requires_credentials(self):
         context = {
-            "blueprint": {"campaign_name": "X", "funnel_stages": [{}]},
+            "blueprint": {
+                "campaign_name": "X",
+                "funnel_stages": [{"funnel_stage": "tofu"}],
+            },
             "creative_packages": [{"ad_units": [{"image_url": "gs://x"}]}],
             "sandbox_mode": False,
             "meta_credentials": {},
@@ -334,3 +389,17 @@ class TestValidate:
         errors = self.loader.validate(context)
         assert any("access_token" in e for e in errors)
         assert any("ad_account_id" in e for e in errors)
+
+    def test_diagnostics_included_in_errors(self):
+        """Backend fetch diagnostics are surfaced in validation errors."""
+        context = {
+            "blueprint": {"campaign_name": "", "funnel_stages": []},
+            "creative_packages": [],
+            "sandbox_mode": True,
+            "_backend_diagnostics": [
+                "CAA fetch failed: HTTP 404 from http://x/caa-context/"
+            ],
+        }
+        errors = self.loader.validate(context)
+        assert any("Backend enrichment diagnostics" in e for e in errors)
+        assert any("HTTP 404" in e for e in errors)

--- a/ad-publishing-agent-svc/tests/test_context_loader.py
+++ b/ad-publishing-agent-svc/tests/test_context_loader.py
@@ -1,0 +1,289 @@
+"""Tests for AdPubContextLoader — load, enrich_from_backend, _extract_blueprint."""
+
+import pytest
+from unittest.mock import patch, AsyncMock
+
+import httpx
+
+from app.services.context_loader import AdPubContextLoader
+
+
+class TestLoad:
+    def setup_method(self):
+        self.loader = AdPubContextLoader()
+
+    def test_load_from_previous_outputs(
+        self, sample_campaign_blueprint, sample_creative_package
+    ):
+        previous_outputs = {
+            **sample_campaign_blueprint,
+            **sample_creative_package,
+        }
+        context = self.loader.load(
+            previous_outputs=previous_outputs,
+            input_context={"company": {"name": "Acme"}},
+            tenant_context={"tenant_id": "t1"},
+            config={"meta_ads_sandbox_mode": True},
+        )
+        assert context["blueprint"]["campaign_name"] == "Q2 2026 Brand Awareness"
+        assert len(context["creative_packages"]) == 1
+        assert context["sandbox_mode"] is True
+        assert context["_needs_caa_fetch"] is False
+        assert context["_needs_cga_fetch"] is False
+
+    def test_load_sets_needs_fetch_flags_when_missing(self):
+        context = self.loader.load(
+            previous_outputs={},
+            input_context={},
+            tenant_context={"tenant_id": "t1"},
+            config={},
+        )
+        assert context["_needs_caa_fetch"] is True
+        assert context["_needs_cga_fetch"] is True
+        assert context["blueprint"]["campaign_name"] == ""
+
+    def test_sandbox_mode_defaults_true(self):
+        context = self.loader.load(
+            previous_outputs={},
+            input_context={},
+            tenant_context={},
+            config={},
+        )
+        assert context["sandbox_mode"] is True
+
+
+class TestEnrichFromBackend:
+    def setup_method(self):
+        self.loader = AdPubContextLoader()
+
+    @pytest.mark.asyncio
+    async def test_enrich_caa_success(self):
+        context = {
+            "_tenant_id": "t1",
+            "_needs_caa_fetch": True,
+            "_needs_cga_fetch": False,
+            "blueprint": {"campaign_name": ""},
+            "creative_packages": [],
+            "persona_profiles": [],
+        }
+        caa_response = httpx.Response(
+            200,
+            json={
+                "blueprint": {
+                    "campaign_name": "Fetched Campaign",
+                    "objective": "OUTCOME_AWARENESS",
+                    "total_budget_usd": 500,
+                    "duration_days": 14,
+                    "funnel_stages": [{"stage": "TOFU"}],
+                    "placements": [],
+                    "special_ad_categories": [],
+                },
+            },
+        )
+
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=caa_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = mock_client
+
+            result = await self.loader.enrich_from_backend(context)
+
+        assert result["blueprint"]["campaign_name"] == "Fetched Campaign"
+        assert "_needs_caa_fetch" not in result
+
+    @pytest.mark.asyncio
+    async def test_enrich_cga_success(self):
+        context = {
+            "_tenant_id": "t1",
+            "_needs_caa_fetch": False,
+            "_needs_cga_fetch": True,
+            "blueprint": {"campaign_name": "X"},
+            "creative_packages": [],
+            "persona_profiles": ["existing"],
+        }
+        cga_response = httpx.Response(
+            200,
+            json={
+                "creative_packages": [{"ad_units": [{"image_url": "gs://x"}]}],
+                "approval_status": "approved",
+            },
+        )
+
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=cga_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = mock_client
+
+            result = await self.loader.enrich_from_backend(context)
+
+        assert len(result["creative_packages"]) == 1
+        assert result["creative_approval_status"] == "approved"
+
+    @pytest.mark.asyncio
+    async def test_enrich_no_tenant_id_skips(self):
+        context = {
+            "_tenant_id": "",
+            "_needs_caa_fetch": True,
+            "_needs_cga_fetch": True,
+            "blueprint": {"campaign_name": ""},
+            "creative_packages": [],
+            "persona_profiles": [],
+        }
+        result = await self.loader.enrich_from_backend(context)
+        # Should return unchanged — no HTTP calls made
+        assert result["blueprint"]["campaign_name"] == ""
+
+    @pytest.mark.asyncio
+    async def test_enrich_http_error_handled(self):
+        context = {
+            "_tenant_id": "t1",
+            "_needs_caa_fetch": True,
+            "_needs_cga_fetch": False,
+            "blueprint": {"campaign_name": ""},
+            "creative_packages": [],
+            "persona_profiles": [],
+        }
+        error_response = httpx.Response(500, json={"error": "Internal"})
+
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=error_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = mock_client
+
+            result = await self.loader.enrich_from_backend(context)
+
+        # Should not crash, blueprint stays empty
+        assert result["blueprint"]["campaign_name"] == ""
+
+    @pytest.mark.asyncio
+    async def test_enrich_network_exception_handled(self):
+        context = {
+            "_tenant_id": "t1",
+            "_needs_caa_fetch": True,
+            "_needs_cga_fetch": False,
+            "blueprint": {"campaign_name": ""},
+            "creative_packages": [],
+            "persona_profiles": [],
+        }
+
+        with patch("httpx.AsyncClient") as MockClient:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(
+                side_effect=httpx.ConnectError("Connection refused")
+            )
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = mock_client
+
+            result = await self.loader.enrich_from_backend(context)
+
+        assert result["blueprint"]["campaign_name"] == ""
+
+
+class TestExtractBlueprint:
+    def test_empty_input_returns_defaults(self):
+        result = AdPubContextLoader._extract_blueprint({})
+        assert result["campaign_name"] == ""
+        assert result["objective"] == "OUTCOME_AWARENESS"
+        assert result["total_budget_usd"] == 0
+        assert result["duration_days"] == 30
+
+    def test_direct_caa_output(self):
+        caa = {
+            "campaign_name": "Direct",
+            "objective": "OUTCOME_TRAFFIC",
+            "total_budget_usd": 2000,
+            "duration_days": 7,
+            "funnel_stages": [{"stage": "MOFU"}],
+            "placements": ["FACEBOOK_FEED"],
+            "special_ad_categories": [],
+        }
+        result = AdPubContextLoader._extract_blueprint(caa)
+        assert result["campaign_name"] == "Direct"
+        assert result["objective"] == "OUTCOME_TRAFFIC"
+
+    def test_nested_blueprint_key(self):
+        caa = {
+            "blueprint": {
+                "campaign_name": "Nested",
+                "objective": "OUTCOME_CONVERSIONS",
+                "total_budget_usd": 3000,
+                "duration_days": 14,
+                "funnel_stages": [],
+                "placements": [],
+                "special_ad_categories": ["HOUSING"],
+            }
+        }
+        result = AdPubContextLoader._extract_blueprint(caa)
+        assert result["campaign_name"] == "Nested"
+        assert result["special_ad_categories"] == ["HOUSING"]
+
+    def test_preserves_zero_budget(self):
+        """Falsy values like 0 should be preserved, not treated as missing."""
+        caa = {
+            "campaign_name": "Zero Budget Test",
+            "total_budget_usd": 0,
+            "duration_days": 0,
+            "funnel_stages": [],
+            "placements": [],
+            "special_ad_categories": [],
+        }
+        result = AdPubContextLoader._extract_blueprint(caa)
+        assert result["total_budget_usd"] == 0
+        assert result["duration_days"] == 0
+        assert result["funnel_stages"] == []
+
+    def test_preserves_empty_list(self):
+        """Empty lists should be preserved, not fall through to defaults."""
+        caa = {
+            "blueprint": {
+                "campaign_name": "Test",
+                "funnel_stages": [],
+                "placements": [],
+                "special_ad_categories": [],
+            },
+            "funnel_stages": [{"stage": "TOFU"}],  # outer fallback
+        }
+        result = AdPubContextLoader._extract_blueprint(caa)
+        # Should use blueprint's empty list, NOT fall through to outer
+        assert result["funnel_stages"] == []
+
+
+class TestValidate:
+    def setup_method(self):
+        self.loader = AdPubContextLoader()
+
+    def test_valid_context(self):
+        context = {
+            "blueprint": {"campaign_name": "X", "funnel_stages": [{}]},
+            "creative_packages": [{"ad_units": [{"image_url": "gs://x"}]}],
+            "sandbox_mode": True,
+        }
+        assert self.loader.validate(context) == []
+
+    def test_sandbox_skips_credential_check(self):
+        context = {
+            "blueprint": {"campaign_name": "X", "funnel_stages": [{}]},
+            "creative_packages": [{"ad_units": [{"image_url": "gs://x"}]}],
+            "sandbox_mode": True,
+            "meta_credentials": {},
+        }
+        errors = self.loader.validate(context)
+        assert not any("access_token" in e for e in errors)
+
+    def test_production_requires_credentials(self):
+        context = {
+            "blueprint": {"campaign_name": "X", "funnel_stages": [{}]},
+            "creative_packages": [{"ad_units": [{"image_url": "gs://x"}]}],
+            "sandbox_mode": False,
+            "meta_credentials": {},
+        }
+        errors = self.loader.validate(context)
+        assert any("access_token" in e for e in errors)
+        assert any("ad_account_id" in e for e in errors)

--- a/ad-publishing-agent-svc/tests/test_context_loader.py
+++ b/ad-publishing-agent-svc/tests/test_context_loader.py
@@ -121,7 +121,6 @@ class TestEnrichFromBackend:
             result = await self.loader.enrich_from_backend(context)
 
         assert len(result["creative_packages"]) == 1
-        assert result["creative_approval_status"] == "approved"
 
     @pytest.mark.asyncio
     async def test_enrich_no_tenant_id_skips(self):
@@ -253,6 +252,54 @@ class TestExtractBlueprint:
         result = AdPubContextLoader._extract_blueprint(caa)
         # Should use blueprint's empty list, NOT fall through to outer
         assert result["funnel_stages"] == []
+
+
+class TestExtractCreativePackages:
+    def test_empty_input(self):
+        assert AdPubContextLoader._extract_creative_packages({}) == []
+
+    def test_from_creative_packages_key(self):
+        """Already-mapped format (from cga-context endpoint)."""
+        cga = {
+            "creative_packages": [
+                {"ad_set_name": "TOFU", "ad_units": [{"image_url": "x"}]}
+            ]
+        }
+        result = AdPubContextLoader._extract_creative_packages(cga)
+        assert len(result) == 1
+        assert result[0]["ad_set_name"] == "TOFU"
+
+    def test_from_ad_set_packages(self):
+        """Raw CGA output format (pipeline chaining)."""
+        cga = {
+            "ad_set_packages": [
+                {
+                    "ad_set_name": "TOFU - Tech",
+                    "persona": "Tech Enthusiast",
+                    "funnel_stage": "TOFU",
+                    "creative_units": [
+                        {"gcs_url": "gs://bucket/img.jpg", "headline": "Test"}
+                    ],
+                }
+            ]
+        }
+        result = AdPubContextLoader._extract_creative_packages(cga)
+        assert len(result) == 1
+        assert result[0]["ad_set_name"] == "TOFU - Tech"
+        assert result[0]["persona"] == "Tech Enthusiast"
+        assert len(result[0]["ad_units"]) == 1
+
+    def test_fallback_to_top_level_ad_units(self):
+        """Fallback when neither creative_packages nor ad_set_packages exist."""
+        cga = {"ad_units": [{"gcs_url": "gs://bucket/img.jpg", "headline": "Fallback"}]}
+        result = AdPubContextLoader._extract_creative_packages(cga)
+        assert len(result) == 1
+        assert result[0]["ad_set_name"] == "Default"
+        assert len(result[0]["ad_units"]) == 1
+
+    def test_no_creative_data(self):
+        cga = {"confidence_score": 0.5, "findings": []}
+        assert AdPubContextLoader._extract_creative_packages(cga) == []
 
 
 class TestValidate:

--- a/ad-publishing-agent-svc/tests/test_guardrails.py
+++ b/ad-publishing-agent-svc/tests/test_guardrails.py
@@ -50,9 +50,25 @@ class TestInputGuardrails:
             "creative_packages": [{"ad_units": [{"image_url": "x"}]}],
             "blueprint": {"campaign_name": "X", "funnel_stages": [{}]},
             "meta_credentials": {},
+            "sandbox_mode": False,
         }
         errors = self.guard.check(context)
         assert any("IG-10" in e for e in errors)
+
+    def test_sandbox_mode_skips_credential_check(self):
+        context = {
+            "creative_packages": [{"ad_units": [{"image_url": "x"}]}],
+            "blueprint": {
+                "campaign_name": "X",
+                "funnel_stages": [{}],
+                "total_budget_usd": 100,
+                "duration_days": 30,
+            },
+            "meta_credentials": {},
+            "sandbox_mode": True,
+        }
+        errors = self.guard.check(context)
+        assert not any("IG-10" in e for e in errors)
 
     def test_spend_cap_exceeded(self):
         context = {

--- a/ad-publishing-agent-svc/tests/test_guardrails.py
+++ b/ad-publishing-agent-svc/tests/test_guardrails.py
@@ -84,6 +84,21 @@ class TestInputGuardrails:
         errors = self.guard.check(context, daily_spend_cap_usd=500.0)
         assert any("IG-11" in e for e in errors)
 
+    def test_gcs_url_accepted_as_image(self):
+        """CGA uses gcs_url instead of image_url — should pass validation."""
+        context = {
+            "creative_packages": [{"ad_units": [{"gcs_url": "gs://bucket/img.jpg"}]}],
+            "blueprint": {
+                "campaign_name": "X",
+                "funnel_stages": [{}],
+                "total_budget_usd": 100,
+                "duration_days": 30,
+            },
+            "company": {},
+        }
+        errors = self.guard.check(context)
+        assert not any("IG-08" in e and "image" in e for e in errors)
+
     def test_housing_industry_missing_category(self):
         context = {
             "creative_packages": [{"ad_units": [{"image_url": "x"}]}],

--- a/ai-brand-automator/analytics/tests/test_cga_context.py
+++ b/ai-brand-automator/analytics/tests/test_cga_context.py
@@ -14,11 +14,10 @@ import pytest
 from unittest.mock import patch
 
 from django.conf import settings as django_settings
-from django.contrib.auth import get_user_model
 from django.db import connection
 from rest_framework.test import APIClient
 
-User = get_user_model()
+TEST_SERVICE_TOKEN = "test-service-token"
 
 
 @pytest.fixture
@@ -114,81 +113,97 @@ def _service_headers(tenant_id=None, token=None):
 @pytest.mark.django_db
 class TestCGAContextViewAuth:
     def test_valid_token_returns_200(
-        self, service_client, cga_tenant, cga_completed_job
+        self, service_client, cga_tenant, cga_completed_job, settings
     ):
-        token = getattr(django_settings, "ORCHESTRATOR_SERVICE_TOKEN", "")
-        if not token:
-            pytest.skip("ORCHESTRATOR_SERVICE_TOKEN not set")
-
+        settings.ORCHESTRATOR_SERVICE_TOKEN = TEST_SERVICE_TOKEN
+        settings.DEBUG = True
         resp = service_client.get(
             "/api/v1/analytics/cga-context/",
-            **_service_headers(cga_tenant.id, token),
+            **_service_headers(cga_tenant.id, TEST_SERVICE_TOKEN),
         )
         assert resp.status_code == 200
 
-    def test_invalid_token_returns_403(self, service_client, cga_tenant):
+    def test_invalid_token_returns_403(self, service_client, cga_tenant, settings):
+        settings.ORCHESTRATOR_SERVICE_TOKEN = TEST_SERVICE_TOKEN
+        settings.DEBUG = True
         resp = service_client.get(
             "/api/v1/analytics/cga-context/",
             **_service_headers(cga_tenant.id, "bad-token"),
         )
-        # Either 403 (token mismatch) or 500 (token not configured)
-        assert resp.status_code in (403, 500)
+        assert resp.status_code == 403
 
-    def test_missing_token_returns_403(self, service_client, cga_tenant):
+    def test_missing_token_returns_403(self, service_client, cga_tenant, settings):
+        settings.ORCHESTRATOR_SERVICE_TOKEN = TEST_SERVICE_TOKEN
+        settings.DEBUG = True
         resp = service_client.get(
             "/api/v1/analytics/cga-context/",
             **_service_headers(cga_tenant.id, ""),
         )
-        assert resp.status_code in (403, 500)
+        assert resp.status_code == 403
 
-    def test_unconfigured_token_returns_500(self, service_client, cga_tenant):
+    def test_unconfigured_token_returns_500(self, service_client, cga_tenant, settings):
         """When ORCHESTRATOR_SERVICE_TOKEN is not set, return 500."""
-        with patch.object(django_settings, "ORCHESTRATOR_SERVICE_TOKEN", ""):
-            resp = service_client.get(
-                "/api/v1/analytics/cga-context/",
-                **_service_headers(cga_tenant.id, "any-token"),
-            )
-            assert resp.status_code == 500
-            assert "not configured" in resp.json()["error"]
+        settings.ORCHESTRATOR_SERVICE_TOKEN = ""
+        resp = service_client.get(
+            "/api/v1/analytics/cga-context/",
+            **_service_headers(cga_tenant.id, "any-token"),
+        )
+        assert resp.status_code == 500
+        assert "not configured" in resp.json()["error"]
+
+    def test_dev_token_rejected_in_production(
+        self, service_client, cga_tenant, settings
+    ):
+        """Default dev-service-token rejected when DEBUG=False."""
+        settings.ORCHESTRATOR_SERVICE_TOKEN = "dev-service-token"
+        settings.DEBUG = False
+        resp = service_client.get(
+            "/api/v1/analytics/cga-context/",
+            **_service_headers(cga_tenant.id, "dev-service-token"),
+        )
+        assert resp.status_code == 500
+        assert "not configured" in resp.json()["error"]
 
 
 @pytest.mark.django_db
 class TestCGAContextViewTenant:
-    def _get_with_token(self, client, tenant_id=None):
-        token = getattr(django_settings, "ORCHESTRATOR_SERVICE_TOKEN", "")
-        if not token:
-            pytest.skip("ORCHESTRATOR_SERVICE_TOKEN not set")
+    def _get_with_token(self, client, tenant_id, settings):
+        settings.ORCHESTRATOR_SERVICE_TOKEN = TEST_SERVICE_TOKEN
+        settings.DEBUG = True
         return client.get(
             "/api/v1/analytics/cga-context/",
-            **_service_headers(tenant_id, token),
+            **_service_headers(tenant_id, TEST_SERVICE_TOKEN),
         )
 
-    def test_tenant_from_header(self, service_client, cga_tenant, cga_completed_job):
-        resp = self._get_with_token(service_client, cga_tenant.id)
+    def test_tenant_from_header(
+        self, service_client, cga_tenant, cga_completed_job, settings
+    ):
+        resp = self._get_with_token(service_client, cga_tenant.id, settings)
         assert resp.status_code == 200
 
-    def test_missing_tenant_returns_404(self, service_client):
-        resp = self._get_with_token(service_client, None)
+    def test_missing_tenant_returns_404(self, service_client, settings):
+        resp = self._get_with_token(service_client, None, settings)
         assert resp.status_code == 404
 
-    def test_invalid_tenant_id_returns_404(self, service_client):
-        resp = self._get_with_token(service_client, uuid.uuid4())
+    def test_invalid_tenant_id_returns_404(self, service_client, settings):
+        resp = self._get_with_token(service_client, uuid.uuid4(), settings)
         assert resp.status_code == 404
 
 
 @pytest.mark.django_db
 class TestCGAContextViewResponse:
-    def _get(self, client, tenant_id):
-        token = getattr(django_settings, "ORCHESTRATOR_SERVICE_TOKEN", "")
-        if not token:
-            pytest.skip("ORCHESTRATOR_SERVICE_TOKEN not set")
+    def _get(self, client, tenant_id, settings):
+        settings.ORCHESTRATOR_SERVICE_TOKEN = TEST_SERVICE_TOKEN
+        settings.DEBUG = True
         return client.get(
             "/api/v1/analytics/cga-context/",
-            **_service_headers(tenant_id, token),
+            **_service_headers(tenant_id, TEST_SERVICE_TOKEN),
         )
 
-    def test_response_shape(self, service_client, cga_tenant, cga_completed_job):
-        resp = self._get(service_client, cga_tenant.id)
+    def test_response_shape(
+        self, service_client, cga_tenant, cga_completed_job, settings
+    ):
+        resp = self._get(service_client, cga_tenant.id, settings)
         assert resp.status_code == 200
         data = resp.json()
         assert "creative_packages" in data
@@ -199,8 +214,10 @@ class TestCGAContextViewResponse:
         assert "cga_completed_at" in data
         assert "cga_job_id" in data
 
-    def test_response_data(self, service_client, cga_tenant, cga_completed_job):
-        resp = self._get(service_client, cga_tenant.id)
+    def test_response_data(
+        self, service_client, cga_tenant, cga_completed_job, settings
+    ):
+        resp = self._get(service_client, cga_tenant.id, settings)
         data = resp.json()
         # creative_packages mapped from ad_set_packages
         assert len(data["creative_packages"]) == 1
@@ -209,7 +226,7 @@ class TestCGAContextViewResponse:
         assert data["confidence_score"] == 0.92
         assert data["cga_job_id"] == str(cga_completed_job.job_id)
 
-    def test_no_cga_data_returns_404(self, service_client, cga_tenant):
-        resp = self._get(service_client, cga_tenant.id)
+    def test_no_cga_data_returns_404(self, service_client, cga_tenant, settings):
+        resp = self._get(service_client, cga_tenant.id, settings)
         assert resp.status_code == 404
         assert resp.json()["error"] == "No CGA data"

--- a/ai-brand-automator/analytics/tests/test_cga_context.py
+++ b/ai-brand-automator/analytics/tests/test_cga_context.py
@@ -63,21 +63,29 @@ def cga_completed_job(db, cga_tenant, cga_manifest):
         result_data={
             "node_results": {
                 "creative_generation": {
-                    "creative_packages": [
+                    "creative_package": {
+                        "campaign_id": "camp_123",
+                        "brand_name": "TestBrand",
+                    },
+                    "ad_set_packages": [
                         {
                             "ad_set_name": "TOFU - Test",
-                            "ad_units": [
+                            "persona": "Tech Enthusiast",
+                            "funnel_stage": "TOFU",
+                            "creative_units": [
                                 {
-                                    "image_url": "gs://bucket/img.jpg",
+                                    "gcs_url": "gs://bucket/img.jpg",
                                     "headline": "Test",
                                 }
                             ],
                         }
                     ],
-                    "approval_status": "approved",
-                    "gallery": [{"url": "https://example.com/img.jpg"}],
-                    "ad_units": [{"headline": "Test"}],
+                    "ad_units": [
+                        {"gcs_url": "gs://bucket/img.jpg", "headline": "Test"}
+                    ],
+                    "generated_images": [{"gcs_url": "gs://bucket/img.jpg"}],
                     "confidence_score": 0.92,
+                    "compliance_pass_rate": 0.85,
                 }
             }
         },
@@ -184,9 +192,9 @@ class TestCGAContextViewResponse:
         assert resp.status_code == 200
         data = resp.json()
         assert "creative_packages" in data
-        assert "approval_status" in data
-        assert "gallery" in data
+        assert "ad_set_packages" in data
         assert "ad_units" in data
+        assert "creative_package" in data
         assert "confidence_score" in data
         assert "cga_completed_at" in data
         assert "cga_job_id" in data
@@ -194,8 +202,10 @@ class TestCGAContextViewResponse:
     def test_response_data(self, service_client, cga_tenant, cga_completed_job):
         resp = self._get(service_client, cga_tenant.id)
         data = resp.json()
+        # creative_packages mapped from ad_set_packages
         assert len(data["creative_packages"]) == 1
-        assert data["approval_status"] == "approved"
+        assert data["creative_packages"][0]["ad_set_name"] == "TOFU - Test"
+        assert len(data["creative_packages"][0]["ad_units"]) == 1
         assert data["confidence_score"] == 0.92
         assert data["cga_job_id"] == str(cga_completed_job.job_id)
 

--- a/ai-brand-automator/analytics/tests/test_cga_context.py
+++ b/ai-brand-automator/analytics/tests/test_cga_context.py
@@ -229,4 +229,4 @@ class TestCGAContextViewResponse:
     def test_no_cga_data_returns_404(self, service_client, cga_tenant, settings):
         resp = self._get(service_client, cga_tenant.id, settings)
         assert resp.status_code == 404
-        assert resp.json()["error"] == "No CGA data"
+        assert resp.json()["error"] == "No CGA data with creative packages"

--- a/ai-brand-automator/analytics/tests/test_cga_context.py
+++ b/ai-brand-automator/analytics/tests/test_cga_context.py
@@ -1,0 +1,205 @@
+"""
+Tests for CGAContextView — service-to-service CGA context endpoint.
+
+Covers:
+- Service-token auth (valid, invalid, missing config)
+- Tenant selection (X-Tenant-ID header vs request tenant)
+- Response shape with CGA data
+- 404 when no CGA data exists
+"""
+
+import uuid
+
+import pytest
+from unittest.mock import patch
+
+from django.conf import settings as django_settings
+from django.contrib.auth import get_user_model
+from django.db import connection
+from rest_framework.test import APIClient
+
+User = get_user_model()
+
+
+@pytest.fixture
+def cga_tenant(db):
+    """Create a test tenant for CGA context tests."""
+    from tenants.models import Tenant, Domain
+
+    connection.set_schema_to_public()
+    tenant = Tenant.objects.create(
+        name="CGA Context Test",
+        schema_name="cga_test",
+        subscription_status="active",
+        max_users=10,
+        storage_limit_gb=5,
+    )
+    Domain.objects.create(tenant=tenant, domain="cgatest.localhost", is_primary=True)
+    return tenant
+
+
+@pytest.fixture
+def cga_manifest(db, cga_tenant):
+    """Pipeline manifest for creative generation."""
+    from orchestration.models import PipelineManifest
+
+    return PipelineManifest.objects.create(
+        tenant=cga_tenant,
+        pipeline_id="meta-creative-generation",
+        name="Meta Creative Generation",
+        manifest_data={"nodes": []},
+    )
+
+
+@pytest.fixture
+def cga_completed_job(db, cga_tenant, cga_manifest):
+    """A completed CGA job with creative packages in result_data."""
+    from orchestration.models import AnalysisJob
+
+    job = AnalysisJob.objects.create(
+        tenant=cga_tenant,
+        manifest=cga_manifest,
+        status=AnalysisJob.Status.COMPLETED,
+        result_data={
+            "node_results": {
+                "creative_generation": {
+                    "creative_packages": [
+                        {
+                            "ad_set_name": "TOFU - Test",
+                            "ad_units": [
+                                {
+                                    "image_url": "gs://bucket/img.jpg",
+                                    "headline": "Test",
+                                }
+                            ],
+                        }
+                    ],
+                    "approval_status": "approved",
+                    "gallery": [{"url": "https://example.com/img.jpg"}],
+                    "ad_units": [{"headline": "Test"}],
+                    "confidence_score": 0.92,
+                }
+            }
+        },
+    )
+    return job
+
+
+@pytest.fixture
+def service_client():
+    """APIClient with valid service token."""
+    client = APIClient()
+    client.defaults["SERVER_NAME"] = "localhost"
+    return client
+
+
+def _service_headers(tenant_id=None, token=None):
+    """Build service-to-service headers."""
+    headers = {}
+    if token is not None:
+        headers["HTTP_X_SERVICE_TOKEN"] = token
+    if tenant_id is not None:
+        headers["HTTP_X_TENANT_ID"] = str(tenant_id)
+    return headers
+
+
+@pytest.mark.django_db
+class TestCGAContextViewAuth:
+    def test_valid_token_returns_200(
+        self, service_client, cga_tenant, cga_completed_job
+    ):
+        token = getattr(django_settings, "ORCHESTRATOR_SERVICE_TOKEN", "")
+        if not token:
+            pytest.skip("ORCHESTRATOR_SERVICE_TOKEN not set")
+
+        resp = service_client.get(
+            "/api/v1/analytics/cga-context/",
+            **_service_headers(cga_tenant.id, token),
+        )
+        assert resp.status_code == 200
+
+    def test_invalid_token_returns_403(self, service_client, cga_tenant):
+        resp = service_client.get(
+            "/api/v1/analytics/cga-context/",
+            **_service_headers(cga_tenant.id, "bad-token"),
+        )
+        # Either 403 (token mismatch) or 500 (token not configured)
+        assert resp.status_code in (403, 500)
+
+    def test_missing_token_returns_403(self, service_client, cga_tenant):
+        resp = service_client.get(
+            "/api/v1/analytics/cga-context/",
+            **_service_headers(cga_tenant.id, ""),
+        )
+        assert resp.status_code in (403, 500)
+
+    def test_unconfigured_token_returns_500(self, service_client, cga_tenant):
+        """When ORCHESTRATOR_SERVICE_TOKEN is not set, return 500."""
+        with patch.object(django_settings, "ORCHESTRATOR_SERVICE_TOKEN", ""):
+            resp = service_client.get(
+                "/api/v1/analytics/cga-context/",
+                **_service_headers(cga_tenant.id, "any-token"),
+            )
+            assert resp.status_code == 500
+            assert "not configured" in resp.json()["error"]
+
+
+@pytest.mark.django_db
+class TestCGAContextViewTenant:
+    def _get_with_token(self, client, tenant_id=None):
+        token = getattr(django_settings, "ORCHESTRATOR_SERVICE_TOKEN", "")
+        if not token:
+            pytest.skip("ORCHESTRATOR_SERVICE_TOKEN not set")
+        return client.get(
+            "/api/v1/analytics/cga-context/",
+            **_service_headers(tenant_id, token),
+        )
+
+    def test_tenant_from_header(self, service_client, cga_tenant, cga_completed_job):
+        resp = self._get_with_token(service_client, cga_tenant.id)
+        assert resp.status_code == 200
+
+    def test_missing_tenant_returns_404(self, service_client):
+        resp = self._get_with_token(service_client, None)
+        assert resp.status_code == 404
+
+    def test_invalid_tenant_id_returns_404(self, service_client):
+        resp = self._get_with_token(service_client, uuid.uuid4())
+        assert resp.status_code == 404
+
+
+@pytest.mark.django_db
+class TestCGAContextViewResponse:
+    def _get(self, client, tenant_id):
+        token = getattr(django_settings, "ORCHESTRATOR_SERVICE_TOKEN", "")
+        if not token:
+            pytest.skip("ORCHESTRATOR_SERVICE_TOKEN not set")
+        return client.get(
+            "/api/v1/analytics/cga-context/",
+            **_service_headers(tenant_id, token),
+        )
+
+    def test_response_shape(self, service_client, cga_tenant, cga_completed_job):
+        resp = self._get(service_client, cga_tenant.id)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "creative_packages" in data
+        assert "approval_status" in data
+        assert "gallery" in data
+        assert "ad_units" in data
+        assert "confidence_score" in data
+        assert "cga_completed_at" in data
+        assert "cga_job_id" in data
+
+    def test_response_data(self, service_client, cga_tenant, cga_completed_job):
+        resp = self._get(service_client, cga_tenant.id)
+        data = resp.json()
+        assert len(data["creative_packages"]) == 1
+        assert data["approval_status"] == "approved"
+        assert data["confidence_score"] == 0.92
+        assert data["cga_job_id"] == str(cga_completed_job.job_id)
+
+    def test_no_cga_data_returns_404(self, service_client, cga_tenant):
+        resp = self._get(service_client, cga_tenant.id)
+        assert resp.status_code == 404
+        assert resp.json()["error"] == "No CGA data"

--- a/ai-brand-automator/analytics/urls.py
+++ b/ai-brand-automator/analytics/urls.py
@@ -8,6 +8,7 @@ from analytics.views import (
     BrandContextSyncView,
     BrandPersonalitySyncView,
     CAAContextView,
+    CGAContextView,
     CompanyContextView,
     ComparisonView,
     CoverageView,
@@ -52,4 +53,5 @@ urlpatterns = [
     path("nta-context/", NTAContextView.as_view(), name="analytics-nta-context"),
     path("bsa-context/", BSAContextView.as_view(), name="analytics-bsa-context"),
     path("caa-context/", CAAContextView.as_view(), name="analytics-caa-context"),
+    path("cga-context/", CGAContextView.as_view(), name="analytics-cga-context"),
 ]

--- a/ai-brand-automator/analytics/views.py
+++ b/ai-brand-automator/analytics/views.py
@@ -1260,6 +1260,98 @@ class CAAContextView(APIView):
         )
 
 
+class CGAContextView(APIView):
+    """GET /api/v1/analytics/cga-context/ — Latest CGA creative packages.
+
+    Used by WF3 agents (Ad Publishing, etc.) to consume CGA creative output.
+    Authenticated via X-Service-Token.
+    """
+
+    permission_classes = [AllowAny]
+
+    def get(self, request):
+        # Service-token auth
+        service_token = request.headers.get("X-Service-Token", "")
+        expected_token = getattr(
+            django_settings,
+            "ORCHESTRATOR_SERVICE_TOKEN",
+            "dev-service-token",
+        )
+        if service_token != expected_token:
+            return Response(
+                {"error": "Invalid service token"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        tenant = None
+        tenant_id = request.headers.get("X-Tenant-ID", "")
+        if tenant_id:
+            from tenants.models import Tenant
+
+            try:
+                tenant = Tenant.objects.get(pk=tenant_id)
+            except (Tenant.DoesNotExist, ValueError):
+                pass
+        if not tenant:
+            tenant = _get_tenant(request)
+
+        if not tenant:
+            return Response(
+                {"error": "Tenant required"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        from orchestration.models import AnalysisJob
+
+        # Find latest completed CGA job
+        job = (
+            AnalysisJob.objects.filter(
+                Q(tenant=tenant) | Q(tenant__isnull=True),
+                status=AnalysisJob.Status.COMPLETED,
+                manifest__pipeline_id="meta-creative-generation",
+            )
+            .select_related("manifest")
+            .order_by("-completed_at")
+            .first()
+        )
+
+        # Fallback: any job with creative_generation node results
+        if not job:
+            candidates = AnalysisJob.objects.filter(
+                Q(tenant=tenant) | Q(tenant__isnull=True),
+                status=AnalysisJob.Status.COMPLETED,
+            ).order_by("-completed_at")[:20]
+            for candidate in candidates:
+                nr = (candidate.result_data or {}).get("node_results", {})
+                if "creative_generation" in nr:
+                    job = candidate
+                    break
+
+        if not job:
+            return Response(
+                {"error": "No CGA data"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        result_data = job.result_data or {}
+        node_results = result_data.get("node_results", {})
+        cga = node_results.get("creative_generation", {})
+
+        return Response(
+            {
+                "creative_packages": cga.get("creative_packages", []),
+                "approval_status": cga.get("approval_status", ""),
+                "gallery": cga.get("gallery", []),
+                "ad_units": cga.get("ad_units", []),
+                "confidence_score": cga.get("confidence_score", 0.0),
+                "cga_completed_at": (
+                    job.completed_at.isoformat() if job.completed_at else None
+                ),
+                "cga_job_id": str(job.job_id),
+            }
+        )
+
+
 class BrandPersonalitySyncView(APIView):
     """POST /api/v1/analytics/brand-personality-sync/
 

--- a/ai-brand-automator/analytics/views.py
+++ b/ai-brand-automator/analytics/views.py
@@ -1345,13 +1345,45 @@ class CGAContextView(APIView):
         node_results = result_data.get("node_results", {})
         cga = node_results.get("creative_generation", {})
 
+        # Map CGA output to ad-publishing expected format.
+        # CGA stores per-ad-set packages in "ad_set_packages", each
+        # containing "creative_units" (assembled image+copy+CTA).
+        # Ad publishing expects "creative_packages" — a list of dicts
+        # with "ad_set_name" and "ad_units" (image_url, headline, etc.).
+        ad_set_packages = cga.get("ad_set_packages", [])
+        creative_units = cga.get("ad_units", [])
+
+        # Build creative_packages from ad_set_packages
+        creative_packages = []
+        for pkg in ad_set_packages:
+            units = pkg.get("creative_units", [])
+            creative_packages.append(
+                {
+                    "ad_set_name": pkg.get("ad_set_name", ""),
+                    "persona": pkg.get("persona", ""),
+                    "funnel_stage": pkg.get("funnel_stage", ""),
+                    "ad_units": units,
+                }
+            )
+
+        # Fallback: if no ad_set_packages, build from top-level ad_units
+        if not creative_packages and creative_units:
+            creative_packages.append(
+                {
+                    "ad_set_name": "Default",
+                    "ad_units": creative_units,
+                }
+            )
+
         return Response(
             {
-                "creative_packages": cga.get("creative_packages", []),
-                "approval_status": cga.get("approval_status", ""),
-                "gallery": cga.get("gallery", []),
-                "ad_units": cga.get("ad_units", []),
+                "creative_packages": creative_packages,
+                "ad_set_packages": ad_set_packages,
+                "ad_units": creative_units,
+                "creative_package": cga.get("creative_package", {}),
+                "generated_images": cga.get("generated_images", []),
                 "confidence_score": cga.get("confidence_score", 0.0),
+                "compliance_pass_rate": cga.get("compliance_pass_rate", 0.0),
                 "cga_completed_at": (
                     job.completed_at.isoformat() if job.completed_at else None
                 ),

--- a/ai-brand-automator/analytics/views.py
+++ b/ai-brand-automator/analytics/views.py
@@ -1269,6 +1269,9 @@ class CGAContextView(APIView):
 
     permission_classes = [AllowAny]
 
+    # Default dev token that ships in settings.py — reject in production
+    _DEV_TOKEN = "dev-service-token"
+
     def get(self, request):
         # Service-token auth
         service_token = request.headers.get("X-Service-Token", "")
@@ -1277,9 +1280,13 @@ class CGAContextView(APIView):
             "ORCHESTRATOR_SERVICE_TOKEN",
             "",
         )
-        if not expected_token:
+        if not expected_token or (
+            expected_token == self._DEV_TOKEN
+            and not getattr(django_settings, "DEBUG", False)
+        ):
             logger.error(
-                "CGAContextView misconfigured: " "ORCHESTRATOR_SERVICE_TOKEN is not set"
+                "CGAContextView misconfigured: "
+                "ORCHESTRATOR_SERVICE_TOKEN is not set or using default"
             )
             return Response(
                 {"error": "Service authentication is not configured"},

--- a/ai-brand-automator/analytics/views.py
+++ b/ai-brand-automator/analytics/views.py
@@ -1275,8 +1275,16 @@ class CGAContextView(APIView):
         expected_token = getattr(
             django_settings,
             "ORCHESTRATOR_SERVICE_TOKEN",
-            "dev-service-token",
+            "",
         )
+        if not expected_token:
+            logger.error(
+                "CGAContextView misconfigured: " "ORCHESTRATOR_SERVICE_TOKEN is not set"
+            )
+            return Response(
+                {"error": "Service authentication is not configured"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
         if service_token != expected_token:
             return Response(
                 {"error": "Invalid service token"},

--- a/ai-brand-automator/analytics/views.py
+++ b/ai-brand-automator/analytics/views.py
@@ -1204,19 +1204,30 @@ class CAAContextView(APIView):
 
         from orchestration.models import AnalysisJob
 
-        # Find latest completed CAA job
-        job = (
+        # Find latest completed CAA job with actual blueprint data.
+        # Skip jobs where CAA returned empty results due to missing
+        # prerequisites.
+        job = None
+
+        # Primary: standalone CAA pipeline
+        caa_jobs = (
             AnalysisJob.objects.filter(
                 Q(tenant=tenant) | Q(tenant__isnull=True),
                 status=AnalysisJob.Status.COMPLETED,
                 manifest__pipeline_id="meta-campaign-architecture",
             )
             .select_related("manifest")
-            .order_by("-completed_at")
-            .first()
+            .order_by("-completed_at")[:10]
         )
+        for candidate in caa_jobs:
+            nr = (candidate.result_data or {}).get("node_results", {})
+            caa_node = nr.get("campaign_architecture", {})
+            bp = caa_node.get("blueprint", caa_node)
+            if bp.get("campaign_name") or bp.get("ad_sets"):
+                job = candidate
+                break
 
-        # Fallback: any job with campaign_architecture node results
+        # Fallback: any job with non-empty campaign_architecture results
         if not job:
             candidates = AnalysisJob.objects.filter(
                 Q(tenant=tenant) | Q(tenant__isnull=True),
@@ -1224,13 +1235,15 @@ class CAAContextView(APIView):
             ).order_by("-completed_at")[:20]
             for candidate in candidates:
                 nr = (candidate.result_data or {}).get("node_results", {})
-                if "campaign_architecture" in nr:
+                caa_node = nr.get("campaign_architecture", {})
+                bp = caa_node.get("blueprint", caa_node)
+                if bp.get("campaign_name") or bp.get("ad_sets"):
                     job = candidate
                     break
 
         if not job:
             return Response(
-                {"error": "No CAA data"},
+                {"error": "No CAA data with campaign blueprint"},
                 status=status.HTTP_404_NOT_FOUND,
             )
 
@@ -1318,19 +1331,29 @@ class CGAContextView(APIView):
 
         from orchestration.models import AnalysisJob
 
-        # Find latest completed CGA job
-        job = (
+        # Find latest completed CGA job with actual creative data.
+        # A CGA job may complete with empty packages if prerequisites
+        # were missing — skip those.
+        job = None
+
+        # Primary: standalone CGA pipeline
+        cga_jobs = (
             AnalysisJob.objects.filter(
                 Q(tenant=tenant) | Q(tenant__isnull=True),
                 status=AnalysisJob.Status.COMPLETED,
                 manifest__pipeline_id="meta-creative-generation",
             )
             .select_related("manifest")
-            .order_by("-completed_at")
-            .first()
+            .order_by("-completed_at")[:10]
         )
+        for candidate in cga_jobs:
+            nr = (candidate.result_data or {}).get("node_results", {})
+            cga_node = nr.get("creative_generation", {})
+            if cga_node.get("ad_set_packages") or cga_node.get("ad_units"):
+                job = candidate
+                break
 
-        # Fallback: any job with creative_generation node results
+        # Fallback: any job with non-empty creative_generation results
         if not job:
             candidates = AnalysisJob.objects.filter(
                 Q(tenant=tenant) | Q(tenant__isnull=True),
@@ -1338,13 +1361,16 @@ class CGAContextView(APIView):
             ).order_by("-completed_at")[:20]
             for candidate in candidates:
                 nr = (candidate.result_data or {}).get("node_results", {})
-                if "creative_generation" in nr:
+                cga_node = nr.get("creative_generation", {})
+                if cga_node.get("ad_set_packages") or cga_node.get(
+                    "ad_units"
+                ):
                     job = candidate
                     break
 
         if not job:
             return Response(
-                {"error": "No CGA data"},
+                {"error": "No CGA data with creative packages"},
                 status=status.HTTP_404_NOT_FOUND,
             )
 


### PR DESCRIPTION
## Summary

- **CGA format mapping**: CGA outputs `ad_set_packages` with `creative_units` and `gcs_url`, not `creative_packages`/`ad_units`/`image_url`. Added `_extract_creative_packages()` to handle both formats.
- **CAA field alignment**: CAA outputs `campaign_objective` (not `objective`), `daily_budget` (not `total_budget_usd`), `ad_sets` (not `funnel_stages`). Rewrote `_extract_blueprint()` to map actual CAA output while staying backward-compatible.
- **Django context views**: `CGAContextView` and `CAAContextView` now skip completed jobs that have empty data (prerequisite failures). Previously, a CGA job that completed with 0 packages was returned as valid data.
- **Backend enrichment diagnostics**: When `enrich_from_backend()` fails, HTTP status, response body, and tenant_id are surfaced in the pipeline error findings instead of being silently swallowed.
- **Sandbox mode**: Guardrails skip Meta credential validation in sandbox mode. Accept `gcs_url` as valid image source.
- **URL sanitization**: `ADPUB_BACKEND_URL` is stripped of whitespace to prevent invalid URL errors.

## Test plan
- [x] 82 ad-publishing-agent-svc tests pass
- [x] 11 Django CGA context tests pass
- [ ] Run `meta-ads-full` pipeline end-to-end on Railway
- [ ] Verify standalone `meta-ad-publishing` fetches non-empty CGA data after successful CGA run

🤖 Generated with [Claude Code](https://claude.com/claude-code)