### PR TITLE
feat(orchestrator): register Intelligence Loop Agent in node registry

### DIFF
--- a/pipeline-orchestrator-svc/app/factory/node_registry.py
+++ b/pipeline-orchestrator-svc/app/factory/node_registry.py
@@ -52,6 +52,7 @@ EXTERNAL_ENDPOINTS: dict[str, str] = {
     "creative_generation": "http://creative-generation-agent-svc:8042/v1/execute",
     "ad_publishing": "http://ad-publishing-agent-svc:8043/v1/execute",
     "campaign_optimization": "http://campaign-optimization-agent-svc:8044/v1/execute",
+    "intelligence_loop": "http://intelligence-loop-agent-svc:8045/v1/execute",
 }
 
 


### PR DESCRIPTION
## Summary
- The Intelligence Loop Agent (WF3.5, port 8045) was never registered in the pipeline orchestrator's `EXTERNAL_ENDPOINTS`, so it could never be triggered as part of any pipeline — the `/intelligence` page was always empty.
- Added `intelligence_loop` → `http://intelligence-loop-agent-svc:8045/v1/execute` to the node registry.
- Also set `PORT=8045` on the ILA Railway service (was unset, Railway defaulted to 8080, causing a port mismatch with `ILA_SERVICE_URL`).

## Test plan
- [ ] After merge + redeploy orchestrator: run WF3 pipeline — ILA should now be composable by PipelineComposer
- [ ] Alternatively, use the manual "Trigger" button on `/intelligence` for a campaign — ILA service is now reachable on port 8045

🤖 Generated with [Claude Code](https://claude.com/claude-code)