### PR TITLE
fix: approval panel images, partial status, and page refresh

### DIFF
--- a/ad-publishing-agent-svc/app/services/adpub_analyzer.py
+++ b/ad-publishing-agent-svc/app/services/adpub_analyzer.py
@@ -165,6 +165,9 @@ class AdPubAnalyzer:
                             "ad_set_id": ad_set_id,
                             "ad_set_name": ad_set_name,
                             "image_hash": image_result["hash"],
+                            "image_url": (
+                                image_result.get("url") or unit.get("image_url", "")
+                            ),
                             "headline": unit.get("headline", ""),
                             "primary_text": unit.get("primary_text", ""),
                             "cta": unit.get("cta", "LEARN_MORE"),

--- a/ai-brand-automator-frontend/src/app/dashboard/pipelines/[jobId]/page.tsx
+++ b/ai-brand-automator-frontend/src/app/dashboard/pipelines/[jobId]/page.tsx
@@ -262,6 +262,7 @@ export default function JobDetailPage({ params }: PageProps) {
                     manifestName={job.manifest_name}
                     jobId={job.job_id}
                     jobStatus={job.status}
+                    onApprovalComplete={refresh}
                   />
                 )}
               </div>

--- a/ai-brand-automator/orchestration/views.py
+++ b/ai-brand-automator/orchestration/views.py
@@ -465,7 +465,7 @@ class AnalysisJobViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):
             )
         elif decision in ("approve_all", "approve_selected"):
             publish_status = result.get("status", "")
-            if publish_status in ("published", "completed"):
+            if publish_status in ("published", "completed", "partial"):
                 job.status = AnalysisJob.Status.COMPLETED
                 job.completed_at = timezone.now()
                 # Merge publish result into existing result_data


### PR DESCRIPTION
## Summary
- Include `image_url` in creatives dict from Meta upload result so approval panel can render ad images
- Treat `"partial"` publish status as completed in Django's approve endpoint (ad-publishing returns this for partial approvals)
- Pass `onApprovalComplete={refresh}` to ResultDashboard on pipeline detail page so status updates after approve/reject

## Test plan
- [x] ad-publishing-agent-svc: 84 tests pass
- [x] Django orchestration view tests: 31 tests pass
- [x] Frontend TypeScript check passes
- [ ] Deploy to Railway and verify images appear in approval panel
- [ ] Approve ads and verify job status updates to completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)