### PR TITLE
debug(optimization): log performance payload in tick callback

### DIFF
--- a/ai-brand-automator/optimization/views.py
+++ b/ai-brand-automator/optimization/views.py
@@ -425,6 +425,12 @@ def optimization_tick_callback(request):
     # Update campaign entity tree if provided
     entity_updates = data.get("entity_updates", {})
     perf = data.get("performance") or {}
+    logger.info(
+        "Tick callback debug: campaign=%s perf=%r entity_updates_keys=%s",
+        campaign_id,
+        perf,
+        list(entity_updates.keys()) if entity_updates else "none",
+    )
     if entity_updates or perf:
         update_fields = ["updated_at"]
         if "ad_sets" in entity_updates:


### PR DESCRIPTION
Temporary debug logging to see what performance data COA is sending to the tick callback. Will reveal whether the issue is empty perf dict (COA side) or a save/display issue (Django/frontend side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)