### PR TITLE
debug(ila): log WF2 dispatch mode, targets, and confidence

### DIFF
--- a/intelligence-loop-agent-svc/app/services/extractor.py
+++ b/intelligence-loop-agent-svc/app/services/extractor.py
@@ -146,6 +146,13 @@ class IntelligenceExtractor:
         report.rag_writes = rag_writes
 
         # Auto-trigger only when explicitly enabled.
+        logger.info(
+            "Dispatch check: mode=%s, learnings=%d, targets=%s, confidences=%s",
+            report.mode,
+            len(report.learnings),
+            [le.target_workflow for le in report.learnings],
+            [le.confidence for le in report.learnings],
+        )
         if report.mode != "auto_trigger":
             return
 
@@ -155,6 +162,11 @@ class IntelligenceExtractor:
         triggered = 0
         for learning in report.learnings:
             if learning.confidence < settings.MIN_CONFIDENCE_AUTO_TRIGGER:
+                logger.info(
+                    "Skipping learning %s: confidence %d < threshold %d",
+                    learning.learning_id, learning.confidence,
+                    settings.MIN_CONFIDENCE_AUTO_TRIGGER,
+                )
                 continue
             if learning.target_workflow == "WF2":
                 # WF2 is always behind human approval.


### PR DESCRIPTION
## Summary
- Add temporary diagnostic logging to ILA extractor's `_persist_and_dispatch` to understand why WF2 approval requests aren't being created in `auto_trigger` mode
- Logs the received mode, number of learnings, target workflows, and confidence scores
- Logs when individual learnings are skipped due to confidence below threshold

## Test plan
- [ ] Merge and let ILA redeploy
- [ ] Trigger extraction with Auto-trigger mode from `/intelligence`
- [ ] Check ILA logs for "Dispatch check" line to see actual mode/targets/confidence
- [ ] Remove logging once root cause identified

🤖 Generated with [Claude Code](https://claude.com/claude-code)