### PR TITLE
debug(ila): log Claude raw response to diagnose empty learnings

### DIFF
--- a/intelligence-loop-agent-svc/app/services/anthropic_client.py
+++ b/intelligence-loop-agent-svc/app/services/anthropic_client.py
@@ -63,7 +63,12 @@ class AnthropicClient:
             text = "".join(
                 block.text for block in msg.content if getattr(block, "text", None)
             )
-            return _safe_json_loads(text)
+            parsed = _safe_json_loads(text)
+            logger.info(
+                "Claude raw response: text_len=%d, parsed_keys=%s, learnings_count=%d",
+                len(text), list(parsed.keys()), len(parsed.get("learnings", [])),
+            )
+            return parsed
         except Exception as exc:
             logger.warning("Anthropic call failed (fail-open): %s", exc)
             return {}

--- a/intelligence-loop-agent-svc/app/services/extractor.py
+++ b/intelligence-loop-agent-svc/app/services/extractor.py
@@ -66,6 +66,10 @@ class IntelligenceExtractor:
 
         # 2. Call Claude (or fall back).
         summary, learnings = await self._call_claude(campaign_ctx)
+        logger.info(
+            "Claude extraction: summary_len=%d, learnings=%d, fallback=%s",
+            len(summary), len(learnings), "yes" if not learnings else "no",
+        )
         if not learnings:
             summary, learnings = _mock_report(campaign_id)
 


### PR DESCRIPTION
## Summary
- Claude returns 200 OK but learnings are empty, causing mock fallback
- Added logging to see Claude's raw response length, parsed keys, and learnings count
- Added logging to see extraction result before mock fallback decision

## Test plan
- [ ] Merge, redeploy, trigger extraction, check logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)