### PR TITLE
fix(frontend): hide WF3 approval panel once job leaves awaiting_approval

### DIFF
--- a/ai-brand-automator-frontend/src/components/pipelines/ResultDashboard.tsx
+++ b/ai-brand-automator-frontend/src/components/pipelines/ResultDashboard.tsx
@@ -7384,10 +7384,12 @@ export default function ResultDashboard({
 
   // ── Route to approval panel for ad-publishing awaiting_approval ──
   const approvalRequestId = (adPubData?.approval_request_id ?? resultData.approval_request_id) as string | undefined;
-  const isAwaitingApproval =
-    jobStatus === 'awaiting_approval' ||
-    (resultData.status as string) === 'awaiting_approval' ||
-    (adPubData?.status as string) === 'awaiting_approval';
+  // Only treat the job as awaiting approval when the live job status
+  // says so. The persisted node_payloads still carry the original
+  // gate output (status=awaiting_approval) even after the user
+  // approves, so relying on them would keep the approval panel up
+  // forever once the job flips to completed/failed.
+  const isAwaitingApproval = jobStatus === 'awaiting_approval';
   if (hasAdPublishing && approvalRequestId && isAwaitingApproval && jobId) {
     const previewData = (adPubData?.preview_data ?? resultData.preview_data ?? {}) as Record<string, unknown>;
     const sandboxMode = (adPubData?.sandbox_mode ?? resultData.sandbox_mode ?? true) as boolean;


### PR DESCRIPTION
## Summary
- After the user approves the Meta Ads campaign, the job flips to \`completed\` but the persisted \`node_payloads.ad_publishing.status\` is still \`awaiting_approval\` (that's what the gate emitted). The dashboard was OR-ing those persisted values into \`isAwaitingApproval\`, so the ApprovalPanel stayed up forever and the campaign summary never appeared.
- Gate the approval-panel branch on the live \`jobStatus\` only.

## Test plan
- [ ] Approve a WF3 run and confirm the ApprovalPanel is replaced with the campaign summary
- [ ] Reload a completed WF3 job and confirm the summary (not the panel) is shown