### PR TITLE
fix(apa): prefer GCS URL over base64 thumbnail in CGA context enricher

### DIFF
--- a/ad-publishing-agent-svc/app/services/context_loader.py
+++ b/ad-publishing-agent-svc/app/services/context_loader.py
@@ -428,10 +428,20 @@ class AdPubContextLoader:
             variant_id = unit.get("image_variant_id", "")
             img_data = image_lookup.get((set_name, variant_id))
             if img_data:
-                # Prefer thumbnail_url (smaller), fall back to gcs_url
-                resolved_url = (
-                    img_data.get("thumbnail_url") or img_data.get("gcs_url") or ""
-                )
+                # Prefer the real GCS/HTTPS URL — thumbnails are base64
+                # data URIs generated in-memory and Meta's image upload
+                # endpoint can't fetch them. Only fall back to the
+                # thumbnail when GCS isn't configured or returned a
+                # data URI itself.
+                gcs_url = img_data.get("gcs_url") or ""
+                thumb = img_data.get("thumbnail_url") or ""
+                if gcs_url and not gcs_url.startswith("data:"):
+                    resolved_url = gcs_url
+                elif thumb and not thumb.startswith("data:"):
+                    resolved_url = thumb
+                else:
+                    # Both are data URIs or empty — prefer gcs_url if any
+                    resolved_url = gcs_url or thumb
                 if resolved_url:
                     enriched["image_url"] = resolved_url
                 enriched["image_generated"] = img_data.get("image_generated", True)


### PR DESCRIPTION
## Summary
- APA's CGA context enricher preferred `thumbnail_url` (in-memory base64 data URI) over `gcs_url` (real GCS URL). Every image upload to Meta failed with 'Request URL is missing an http(s) protocol'.
- Now prefers `gcs_url` unless empty or itself a data URI, then falls back to `thumbnail_url`.

## Why
With GCS now configured for CGA, `gcs_url` is populated with real `gs://…` URLs but the enricher still picked the thumbnail, breaking the WF3 publish step even though CGA itself succeeded (12 units, confidence 0.87).

## Test plan
- [ ] Redeploy APA, rerun WF3, confirm no "Failed to download image from data:image/..." warnings in APA logs
- [ ] Confirm creative upload to Meta sandbox succeeds