### PR TITLE
fix(ui): align brand dropdown to right edge and wrap long names (#342)

### DIFF
--- a/ai-brand-automator-frontend/src/components/brand/BrandContextSelector.tsx
+++ b/ai-brand-automator-frontend/src/components/brand/BrandContextSelector.tsx
@@ -61,7 +61,7 @@ export default function BrandContextSelector() {
       </button>
 
       {open && (
-        <div className="absolute top-full left-0 mt-1 z-50 min-w-[200px] max-w-[280px] rounded-lg bg-brand-midnight border border-white/10 shadow-xl overflow-hidden">
+        <div className="absolute top-full right-0 mt-1 z-50 min-w-[200px] max-w-[280px] rounded-lg bg-brand-midnight border border-white/10 shadow-xl overflow-hidden">
           {brands.map((brand) => {
             const BIcon = SCOPE_ICONS[brand.brand_scope] ?? Building2;
             const isActive =
@@ -86,7 +86,7 @@ export default function BrandContextSelector() {
                   }`}
                 />
                 <div className="min-w-0 flex-1">
-                  <div className="truncate">{brand.name}</div>
+                  <div className="break-words">{brand.name}</div>
                   <div className="text-[10px] text-brand-silver/50">
                     {SCOPE_LABELS[brand.brand_scope] ?? brand.brand_scope}
                   </div>


### PR DESCRIPTION
## Summary
- Dropdown was anchored `left-0` causing it to overflow off-screen since the selector sits at the right side of the chat header
- Changed to `right-0` so the dropdown expands leftward
- Replaced `truncate` with `break-words` so long brand names wrap within the dropdown

## Test plan
- [ ] Open brand selector in chat — dropdown should stay within screen bounds
- [ ] Long brand names should wrap instead of clipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)