### PR TITLE
fix(cga): return HTTPS signed URL from GCS upload instead of gs:// URI

### DIFF
--- a/creative-generation-agent-svc/app/services/gcs_client.py
+++ b/creative-generation-agent-svc/app/services/gcs_client.py
@@ -4,10 +4,14 @@ import asyncio
 import base64
 import json
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+# Signed URL validity for images handed off to APA/Meta. 7 days is the
+# max supported by v4 signing and comfortably longer than any WF3 run.
+_SIGNED_URL_TTL = timedelta(days=7)
 
 
 class GCSClient:
@@ -85,9 +89,34 @@ class GCSClient:
                 image_data,
                 content_type=content_type,
             )
-            uri = f"gs://{self._bucket_name}/{path}"
-            logger.info("Uploaded image to %s", uri)
-            return uri
+            # Return an HTTPS signed URL so APA / Meta / the frontend can
+            # fetch without needing GCS credentials. gs:// URIs are not
+            # usable by httpx or the Meta Ads image upload endpoint.
+            try:
+                signed_url = await asyncio.to_thread(
+                    blob.generate_signed_url,
+                    version="v4",
+                    expiration=_SIGNED_URL_TTL,
+                    method="GET",
+                )
+                logger.info(
+                    "Uploaded image to gs://%s/%s (signed URL issued)",
+                    self._bucket_name,
+                    path,
+                )
+                return signed_url
+            except Exception as exc:
+                # ADC / workload identity can't sign — fall back to the
+                # public URL (works if the bucket is public) and log.
+                logger.warning(
+                    "GCS signed URL generation failed (%s); "
+                    "returning unsigned public URL",
+                    exc,
+                )
+                return (
+                    f"https://storage.googleapis.com/"
+                    f"{self._bucket_name}/{path}"
+                )
         except Exception as exc:
             logger.warning("GCS image upload failed: %s", exc)
             return ""

--- a/creative-generation-agent-svc/app/services/gcs_client.py
+++ b/creative-generation-agent-svc/app/services/gcs_client.py
@@ -74,7 +74,18 @@ class GCSClient:
         filename: str,
         content_type: str = "image/png",
     ) -> str:
-        """Upload image bytes to GCS. Returns GCS URI or empty string."""
+        """Upload image bytes to GCS and return a fetchable URL.
+
+        Returns:
+            - v4 HTTPS signed URL (7-day TTL) when signing credentials
+              are available — the default path.
+            - Unsigned public HTTPS URL (``blob.public_url``) when
+              signing fails (e.g. ADC / workload identity without a
+              private key). Only resolvable if the bucket is public.
+            - ``data:<content_type>;base64,...`` URI when GCS is not
+              configured at all (stub mode).
+            - Empty string on upload failure or empty input.
+        """
         if not self._ensure_client():
             logger.info("GCS not configured, returning data URI")
             if image_data and len(image_data) > 8:
@@ -107,16 +118,15 @@ class GCSClient:
                 return signed_url
             except Exception as exc:
                 # ADC / workload identity can't sign — fall back to the
-                # public URL (works if the bucket is public) and log.
+                # public URL (works if the bucket is public). Use
+                # blob.public_url which handles URL-encoding of any
+                # reserved characters in the object name.
                 logger.warning(
                     "GCS signed URL generation failed (%s); "
                     "returning unsigned public URL",
                     exc,
                 )
-                return (
-                    f"https://storage.googleapis.com/"
-                    f"{self._bucket_name}/{path}"
-                )
+                return blob.public_url
         except Exception as exc:
             logger.warning("GCS image upload failed: %s", exc)
             return ""

--- a/creative-generation-agent-svc/tests/test_gcs_client.py
+++ b/creative-generation-agent-svc/tests/test_gcs_client.py
@@ -1,0 +1,80 @@
+"""Unit tests for GCSClient URL-generation branches."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.services.gcs_client import GCSClient
+
+
+def _make_client_with_fake_bucket(blob_mock: MagicMock) -> GCSClient:
+    client = GCSClient(
+        project_id="proj",
+        bucket_name="bkt",
+        credentials_json="",
+        credentials_path="",
+    )
+    # Bypass _ensure_client so we don't touch google-cloud-storage.
+    client._client = MagicMock()
+    bucket = MagicMock()
+    bucket.blob.return_value = blob_mock
+    client._bucket = bucket
+    return client
+
+
+async def test_upload_image_returns_signed_url_on_success():
+    blob = MagicMock()
+    blob.upload_from_string = MagicMock(return_value=None)
+    blob.generate_signed_url = MagicMock(
+        return_value="https://storage.googleapis.com/bkt/signed?sig=abc"
+    )
+    client = _make_client_with_fake_bucket(blob)
+
+    url = await client.upload_image(
+        tenant_id="11",
+        job_id="job-1",
+        image_data=b"\x89PNGfakebytes",
+        filename="ad_v1_1x1.png",
+    )
+
+    assert url == "https://storage.googleapis.com/bkt/signed?sig=abc"
+    blob.generate_signed_url.assert_called_once()
+    kwargs = blob.generate_signed_url.call_args.kwargs
+    assert kwargs["version"] == "v4"
+    assert kwargs["method"] == "GET"
+
+
+async def test_upload_image_falls_back_to_public_url_when_signing_fails():
+    blob = MagicMock()
+    blob.upload_from_string = MagicMock(return_value=None)
+    blob.generate_signed_url = MagicMock(
+        side_effect=AttributeError("you need a private key to sign credentials")
+    )
+    # blob.public_url already handles URL-encoding of reserved characters.
+    blob.public_url = (
+        "https://storage.googleapis.com/bkt/cga/11/job-1/" "images/ad%20v1_1x1.png"
+    )
+    client = _make_client_with_fake_bucket(blob)
+
+    url = await client.upload_image(
+        tenant_id="11",
+        job_id="job-1",
+        image_data=b"\x89PNGfakebytes",
+        filename="ad v1_1x1.png",
+    )
+
+    assert url == blob.public_url
+    assert "%20" in url  # encoded space survived the fallback
+    blob.generate_signed_url.assert_called_once()
+
+
+async def test_upload_image_returns_data_uri_when_gcs_not_configured():
+    client = GCSClient(bucket_name="")  # _ensure_client() will return False
+    url = await client.upload_image(
+        tenant_id="11",
+        job_id="job-1",
+        image_data=b"somebytes-longer-than-8",
+        filename="ad.png",
+        content_type="image/png",
+    )
+    assert url.startswith("data:image/png;base64,")


### PR DESCRIPTION
## Summary
- CGA's GCS upload now returns an HTTPS v4 signed URL (7-day TTL) instead of a \`gs://\` URI.
- Falls back to unsigned public URL if signing fails (ADC without a private key).

## Why
APA's image downloader uses httpx, which can't fetch \`gs://\` URIs. Meta's image upload endpoint also needs HTTP(S). Every WF3 run made it through CGA successfully but APA failed every image download with \`Request URL has an unsupported protocol 'gs://'\`.

## Test plan
- [ ] Redeploy CGA, rerun WF3
- [ ] Confirm APA logs no longer show gs:// download failures
- [ ] Confirm Meta sandbox upload succeeds and WF3 reaches the approval gate