### PR TITLE
fix(chat): show brand hierarchy dropdown after WF2 pipeline completes (#340)

### DIFF
--- a/ai-brand-automator-frontend/src/components/chat/ChatInterface.tsx
+++ b/ai-brand-automator-frontend/src/components/chat/ChatInterface.tsx
@@ -46,7 +46,7 @@ const WELCOME_MESSAGE: Message = {
 
 export function ChatInterface() {
   const { canEdit: canEditFlag } = useTenantRole();
-  const { activeBrand } = useBrandContext();
+  const { activeBrand, refreshBrands } = useBrandContext();
   const [hasMounted, setHasMounted] = useState(false);
   useEffect(() => {
     requestAnimationFrame(() => setHasMounted(true));
@@ -148,6 +148,10 @@ export function ChatInterface() {
           pipelinePollTimerRef.current = null;
           setIsPipelineRunning(false);
           setIsLoading(false);
+          // Refresh brand hierarchy — WF2 (BAA) may have created sub-brands
+          if (qs.status === 'completed') {
+            refreshBrands();
+          }
           return;
         }
       } catch {
@@ -159,7 +163,7 @@ export function ChatInterface() {
 
     // First poll after a short delay (pipeline needs a moment to register)
     pipelinePollTimerRef.current = setTimeout(poll, 2000);
-  }, []);
+  }, [refreshBrands]);
 
   // Cleanup pipeline poll timer on unmount or session change
   useEffect(() => {


### PR DESCRIPTION
## Summary
- The `BrandContextSelector` dropdown was already rendered in the chat header but stayed hidden because `refreshBrands()` was only called on tenant change
- After WF2 pipeline completes and BAA creates sub-brands in Redis, the dropdown now appears automatically by calling `refreshBrands()` on successful pipeline job completion

## Changes
- `ChatInterface.tsx`: Destructure `refreshBrands` from `useBrandContext()` and call it when pipeline polling detects `status === 'completed'`

## Test plan
- [ ] Run a WF2 brand strategy pipeline from chat
- [ ] After pipeline completes, brand hierarchy dropdown should appear in chat header
- [ ] Selecting a sub-brand should persist across messages
- [ ] Dropdown should not flash or re-render unnecessarily on non-BAA pipelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)