### PR TITLE
fix(composer): default brand discovery to complete 5-agent WF1

### DIFF
--- a/pipeline-orchestrator-svc/app/nodes/internal/pipeline_composer.py
+++ b/pipeline-orchestrator-svc/app/nodes/internal/pipeline_composer.py
@@ -536,20 +536,23 @@ _PIPELINE_DESCRIPTIONS: list[dict[str, str]] = [
         ),
     },
     {
-        "id": "brand-discovery-full",
+        "id": "brand-discovery-complete",
         "description": (
-            "Complete brand discovery workflow: market research, competitor "
-            "intelligence, audience personas, and trend/cultural insights. "
-            "Full 4-agent chain for comprehensive brand intelligence"
+            "DEFAULT brand discovery workflow (5 agents): market research, "
+            "competitor intelligence, audience personas, trend insights, "
+            "AND voice of customer analysis. Use this for any generic "
+            "'brand discovery' request. The most comprehensive brand "
+            "intelligence pipeline available"
         ),
     },
     {
-        "id": "brand-discovery-complete",
+        "id": "brand-discovery-full",
         "description": (
-            "Complete brand discovery workflow with all 5 agents: market "
-            "research, competitor intelligence, audience personas, trend "
-            "insights, AND voice of customer analysis. The most comprehensive "
-            "brand intelligence pipeline available"
+            "Reduced brand discovery workflow (4 agents, NO voice of "
+            "customer): market research, competitor intelligence, audience "
+            "personas, and trend/cultural insights. ONLY select this when "
+            "the user explicitly says 'full brand discovery' or "
+            "'full brand analysis'"
         ),
     },
     {
@@ -937,8 +940,7 @@ def _expand_chain(
         if "manager" in node_ids:
             reordered.append("manager")
         logger.info(
-            "Rewrite rule applied: expanded incomplete %s to full "
-            "chain %s",
+            "Rewrite rule applied: expanded incomplete %s to full " "chain %s",
             label,
             " → ".join(reordered),
         )
@@ -993,25 +995,8 @@ class PipelineComposer:
             try:
                 manifest_id = await self._llm_classify_fallback(state)
                 if manifest_id:
-                    # Apply manifest-level rewrite for known misroutes
-                    if manifest_id == "competitor-audit":
-                        prompt = (state.get("input_prompt") or "").lower()
-                        competitor_signals = {
-                            "competitor",
-                            "competitors",
-                            "competitive",
-                            "swot",
-                            "benchmark",
-                            "benchmarking",
-                            "positioning gap",
-                            "competitive landscape",
-                        }
-                        if any(s in prompt for s in competitor_signals):
-                            logger.info(
-                                "Tier 2 rewrite: competitor-audit → "
-                                "competitor-intelligence"
-                            )
-                            manifest_id = "competitor-intelligence"
+                    # Apply manifest-level rewrites for known misroutes
+                    manifest_id = self._apply_tier2_rewrites(manifest_id, state)
                     logger.info("LLM classify selected: %s", manifest_id)
                     return {"resolved_manifest_id": manifest_id}
             except Exception:
@@ -1272,6 +1257,106 @@ class PipelineComposer:
         logger.warning("LLM classify did not return a select_pipeline call")
         return None
 
+    # ── Tier 2 manifest rewrites ──
+
+    @staticmethod
+    def _apply_tier2_rewrites(manifest_id: str, state: AgentState) -> str:
+        """Deterministic rewrites for Tier 2 manifest classification.
+
+        Corrects known LLM misroutes where Gemini picks a single-agent
+        manifest instead of the intended multi-agent workflow.
+        """
+        prompt = (state.get("input_prompt") or "").lower()
+
+        # Rewrite: competitor-audit → competitor-intelligence
+        if manifest_id == "competitor-audit":
+            competitor_signals = {
+                "competitor",
+                "competitors",
+                "competitive",
+                "swot",
+                "benchmark",
+                "benchmarking",
+                "positioning gap",
+                "competitive landscape",
+            }
+            if any(s in prompt for s in competitor_signals):
+                logger.info(
+                    "Tier 2 rewrite: competitor-audit → " "competitor-intelligence"
+                )
+                return "competitor-intelligence"
+
+        # Rewrite: brand discovery signals → correct manifest variant.
+        # Generic "brand discovery" → brand-discovery-complete (5-agent).
+        # Explicit "full brand discovery" → brand-discovery-full (4-agent).
+        _discovery_signals = (
+            "brand discovery",
+            "brand intelligence",
+            "complete brand analysis",
+            "complete brand discovery",
+        )
+        _discovery_full_signals = (
+            "full brand discovery",
+            "full brand analysis",
+        )
+        if any(s in prompt for s in _discovery_signals):
+            if any(s in prompt for s in _discovery_full_signals):
+                if manifest_id != "brand-discovery-full":
+                    logger.info(
+                        "Tier 2 rewrite: %s → brand-discovery-full "
+                        "(explicit 'full' in prompt)",
+                        manifest_id,
+                    )
+                    return "brand-discovery-full"
+            elif manifest_id != "brand-discovery-complete":
+                logger.info(
+                    "Tier 2 rewrite: %s → brand-discovery-complete "
+                    "(default for generic brand discovery)",
+                    manifest_id,
+                )
+                return "brand-discovery-complete"
+
+        # Rewrite: brand strategy signals → brand-strategy-positioning
+        # (full 5-agent WF2 chain).
+        _strategy_signals = (
+            "brand strategy",
+            "full brand strategy",
+            "complete brand strategy",
+            "brand strategy end to end",
+        )
+        if any(s in prompt for s in _strategy_signals):
+            if manifest_id != "brand-strategy-positioning":
+                logger.info(
+                    "Tier 2 rewrite: %s → brand-strategy-positioning "
+                    "(brand strategy signal in prompt)",
+                    manifest_id,
+                )
+                return "brand-strategy-positioning"
+
+        # Rewrite: Meta Ads signals → meta-ads-full (3-agent chain).
+        _meta_ads_signals = (
+            "meta ads",
+            "facebook ads",
+            "instagram ads",
+            "launch meta ads",
+            "run meta ads",
+            "meta ads campaign",
+            "ad campaign",
+        )
+        if any(s in prompt for s in _meta_ads_signals):
+            if manifest_id not in (
+                "meta-ads-full",
+                "meta-campaign-architecture",
+                "meta-creative-generation",
+            ):
+                logger.info(
+                    "Tier 2 rewrite: %s → meta-ads-full " "(meta ads signal in prompt)",
+                    manifest_id,
+                )
+                return "meta-ads-full"
+
+        return manifest_id
+
     # ── Tier 3: Keyword Fallback ──
 
     @staticmethod
@@ -1383,7 +1468,10 @@ class PipelineComposer:
         # Rule 4: creative_generation MUST be preceded by
         # campaign_architecture.  The CGA agent requires a campaign
         # blueprint produced by CAA.
-        if "creative_generation" in node_ids and "campaign_architecture" not in node_ids:
+        if (
+            "creative_generation" in node_ids
+            and "campaign_architecture" not in node_ids
+        ):
             idx = node_ids.index("creative_generation")
             node_ids.insert(idx, "campaign_architecture")
             logger.info(

--- a/pipeline-orchestrator-svc/app/nodes/internal/router_node.py
+++ b/pipeline-orchestrator-svc/app/nodes/internal/router_node.py
@@ -190,18 +190,20 @@ KEYWORD_MAP: dict[str, list[tuple[str, int]]] = {
         ("audience discovery pipeline", 3),
         ("market research and personas", 3),
     ],
-    "brand-discovery-full": [
-        # Strong signals (weight 3)
-        ("trend analysis", 3),
-        ("cultural trends", 3),
-        ("cultural insights", 3),
-        ("brand discovery", 3),
-        ("full brand analysis", 3),
-        ("trend monitoring", 3),
-        ("emerging trends", 3),
-        ("viral trends", 3),
-        ("generational trends", 3),
-        # Moderate signals (weight 2)
+    "brand-discovery-complete": [
+        # Strong signals (weight 4) — default for generic "brand discovery"
+        ("brand discovery", 4),
+        ("complete brand discovery", 4),
+        ("complete brand analysis", 4),
+        ("brand intelligence", 4),
+        # Moderate signals (weight 2) — trend/cultural overlap
+        ("trend analysis", 2),
+        ("cultural trends", 2),
+        ("cultural insights", 2),
+        ("trend monitoring", 2),
+        ("emerging trends", 2),
+        ("viral trends", 2),
+        ("generational trends", 2),
         ("social media trends", 2),
         ("cultural shift", 2),
         ("brand relevance", 2),
@@ -218,6 +220,12 @@ KEYWORD_MAP: dict[str, list[tuple[str, int]]] = {
         ("viral", 1),
         ("relevance", 1),
         ("zeitgeist", 1),
+    ],
+    "brand-discovery-full": [
+        # Only match explicit "full" brand discovery (weight 10 to
+        # beat brand-discovery-complete's combined score)
+        ("full brand discovery", 10),
+        ("full brand analysis", 10),
     ],
     "trend-cultural-insights": [
         ("cultural trends", 3),
@@ -479,6 +487,13 @@ KEYWORD_MAP: dict[str, list[tuple[str, int]]] = {
         ("copy", 1),
     ],
     "meta-ads-full": [
+        # Generic meta ads signals — weight 4 to beat standalone (weight 3)
+        ("meta ads", 4),
+        ("facebook ads", 4),
+        ("instagram ads", 4),
+        ("launch ads", 4),
+        ("run ads", 4),
+        # Strong composite signals (weight 3)
         ("full meta ads", 3),
         ("meta ads campaign", 3),
         ("complete ad campaign", 3),

--- a/pipeline-orchestrator-svc/app/services/job_executor.py
+++ b/pipeline-orchestrator-svc/app/services/job_executor.py
@@ -503,9 +503,7 @@ class JobExecutor:
                         remaining_start = executed_node_count + len(level_nodes)
                         for remaining_id in flat_sorted[remaining_start:]:
                             if (
-                                state["progress"]
-                                .get(remaining_id, {})
-                                .get("status")
+                                state["progress"].get(remaining_id, {}).get("status")
                                 == "pending"
                             ):
                                 state["progress"][remaining_id] = {

--- a/pipeline-orchestrator-svc/tests/test_internal_nodes.py
+++ b/pipeline-orchestrator-svc/tests/test_internal_nodes.py
@@ -558,7 +558,10 @@ class TestManagerNode:
         result = await node(state)
         rd = result["result_data"]
         # Trend cultural fields promoted to top level
-        assert rd["trend_report"]["executive_summary"] == "Gen Z sustainability trends rising."
+        assert (
+            rd["trend_report"]["executive_summary"]
+            == "Gen Z sustainability trends rising."
+        )
         assert len(rd["scored_trends"]) == 1
         assert rd["scored_trends"][0]["topic"] == "Sustainable Fashion"
         assert rd["scored_trends"][0]["relevance_score"] == 85
@@ -665,13 +668,13 @@ class TestNeedsRagBoost:
         )
         assert result["resolved_manifest_id"] == "blog-authoring"
 
-    async def test_cultural_trends_routes_to_brand_discovery_full(self):
-        """'cultural trends' is a strong signal for brand-discovery-full."""
+    async def test_cultural_trends_routes_to_trend_cultural(self):
+        """'cultural trends' without 'brand discovery' routes to standalone."""
         node = RouterNode()
         result = await node(
             _base_state(input_prompt="analyze cultural trends for our brand")
         )
-        assert result["resolved_manifest_id"] == "brand-discovery-full"
+        assert result["resolved_manifest_id"] == "trend-cultural-insights"
 
     async def test_trend_cultural_standalone_with_available_manifests(self):
         """When only trend-cultural-insights is available, it is selected."""
@@ -690,8 +693,16 @@ class TestNeedsRagBoost:
     async def test_brand_discovery_full_route(self):
         node = RouterNode()
         result = await node(
-            _base_state(
-                input_prompt="run a full brand discovery with trend analysis"
-            )
+            _base_state(input_prompt="run a full brand discovery with trend analysis")
         )
         assert result["resolved_manifest_id"] == "brand-discovery-full"
+
+    async def test_generic_brand_discovery_routes_to_complete(self):
+        """Generic 'brand discovery' defaults to brand-discovery-complete."""
+        node = RouterNode()
+        result = await node(
+            _base_state(
+                input_prompt="Can you please run the Brand discovery for Pomodoro?"
+            )
+        )
+        assert result["resolved_manifest_id"] == "brand-discovery-complete"


### PR DESCRIPTION
## Summary
- **Root cause**: Previous chat→pipeline routing fix (#332) only applied rewrite rules at Tier 1 (Gemini dynamic composition). When Tier 1 failed or Gemini misrouted at Tier 2 (manifest classification) or Tier 3 (keyword fallback), the rewrites were bypassed — and `KEYWORD_MAP` had no entry for `brand-discovery-complete`, so generic "brand discovery" prompts were misrouted to single-agent pipelines like `audience-persona`.
- Adds `_apply_tier2_rewrites()` method with deterministic manifest rewrites for brand discovery, brand strategy, and meta ads signals at Tier 2
- Adds `brand-discovery-complete` to `KEYWORD_MAP` (Tier 3) as the default for generic brand discovery requests; demotes `brand-discovery-full` to only match explicit "full brand discovery"
- Boosts `meta-ads-full` keyword weights so it beats standalone `meta-campaign-architecture` for generic meta ads requests

## Test plan
- [x] All 302 orchestrator tests pass (1 new test added)
- [x] Verified Tier 3 keyword routing: `"Brand discovery for Pomodoro"` → `brand-discovery-complete`
- [x] Verified Tier 3 keyword routing: `"full brand discovery"` → `brand-discovery-full`
- [x] Verified Tier 3 keyword routing: `"brand strategy"` → `brand-strategy-positioning`
- [x] Verified Tier 3 keyword routing: `"meta ads"` → `meta-ads-full`
- [x] Black formatting passes
- [ ] Manual E2E: test chat prompt "Can you please run the Brand discovery for Pomodoro?" triggers 5-agent complete WF1

🤖 Generated with [Claude Code](https://claude.com/claude-code)