### PR TITLE
fix(wf3): preserve approval context on awaiting_approval callback

### DIFF
--- a/ai-brand-automator/orchestration/result_handler.py
+++ b/ai-brand-automator/orchestration/result_handler.py
@@ -89,16 +89,23 @@ def handle_pipeline_result(
         # each other's data (each level only sends its own node_results).
         if result_data is not None:
             existing = job.result_data or {}
-            incoming_nodes = result_data.get("node_results", {})
-            existing_nodes = existing.get("node_results", {})
-
-            if incoming_nodes and existing_nodes:
-                # Deep-merge node_results: incoming overwrites per-key
-                merged_nodes = {**existing_nodes, **incoming_nodes}
-                merged = {**existing, **result_data, "node_results": merged_nodes}
-                job.result_data = merged
-            else:
-                job.result_data = result_data
+            merged = {**existing, **result_data}
+            # Deep-merge node_results across per-level progress callbacks.
+            incoming_nodes = result_data.get("node_results") or {}
+            existing_nodes = existing.get("node_results") or {}
+            if incoming_nodes or existing_nodes:
+                merged["node_results"] = {**existing_nodes, **incoming_nodes}
+            # Deep-merge node_payloads so CAA/CGA payloads accumulated on
+            # earlier callbacks aren't dropped when the awaiting_approval
+            # callback arrives carrying only ad_publishing's output.
+            incoming_payloads = result_data.get("node_payloads") or {}
+            existing_payloads = existing.get("node_payloads") or {}
+            if incoming_payloads or existing_payloads:
+                merged["node_payloads"] = {
+                    **existing_payloads,
+                    **incoming_payloads,
+                }
+            job.result_data = merged
             update_fields.append("result_data")
 
         # Update error_message

--- a/pipeline-orchestrator-svc/app/services/job_executor.py
+++ b/pipeline-orchestrator-svc/app/services/job_executor.py
@@ -510,9 +510,34 @@ class JobExecutor:
                             job_id,
                             awaiting_node,
                         )
+                        # Surface the gating node's top-level keys
+                        # (approval_request_id, preview_data, sandbox_mode,
+                        # plan_warnings, status) alongside the accumulated
+                        # result_data so Django's callback handler and the
+                        # frontend ResultDashboard can find them without
+                        # digging into node_payloads.
+                        approval_result_data: dict[str, Any] = {}
+                        if isinstance(result_data, dict):
+                            approval_result_data.update(result_data)
+                        gate_output = state["node_outputs"].get(awaiting_node)
+                        if isinstance(gate_output, dict):
+                            for key in (
+                                "status",
+                                "approval_request_id",
+                                "preview_data",
+                                "sandbox_mode",
+                                "plan_warnings",
+                            ):
+                                if key in gate_output:
+                                    approval_result_data[key] = gate_output[key]
+                            payloads = approval_result_data.setdefault(
+                                "node_payloads", {}
+                            )
+                            if isinstance(payloads, dict):
+                                payloads[awaiting_node] = gate_output
                         await self.callback.send_awaiting_approval(
                             callback_url,
-                            result_data=partial_result_data,
+                            result_data=approval_result_data,
                             progress=copy.deepcopy(state["progress"]),
                         )
                         return


### PR DESCRIPTION
## Summary
- Orchestrator was sending only the gating level's `node_results` as partial result_data on the awaiting_approval callback, dropping both `approval_request_id` and the CAA/CGA `node_payloads` that accumulated earlier in the run — so the UI never routed to the ApprovalPanel.
- **Orchestrator** (`job_executor.py`): on awaiting_approval, lift `approval_request_id`, `preview_data`, `sandbox_mode`, `plan_warnings`, `status` from the gating node's output onto the accumulated `result_data`, and ensure its payload is present under `node_payloads[awaiting_node]`.
- **Django** (`result_handler.py`): deep-merge both `node_results` and `node_payloads` across progressive callbacks so previously accumulated WF3 agent outputs survive the awaiting_approval callback instead of being overwritten.

## Test plan
- [ ] Run a WF3 job to the human approval gate; verify job status flips to `awaiting_approval`, CAA + CGA sections render, and the Campaign Approval panel appears with Approve/Reject buttons.