### PR TITLE
fix(coa): demote IG-02 to soft-skip in sandbox mode

### DIFF
--- a/campaign-optimization-agent-svc/app/services/tick_executor.py
+++ b/campaign-optimization-agent-svc/app/services/tick_executor.py
@@ -210,7 +210,13 @@ class TickExecutor:
             # optimized this tick. For soft skips we still fetch
             # insights and post a metrics-only callback so the
             # /optimization dashboard stays populated.
-            hard_skip_rules = {"IG-01", "IG-02", "IG-07", "IG-08"}
+            # In sandbox mode the insights client returns stub data
+            # without calling Meta, so IG-02 (missing Meta credentials)
+            # is not a real blocker — demote it to a soft skip so the
+            # dashboard still gets stubbed KPIs.
+            hard_skip_rules = {"IG-01", "IG-07", "IG-08"}
+            if not settings.META_ADS_SANDBOX_MODE:
+                hard_skip_rules.add("IG-02")
             is_hard_skip = any(
                 f.rule_id in hard_skip_rules for f in guard_report.failures
             )


### PR DESCRIPTION
## Summary
Follow-up to #313. Sandbox campaigns published by APA have no Meta access token, so they were hard-skipping on IG-02 (missing Meta credentials) — bypassing the metrics-only callback path #313 added, leaving /optimization KPIs empty.

Since \`MetaInsightsClient\` returns stub data without calling Meta when \`META_ADS_SANDBOX_MODE=true\`, IG-02 is not a real blocker in sandbox. Demoting it to a soft skip lets insights fetch (stub) and populate \`CampaignRegistry.actual_*\` fields.

## Test plan
- [x] \`pytest tests/ -q\` (164 passing)
- [ ] After merge + redeploy, click Trigger Tick on /optimization — KPIs should populate immediately with stubbed CPA/ROAS/CTR/spend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)