### PR TITLE
fix: executor awaiting_approval progress + frontend cache bypass

### DIFF
--- a/ai-brand-automator-frontend/src/lib/orchestration.ts
+++ b/ai-brand-automator-frontend/src/lib/orchestration.ts
@@ -52,7 +52,9 @@ export async function listJobs(): Promise<AnalysisJob[]> {
 }
 
 export async function getJob(jobId: string): Promise<AnalysisJob> {
-  const res = await apiClient.get(`${BASE}/jobs/${jobId}/`);
+  const res = await apiClient.request(`${BASE}/jobs/${jobId}/`, {
+    cache: 'no-store',
+  });
   return parseOrThrow<AnalysisJob>(res);
 }
 

--- a/pipeline-orchestrator-svc/app/services/job_executor.py
+++ b/pipeline-orchestrator-svc/app/services/job_executor.py
@@ -415,14 +415,34 @@ class JobExecutor:
                                 if "result_data" in result:
                                     result_data = result["result_data"]
 
-                    # Mark all nodes in this level as done
+                    # Check if any node requires human approval BEFORE
+                    # marking as done, so progress shows the correct state.
+                    awaiting_node = None
+                    for nid in level_nodes:
+                        node_out = state["node_outputs"].get(nid)
+                        if (
+                            isinstance(node_out, dict)
+                            and node_out.get("status") == "awaiting_approval"
+                        ):
+                            awaiting_node = nid
+                            break
+
+                    # Mark all nodes in this level as done (or
+                    # awaiting_approval for the gated node).
                     completed_at = self._now_iso()
                     for nid in level_nodes:
-                        state["progress"][nid] = {
-                            "status": "done",
-                            "started_at": started_at,
-                            "completed_at": completed_at,
-                        }
+                        if nid == awaiting_node:
+                            state["progress"][nid] = {
+                                "status": "awaiting_approval",
+                                "started_at": started_at,
+                                "completed_at": completed_at,
+                            }
+                        else:
+                            state["progress"][nid] = {
+                                "status": "done",
+                                "started_at": started_at,
+                                "completed_at": completed_at,
+                            }
                     executed_node_count += len(level_nodes)
 
                     for nid in level_nodes:
@@ -447,35 +467,28 @@ class JobExecutor:
                     if result_data:
                         partial_result_data.update(result_data)
 
+                    # If a node requires human approval, send the
+                    # awaiting_approval callback and pause the pipeline.
+                    if awaiting_node:
+                        logger.info(
+                            "Job %s: node %s requires human approval "
+                            "— pausing pipeline",
+                            job_id,
+                            awaiting_node,
+                        )
+                        await self.callback.send_awaiting_approval(
+                            callback_url,
+                            result_data=partial_result_data,
+                            progress=copy.deepcopy(state["progress"]),
+                        )
+                        return
+
                     # Send per-level progress callback with partial results
                     await self.callback.send_progress(
                         callback_url,
                         copy.deepcopy(state["progress"]),
                         result_data=partial_result_data,
                     )
-
-                    # Check if any node in this level returned
-                    # status="awaiting_approval" (human approval gate).
-                    # If so, pause the pipeline and send an
-                    # awaiting_approval callback to Django.
-                    for nid in level_nodes:
-                        node_out = state["node_outputs"].get(nid)
-                        if (
-                            isinstance(node_out, dict)
-                            and node_out.get("status") == "awaiting_approval"
-                        ):
-                            logger.info(
-                                "Job %s: node %s requires human approval "
-                                "— pausing pipeline",
-                                job_id,
-                                nid,
-                            )
-                            await self.callback.send_awaiting_approval(
-                                callback_url,
-                                result_data=partial_result_data,
-                                progress=copy.deepcopy(state["progress"]),
-                            )
-                            return
 
             except Exception as exc:
                 logger.error(


### PR DESCRIPTION
## Summary
- **Root cause fix**: The orchestrator's `JobExecutor` was marking the ad-publishing node's progress as `"done"` before checking if it returned `awaiting_approval` status. The frontend checks `progress.ad_publishing.status` to decide whether to render the ApprovalPanel — seeing `"done"` instead of `"awaiting_approval"` caused it to skip the approval UI entirely.
- **Fix**: Check for `awaiting_approval` in node output BEFORE updating progress, set gated node's progress to `"awaiting_approval"`, and send the awaiting_approval callback instead of the regular progress callback.
- **Frontend cache fix**: `getJob()` now uses `cache: 'no-store'` (matching `getJobQuickStatus()`) to prevent the browser from serving stale job data after approval completes.

## Issues Fixed
1. **Results tab not shown when awaiting approval** — Progress now correctly shows `awaiting_approval` status
2. **Status not updating after approval** — `getJob()` cache bypass ensures fresh data is fetched
3. **Raw JSON after hard refresh** — Already fixed in PR #282 (result_data cached for awaiting_approval in Redis)

## Test plan
- [ ] Run `pytest tests/ -v` in pipeline-orchestrator-svc (301 tests pass)
- [ ] Run `npx tsc --noEmit` in frontend (clean)
- [ ] Deploy orchestrator + frontend to Railway
- [ ] Trigger meta-ad-publishing pipeline → verify ApprovalPanel appears
- [ ] Click Approve → verify status updates to completed without hard refresh
- [ ] Hard refresh → verify results render correctly (not raw JSON)

🤖 Generated with [Claude Code](https://claude.com/claude-code)