### PR TITLE
fix(cga): surface real image generation errors

### DIFF
--- a/creative-generation-agent-svc/app/logic/image_generator.py
+++ b/creative-generation-agent-svc/app/logic/image_generator.py
@@ -82,11 +82,19 @@ class ImageGenerator:
 
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
+        failure_reasons: list[str] = []
         for result in results:
             if isinstance(result, Exception):
-                logger.warning("Image generation task failed: %s", result)
+                logger.warning(
+                    "Image generation task failed: %s: %s",
+                    type(result).__name__,
+                    result,
+                    exc_info=result,
+                )
+                failure_reasons.append(f"{type(result).__name__}: {result}")
                 failed_count += 1
             elif result is None:
+                failure_reasons.append("returned None (no image data)")
                 failed_count += 1
             else:
                 generated_images.append(result)
@@ -105,6 +113,7 @@ class ImageGenerator:
             "total_images": len(generated_images),
             "total_cost_usd": round(total_cost, 4),
             "failed_count": failed_count,
+            "failure_reasons": failure_reasons[:10],
         }
 
     async def _generate_single(

--- a/creative-generation-agent-svc/app/logic/image_generator.py
+++ b/creative-generation-agent-svc/app/logic/image_generator.py
@@ -89,7 +89,7 @@ class ImageGenerator:
                     "Image generation task failed: %s: %s",
                     type(result).__name__,
                     result,
-                    exc_info=result,
+                    exc_info=(type(result), result, result.__traceback__),
                 )
                 failure_reasons.append(f"{type(result).__name__}: {result}")
                 failed_count += 1
@@ -222,7 +222,13 @@ class ImageGenerator:
                     generation_time_ms,
                     exc,
                 )
-                return None
+                # Re-raise so asyncio.gather(return_exceptions=True) can
+                # surface the exception type/message to the caller. None
+                # is reserved for non-error skips (e.g., empty prompt).
+                raise RuntimeError(
+                    f"{ad_set_name}/{variant_id}/{aspect_ratio}: "
+                    f"{type(exc).__name__}: {exc}"
+                ) from exc
 
 
 def _make_thumbnail(image_data: bytes, max_size: int = 200) -> str:

--- a/creative-generation-agent-svc/app/services/cga_analyzer.py
+++ b/creative-generation-agent-svc/app/services/cga_analyzer.py
@@ -242,10 +242,19 @@ class CGAAnalyzer:
                 failed_count = gen_result.get("failed_count", 0)
 
                 if failed_count > 0:
+                    failure_reasons = gen_result.get("failure_reasons", [])
+                    reasons_str = (
+                        "; ".join(failure_reasons)
+                        if failure_reasons
+                        else "see logs"
+                    )
                     findings.append(
                         f"Image generation: {failed_count} images failed "
-                        f"out of {total_images + failed_count} attempted"
+                        f"out of {total_images + failed_count} attempted. "
+                        f"Reasons: {reasons_str}"
                     )
+                if total_images == 0 and failed_count > 0:
+                    image_gen_failed = True
 
                 await self._events.emit(
                     EventType.IMAGE_GENERATION_COMPLETED, tenant_id, job_id,
@@ -257,9 +266,15 @@ class CGAAnalyzer:
                 )
             except Exception as exc:
                 image_gen_failed = True
-                logger.error("Image generation failed entirely: %s", exc)
+                logger.error(
+                    "Image generation failed entirely: %s: %s",
+                    type(exc).__name__,
+                    exc,
+                    exc_info=True,
+                )
                 findings.append(
-                    f"Image generation failed: {exc}. "
+                    f"CRITICAL: Image generation failed entirely. "
+                    f"{type(exc).__name__}: {exc}. "
                     "Creative package will contain copy only."
                 )
                 await self._events.emit(

--- a/creative-generation-agent-svc/app/services/cga_analyzer.py
+++ b/creative-generation-agent-svc/app/services/cga_analyzer.py
@@ -255,6 +255,17 @@ class CGAAnalyzer:
                     )
                 if total_images == 0 and failed_count > 0:
                     image_gen_failed = True
+                    first_reason = (
+                        gen_result.get("failure_reasons", ["unknown"])[0]
+                        if gen_result.get("failure_reasons")
+                        else "unknown"
+                    )
+                    findings.append(
+                        f"CRITICAL: Image generation produced 0 images "
+                        f"({failed_count} attempts failed). "
+                        f"First reason: {first_reason}. "
+                        "Creative package will contain copy only."
+                    )
 
                 await self._events.emit(
                     EventType.IMAGE_GENERATION_COMPLETED, tenant_id, job_id,

--- a/creative-generation-agent-svc/app/services/image_gen_client.py
+++ b/creative-generation-agent-svc/app/services/image_gen_client.py
@@ -222,22 +222,62 @@ class NanoBanana2Adapter(ImageGenAdapter):
             f"Generate a high-quality {ratio_str} aspect ratio "
             f"advertising image: {prompt}"
         )
-        response = await asyncio.to_thread(
-            self._client.models.generate_content,
-            model=settings.IMAGE_GEN_MODEL,
-            contents=[enhanced_prompt],
-            config=types.GenerateContentConfig(
-                response_modalities=["IMAGE", "TEXT"],
-            ),
+        logger.info(
+            "Gemini image gen: calling generate_content model=%s ratio=%s "
+            "prompt_len=%d",
+            settings.IMAGE_GEN_MODEL,
+            ratio_str,
+            len(enhanced_prompt),
         )
+        try:
+            response = await asyncio.to_thread(
+                self._client.models.generate_content,
+                model=settings.IMAGE_GEN_MODEL,
+                contents=[enhanced_prompt],
+                config=types.GenerateContentConfig(
+                    response_modalities=["IMAGE", "TEXT"],
+                ),
+            )
+        except Exception as exc:
+            logger.error(
+                "Gemini image gen: generate_content raised %s: %s",
+                type(exc).__name__,
+                exc,
+                exc_info=True,
+            )
+            raise
         image_data = b""
         text_desc = ""
+        # Surface prompt feedback / safety blocks if present
+        prompt_feedback = getattr(response, "prompt_feedback", None)
+        if prompt_feedback:
+            logger.warning(
+                "Gemini image gen: prompt_feedback=%s", prompt_feedback
+            )
         if not response.candidates:
-            logger.warning("Gemini image gen: no candidates in response")
+            logger.warning(
+                "Gemini image gen: no candidates in response "
+                "(prompt_feedback=%s)",
+                prompt_feedback,
+            )
             return b"", ""
-        parts = response.candidates[0].content.parts
+        candidate = response.candidates[0]
+        finish_reason = getattr(candidate, "finish_reason", None)
+        safety_ratings = getattr(candidate, "safety_ratings", None)
+        if finish_reason and str(finish_reason) not in ("FinishReason.STOP", "STOP", "1"):
+            logger.warning(
+                "Gemini image gen: non-STOP finish_reason=%s safety=%s",
+                finish_reason,
+                safety_ratings,
+            )
+        parts = candidate.content.parts if candidate.content else None
         if not parts:
-            logger.warning("Gemini image gen: no parts in response")
+            logger.warning(
+                "Gemini image gen: no parts in response "
+                "(finish_reason=%s safety=%s)",
+                finish_reason,
+                safety_ratings,
+            )
             return b"", ""
         for part in parts:
             if hasattr(part, "inline_data") and part.inline_data:

--- a/creative-generation-agent-svc/app/services/image_gen_client.py
+++ b/creative-generation-agent-svc/app/services/image_gen_client.py
@@ -19,6 +19,26 @@ logger = logging.getLogger(__name__)
 # Nano Banana 2 cost estimate per image
 _COST_PER_IMAGE_USD = 0.065
 
+# google-genai uses both enum names ("STOP") and string-formatted enum reprs
+# ("FinishReason.STOP"). Some SDK versions also serialize enums as their
+# integer value, where 1 == STOP per the proto definition.
+_STOP_FINISH_REASON_TOKENS = frozenset(
+    {"STOP", "FINISH_REASON_STOP", "FinishReason.STOP", "1"}
+)
+
+
+def _is_stop_finish_reason(finish_reason: Any) -> bool:
+    """True if the Gemini finish_reason represents a normal STOP.
+
+    Tolerates enum, string, or integer representations across google-genai
+    SDK versions. Falls back to .name attribute when present.
+    """
+    name = getattr(finish_reason, "name", None)
+    if name:
+        return name == "STOP"
+    return str(finish_reason) in _STOP_FINISH_REASON_TOKENS
+
+
 # Supported aspect ratios for Meta Ads
 ASPECT_RATIOS = {
     "1:1": "1:1",  # Feed (1080×1080)
@@ -264,7 +284,9 @@ class NanoBanana2Adapter(ImageGenAdapter):
         candidate = response.candidates[0]
         finish_reason = getattr(candidate, "finish_reason", None)
         safety_ratings = getattr(candidate, "safety_ratings", None)
-        if finish_reason and str(finish_reason) not in ("FinishReason.STOP", "STOP", "1"):
+        if finish_reason is not None and not _is_stop_finish_reason(
+            finish_reason
+        ):
             logger.warning(
                 "Gemini image gen: non-STOP finish_reason=%s safety=%s",
                 finish_reason,


### PR DESCRIPTION
## Summary
Image generation failures in CGA were silently swallowed, so the workflow result only said "failed to create creative ads" without telling us why.

## Changes
- **`image_gen_client.py`**: wrap `generate_content` in try/except with full stack trace; log `prompt_feedback`, `finish_reason`, and `safety_ratings` so we can see safety blocks / quota issues / bad model names
- **`image_generator.py`**: collect per-task failure reasons (exception type + message) and return them in the result
- **`cga_analyzer.py`**: include those reasons in the findings array and flag total failure with the exception type when 0 images succeed

## Test plan
- [ ] Re-run a Meta Ads workflow that previously failed
- [ ] Confirm the CGA result panel shows the actual Gemini error (model/safety/quota) in findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)