### PR TITLE
fix: approve view — mark all nodes done, populate cache, run completion handlers

### DIFF
--- a/ai-brand-automator/orchestration/views.py
+++ b/ai-brand-automator/orchestration/views.py
@@ -451,8 +451,19 @@ class AnalysisJobViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):
             )
 
         # Persist outcome on the job so it doesn't stay awaiting_approval
+        from orchestration.result_handler import (
+            _update_redis_cache,
+            _release_session_lock,
+            _save_final_chat_message,
+            _update_workflow_snapshot,
+            _broadcast_to_workspace,
+        )
+
+        new_status = None
+
         if decision == "reject":
-            job.status = AnalysisJob.Status.FAILED
+            new_status = AnalysisJob.Status.FAILED
+            job.status = new_status
             job.error_message = "Rejected by user"
             job.completed_at = timezone.now()
             job.save(
@@ -466,7 +477,8 @@ class AnalysisJobViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):
         elif decision in ("approve_all", "approve_selected"):
             publish_status = result.get("status", "")
             if publish_status in ("published", "completed", "partial"):
-                job.status = AnalysisJob.Status.COMPLETED
+                new_status = AnalysisJob.Status.COMPLETED
+                job.status = new_status
                 job.completed_at = timezone.now()
                 # Merge publish result into node_results.ad_publishing
                 # so the frontend finds it in the expected location.
@@ -482,11 +494,18 @@ class AnalysisJobViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):
                 existing["node_results"] = node_results
                 existing["publish_result"] = result
                 job.result_data = existing
-                # Mark ad_publishing node as done in progress
+                # Mark ALL remaining pipeline nodes as done so the
+                # pipeline graph shows complete (e.g. manager node).
                 progress = job.progress or {}
-                if "ad_publishing" in progress:
-                    progress["ad_publishing"]["status"] = "done"
-                    job.progress = progress
+                completed_at = timezone.now().isoformat()
+                for node_id, node_info in progress.items():
+                    if isinstance(node_info, dict) and node_info.get("status") in (
+                        "pending",
+                        "awaiting_approval",
+                    ):
+                        node_info["status"] = "done"
+                        node_info.setdefault("completed_at", completed_at)
+                job.progress = progress
                 job.save(
                     update_fields=[
                         "status",
@@ -497,7 +516,8 @@ class AnalysisJobViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):
                     ]
                 )
             elif publish_status in ("failed", "error"):
-                job.status = AnalysisJob.Status.FAILED
+                new_status = AnalysisJob.Status.FAILED
+                job.status = new_status
                 job.error_message = result.get("error", "Publishing failed")
                 job.completed_at = timezone.now()
                 job.save(
@@ -509,8 +529,27 @@ class AnalysisJobViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):
                     ]
                 )
 
-        # Invalidate quick-status cache so polling picks up new state
-        cache.delete(f"job:status:{job_id}")
+        # Update Redis cache and run post-completion handlers
+        # (same as handle_pipeline_result does for normal completions)
+        _update_redis_cache(job)
+        _broadcast_to_workspace(job, new_status)
+        if new_status in (
+            AnalysisJob.Status.COMPLETED,
+            AnalysisJob.Status.FAILED,
+        ):
+            _release_session_lock(job)
+            if new_status == AnalysisJob.Status.COMPLETED:
+                _save_final_chat_message(job)
+                _update_workflow_snapshot(job)
+                try:
+                    from analytics.tasks import extract_metrics_task
+
+                    extract_metrics_task.delay(job.id)
+                except Exception:
+                    logger.exception(
+                        "Failed to dispatch analytics for job %s",
+                        job.job_id,
+                    )
 
         logger.info(
             "Job %s approval proxied: decision=%s, result_status=%s",


### PR DESCRIPTION
## Summary
Fixes three bugs in the Django `/jobs/{jobId}/approve/` endpoint that caused the approval workflow to behave incorrectly after the user approves a campaign.

### Bug 1: Pipeline graph shows incomplete after approval
The approve view only marked the `ad_publishing` node as `"done"` in progress. Remaining pipeline nodes (like `manager`) stayed `"pending"`, making the pipeline graph look incomplete even though the job was marked COMPLETED.

**Fix:** Mark ALL nodes with `"pending"` or `"awaiting_approval"` status as `"done"` after approval.

### Bug 2: Redis cache deleted but never repopulated
The approve view used `cache.delete()` to invalidate the quick-status cache. The next poll fell through to a DB read, but the cache was never rebuilt with COMPLETED data (including `result_data` and `manifest_name`). Subsequent polls to the same endpoint would re-read from DB every time instead of getting a fast cache hit.

**Fix:** Call `_update_redis_cache(job)` from `result_handler.py` to properly populate the Redis cache with all required fields for the COMPLETED state.

### Bug 3: Post-completion handlers never called
Normal pipeline completions (via `handle_pipeline_result`) trigger:
- `_release_session_lock()` — so new chat messages can proceed
- `_save_final_chat_message()` — creates assistant message with result summary
- `_update_workflow_snapshot()` — updates workspace dashboard data
- `extract_metrics_task` — dispatches analytics extraction
- `_broadcast_to_workspace()` — sends WebSocket notification

The approve view bypassed all of these, leading to stuck session locks, missing chat messages, and no analytics data for approved campaigns.

**Fix:** Import and call the same post-completion handlers from `result_handler.py`.

## Test plan
- [x] `pytest orchestration/tests/ -v` — 134 tests pass
- [ ] Deploy Django backend to Railway
- [ ] Trigger meta-ad-publishing pipeline → approve → verify:
  - Pipeline graph shows all nodes as done (including manager)
  - Status updates to completed in the UI without hard refresh
  - Results render correctly (not raw JSON)
  - Chat message created with result summary
  - Quick-status returns cached COMPLETED data

🤖 Generated with [Claude Code](https://claude.com/claude-code)