### PR TITLE
fix(ila): increase trigger proxy timeout from 10s to 60s

### DIFF
--- a/ai-brand-automator/intelligence_loop/views.py
+++ b/ai-brand-automator/intelligence_loop/views.py
@@ -462,7 +462,7 @@ def trigger_extraction(request):
                 "config": {"default_mode": payload["mode"]},
             },
             headers={"X-Service-Token": ila_token},
-            timeout=10,
+            timeout=60,
         )
     except requests.RequestException as exc:
         logger.error("ILA trigger proxy failed: %s", exc)


### PR DESCRIPTION
## Summary
- ILA extraction takes ~10-15s (Claude call + RAG writes + auto-triggers), exceeding the 10s Django proxy timeout
- This caused 502 "Intelligence Loop service unreachable" even though extraction completed successfully
- Increased timeout to 60s
- Also lowered `ILA_MIN_CONFIDENCE_AUTO_TRIGGER` from 75 to 65 on Railway so WF2 learnings pass the threshold

## Test plan
- [ ] Merge and redeploy Django backend
- [ ] Trigger extraction from `/intelligence` with Auto-trigger mode
- [ ] Verify no 502 error — should get successful response
- [ ] Verify WF2 approval request appears in Approval Queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)