### PR TITLE
fix(optimization): use dual-token auth for tick callback endpoint

### DIFF
--- a/ai-brand-automator/optimization/views.py
+++ b/ai-brand-automator/optimization/views.py
@@ -338,10 +338,8 @@ def optimization_tick_callback(request):
     Authenticates via X-Callback-Token header (service-to-service).
     Receives tick results and persists recommendations/actions to Django models.
     """
-    # Verify callback token
-    token = request.META.get("HTTP_X_CALLBACK_TOKEN", "")
-    expected_token = getattr(settings, "ORCHESTRATOR_CALLBACK_TOKEN", "")
-    if not expected_token or token != expected_token:
+    # Verify service-to-service auth (X-Service-Token or X-Callback-Token)
+    if not _verify_service_or_callback_token(request):
         logger.warning("Invalid callback token for optimization tick")
         return Response(
             {"error": "Invalid callback token"},

--- a/campaign-optimization-agent-svc/app/services/callback_client.py
+++ b/campaign-optimization-agent-svc/app/services/callback_client.py
@@ -39,6 +39,7 @@ class CallbackClient:
     def _callback_headers(self, tenant_id: str = "") -> dict[str, str]:
         headers = {
             "X-Callback-Token": settings.CALLBACK_TOKEN,
+            "X-Service-Token": settings.BACKEND_SERVICE_TOKEN,
             "Content-Type": "application/json",
         }
         if tenant_id:


### PR DESCRIPTION
## Summary
- COA tick callbacks to `/api/v1/optimization/callback/tick-result/` return 403 despite matching tokens in Railway env vars (`COA_CALLBACK_TOKEN` = `ORCHESTRATOR_CALLBACK_TOKEN`)
- The view used direct `X-Callback-Token` comparison only. Switched to `_verify_service_or_callback_token()` which accepts **either** `X-Service-Token` or `X-Callback-Token` — consistent with the other optimization s2s endpoints (register, list_active_campaigns, trigger-tick)
- COA callback client now sends both `X-Service-Token` and `X-Callback-Token` headers for belt-and-suspenders auth
- `X-Service-Token` (`ORCHESTRATOR_SERVICE_TOKEN`) is already proven working (campaign discovery returns 200)

## Test plan
- [x] All 18 optimization view tests pass (Django)
- [ ] After merge + redeploy both Django & COA: Trigger Tick → callbacks should return 200 → KPIs populate on `/optimization`

🤖 Generated with [Claude Code](https://claude.com/claude-code)