### PR TITLE
fix(cga): defensive coercion + surface traceback in findings

### DIFF
--- a/creative-generation-agent-svc/app/logic/creative_context_loader.py
+++ b/creative-generation-agent-svc/app/logic/creative_context_loader.py
@@ -79,7 +79,14 @@ class CreativeContextLoader:
         if not ad_sets:
             ad_sets = caa_context.get("ad_sets", [])
 
+        # Defensive: upstream CAA may return a malformed blueprint where
+        # ad_sets is an int, dict, or other non-iterable. Coerce to list.
+        if not isinstance(ad_sets, list):
+            ad_sets = []
+
         for ad_set in ad_sets:
+            if not isinstance(ad_set, dict):
+                continue
             brief: dict[str, Any] = {
                 # Prefer CAA-style keys, fall back to blueprint-style keys
                 "ad_set_name": ad_set.get("ad_set_name") or ad_set.get("name", ""),

--- a/creative-generation-agent-svc/app/logic/image_prompt_builder.py
+++ b/creative-generation-agent-svc/app/logic/image_prompt_builder.py
@@ -154,6 +154,8 @@ class ImagePromptBuilder:
         )
 
         personas = creative_context.get("audience_personas", [])
+        if not isinstance(personas, list):
+            personas = []
         persona_map: dict[str, dict[str, Any]] = {}
         for p in personas:
             if isinstance(p, dict):

--- a/creative-generation-agent-svc/app/services/cga_executor.py
+++ b/creative-generation-agent-svc/app/services/cga_executor.py
@@ -2,6 +2,7 @@
 
 import logging
 import time
+import traceback
 import uuid
 from typing import Any
 
@@ -224,10 +225,20 @@ class CGAExecutor:
 
         except Exception as exc:
             logger.error("CGA analysis failed: %s", exc, exc_info=True)
+            tb = traceback.extract_tb(exc.__traceback__)
+            last = tb[-1] if tb else None
+            location = (
+                f"{last.filename.split('/')[-1]}:{last.lineno} in {last.name}"
+                if last
+                else "unknown"
+            )
             result = _empty_result(
                 prompt,
                 start_time,
-                findings=[f"Analysis failed: {exc}"],
+                findings=[
+                    f"Analysis failed: {type(exc).__name__}: {exc} "
+                    f"(at {location})"
+                ],
             )
 
         finally:


### PR DESCRIPTION
## Summary
Workflow was failing with three cascading errors:
1. **CAA**: \`Budget allocation sums to 0.0% (must be 99-101%)\` — malformed blueprint
2. **CGA**: \`Analysis failed: 'int' object is not iterable\` — CGA tries to iterate the malformed blueprint
3. **APA**: \`No creative packages found\` — downstream consequence of #2

This PR addresses the **CGA crash** so the agent degrades gracefully instead of taking down the entire WF3 chain, and surfaces the exact failure location in findings so we can debug without Railway logs.

## Changes
- **\`creative_context_loader.py\`**: coerce \`ad_sets\` to a list (CAA may return int/dict when its own budget validation fails upstream); skip non-dict entries
- **\`image_prompt_builder.py\`**: same defensive coercion for \`audience_personas\`
- **\`cga_executor.py\`**: include \`type(exc).__name__\` and \`file:line\` in the "Analysis failed" finding

## Note
This is a defensive fix in CGA. The **root cause** is in CAA — its budget allocation validator is producing a 0.0% sum and returning a malformed blueprint. That fix is a separate PR.

## Test plan
- [ ] Re-run Meta Ads workflow
- [ ] Confirm CGA produces a creative package (even minimal) instead of crashing
- [ ] Confirm any remaining failure shows file:line in findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)