### PR TITLE
fix(optimization+intelligence): dashboard data, tooltips, and approval queue auto-refresh

### DIFF
--- a/ai-brand-automator-frontend/src/app/intelligence/page.tsx
+++ b/ai-brand-automator-frontend/src/app/intelligence/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
 import { useAuth } from '@/hooks/useAuth';
@@ -11,9 +11,14 @@ export default function IntelligencePage() {
   useAuth();
 
   const [hasMounted, setHasMounted] = useState(false);
+  const [approvalRefreshKey, setApprovalRefreshKey] = useState(0);
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setHasMounted(true);
+  }, []);
+
+  const handleExtractionComplete = useCallback(() => {
+    setApprovalRefreshKey((k) => k + 1);
   }, []);
 
   if (!hasMounted) {
@@ -48,10 +53,10 @@ export default function IntelligencePage() {
 
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
           <div className="lg:col-span-2">
-            <IntelligenceFeed />
+            <IntelligenceFeed onExtractionComplete={handleExtractionComplete} />
           </div>
           <div className="lg:col-span-1">
-            <WF2ApprovalQueue />
+            <WF2ApprovalQueue refreshKey={approvalRefreshKey} />
           </div>
         </div>
       </div>

--- a/ai-brand-automator-frontend/src/components/intelligence/IntelligenceFeed.tsx
+++ b/ai-brand-automator-frontend/src/components/intelligence/IntelligenceFeed.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { ChevronDown, ChevronRight, Loader2, RefreshCw, Brain, Zap } from 'lucide-react';
 import { useTenantRole } from '@/hooks/useTenantRole';
 import {
@@ -32,6 +32,7 @@ export default function IntelligenceFeed({ campaignId, onExtractionComplete }: P
   const [triggering, setTriggering] = useState(false);
   const [triggerMsg, setTriggerMsg] = useState<string | null>(null);
   const [triggerMode, setTriggerMode] = useState<'store_only' | 'auto_trigger'>('store_only');
+  const triggerTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -50,6 +51,12 @@ export default function IntelligenceFeed({ campaignId, onExtractionComplete }: P
   useEffect(() => {
     load();
   }, [load]);
+
+  useEffect(() => {
+    return () => {
+      if (triggerTimerRef.current) clearTimeout(triggerTimerRef.current);
+    };
+  }, []);
 
   useEffect(() => {
     fetchCampaigns()
@@ -72,7 +79,8 @@ export default function IntelligenceFeed({ campaignId, onExtractionComplete }: P
           ? 'Extraction triggered with auto-trigger — WF2 approvals may appear shortly.'
           : 'Extraction triggered — results will appear shortly.'
       );
-      setTimeout(() => {
+      if (triggerTimerRef.current) clearTimeout(triggerTimerRef.current);
+      triggerTimerRef.current = setTimeout(() => {
         load();
         if (triggerMode === 'auto_trigger' && onExtractionComplete) {
           onExtractionComplete();

--- a/ai-brand-automator-frontend/src/components/intelligence/IntelligenceFeed.tsx
+++ b/ai-brand-automator-frontend/src/components/intelligence/IntelligenceFeed.tsx
@@ -16,9 +16,10 @@ import LearningCard from './LearningCard';
 
 interface Props {
   campaignId?: string;
+  onExtractionComplete?: () => void;
 }
 
-export default function IntelligenceFeed({ campaignId }: Props) {
+export default function IntelligenceFeed({ campaignId, onExtractionComplete }: Props) {
   const { canEdit } = useTenantRole();
   const [reports, setReports] = useState<CampaignIntelligenceList[]>([]);
   const [loading, setLoading] = useState(true);
@@ -71,7 +72,12 @@ export default function IntelligenceFeed({ campaignId }: Props) {
           ? 'Extraction triggered with auto-trigger — WF2 approvals may appear shortly.'
           : 'Extraction triggered — results will appear shortly.'
       );
-      setTimeout(() => load(), 3000);
+      setTimeout(() => {
+        load();
+        if (triggerMode === 'auto_trigger' && onExtractionComplete) {
+          onExtractionComplete();
+        }
+      }, 3000);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to trigger extraction');
     } finally {

--- a/ai-brand-automator-frontend/src/components/intelligence/WF2ApprovalQueue.tsx
+++ b/ai-brand-automator-frontend/src/components/intelligence/WF2ApprovalQueue.tsx
@@ -11,7 +11,11 @@ import {
   type WF2RerunRequest,
 } from '@/lib/intelligence';
 
-export default function WF2ApprovalQueue() {
+interface WF2ApprovalQueueProps {
+  refreshKey?: number;
+}
+
+export default function WF2ApprovalQueue({ refreshKey }: WF2ApprovalQueueProps) {
   const { isAdmin } = useTenantRole();
   const [requests, setRequests] = useState<WF2RerunRequest[]>([]);
   const [loading, setLoading] = useState(true);
@@ -38,6 +42,11 @@ export default function WF2ApprovalQueue() {
   useEffect(() => {
     if (isAdmin) load();
   }, [isAdmin, load]);
+
+  // Auto-refresh when parent bumps refreshKey
+  useEffect(() => {
+    if (isAdmin && refreshKey) load();
+  }, [isAdmin, refreshKey, load]);
 
   if (!isAdmin) {
     return null;

--- a/ai-brand-automator-frontend/src/components/optimization/CampaignMetricsCard.tsx
+++ b/ai-brand-automator-frontend/src/components/optimization/CampaignMetricsCard.tsx
@@ -117,10 +117,18 @@ export default function CampaignMetricsCard({
       {metrics.map((metric) => (
         <div
           key={metric.label}
+          tabIndex={0}
+          role="group"
+          aria-label={metric.label}
+          aria-describedby={`tooltip-${metric.label}`}
           className="glass-card p-4 group relative cursor-default"
         >
           {/* Tooltip */}
-          <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-64 px-3 py-2 rounded-lg bg-brand-midnight border border-white/10 shadow-lg text-xs text-brand-silver opacity-0 pointer-events-none group-hover:opacity-100 transition-opacity duration-200 z-50">
+          <div
+            id={`tooltip-${metric.label}`}
+            role="tooltip"
+            className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-64 px-3 py-2 rounded-lg bg-brand-midnight border border-white/10 shadow-lg text-xs text-brand-silver opacity-0 pointer-events-none group-hover:opacity-100 focus-within:opacity-100 transition-opacity duration-200 z-50"
+          >
             {metric.tooltip}
             <div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-white/10" />
           </div>

--- a/ai-brand-automator-frontend/src/components/optimization/CampaignMetricsCard.tsx
+++ b/ai-brand-automator-frontend/src/components/optimization/CampaignMetricsCard.tsx
@@ -16,6 +16,7 @@ interface MetricCardData {
   label: string;
   value: string;
   target: string | null;
+  tooltip: string;
   icon: React.ReactNode;
   status: 'good' | 'warning' | 'neutral';
   progress: number | null;
@@ -62,6 +63,8 @@ export default function CampaignMetricsCard({
       label: 'CPA',
       value: actualCpa !== null ? `$${actualCpa.toFixed(2)}` : '--',
       target: targetCpa !== null ? `Target: $${targetCpa.toFixed(2)}` : null,
+      tooltip:
+        'Cost Per Acquisition — the average cost to acquire one customer or conversion. Lower is better.',
       icon: <DollarSign className={iconCls} />,
       status: cpaStatus,
       progress: null,
@@ -70,6 +73,8 @@ export default function CampaignMetricsCard({
       label: 'ROAS',
       value: actualRoas !== null ? `${actualRoas.toFixed(1)}x` : '--',
       target: targetRoas !== null ? `Target: ${targetRoas.toFixed(1)}x` : null,
+      tooltip:
+        'Return On Ad Spend — revenue generated per dollar spent on ads. A 3.0x ROAS means $3 revenue for every $1 spent. Higher is better.',
       icon: <TrendingUp className={iconCls} />,
       status: roasStatus,
       progress: null,
@@ -78,6 +83,8 @@ export default function CampaignMetricsCard({
       label: 'CTR',
       value: actualCtr !== null ? `${actualCtr.toFixed(2)}%` : '--',
       target: null,
+      tooltip:
+        'Click-Through Rate — the percentage of people who clicked your ad after seeing it. Higher CTR indicates more engaging ad creative.',
       icon: <MousePointerClick className={iconCls} />,
       status: 'neutral',
       progress: null,
@@ -88,6 +95,8 @@ export default function CampaignMetricsCard({
         spendToday !== null
           ? `$${spendToday.toFixed(2)}`
           : `$${daily.toFixed(2)}`,
+      tooltip:
+        'Daily Spend — how much budget has been spent today. Tracked against your daily and lifetime budget limits.',
       target:
         spendToday !== null
           ? `Budget: $${daily.toFixed(2)}`
@@ -106,7 +115,15 @@ export default function CampaignMetricsCard({
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
       {metrics.map((metric) => (
-        <div key={metric.label} className="glass-card p-4">
+        <div
+          key={metric.label}
+          className="glass-card p-4 group relative cursor-default"
+        >
+          {/* Tooltip */}
+          <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-64 px-3 py-2 rounded-lg bg-brand-midnight border border-white/10 shadow-lg text-xs text-brand-silver opacity-0 pointer-events-none group-hover:opacity-100 transition-opacity duration-200 z-50">
+            {metric.tooltip}
+            <div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-white/10" />
+          </div>
           <div className="flex items-center justify-between mb-2">
             <span className="text-xs font-medium text-brand-silver uppercase tracking-wider">
               {metric.label}

--- a/ai-brand-automator-frontend/src/components/optimization/RecommendationCard.tsx
+++ b/ai-brand-automator-frontend/src/components/optimization/RecommendationCard.tsx
@@ -203,7 +203,24 @@ export default function RecommendationCard({
 
       {/* Actions */}
       <div className="flex items-center gap-2 pt-2 border-t border-white/5">
-        {!showRejectInput ? (
+        {rec.status !== 'pending' ? (
+          <span
+            className={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg ${
+              rec.status === 'approved' || rec.status === 'executed'
+                ? 'bg-emerald-500/20 text-emerald-400'
+                : rec.status === 'rejected'
+                ? 'bg-red-500/20 text-red-400'
+                : 'bg-white/10 text-brand-silver'
+            }`}
+          >
+            {rec.status === 'approved' || rec.status === 'executed' ? (
+              <Check className="w-3.5 h-3.5" />
+            ) : rec.status === 'rejected' ? (
+              <X className="w-3.5 h-3.5" />
+            ) : null}
+            {rec.status.charAt(0).toUpperCase() + rec.status.slice(1)}
+          </span>
+        ) : !showRejectInput ? (
           <>
             <button
               onClick={() => onApprove(rec.recommendation_id)}

--- a/ai-brand-automator/optimization/management/commands/backfill_optimization_data.py
+++ b/ai-brand-automator/optimization/management/commands/backfill_optimization_data.py
@@ -8,6 +8,8 @@ Usage:
     python manage.py backfill_optimization_data --dry-run
 """
 
+from decimal import Decimal
+
 from django.core.management.base import BaseCommand
 
 from optimization.models import (
@@ -34,15 +36,22 @@ class Command(BaseCommand):
         dry_run = options["dry_run"]
         campaigns = CampaignRegistry.objects.all()
 
+        # Precompute sets to avoid N+1 queries inside the loop.
+        existing_action_ids = set(
+            OptimizationAction.objects.filter(action_type="ACTIVATE").values_list(
+                "campaign_id", flat=True
+            )
+        )
+        existing_snapshot_ids = set(
+            PerformanceSnapshot.objects.values_list("campaign_id", flat=True).distinct()
+        )
+
         actions_created = 0
         snapshots_created = 0
 
         for campaign in campaigns:
             # Check if an ACTIVATE action already exists
-            has_action = OptimizationAction.objects.filter(
-                campaign=campaign,
-                action_type="ACTIVATE",
-            ).exists()
+            has_action = campaign.pk in existing_action_ids
 
             if not has_action:
                 if dry_run:
@@ -82,9 +91,7 @@ class Command(BaseCommand):
                 actions_created += 1
 
             # Check if any PerformanceSnapshot exists
-            has_snapshot = PerformanceSnapshot.objects.filter(
-                campaign=campaign,
-            ).exists()
+            has_snapshot = campaign.pk in existing_snapshot_ids
 
             if not has_snapshot:
                 if dry_run:
@@ -93,17 +100,17 @@ class Command(BaseCommand):
                         f"for {campaign.campaign_name}"
                     )
                 else:
-                    daily_budget = float(campaign.daily_budget_usd or 0)
+                    daily_budget = Decimal(str(campaign.daily_budget_usd or 0))
                     cpa = campaign.actual_cpa_usd or campaign.target_cpa_usd
                     roas = campaign.actual_roas or campaign.target_roas
                     PerformanceSnapshot.objects.create(
                         tenant=campaign.tenant,
                         campaign=campaign,
                         tick_id=f"backfill-{campaign.campaign_id}",
-                        cpa_usd=float(cpa) if cpa is not None else None,
-                        roas=float(roas) if roas is not None else None,
+                        cpa_usd=(Decimal(str(cpa)) if cpa is not None else None),
+                        roas=(Decimal(str(roas)) if roas is not None else None),
                         ctr=(
-                            float(campaign.actual_ctr)
+                            Decimal(str(campaign.actual_ctr))
                             if campaign.actual_ctr is not None
                             else None
                         ),

--- a/ai-brand-automator/optimization/management/commands/backfill_optimization_data.py
+++ b/ai-brand-automator/optimization/management/commands/backfill_optimization_data.py
@@ -1,0 +1,122 @@
+"""
+Management command to backfill OptimizationAction (ACTIVATE) and
+PerformanceSnapshot records for existing CampaignRegistry rows that
+were registered before those records were created at registration time.
+
+Usage:
+    python manage.py backfill_optimization_data
+    python manage.py backfill_optimization_data --dry-run
+"""
+
+from django.core.management.base import BaseCommand
+
+from optimization.models import (
+    CampaignRegistry,
+    OptimizationAction,
+    PerformanceSnapshot,
+)
+
+
+class Command(BaseCommand):
+    help = (
+        "Backfill ACTIVATE actions and baseline PerformanceSnapshots "
+        "for campaigns that lack them."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show what would be created without writing to the database.",
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        campaigns = CampaignRegistry.objects.all()
+
+        actions_created = 0
+        snapshots_created = 0
+
+        for campaign in campaigns:
+            # Check if an ACTIVATE action already exists
+            has_action = OptimizationAction.objects.filter(
+                campaign=campaign,
+                action_type="ACTIVATE",
+            ).exists()
+
+            if not has_action:
+                if dry_run:
+                    self.stdout.write(
+                        f"  [DRY RUN] Would create ACTIVATE action "
+                        f"for {campaign.campaign_name}"
+                    )
+                else:
+                    OptimizationAction.objects.create(
+                        tenant=campaign.tenant,
+                        campaign=campaign,
+                        action_type="ACTIVATE",
+                        entity_type="campaign",
+                        entity_id=campaign.meta_campaign_id
+                        or str(campaign.campaign_id),
+                        old_value={},
+                        new_value={
+                            "status": campaign.status,
+                            "daily_budget_usd": float(campaign.daily_budget_usd or 0),
+                            "ad_sets": len(campaign.ad_sets or []),
+                            "ads": len(campaign.ads or []),
+                            "sandbox_mode": campaign.sandbox_mode,
+                        },
+                        mode="manual",
+                        rationale=(
+                            f'Campaign "{campaign.campaign_name}" published '
+                            f"via Ad Publishing workflow. Daily budget "
+                            f"${float(campaign.daily_budget_usd or 0):.2f}, "
+                            f"{len(campaign.ad_sets or [])} ad set(s), "
+                            f"{len(campaign.ads or [])} ad(s)."
+                        ),
+                        guardrails_applied=[],
+                        meta_api_response={},
+                        verified=True,
+                        verification_result={"source": "backfill_optimization_data"},
+                    )
+                actions_created += 1
+
+            # Check if any PerformanceSnapshot exists
+            has_snapshot = PerformanceSnapshot.objects.filter(
+                campaign=campaign,
+            ).exists()
+
+            if not has_snapshot:
+                if dry_run:
+                    self.stdout.write(
+                        f"  [DRY RUN] Would create baseline snapshot "
+                        f"for {campaign.campaign_name}"
+                    )
+                else:
+                    daily_budget = float(campaign.daily_budget_usd or 0)
+                    cpa = campaign.actual_cpa_usd or campaign.target_cpa_usd
+                    roas = campaign.actual_roas or campaign.target_roas
+                    PerformanceSnapshot.objects.create(
+                        tenant=campaign.tenant,
+                        campaign=campaign,
+                        tick_id=f"backfill-{campaign.campaign_id}",
+                        cpa_usd=float(cpa) if cpa is not None else None,
+                        roas=float(roas) if roas is not None else None,
+                        ctr=(
+                            float(campaign.actual_ctr)
+                            if campaign.actual_ctr is not None
+                            else None
+                        ),
+                        spend_usd=daily_budget if daily_budget > 0 else None,
+                    )
+                snapshots_created += 1
+
+        prefix = "[DRY RUN] " if dry_run else ""
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"{prefix}Backfill complete: "
+                f"{actions_created} actions, "
+                f"{snapshots_created} snapshots "
+                f"across {campaigns.count()} campaigns."
+            )
+        )

--- a/ai-brand-automator/optimization/management/commands/seed_sandbox_recommendations.py
+++ b/ai-brand-automator/optimization/management/commands/seed_sandbox_recommendations.py
@@ -1,0 +1,244 @@
+"""
+Seed sample OptimizationRecommendation records for sandbox/demo campaigns.
+
+All seeded recommendations include [SANDBOX] in the rationale so demo users
+understand the data is illustrative, not from real Meta Insights.
+
+Usage:
+    python manage.py seed_sandbox_recommendations
+    python manage.py seed_sandbox_recommendations --dry-run
+    python manage.py seed_sandbox_recommendations --clear   # remove seeded recs
+"""
+
+import uuid
+from datetime import timedelta
+
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from optimization.models import CampaignRegistry, OptimizationRecommendation
+
+SANDBOX_TICK_PREFIX = "sandbox-seed-"
+
+RECOMMENDATION_TEMPLATES = [
+    {
+        "action_type": "PAUSE",
+        "entity_type": "ad_set",
+        "priority": "HIGH",
+        "rationale": (
+            "[SANDBOX DEMO] This ad set has a CPA of $18.42, which is "
+            "2.1x above the campaign target of $8.75. CTR has declined "
+            "32% over the past 3 days, suggesting audience fatigue. "
+            "Recommend pausing to stop budget waste."
+        ),
+        "current_values": {
+            "cpa_usd": 18.42,
+            "ctr_pct": 0.68,
+            "daily_spend_usd": 24.50,
+            "impressions_3d": 3620,
+        },
+        "proposed_values": {
+            "status": "PAUSED",
+            "daily_spend_usd": 0,
+        },
+        "projected_impact": {
+            "daily_savings_usd": 24.50,
+            "projected_cpa_reduction_pct": 15,
+        },
+    },
+    {
+        "action_type": "SCALE",
+        "entity_type": "ad_set",
+        "priority": "MEDIUM",
+        "rationale": (
+            "[SANDBOX DEMO] This ad set is performing well with a CPA "
+            "of $3.12 (64% below target) and a ROAS of 4.8x. "
+            "Increasing budget by 20% could capture additional "
+            "conversions while staying within guardrails."
+        ),
+        "current_values": {
+            "cpa_usd": 3.12,
+            "roas": 4.8,
+            "daily_budget_usd": 25.00,
+            "conversions_7d": 56,
+        },
+        "proposed_values": {
+            "daily_budget_usd": 30.00,
+            "budget_increase_pct": 20,
+        },
+        "projected_impact": {
+            "additional_conversions_weekly": 11,
+            "projected_roas": 4.5,
+        },
+    },
+    {
+        "action_type": "REALLOCATE",
+        "entity_type": "campaign",
+        "priority": "MEDIUM",
+        "rationale": (
+            "[SANDBOX DEMO] Budget is unevenly distributed across ad "
+            "sets. TOFU set is spending 45% of budget but delivering "
+            "only 18% of conversions. Recommend shifting $10/day from "
+            "TOFU to the high-performing BOFU set."
+        ),
+        "current_values": {
+            "tofu_spend_pct": 45,
+            "tofu_conversion_pct": 18,
+            "bofu_spend_pct": 20,
+            "bofu_conversion_pct": 52,
+        },
+        "proposed_values": {
+            "tofu_daily_budget_usd": 15.00,
+            "bofu_daily_budget_usd": 35.00,
+        },
+        "projected_impact": {
+            "projected_cpa_reduction_pct": 22,
+            "projected_conversion_increase_pct": 15,
+        },
+    },
+    {
+        "action_type": "REFRESH",
+        "entity_type": "ad",
+        "priority": "LOW",
+        "rationale": (
+            "[SANDBOX DEMO] Ad creative has been running for 12 days. "
+            "Frequency is 3.8 (above the 3.0 threshold) and CTR has "
+            "dropped 28% from its peak. Recommend refreshing the "
+            "creative to combat audience fatigue."
+        ),
+        "current_values": {
+            "frequency": 3.8,
+            "ctr_pct": 1.02,
+            "ctr_peak_pct": 1.42,
+            "days_running": 12,
+        },
+        "proposed_values": {
+            "action": "generate_new_creative",
+            "keep_targeting": True,
+        },
+        "projected_impact": {
+            "projected_ctr_recovery_pct": 20,
+            "estimated_frequency_reset": 1.0,
+        },
+    },
+    {
+        "action_type": "ADJUST_BID",
+        "entity_type": "ad_set",
+        "priority": "CRITICAL",
+        "rationale": (
+            "[SANDBOX DEMO] CPA has spiked to $25.60 in the last 24h "
+            "(3x target). The competitive landscape shows increased "
+            "auction pressure. Recommend lowering bid cap by 15% and "
+            "monitoring for 24h before further action."
+        ),
+        "current_values": {
+            "cpa_usd": 25.60,
+            "bid_cap_usd": 12.00,
+            "auction_overlap_pct": 67,
+            "cost_per_click_usd": 2.85,
+        },
+        "proposed_values": {
+            "bid_cap_usd": 10.20,
+            "bid_reduction_pct": 15,
+        },
+        "projected_impact": {
+            "projected_cpa_usd": 18.50,
+            "projected_savings_daily_usd": 8.40,
+        },
+    },
+]
+
+
+class Command(BaseCommand):
+    help = "Seed sandbox recommendation records for demo purposes."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Preview without writing to the database.",
+        )
+        parser.add_argument(
+            "--clear",
+            action="store_true",
+            help="Remove all previously seeded sandbox recommendations.",
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+
+        if options["clear"]:
+            qs = OptimizationRecommendation.objects.filter(
+                tick_id__startswith=SANDBOX_TICK_PREFIX
+            )
+            count = qs.count()
+            if not dry_run:
+                qs.delete()
+            prefix = "[DRY RUN] " if dry_run else ""
+            self.stdout.write(
+                self.style.SUCCESS(f"{prefix}Removed {count} sandbox recommendations.")
+            )
+            return
+
+        campaigns = list(CampaignRegistry.objects.all()[:5])
+        if not campaigns:
+            self.stdout.write(
+                self.style.WARNING("No campaigns found. Nothing to seed.")
+            )
+            return
+
+        now = timezone.now()
+        created = 0
+
+        for i, template in enumerate(RECOMMENDATION_TEMPLATES):
+            campaign = campaigns[i % len(campaigns)]
+            tick_id = f"{SANDBOX_TICK_PREFIX}{uuid.uuid4().hex[:8]}"
+
+            # Use a real-looking entity ID from the campaign
+            if template["entity_type"] == "campaign":
+                entity_id = campaign.meta_campaign_id or str(campaign.campaign_id)
+            elif template["entity_type"] == "ad_set":
+                ad_sets = campaign.ad_sets or []
+                entity_id = (
+                    ad_sets[0].get("id", f"stub_adset_{i}")
+                    if ad_sets
+                    else f"stub_adset_{i}"
+                )
+            else:
+                ads = campaign.ads or []
+                entity_id = ads[0].get("id", f"stub_ad_{i}") if ads else f"stub_ad_{i}"
+
+            if dry_run:
+                self.stdout.write(
+                    f"  [DRY RUN] Would create {template['priority']} "
+                    f"{template['action_type']} recommendation for "
+                    f"{campaign.campaign_name}"
+                )
+            else:
+                OptimizationRecommendation.objects.create(
+                    tenant=campaign.tenant,
+                    campaign=campaign,
+                    recommendation_id=uuid.uuid4(),
+                    action_type=template["action_type"],
+                    entity_type=template["entity_type"],
+                    entity_id=entity_id,
+                    current_values=template["current_values"],
+                    proposed_values=template["proposed_values"],
+                    rationale=template["rationale"],
+                    projected_impact=template["projected_impact"],
+                    priority=template["priority"],
+                    status="pending",
+                    expires_at=now + timedelta(hours=48),
+                    tick_id=tick_id,
+                    data_freshness=now - timedelta(minutes=15),
+                    guardrails_applied=["GR-01", "GR-03", "GR-07"],
+                )
+            created += 1
+
+        prefix = "[DRY RUN] " if dry_run else ""
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"{prefix}Seeded {created} sandbox recommendations "
+                f"across {len(campaigns)} campaigns."
+            )
+        )

--- a/ai-brand-automator/optimization/management/commands/seed_sandbox_recommendations.py
+++ b/ai-brand-automator/optimization/management/commands/seed_sandbox_recommendations.py
@@ -1,7 +1,7 @@
 """
 Seed sample OptimizationRecommendation records for sandbox/demo campaigns.
 
-All seeded recommendations include [SANDBOX] in the rationale so demo users
+All seeded recommendations include [SANDBOX DEMO] in the rationale so demo users
 understand the data is illustrative, not from real Meta Insights.
 
 Usage:
@@ -180,7 +180,10 @@ class Command(BaseCommand):
             )
             return
 
-        campaigns = list(CampaignRegistry.objects.all()[:5])
+        campaigns = list(CampaignRegistry.objects.filter(sandbox_mode=True)[:5])
+        if not campaigns:
+            # Fallback to all campaigns if none are sandbox
+            campaigns = list(CampaignRegistry.objects.all()[:5])
         if not campaigns:
             self.stdout.write(
                 self.style.WARNING("No campaigns found. Nothing to seed.")

--- a/ai-brand-automator/optimization/views.py
+++ b/ai-brand-automator/optimization/views.py
@@ -796,6 +796,61 @@ def register_campaign(request):
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
 
+    # Create an ACTIVATE action record for audit trail + dashboard visibility
+    try:
+        OptimizationAction.objects.create(
+            tenant=tenant,
+            campaign=campaign,
+            action_type="ACTIVATE",
+            entity_type="campaign",
+            entity_id=meta_campaign_id,
+            old_value={},
+            new_value={
+                "status": "active",
+                "daily_budget_usd": float(data.get("daily_budget_usd") or 0),
+                "ad_sets": len(data.get("ad_sets") or []),
+                "ads": len(data.get("ads") or []),
+                "sandbox_mode": data.get("sandbox_mode", True),
+            },
+            mode="manual",
+            rationale=(
+                f'Campaign "{defaults["campaign_name"]}" published via '
+                f"Ad Publishing workflow. Daily budget "
+                f'${float(data.get("daily_budget_usd") or 0):.2f}, '
+                f'{len(data.get("ad_sets") or [])} ad set(s), '
+                f'{len(data.get("ads") or [])} ad(s).'
+            ),
+            guardrails_applied=[],
+            meta_api_response={},
+            verified=True,
+            verification_result={"source": "ad_publishing_registration"},
+        )
+    except Exception:
+        logger.warning(
+            "Failed to create ACTIVATE action for campaign %s", campaign.campaign_id
+        )
+
+    # Create a baseline PerformanceSnapshot so the trend chart has
+    # at least one data point from day one.
+    try:
+        daily_budget = float(data.get("daily_budget_usd") or 0)
+        target_cpa = data.get("target_cpa_usd")
+        target_roas = data.get("target_roas")
+        PerformanceSnapshot.objects.create(
+            tenant=tenant,
+            campaign=campaign,
+            tick_id=f"registration-{campaign.campaign_id}",
+            cpa_usd=float(target_cpa) if target_cpa is not None else None,
+            roas=float(target_roas) if target_roas is not None else None,
+            ctr=None,
+            spend_usd=daily_budget if daily_budget > 0 else None,
+        )
+    except Exception:
+        logger.warning(
+            "Failed to create baseline snapshot for campaign %s",
+            campaign.campaign_id,
+        )
+
     logger.info(
         "Campaign registered for optimization: meta=%s internal=%s created=%s",
         meta_campaign_id,

--- a/ai-brand-automator/optimization/views.py
+++ b/ai-brand-automator/optimization/views.py
@@ -6,6 +6,7 @@ Includes callback endpoint for COA tick results and recommendation approval flow
 """
 
 import logging
+from decimal import Decimal
 
 from django.conf import settings
 from django.db import transaction
@@ -797,59 +798,64 @@ def register_campaign(request):
         )
 
     # Create an ACTIVATE action record for audit trail + dashboard visibility
-    try:
-        OptimizationAction.objects.create(
-            tenant=tenant,
-            campaign=campaign,
-            action_type="ACTIVATE",
-            entity_type="campaign",
-            entity_id=meta_campaign_id,
-            old_value={},
-            new_value={
-                "status": "active",
-                "daily_budget_usd": float(data.get("daily_budget_usd") or 0),
-                "ad_sets": len(data.get("ad_sets") or []),
-                "ads": len(data.get("ads") or []),
-                "sandbox_mode": data.get("sandbox_mode", True),
-            },
-            mode="manual",
-            rationale=(
-                f'Campaign "{defaults["campaign_name"]}" published via '
-                f"Ad Publishing workflow. Daily budget "
-                f'${float(data.get("daily_budget_usd") or 0):.2f}, '
-                f'{len(data.get("ad_sets") or [])} ad set(s), '
-                f'{len(data.get("ads") or [])} ad(s).'
-            ),
-            guardrails_applied=[],
-            meta_api_response={},
-            verified=True,
-            verification_result={"source": "ad_publishing_registration"},
-        )
-    except Exception:
-        logger.warning(
-            "Failed to create ACTIVATE action for campaign %s", campaign.campaign_id
-        )
+    if created:
+        try:
+            OptimizationAction.objects.create(
+                tenant=tenant,
+                campaign=campaign,
+                action_type="ACTIVATE",
+                entity_type="campaign",
+                entity_id=meta_campaign_id,
+                old_value={},
+                new_value={
+                    "status": "active",
+                    "daily_budget_usd": float(data.get("daily_budget_usd") or 0),
+                    "ad_sets": len(data.get("ad_sets") or []),
+                    "ads": len(data.get("ads") or []),
+                    "sandbox_mode": data.get("sandbox_mode", True),
+                },
+                mode="manual",
+                rationale=(
+                    f'Campaign "{defaults["campaign_name"]}" published via '
+                    f"Ad Publishing workflow. Daily budget "
+                    f'${float(data.get("daily_budget_usd") or 0):.2f}, '
+                    f'{len(data.get("ad_sets") or [])} ad set(s), '
+                    f'{len(data.get("ads") or [])} ad(s).'
+                ),
+                guardrails_applied=[],
+                meta_api_response={},
+                verified=True,
+                verification_result={"source": "ad_publishing_registration"},
+            )
+        except Exception:
+            logger.warning(
+                "Failed to create ACTIVATE action for campaign %s",
+                campaign.campaign_id,
+                exc_info=True,
+            )
 
     # Create a baseline PerformanceSnapshot so the trend chart has
     # at least one data point from day one.
-    try:
-        daily_budget = float(data.get("daily_budget_usd") or 0)
-        target_cpa = data.get("target_cpa_usd")
-        target_roas = data.get("target_roas")
-        PerformanceSnapshot.objects.create(
-            tenant=tenant,
-            campaign=campaign,
-            tick_id=f"registration-{campaign.campaign_id}",
-            cpa_usd=float(target_cpa) if target_cpa is not None else None,
-            roas=float(target_roas) if target_roas is not None else None,
-            ctr=None,
-            spend_usd=daily_budget if daily_budget > 0 else None,
-        )
-    except Exception:
-        logger.warning(
-            "Failed to create baseline snapshot for campaign %s",
-            campaign.campaign_id,
-        )
+    if created:
+        try:
+            daily_budget = Decimal(str(data.get("daily_budget_usd") or 0))
+            target_cpa = data.get("target_cpa_usd")
+            target_roas = data.get("target_roas")
+            PerformanceSnapshot.objects.create(
+                tenant=tenant,
+                campaign=campaign,
+                tick_id=f"registration-{campaign.campaign_id}",
+                cpa_usd=(Decimal(str(target_cpa)) if target_cpa is not None else None),
+                roas=(Decimal(str(target_roas)) if target_roas is not None else None),
+                ctr=None,
+                spend_usd=daily_budget if daily_budget > 0 else None,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to create baseline snapshot for campaign %s",
+                campaign.campaign_id,
+                exc_info=True,
+            )
 
     logger.info(
         "Campaign registered for optimization: meta=%s internal=%s created=%s",


### PR DESCRIPTION
## Summary
- **Optimization dashboard data**: `register_campaign()` now creates ACTIVATE action and baseline PerformanceSnapshot records. Adds `backfill_optimization_data` management command (already executed on Railway)
- **Sandbox demo recommendations**: `seed_sandbox_recommendations` management command seeds 5 realistic recommendations with [SANDBOX DEMO] tags (already executed on Railway)
- **Recommendation status badges**: Non-pending recommendations show Approved/Rejected/Expired badge instead of action buttons
- **Metric tooltips**: CPA, ROAS, CTR, and Daily Spend tiles show explanatory tooltips on hover
- **Intelligence Loop auto-refresh**: Brand Strategy Approval Queue automatically refreshes when extraction completes in auto_trigger mode

## Test plan
- [x] All 28 optimization tests pass
- [x] TypeScript compiles cleanly
- [x] Backfill and seed commands executed on Railway
- [x] Frontend deployed and verified on Railway
- [ ] Verify approval queue auto-refreshes after auto_trigger extraction
- [ ] Verify metric tooltips appear on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)