### PR TITLE
fix(composer): deterministic WF routing when Gemini unavailable

### DIFF
--- a/pipeline-orchestrator-svc/app/nodes/internal/pipeline_composer.py
+++ b/pipeline-orchestrator-svc/app/nodes/internal/pipeline_composer.py
@@ -1,11 +1,12 @@
 """
 PipelineComposer — Dynamic, catalog-driven pipeline composition.
 
-Replaces RouterNode for auto-detect mode. Uses a 3-tier routing chain:
+Replaces RouterNode for auto-detect mode. Uses a 4-tier routing chain:
 
-  Tier 1: Enhanced Gemini dynamic composition (context-enriched + retry)
-  Tier 2: Gemini manifest classification (lightweight LLM picks 1 of 9)
-  Tier 3: Improved keyword matching (stemming, weights, neutral default)
+  Tier 1:   Enhanced Gemini dynamic composition (context-enriched + retry)
+  Tier 2:   Gemini manifest classification (lightweight LLM picks 1 of N)
+  Tier 2.5: Deterministic composition for known workflows (no LLM needed)
+  Tier 3:   Improved keyword matching (stemming, weights, neutral default)
 
 Falls back through the tiers on failure. Adding a new agent requires
 only one dict entry in NODE_CATALOG.
@@ -967,13 +968,14 @@ class PipelineComposer:
     async def compose(self, state: AgentState) -> dict[str, Any]:
         """Compose a pipeline for the given state.
 
-        3-tier fallback chain:
-          Tier 1: Gemini dynamic composition (context-enriched + retry)
-          Tier 2: Gemini manifest classification (picks 1 of 9 pipelines)
-          Tier 3: Keyword matching (stemming + RAG boost)
+        4-tier fallback chain:
+          Tier 1:   Gemini dynamic composition (context-enriched + retry)
+          Tier 2:   Gemini manifest classification (picks 1 of N pipelines)
+          Tier 2.5: Deterministic composition for WF1/WF2/WF3 signals
+          Tier 3:   Keyword matching (stemming + RAG boost)
 
         Returns either:
-            {"_composed_manifest": {...}} — Tier 1 succeeded
+            {"_composed_manifest": {...}} — Tier 1 or 2.5 succeeded
             {"resolved_manifest_id": "..."} — Tier 2 or 3
         """
         # Tier 1: Enhanced Gemini dynamic composition
@@ -1009,6 +1011,13 @@ class PipelineComposer:
                     "Tier 2 failed, falling back to keywords",
                     exc_info=True,
                 )
+
+        # Tier 2.5: Deterministic composition for known workflow signals.
+        # Does NOT depend on Gemini or seeded manifests — composes
+        # directly from NODE_CATALOG when prompt matches a workflow.
+        deterministic = self._deterministic_compose(state)
+        if deterministic:
+            return deterministic
 
         # Tier 3: Keyword matching
         resolved_id = self._keyword_fallback(state)
@@ -1368,6 +1377,109 @@ class PipelineComposer:
                 return "meta-ads-full"
 
         return manifest_id
+
+    # ── Tier 2.5: Deterministic Composition ──
+
+    def _deterministic_compose(self, state: AgentState) -> dict[str, Any] | None:
+        """Match known workflow signals and compose directly from NODE_CATALOG.
+
+        Returns a composed manifest dict when a workflow signal is detected,
+        or None to fall through to Tier 3 keyword matching.  This layer is
+        Gemini-independent and does NOT rely on available_manifests, so it
+        works even when Gemini is rate-limited and seed_manifests hasn't
+        been run.
+        """
+        prompt = (state.get("input_prompt") or "").lower()
+
+        # ── WF1: Brand Discovery ──
+        _discovery_full_signals = ("full brand discovery", "full brand analysis")
+        _discovery_signals = (
+            "brand discovery",
+            "brand intelligence",
+            "complete brand analysis",
+            "complete brand discovery",
+        )
+        if any(s in prompt for s in _discovery_full_signals):
+            node_ids = [
+                "market_research",
+                "competitor_intelligence",
+                "audience_persona",
+                "trend_cultural",
+                "manager",
+            ]
+            logger.info(
+                "Deterministic compose: WF1 full (4-agent) → %s",
+                " → ".join(node_ids),
+            )
+            return {"_composed_manifest": self._build_manifest(node_ids)}
+        if any(s in prompt for s in _discovery_signals):
+            node_ids = [
+                "market_research",
+                "competitor_intelligence",
+                "audience_persona",
+                "trend_cultural",
+                "voice_of_customer",
+                "manager",
+            ]
+            logger.info(
+                "Deterministic compose: WF1 complete (5-agent) → %s",
+                " → ".join(node_ids),
+            )
+            return {"_composed_manifest": self._build_manifest(node_ids)}
+
+        # ── WF2: Brand Strategy ──
+        _strategy_signals = (
+            "brand strategy",
+            "full brand strategy",
+            "complete brand strategy",
+            "brand strategy end to end",
+        )
+        if any(s in prompt for s in _strategy_signals):
+            node_ids = [
+                "brand_positioning",
+                "brand_architecture",
+                "brand_personality",
+                "brand_naming",
+                "brand_story",
+                "manager",
+            ]
+            logger.info(
+                "Deterministic compose: WF2 brand strategy (5-agent) → %s",
+                " → ".join(node_ids),
+            )
+            return {"_composed_manifest": self._build_manifest(node_ids)}
+
+        # ── WF3: Meta Ads ──
+        _meta_ads_signals = (
+            "meta ads",
+            "facebook ads",
+            "instagram ads",
+            "launch ads",
+            "run ads",
+            "launch meta ads",
+            "run meta ads",
+            "ad campaign",
+        )
+        _standalone_meta_signals = (
+            "campaign architecture",
+            "campaign blueprint",
+            "ad creative",
+            "creative generation",
+        )
+        if any(s in prompt for s in _meta_ads_signals):
+            if not any(s in prompt for s in _standalone_meta_signals):
+                node_ids = [
+                    "campaign_architecture",
+                    "creative_generation",
+                    "manager",
+                ]
+                logger.info(
+                    "Deterministic compose: WF3 Meta Ads (2-agent) → %s",
+                    " → ".join(node_ids),
+                )
+                return {"_composed_manifest": self._build_manifest(node_ids)}
+
+        return None
 
     # ── Tier 3: Keyword Fallback ──
 

--- a/pipeline-orchestrator-svc/tests/test_internal_nodes.py
+++ b/pipeline-orchestrator-svc/tests/test_internal_nodes.py
@@ -823,3 +823,109 @@ class TestMetaAdsRouting:
             _base_state(input_prompt="Design a Meta Ads campaign architecture")
         )
         assert result["resolved_manifest_id"] == "meta-campaign-architecture"
+
+
+class TestDeterministicCompose:
+    """Tests for Tier 2.5 deterministic composition.
+
+    Verifies that known workflow signals produce a _composed_manifest
+    (not a resolved_manifest_id) even when Gemini is unavailable and
+    seed_manifests hasn't been run.
+    """
+
+    def _make_composer(self):
+        from app.nodes.internal.pipeline_composer import PipelineComposer
+
+        return PipelineComposer()
+
+    def test_brand_discovery_composes_5_agent_chain(self):
+        composer = self._make_composer()
+        result = composer._deterministic_compose(
+            _base_state(
+                input_prompt="Can you please run the Brand discovery for Pomodoro?"
+            )
+        )
+        assert result is not None
+        assert "_composed_manifest" in result
+        node_ids = [n["id"] for n in result["_composed_manifest"]["nodes"]]
+        assert node_ids == [
+            "market_research",
+            "competitor_intelligence",
+            "audience_persona",
+            "trend_cultural",
+            "voice_of_customer",
+            "manager",
+        ]
+
+    def test_full_brand_discovery_composes_4_agent_chain(self):
+        composer = self._make_composer()
+        result = composer._deterministic_compose(
+            _base_state(input_prompt="Run a full brand discovery for our startup")
+        )
+        assert result is not None
+        node_ids = [n["id"] for n in result["_composed_manifest"]["nodes"]]
+        assert node_ids == [
+            "market_research",
+            "competitor_intelligence",
+            "audience_persona",
+            "trend_cultural",
+            "manager",
+        ]
+        assert "voice_of_customer" not in node_ids
+
+    def test_brand_strategy_composes_5_agent_chain(self):
+        composer = self._make_composer()
+        result = composer._deterministic_compose(
+            _base_state(input_prompt="Run the brand strategy for Pomodoro")
+        )
+        assert result is not None
+        node_ids = [n["id"] for n in result["_composed_manifest"]["nodes"]]
+        assert node_ids == [
+            "brand_positioning",
+            "brand_architecture",
+            "brand_personality",
+            "brand_naming",
+            "brand_story",
+            "manager",
+        ]
+
+    def test_meta_ads_composes_2_agent_chain(self):
+        composer = self._make_composer()
+        result = composer._deterministic_compose(
+            _base_state(input_prompt="Launch Meta Ads for our product")
+        )
+        assert result is not None
+        node_ids = [n["id"] for n in result["_composed_manifest"]["nodes"]]
+        assert node_ids == [
+            "campaign_architecture",
+            "creative_generation",
+            "manager",
+        ]
+
+    def test_standalone_meta_returns_none(self):
+        """Explicit 'campaign architecture' should NOT trigger deterministic compose."""
+        composer = self._make_composer()
+        result = composer._deterministic_compose(
+            _base_state(input_prompt="Design a Meta Ads campaign architecture")
+        )
+        assert result is None
+
+    def test_unrelated_prompt_returns_none(self):
+        """Non-workflow prompts should fall through to Tier 3."""
+        composer = self._make_composer()
+        result = composer._deterministic_compose(
+            _base_state(input_prompt="Write a blog about Tesla")
+        )
+        assert result is None
+
+    def test_works_without_available_manifests(self):
+        """Deterministic compose works even with empty available_manifests."""
+        composer = self._make_composer()
+        result = composer._deterministic_compose(
+            _base_state(
+                input_prompt="Brand discovery for Pomodoro",
+                available_manifests=[],
+            )
+        )
+        assert result is not None
+        assert "_composed_manifest" in result


### PR DESCRIPTION
## Summary
- Adds **Tier 2.5** deterministic composition layer between Tier 2 (Gemini classify) and Tier 3 (keyword matching)
- When Gemini is rate-limited (429), both Tier 1 and Tier 2 fail. Previously this fell to Tier 3 keyword matching which filters by `available_manifests` — if `seed_manifests` hasn't been run, `brand-discovery-complete` is missing and the wrong pipeline (e.g. `audience-persona`) gets selected
- Tier 2.5 detects known workflow signals ("brand discovery", "brand strategy", "meta ads") and composes the pipeline directly from `NODE_CATALOG` — no Gemini dependency and no `available_manifests` dependency
- Adds 7 new tests for the deterministic composition layer

## Test plan
- [x] All 317 tests pass
- [x] `TestDeterministicCompose` verifies WF1 (5-agent), WF1-full (4-agent), WF2 (5-agent), WF3 (2-agent) composition
- [x] Verifies non-workflow prompts fall through to Tier 3
- [x] Verifies works without `available_manifests`
- [ ] Test on production: "Can you please run the Brand discovery for Pomodoro?" should trigger 5-agent WF1

🤖 Generated with [Claude Code](https://claude.com/claude-code)