### PR TITLE
fix: approval data flow — cache result_data, merge into node_results, update progress

### DIFF
--- a/ai-brand-automator/orchestration/result_handler.py
+++ b/ai-brand-automator/orchestration/result_handler.py
@@ -206,6 +206,9 @@ def _update_redis_cache(job):
         if job.status == AnalysisJob.Status.COMPLETED:
             cache_data["result_data"] = job.result_data
             cache_data["manifest_name"] = job.manifest.name if job.manifest else None
+        elif job.status == AnalysisJob.Status.AWAITING_APPROVAL:
+            cache_data["result_data"] = job.result_data
+            cache_data["manifest_name"] = job.manifest.name if job.manifest else None
         elif job.status == AnalysisJob.Status.FAILED:
             cache_data["error_message"] = job.error_message
         cache.set(cache_key, cache_data, timeout=3600)

--- a/ai-brand-automator/orchestration/views.py
+++ b/ai-brand-automator/orchestration/views.py
@@ -468,15 +468,31 @@ class AnalysisJobViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):
             if publish_status in ("published", "completed", "partial"):
                 job.status = AnalysisJob.Status.COMPLETED
                 job.completed_at = timezone.now()
-                # Merge publish result into existing result_data
+                # Merge publish result into node_results.ad_publishing
+                # so the frontend finds it in the expected location.
                 existing = job.result_data or {}
+                node_results = existing.get("node_results", {})
+                ad_pub_node = node_results.get("ad_publishing", {})
+                if isinstance(ad_pub_node, dict):
+                    ad_pub_node["publish_result"] = result
+                    ad_pub_node["status"] = "completed"
+                else:
+                    ad_pub_node = {"publish_result": result, "status": "completed"}
+                node_results["ad_publishing"] = ad_pub_node
+                existing["node_results"] = node_results
                 existing["publish_result"] = result
                 job.result_data = existing
+                # Mark ad_publishing node as done in progress
+                progress = job.progress or {}
+                if "ad_publishing" in progress:
+                    progress["ad_publishing"]["status"] = "done"
+                    job.progress = progress
                 job.save(
                     update_fields=[
                         "status",
                         "completed_at",
                         "result_data",
+                        "progress",
                         "updated_at",
                     ]
                 )


### PR DESCRIPTION
## Summary
Root cause fixes for three ad-publishing approval issues:

### 1. Results tab not shown when waiting for approval
**Root cause**: `_update_redis_cache()` in `result_handler.py` only included `result_data` in the Redis cache for `completed` and `failed` statuses. When the quick-status endpoint returned the cached `awaiting_approval` entry, `result_data` was missing, so the frontend couldn't render the approval panel.

**Fix**: Include `result_data` and `manifest_name` in the Redis cache for `awaiting_approval` status.

### 2. Status not updating after approval (workflow not completing)
**Root cause**: The approve endpoint stored `publish_result` as a **top-level key** in `result_data`, but the frontend expects data inside `node_results.ad_publishing`. Also, the `ad_publishing` node progress was never updated to `"done"`, so the pipeline graph showed it as still running.

**Fix**: Merge publish result into `node_results.ad_publishing` (setting `status: "completed"` and `publish_result` inside the node data). Also update the ad_publishing progress to `"done"` so the pipeline graph shows completion.

### 3. Raw JSON after hard refresh
**Root cause**: Same as #2 — `publish_result` as a top-level key wasn't in `knownKeys` (fixed in PR #280) and the frontend's published campaign summary view couldn't find data in `node_results.ad_publishing` because it wasn't merged there.

**Fix**: Now the data exists in both locations (`publish_result` at top level for the summary view, AND inside `node_results.ad_publishing` for detection logic).

## Test plan
- [x] Django orchestration view tests: 31 pass
- [x] Django result handler tests: 18 pass
- [x] TypeScript check passes
- [ ] Deploy and verify:
  - [ ] Approval panel shows immediately when workflow reaches awaiting_approval
  - [ ] After clicking Approve, status updates to Completed automatically
  - [ ] Pipeline graph shows ad_publishing node as done
  - [ ] After hard refresh, shows published campaign summary (not raw JSON)

🤖 Generated with [Claude Code](https://claude.com/claude-code)