### PR TITLE
fix(composer): ensure WF3 Meta Ads triggers full 3-agent chain from chat

### DIFF
--- a/pipeline-orchestrator-svc/app/nodes/internal/pipeline_composer.py
+++ b/pipeline-orchestrator-svc/app/nodes/internal/pipeline_composer.py
@@ -1336,6 +1336,8 @@ class PipelineComposer:
                 return "brand-strategy-positioning"
 
         # Rewrite: Meta Ads signals → meta-ads-full (3-agent chain).
+        # Only keep the standalone manifest when the prompt explicitly
+        # asks for just campaign architecture or just creatives.
         _meta_ads_signals = (
             "meta ads",
             "facebook ads",
@@ -1344,13 +1346,18 @@ class PipelineComposer:
             "run meta ads",
             "meta ads campaign",
             "ad campaign",
+            "run ads",
+            "launch ads",
+        )
+        _standalone_meta_signals = (
+            "campaign architecture",
+            "campaign blueprint",
+            "ad creative",
+            "creative generation",
         )
         if any(s in prompt for s in _meta_ads_signals):
-            if manifest_id not in (
-                "meta-ads-full",
-                "meta-campaign-architecture",
-                "meta-creative-generation",
-            ):
+            is_standalone = any(s in prompt for s in _standalone_meta_signals)
+            if not is_standalone and manifest_id != "meta-ads-full":
                 logger.info(
                     "Tier 2 rewrite: %s → meta-ads-full " "(meta ads signal in prompt)",
                     manifest_id,
@@ -1489,6 +1496,8 @@ class PipelineComposer:
             "instagram ads",
             "launch meta ads",
             "run meta ads",
+            "launch ads",
+            "run ads",
             "complete ad campaign",
             "meta ads campaign",
             "end to end ads",

--- a/pipeline-orchestrator-svc/app/nodes/internal/pipeline_composer.py
+++ b/pipeline-orchestrator-svc/app/nodes/internal/pipeline_composer.py
@@ -922,13 +922,15 @@ def _expand_chain(
 ) -> list[str]:
     """Ensure all agents in *required_chain* are present in *node_ids*.
 
-    If at least one agent from the chain was selected but the chain is
-    incomplete, the missing agents are injected in canonical order
-    (before ``manager``).  Returns the (possibly rewritten) list.
+    When the chain is incomplete — even if **zero** chain agents were
+    selected — the missing agents are injected in canonical order
+    (before ``manager``).  This is critical because Gemini sometimes
+    picks unrelated agents despite the prompt clearly matching a
+    workflow signal.  Returns the (possibly rewritten) list.
     """
     chain_set = set(required_chain)
     present = {nid for nid in node_ids if nid in chain_set}
-    if present and len(present) < len(chain_set):
+    if len(present) < len(chain_set):
         without_manager = [nid for nid in node_ids if nid != "manager"]
         for agent in required_chain:
             if agent not in without_manager:

--- a/pipeline-orchestrator-svc/app/nodes/internal/router_node.py
+++ b/pipeline-orchestrator-svc/app/nodes/internal/router_node.py
@@ -493,6 +493,7 @@ KEYWORD_MAP: dict[str, list[tuple[str, int]]] = {
         ("instagram ads", 4),
         ("launch ads", 4),
         ("run ads", 4),
+        ("ad campaign", 4),
         # Strong composite signals (weight 3)
         ("full meta ads", 3),
         ("meta ads campaign", 3),

--- a/pipeline-orchestrator-svc/tests/test_internal_nodes.py
+++ b/pipeline-orchestrator-svc/tests/test_internal_nodes.py
@@ -773,3 +773,48 @@ class TestExpandChain:
             "WF2 test",
         )
         assert result == node_ids
+
+    def test_injects_wf3_chain_when_zero_agents_present(self):
+        """WF3 chain is injected when Gemini picked no meta ads agents."""
+        from app.nodes.internal.pipeline_composer import _expand_chain
+
+        result = _expand_chain(
+            ["web_research", "manager"],
+            ["campaign_architecture", "creative_generation", "ad_publishing"],
+            "WF3 Meta Ads",
+        )
+        assert result == [
+            "campaign_architecture",
+            "creative_generation",
+            "ad_publishing",
+            "web_research",
+            "manager",
+        ]
+
+
+class TestMetaAdsRouting:
+    """Tests for WF3 Meta Ads keyword routing."""
+
+    async def test_meta_ads_campaign_routes_to_full(self):
+        """Generic 'Meta Ads campaign' routes to meta-ads-full."""
+        node = RouterNode()
+        result = await node(
+            _base_state(
+                input_prompt=("Can you please run the Meta Ads campaign for Pomodoro?")
+            )
+        )
+        assert result["resolved_manifest_id"] == "meta-ads-full"
+
+    async def test_ad_campaign_routes_to_full(self):
+        """Generic 'ad campaign' routes to meta-ads-full."""
+        node = RouterNode()
+        result = await node(_base_state(input_prompt="Run ad campaign for Pomodoro"))
+        assert result["resolved_manifest_id"] == "meta-ads-full"
+
+    async def test_standalone_campaign_architecture(self):
+        """Explicit 'campaign architecture' stays standalone."""
+        node = RouterNode()
+        result = await node(
+            _base_state(input_prompt="Design a Meta Ads campaign architecture")
+        )
+        assert result["resolved_manifest_id"] == "meta-campaign-architecture"

--- a/pipeline-orchestrator-svc/tests/test_internal_nodes.py
+++ b/pipeline-orchestrator-svc/tests/test_internal_nodes.py
@@ -706,3 +706,70 @@ class TestNeedsRagBoost:
             )
         )
         assert result["resolved_manifest_id"] == "brand-discovery-complete"
+
+    async def test_brand_strategy_routes_to_positioning(self):
+        """'brand strategy and positioning' routes to brand-strategy-positioning."""
+        node = RouterNode()
+        result = await node(
+            _base_state(
+                input_prompt=(
+                    "Can you please run the Brand strategy and "
+                    "positioning for Pomodoro?"
+                )
+            )
+        )
+        assert result["resolved_manifest_id"] == "brand-strategy-positioning"
+
+
+class TestExpandChain:
+    """Tests for _expand_chain deterministic rewrite helper."""
+
+    def test_injects_chain_when_zero_agents_present(self):
+        """Chain is injected even when Gemini picked zero chain agents."""
+        from app.nodes.internal.pipeline_composer import _expand_chain
+
+        result = _expand_chain(
+            ["web_research", "manager"],
+            ["brand_positioning", "brand_architecture", "brand_personality"],
+            "WF2 test",
+        )
+        assert result == [
+            "brand_positioning",
+            "brand_architecture",
+            "brand_personality",
+            "web_research",
+            "manager",
+        ]
+
+    def test_expands_partial_chain(self):
+        """Missing agents are added when chain is partially present."""
+        from app.nodes.internal.pipeline_composer import _expand_chain
+
+        result = _expand_chain(
+            ["brand_positioning", "manager"],
+            ["brand_positioning", "brand_architecture", "brand_personality"],
+            "WF2 test",
+        )
+        assert result == [
+            "brand_positioning",
+            "brand_architecture",
+            "brand_personality",
+            "manager",
+        ]
+
+    def test_no_change_when_chain_complete(self):
+        """No change when all chain agents are already present."""
+        from app.nodes.internal.pipeline_composer import _expand_chain
+
+        node_ids = [
+            "brand_positioning",
+            "brand_architecture",
+            "brand_personality",
+            "manager",
+        ]
+        result = _expand_chain(
+            node_ids,
+            ["brand_positioning", "brand_architecture", "brand_personality"],
+            "WF2 test",
+        )
+        assert result == node_ids


### PR DESCRIPTION
## Summary
- **Depends on**: #334 (WF2 `_expand_chain` fix — must merge first)
- **Tier 2 fix**: `_apply_tier2_rewrites()` was excluding `meta-campaign-architecture` from rewrites, so generic "Meta Ads" / "Facebook ads" / "ad campaign" prompts could route to the standalone pipeline instead of `meta-ads-full`. Now rewrites to `meta-ads-full` unless the prompt explicitly asks for standalone "campaign architecture" or "ad creative".
- **Tier 3 fix**: Added `("ad campaign", 4)` to `meta-ads-full` in `KEYWORD_MAP` so "Run ad campaign for Pomodoro" routes correctly (was misrouting to `odoo-erp-operations`).
- **Tier 1 fix**: Added `"launch ads"` and `"run ads"` to Rule 5 signals for broader coverage.

## Test plan
- [x] All 310 orchestrator tests pass (8 new tests across PRs #334 + this)
- [x] Tier 3: `"Meta Ads campaign for Pomodoro"` → `meta-ads-full`
- [x] Tier 3: `"Run ad campaign for Pomodoro"` → `meta-ads-full`
- [x] Tier 3: `"Design a Meta Ads campaign architecture"` → `meta-campaign-architecture` (standalone preserved)
- [x] Tier 2 rewrite: `meta-campaign-architecture` → `meta-ads-full` when prompt has generic meta ads signal
- [x] Black formatting passes
- [ ] Manual E2E: test "Can you please run the Meta Ads campaign for Pomodoro?" triggers full WF3 (CAA → CGA → APA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)