### PR TITLE
fix(composer): inject WF chain when Gemini picks zero chain agents

### DIFF
--- a/pipeline-orchestrator-svc/app/nodes/internal/pipeline_composer.py
+++ b/pipeline-orchestrator-svc/app/nodes/internal/pipeline_composer.py
@@ -922,13 +922,15 @@ def _expand_chain(
 ) -> list[str]:
     """Ensure all agents in *required_chain* are present in *node_ids*.
 
-    If at least one agent from the chain was selected but the chain is
-    incomplete, the missing agents are injected in canonical order
-    (before ``manager``).  Returns the (possibly rewritten) list.
+    When the chain is incomplete — even if **zero** chain agents were
+    selected — the missing agents are injected in canonical order
+    (before ``manager``).  This is critical because Gemini sometimes
+    picks unrelated agents despite the prompt clearly matching a
+    workflow signal.  Returns the (possibly rewritten) list.
     """
     chain_set = set(required_chain)
     present = {nid for nid in node_ids if nid in chain_set}
-    if present and len(present) < len(chain_set):
+    if len(present) < len(chain_set):
         without_manager = [nid for nid in node_ids if nid != "manager"]
         for agent in required_chain:
             if agent not in without_manager:

--- a/pipeline-orchestrator-svc/tests/test_internal_nodes.py
+++ b/pipeline-orchestrator-svc/tests/test_internal_nodes.py
@@ -706,3 +706,70 @@ class TestNeedsRagBoost:
             )
         )
         assert result["resolved_manifest_id"] == "brand-discovery-complete"
+
+    async def test_brand_strategy_routes_to_positioning(self):
+        """'brand strategy and positioning' routes to brand-strategy-positioning."""
+        node = RouterNode()
+        result = await node(
+            _base_state(
+                input_prompt=(
+                    "Can you please run the Brand strategy and "
+                    "positioning for Pomodoro?"
+                )
+            )
+        )
+        assert result["resolved_manifest_id"] == "brand-strategy-positioning"
+
+
+class TestExpandChain:
+    """Tests for _expand_chain deterministic rewrite helper."""
+
+    def test_injects_chain_when_zero_agents_present(self):
+        """Chain is injected even when Gemini picked zero chain agents."""
+        from app.nodes.internal.pipeline_composer import _expand_chain
+
+        result = _expand_chain(
+            ["web_research", "manager"],
+            ["brand_positioning", "brand_architecture", "brand_personality"],
+            "WF2 test",
+        )
+        assert result == [
+            "brand_positioning",
+            "brand_architecture",
+            "brand_personality",
+            "web_research",
+            "manager",
+        ]
+
+    def test_expands_partial_chain(self):
+        """Missing agents are added when chain is partially present."""
+        from app.nodes.internal.pipeline_composer import _expand_chain
+
+        result = _expand_chain(
+            ["brand_positioning", "manager"],
+            ["brand_positioning", "brand_architecture", "brand_personality"],
+            "WF2 test",
+        )
+        assert result == [
+            "brand_positioning",
+            "brand_architecture",
+            "brand_personality",
+            "manager",
+        ]
+
+    def test_no_change_when_chain_complete(self):
+        """No change when all chain agents are already present."""
+        from app.nodes.internal.pipeline_composer import _expand_chain
+
+        node_ids = [
+            "brand_positioning",
+            "brand_architecture",
+            "brand_personality",
+            "manager",
+        ]
+        result = _expand_chain(
+            node_ids,
+            ["brand_positioning", "brand_architecture", "brand_personality"],
+            "WF2 test",
+        )
+        assert result == node_ids


### PR DESCRIPTION
## Summary
- **Root cause**: `_expand_chain()` only injected missing workflow agents when *at least one* chain agent was already present in Gemini's composition. If Gemini picked zero WF2 agents (e.g. `[web_research, manager]`) for a prompt like "Brand strategy and positioning for Pomodoro", the rewrite rule matched the "brand strategy" signal but `_expand_chain` returned unchanged because `present` was empty.
- Removed the `present` guard from `_expand_chain()` so the full chain is injected whenever incomplete, including when zero chain agents are selected
- This fixes WF2 triggering from chat and also hardens WF1 and WF3 against the same class of Gemini misroute

## Test plan
- [x] All 306 orchestrator tests pass (4 new tests added)
- [x] New `TestExpandChain` class verifying: zero-agent injection, partial expansion, no-change when complete
- [x] New `test_brand_strategy_routes_to_positioning` for the exact failing prompt
- [x] Black formatting passes
- [ ] Manual E2E: test "Can you please run the Brand strategy and positioning for Pomodoro?" triggers full WF2

🤖 Generated with [Claude Code](https://claude.com/claude-code)