### PR TITLE
fix: show approval UI for awaiting_approval on ai-assistant page

### DIFF
--- a/ai-brand-automator-frontend/src/app/dashboard/ai-assistant/page.tsx
+++ b/ai-brand-automator-frontend/src/app/dashboard/ai-assistant/page.tsx
@@ -44,7 +44,7 @@ export default function AiAssistantPage() {
   const phase: Phase = (() => {
     if (!activeJobId) return 'input';
     if (!job) return 'running'; // still loading
-    if (job.status === 'completed') return 'completed';
+    if (job.status === 'completed' || job.status === 'awaiting_approval') return 'completed';
     if (job.status === 'failed') return 'failed';
     return 'running';
   })();
@@ -285,6 +285,7 @@ export default function AiAssistantPage() {
                 manifestName={job.manifest_name}
                 jobId={job.job_id}
                 jobStatus={job.status}
+                onApprovalComplete={handleReset}
               />
             )}
           </div>


### PR DESCRIPTION
## Summary
- The `awaiting_approval` status was not handled in the phase derivation on the AI assistant page, causing the running spinner to show instead of the approval panel
- Added `onApprovalComplete` callback to reset the page after approval/rejection

## Test plan
- [ ] Run a meta-ads-full pipeline to completion (awaiting_approval state)
- [ ] Verify the approval panel renders on the ai-assistant page
- [ ] Approve or reject and confirm the page resets

🤖 Generated with [Claude Code](https://claude.com/claude-code)