### PR TITLE
fix(chat): WF2 brand strategy prompts not triggering pipeline (#339)

### DIFF
--- a/ai-brand-automator/ai_services/services.py
+++ b/ai-brand-automator/ai_services/services.py
@@ -937,7 +937,12 @@ class GeminiAIService:
             "full brand strategy",
             "complete brand strategy",
             "brand strategy for",
+            "brand strategy and positioning",
+            "brand strategy and",
             "run brand strategy",
+            "run the brand strategy",
+            "run the brand discovery",
+            "run the brand",
             # WF3 Meta Ads / Campaign phrases
             "run meta ads",
             "create meta ads",


### PR DESCRIPTION
## Summary
Two fixes for WF2 brand strategy from chat:

1. **Intent scoring fix** (`ai_services/services.py`): `classify_intent()` missed WF2 pipeline dispatch for natural language prompts like "Can you please run the brand strategy and positioning for Pomodoro?" because rigid phrase matching required exact substrings. Added 5 phrase patterns to cover natural phrasings.

2. **Brand hierarchy dropdown refresh** (`ChatInterface.tsx`): The `BrandContextSelector` was already rendered in the chat header but hidden because `refreshBrands()` was only called on tenant change. After WF2 pipeline completes and BAA creates sub-brands, the dropdown now appears automatically.

## Details

### Intent scoring (commit 1)
| Prompt | Before | After |
|--------|--------|-------|
| "run the brand strategy and positioning for Pomodoro" | score=1, conversation | score=9, pipeline |
| "run the brand strategy for Pomodoro" | score=1, conversation | score=7, pipeline |
| "brand strategy" (vague) | score=1, conversation | score=1, conversation |

### Brand dropdown (commit 2)
- `refreshBrands()` is now called when any pipeline job completes successfully
- This picks up sub-brands created by BAA and shows the selector dropdown in chat

## Test plan
- [ ] Merge and deploy to Railway
- [ ] Test "Can you please run the brand strategy and positioning for Pomodoro?" in chat → should dispatch pipeline
- [ ] After WF2 completes, brand hierarchy dropdown should appear in chat header
- [ ] Verify WF1 "brand discovery" still works
- [ ] Verify vague "brand strategy" alone still goes to conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)