### PR TITLE
fix: show real images in sandbox mode and make CTA clickable

### DIFF
--- a/ad-publishing-agent-svc/app/services/adpub_analyzer.py
+++ b/ad-publishing-agent-svc/app/services/adpub_analyzer.py
@@ -159,15 +159,22 @@ class AdPubAnalyzer:
                         company,
                         page_id=creds.get("page_id", ""),
                     )
+                    # Prefer the original CGA image URL (real GCS/CDN)
+                    # over the Meta upload URL (stub in sandbox mode).
+                    upload_url = image_result.get("url", "")
+                    original_url = unit.get("image_url", "")
+                    resolved_url = (
+                        original_url
+                        if original_url and upload_url.startswith("https://stub/")
+                        else (upload_url or original_url)
+                    )
                     creatives.append(
                         {
                             "creative_id": creative_id,
                             "ad_set_id": ad_set_id,
                             "ad_set_name": ad_set_name,
                             "image_hash": image_result["hash"],
-                            "image_url": (
-                                image_result.get("url") or unit.get("image_url", "")
-                            ),
+                            "image_url": resolved_url,
                             "headline": unit.get("headline", ""),
                             "primary_text": unit.get("primary_text", ""),
                             "description": unit.get("description", ""),

--- a/ai-brand-automator-frontend/src/components/pipelines/ApprovalPanel.tsx
+++ b/ai-brand-automator-frontend/src/components/pipelines/ApprovalPanel.tsx
@@ -566,9 +566,20 @@ function AdPreviewModal({
                 </p>
               )}
             </div>
-            <span className="shrink-0 px-3 py-1.5 rounded-md bg-brand-electric/20 text-brand-electric text-xs font-semibold whitespace-nowrap">
-              {ctaLabel}
-            </span>
+            {creative.link_url ? (
+              <a
+                href={creative.link_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="shrink-0 px-3 py-1.5 rounded-md bg-brand-electric/20 text-brand-electric hover:bg-brand-electric/30 text-xs font-semibold whitespace-nowrap transition-colors"
+              >
+                {ctaLabel}
+              </a>
+            ) : (
+              <span className="shrink-0 px-3 py-1.5 rounded-md bg-brand-electric/20 text-brand-electric text-xs font-semibold whitespace-nowrap">
+                {ctaLabel}
+              </span>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- **Images not showing**: In sandbox mode, `upload_image()` returns stub URLs (`https://stub/...`) that replaced the real GCS image URLs from CGA. Now prefers the original CGA image URL when the upload returns a stub URL.
- **CTA button not clickable**: The "Learn More" (and other CTA) button in the ad preview modal was a plain `<span>`. Now renders as an `<a>` tag that opens the destination URL in a new tab when `link_url` is available.

## Test plan
- [x] ad-publishing-agent-svc: 84 tests pass
- [x] TypeScript check passes
- [ ] Deploy and verify images display in approval panel thumbnails and modal
- [ ] Verify CTA button opens destination URL in new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)