### PR TITLE
feat(ila): show ILA re-run executions in Workflow Workspace

### DIFF
--- a/ai-brand-automator-frontend/src/components/intelligence/WF2ApprovalQueue.tsx
+++ b/ai-brand-automator-frontend/src/components/intelligence/WF2ApprovalQueue.tsx
@@ -104,12 +104,12 @@ export default function WF2ApprovalQueue() {
 
       {dispatched && (
         <div className="glass-card p-3 rounded-lg border border-emerald-500/40 text-sm text-emerald-300 flex items-center justify-between">
-          <span>Pipeline dispatched successfully!</span>
+          <span>Workflow dispatched successfully!</span>
           <Link
-            href={`/pipelines/${dispatched.jobId}`}
+            href="/dashboard/workflows"
             className="inline-flex items-center gap-1 text-brand-electric hover:underline"
           >
-            View pipeline <ExternalLink className="h-3 w-3" />
+            View in Workspace <ExternalLink className="h-3 w-3" />
           </Link>
         </div>
       )}

--- a/ai-brand-automator/intelligence_loop/views.py
+++ b/ai-brand-automator/intelligence_loop/views.py
@@ -111,11 +111,13 @@ WF3_AGENT_TO_PIPELINE = {
 def _dispatch_rerun(*, tenant, user, pipeline_id, learning, note=""):
     """
     Create an AnalysisJob for a re-run with ILA learning context, then
-    dispatch via OrchestratorDispatcher.
+    dispatch via OrchestratorDispatcher.  Also creates a UserWorkflow +
+    WorkflowSnapshot so the execution appears in the Workflow Workspace.
 
     Returns the created AnalysisJob (or None on failure).
     """
     from orchestration.services import OrchestratorDispatcher
+    from workspace.models import UserWorkflow, WorkflowSnapshot
 
     manifest = (
         PipelineManifest.objects.filter(pipeline_id=pipeline_id)
@@ -130,14 +132,16 @@ def _dispatch_rerun(*, tenant, user, pipeline_id, learning, note=""):
         )
         return None
 
+    input_prompt = (
+        f"ILA-triggered re-run for learning '{learning.headline}'. "
+        f"{note}".strip()
+    )
+
     job = AnalysisJob.objects.create(
         tenant=tenant,
         created_by=user,
         manifest=manifest,
-        input_prompt=(
-            f"ILA-triggered re-run for learning '{learning.headline}'. "
-            f"{note}".strip()
-        ),
+        input_prompt=input_prompt,
         input_context={
             "pipeline_id": pipeline_id,
             "ila_learning_context": {
@@ -155,6 +159,30 @@ def _dispatch_rerun(*, tenant, user, pipeline_id, learning, note=""):
             "trigger_source": "intelligence_loop",
         },
     )
+
+    # Create a UserWorkflow + WorkflowSnapshot so the execution appears
+    # in the Workflow Workspace with live progress tracking.
+    try:
+        workflow = UserWorkflow.objects.create(
+            name=f"ILA Re-run: {learning.headline[:80]}",
+            description=input_prompt,
+            manifest=manifest,
+            layout_data={},
+            source=UserWorkflow.Source.CREATED,
+            tenant=tenant,
+            created_by=user,
+            last_executed_at=timezone.now(),
+            execution_count=1,
+        )
+        WorkflowSnapshot.objects.create(
+            workflow=workflow,
+            job=job,
+            manifest_snapshot=manifest.manifest_data,
+            layout_snapshot={},
+            tenant=tenant,
+        )
+    except Exception as exc:
+        logger.warning("ILA re-run: failed to create workspace workflow: %s", exc)
 
     dispatched = OrchestratorDispatcher().dispatch(job)
     if not dispatched:


### PR DESCRIPTION
## Summary
- ILA re-run dispatches (from WF2 approval or auto-trigger) now create a `UserWorkflow` + `WorkflowSnapshot`, so they appear in the Workflow Workspace with live progress tracking
- Previously, re-runs only created standalone `AnalysisJob`s visible in the pipelines page but invisible in the workspace
- Updated WF2 approval success banner to link to `/dashboard/workflows` instead of the non-existent `/pipelines/{jobId}` route

## Test plan
- [ ] Trigger extraction with Auto-trigger mode, approve a WF2 request
- [ ] Navigate to Workflow Workspace — verify a new workflow named "ILA Re-run: ..." appears
- [ ] Select it to see the execution graph with live progress
- [ ] Verify the "View in Workspace" link navigates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)