### PR TITLE
fix: propagate awaiting_approval from node results to job status

### DIFF
--- a/pipeline-orchestrator-svc/app/services/callback_client.py
+++ b/pipeline-orchestrator-svc/app/services/callback_client.py
@@ -204,6 +204,22 @@ class CallbackClient:
             },
         )
 
+    async def send_awaiting_approval(
+        self,
+        callback_url: str,
+        result_data: dict[str, Any],
+        progress: dict[str, Any],
+    ) -> bool:
+        """Send an awaiting_approval callback (human gate paused the pipeline)."""
+        return await self._patch(
+            callback_url,
+            {
+                "status": "awaiting_approval",
+                "progress": progress,
+                "result_data": result_data,
+            },
+        )
+
     async def send_resolved_manifest(
         self,
         callback_url: str,

--- a/pipeline-orchestrator-svc/app/services/job_executor.py
+++ b/pipeline-orchestrator-svc/app/services/job_executor.py
@@ -385,9 +385,7 @@ class JobExecutor:
                         # If any node failed, abort the pipeline
                         if failed_nodes:
                             # Mark remaining future nodes as failed
-                            remaining_start = (
-                                executed_node_count + len(level_nodes)
-                            )
+                            remaining_start = executed_node_count + len(level_nodes)
                             for remaining_id in flat_sorted[remaining_start:]:
                                 if (
                                     state["progress"]
@@ -455,6 +453,29 @@ class JobExecutor:
                         copy.deepcopy(state["progress"]),
                         result_data=partial_result_data,
                     )
+
+                    # Check if any node in this level returned
+                    # status="awaiting_approval" (human approval gate).
+                    # If so, pause the pipeline and send an
+                    # awaiting_approval callback to Django.
+                    for nid in level_nodes:
+                        node_out = state["node_outputs"].get(nid)
+                        if (
+                            isinstance(node_out, dict)
+                            and node_out.get("status") == "awaiting_approval"
+                        ):
+                            logger.info(
+                                "Job %s: node %s requires human approval "
+                                "— pausing pipeline",
+                                job_id,
+                                nid,
+                            )
+                            await self.callback.send_awaiting_approval(
+                                callback_url,
+                                result_data=partial_result_data,
+                                progress=copy.deepcopy(state["progress"]),
+                            )
+                            return
 
             except Exception as exc:
                 logger.error(


### PR DESCRIPTION
## Summary
- The ad-publishing agent returns `status: "awaiting_approval"` in its node result, but the orchestrator's `JobExecutor` always marked nodes as `"done"` and never propagated this to the job-level callback
- This caused the Django `AnalysisJob.status` to stay as `"running"`, so the frontend never showed the approval UI
- Added `send_awaiting_approval()` method to `CallbackClient`
- After each execution level completes, the executor now checks if any node returned `status="awaiting_approval"` — if so, it pauses the pipeline and sends an `awaiting_approval` callback to Django

## Test plan
- [ ] All 301 orchestrator tests pass (`pytest tests/ -v`)
- [ ] Run meta-ads-full pipeline — verify job transitions to `awaiting_approval` status
- [ ] Verify approval panel renders in frontend
- [ ] After approval, verify job transitions to `completed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)