### PR TITLE
fix(chat): brand hierarchy dropdown z-index (#341)

### DIFF
--- a/ai-brand-automator-frontend/src/components/chat/ChatInterface.tsx
+++ b/ai-brand-automator-frontend/src/components/chat/ChatInterface.tsx
@@ -682,7 +682,7 @@ export function ChatInterface() {
         onDrop={handleDrop}
       >
         {/* Header */}
-        <div className="shrink-0 bg-brand-midnight/80 backdrop-blur border-b border-white/10 px-4 sm:px-6 py-3 sm:py-4">
+        <div className="shrink-0 relative z-20 bg-brand-midnight/80 backdrop-blur border-b border-white/10 px-4 sm:px-6 py-3 sm:py-4">
           <div className="flex items-center gap-3">
             <button
               onClick={() => setSidebarOpen((v) => !v)}


### PR DESCRIPTION
## Summary
- Brand hierarchy dropdown in chat header was rendering behind the messages area
- The chat header div lacked a stacking context (`position: relative`), so the `BrandContextSelector` dropdown (`z-50`) was covered by the messages container which has `position: relative`
- Added `relative z-20` to the header div

## Test plan
- [ ] Open chat with sub-brands available
- [ ] Click brand selector dropdown — should render on top of messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)