### PR TITLE
feat(frontend): add hover tooltips to all dashboard tiles

### DIFF
--- a/ai-brand-automator-frontend/src/components/analytics/AnalyticsCoverage.tsx
+++ b/ai-brand-automator-frontend/src/components/analytics/AnalyticsCoverage.tsx
@@ -2,6 +2,7 @@
 
 import { BarChart3 } from 'lucide-react';
 import type { AnalyticsCoverage as CoverageData } from '@/types/analytics';
+import Tooltip from '@/components/ui/Tooltip';
 
 interface AnalyticsCoverageProps {
   data: CoverageData | null;
@@ -11,17 +12,19 @@ export default function AnalyticsCoverage({ data }: AnalyticsCoverageProps) {
   if (!data || data.total_jobs === 0) return null;
 
   return (
-    <div className="flex items-center gap-2 text-xs text-brand-silver">
-      <BarChart3 className="h-3.5 w-3.5" />
-      <span>
-        {data.analytics_jobs} of {data.total_jobs} workflows analyzed
-        ({data.coverage_pct}%)
-      </span>
-      {data.excluded_jobs > 0 && (
-        <span className="text-amber-400/60">
-          ({data.excluded_jobs} excluded)
+    <Tooltip text="How many completed workflows had metrics successfully extracted. Excluded workflows may have failed extraction or lacked extractable data.">
+      <div className="flex items-center gap-2 text-xs text-brand-silver">
+        <BarChart3 className="h-3.5 w-3.5" />
+        <span>
+          {data.analytics_jobs} of {data.total_jobs} workflows analyzed
+          ({data.coverage_pct}%)
         </span>
-      )}
-    </div>
+        {data.excluded_jobs > 0 && (
+          <span className="text-amber-400/60">
+            ({data.excluded_jobs} excluded)
+          </span>
+        )}
+      </div>
+    </Tooltip>
   );
 }

--- a/ai-brand-automator-frontend/src/components/analytics/AnalyticsDashboard.tsx
+++ b/ai-brand-automator-frontend/src/components/analytics/AnalyticsDashboard.tsx
@@ -12,6 +12,7 @@ import ComparisonBars from './ComparisonBars';
 import DistributionGauge from './DistributionGauge';
 import AnalyticsCoverage from './AnalyticsCoverage';
 import BrandContextSelector from '@/components/brand/BrandContextSelector';
+import Tooltip from '@/components/ui/Tooltip';
 
 export default function AnalyticsDashboard() {
   const [range, setRange] = useState<TimeRange>('30d');
@@ -65,20 +66,24 @@ export default function AnalyticsDashboard() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-xl font-heading font-semibold text-white">
-            Workflow Analytics
-          </h2>
+          <Tooltip text="Aggregated KPIs extracted from completed workflow executions. Metrics are computed from pipeline results across discovery, brand strategy, content, and campaign workflows.">
+            <h2 className="text-xl font-heading font-semibold text-white cursor-default">
+              Workflow Analytics
+            </h2>
+          </Tooltip>
           <AnalyticsCoverage data={coverage} />
         </div>
         <div className="flex items-center gap-3">
           <BrandContextSelector />
           <TimeRangePicker value={range} onChange={setRange} />
-          <a
-            href="/dashboard/analytics"
-            className="text-xs text-brand-electric hover:underline"
-          >
-            View All
-          </a>
+          <Tooltip text="Open the full analytics page with expanded charts, period selectors, and detailed metric breakdowns.">
+            <a
+              href="/dashboard/analytics"
+              className="text-xs text-brand-electric hover:underline"
+            >
+              View All
+            </a>
+          </Tooltip>
         </div>
       </div>
 

--- a/ai-brand-automator-frontend/src/components/analytics/ComparisonBars.tsx
+++ b/ai-brand-automator-frontend/src/components/analytics/ComparisonBars.tsx
@@ -14,6 +14,7 @@ import {
 import { X } from 'lucide-react';
 import { getComparison } from '@/lib/analytics';
 import type { ComparisonItem, TimeRange } from '@/types/analytics';
+import InfoTooltip from '@/components/ui/Tooltip';
 
 interface ComparisonBarsProps {
   range: TimeRange;
@@ -123,9 +124,11 @@ export default function ComparisonBars({ range, brandContext }: ComparisonBarsPr
         className="glass-card p-6 cursor-pointer hover:border-brand-electric/30 hover:bg-white/[0.03] transition-all duration-200"
         onClick={() => setExpanded(true)}
       >
-        <h3 className="text-sm font-medium text-brand-silver mb-4">
-          Period Comparison
-        </h3>
+        <InfoTooltip text="Compares average metric values between the current period and the previous equivalent period. Taller cyan bars mean the metric improved versus the prior period. Click to expand.">
+          <h3 className="text-sm font-medium text-brand-silver mb-4 cursor-default">
+            Period Comparison
+          </h3>
+        </InfoTooltip>
         <ComparisonBarChart chartData={chartData} height={280} />
       </div>
 

--- a/ai-brand-automator-frontend/src/components/analytics/DistributionGauge.tsx
+++ b/ai-brand-automator-frontend/src/components/analytics/DistributionGauge.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { X } from 'lucide-react';
 import { getDistribution } from '@/lib/analytics';
 import type { DistributionData, TimeRange } from '@/types/analytics';
+import InfoTooltip from '@/components/ui/Tooltip';
 
 interface DistributionGaugeProps {
   range: TimeRange;
@@ -145,9 +146,11 @@ export default function DistributionGauge({ range, brandContext }: DistributionG
         className="glass-card p-6 cursor-pointer hover:border-brand-electric/30 hover:bg-white/[0.03] transition-all duration-200"
         onClick={() => setExpanded(true)}
       >
-        <h3 className="text-sm font-medium text-brand-silver mb-4">
-          Sentiment Distribution
-        </h3>
+        <InfoTooltip text="Breakdown of sentiment polarity from Voice of Customer analysis. Shows what percentage of customer feedback is positive, neutral, or negative. Click to expand.">
+          <h3 className="text-sm font-medium text-brand-silver mb-4 cursor-default">
+            Sentiment Distribution
+          </h3>
+        </InfoTooltip>
         <div className="flex items-center justify-center gap-8">
           <DonutGauge data={data} size={130} strokeWidth={12} />
           <SentimentLegend data={data} />

--- a/ai-brand-automator-frontend/src/components/analytics/KpiScorecard.tsx
+++ b/ai-brand-automator-frontend/src/components/analytics/KpiScorecard.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { TrendingDown, TrendingUp, Minus, X } from 'lucide-react';
 import type { ScorecardItem } from '@/types/analytics';
+import Tooltip from '@/components/ui/Tooltip';
 
 interface KpiScorecardProps {
   items: ScorecardItem[];
@@ -186,22 +187,30 @@ export default function KpiScorecard({ items, loading }: KpiScorecardProps) {
               onClick={() => setSelectedItem(item)}
             >
               <div className="flex items-center justify-between mb-2">
-                <span className="text-xs text-brand-silver truncate">
-                  {item.display_name}
-                </span>
-                <TrendIcon trend={item.trend} />
+                <Tooltip text={`${item.display_name} — extracted from completed workflow results. ${item.higher_is_better ? 'Higher values indicate better performance.' : 'Lower values indicate better performance.'} Click for details.`}>
+                  <span className="text-xs text-brand-silver truncate">
+                    {item.display_name}
+                  </span>
+                </Tooltip>
+                <Tooltip text={`Trend: ${item.trend === 'improving' ? 'Improving over the selected period' : item.trend === 'declining' ? 'Declining over the selected period' : 'Stable — no significant change'}.`}>
+                  <span><TrendIcon trend={item.trend} /></span>
+                </Tooltip>
               </div>
               <div className="flex items-end justify-between">
                 <div>
                   <div className="text-2xl font-bold text-white">
                     {formatValue(item.current_value, item.unit)}
                   </div>
-                  <div className={`text-xs mt-1 ${changeBg}`}>
-                    {item.change_pct > 0 ? '+' : ''}
-                    {item.change_pct.toFixed(1)}%
-                  </div>
+                  <Tooltip text={`Percentage change compared to the previous period. ${item.change_pct > 0 ? 'Positive means the metric increased.' : item.change_pct < 0 ? 'Negative means the metric decreased.' : 'No change from previous period.'}`}>
+                    <span className={`text-xs mt-1 inline-block ${changeBg}`}>
+                      {item.change_pct > 0 ? '+' : ''}
+                      {item.change_pct.toFixed(1)}%
+                    </span>
+                  </Tooltip>
                 </div>
-                <SparklineChart data={item.sparkline_data} color={item.color} />
+                <Tooltip text="Sparkline showing recent data points. Click the card to see the full trend chart.">
+                  <span><SparklineChart data={item.sparkline_data} color={item.color} /></span>
+                </Tooltip>
               </div>
             </div>
           );

--- a/ai-brand-automator-frontend/src/components/analytics/TimeRangePicker.tsx
+++ b/ai-brand-automator-frontend/src/components/analytics/TimeRangePicker.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { TimeRange } from '@/types/analytics';
+import Tooltip from '@/components/ui/Tooltip';
 
 interface TimeRangePickerProps {
   value: TimeRange;
@@ -16,20 +17,22 @@ const ranges: { label: string; value: TimeRange }[] = [
 
 export default function TimeRangePicker({ value, onChange }: TimeRangePickerProps) {
   return (
-    <div className="inline-flex rounded-lg border border-white/10 bg-white/5 p-1">
-      {ranges.map((range) => (
-        <button
-          key={range.value}
-          onClick={() => onChange(range.value)}
-          className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
-            value === range.value
-              ? 'bg-brand-electric/20 text-brand-electric'
-              : 'text-brand-silver hover:text-white hover:bg-white/5'
-          }`}
-        >
-          {range.label}
-        </button>
-      ))}
-    </div>
+    <Tooltip text="Select the time window for analytics data. All KPIs, trends, and comparisons will be recalculated for the chosen period.">
+      <div className="inline-flex rounded-lg border border-white/10 bg-white/5 p-1">
+        {ranges.map((range) => (
+          <button
+            key={range.value}
+            onClick={() => onChange(range.value)}
+            className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+              value === range.value
+                ? 'bg-brand-electric/20 text-brand-electric'
+                : 'text-brand-silver hover:text-white hover:bg-white/5'
+            }`}
+          >
+            {range.label}
+          </button>
+        ))}
+      </div>
+    </Tooltip>
   );
 }

--- a/ai-brand-automator-frontend/src/components/analytics/TrendChart.tsx
+++ b/ai-brand-automator-frontend/src/components/analytics/TrendChart.tsx
@@ -12,6 +12,7 @@ import {
 } from 'recharts';
 import { X } from 'lucide-react';
 import type { TrendPoint } from '@/types/analytics';
+import InfoTooltip from '@/components/ui/Tooltip';
 
 interface TrendChartProps {
   data: TrendPoint[];
@@ -116,9 +117,11 @@ export default function TrendChart({
         className="glass-card p-6 cursor-pointer hover:border-brand-electric/30 hover:bg-white/[0.03] transition-all duration-200"
         onClick={() => setExpanded(true)}
       >
-        <h3 className="text-sm font-medium text-brand-silver mb-4">
-          {metricName} Trend
-        </h3>
+        <InfoTooltip text={`Shows how ${metricName} has changed over the selected time range. Each point represents the average value for that period. Click to expand for a larger view.`}>
+          <h3 className="text-sm font-medium text-brand-silver mb-4 cursor-default">
+            {metricName} Trend
+          </h3>
+        </InfoTooltip>
         <TrendAreaChart
           chartData={chartData}
           color={color}

--- a/ai-brand-automator-frontend/src/components/optimization/CampaignPerformanceChart.tsx
+++ b/ai-brand-automator-frontend/src/components/optimization/CampaignPerformanceChart.tsx
@@ -12,6 +12,7 @@ import {
 } from 'recharts';
 import { BarChart3 } from 'lucide-react';
 import type { PerformanceTrendPoint } from '@/lib/optimization';
+import InfoTooltip from './Tooltip';
 
 interface TooltipPayloadEntry {
   color: string;
@@ -58,13 +59,17 @@ export default function CampaignPerformanceChart({
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2">
           <BarChart3 className="w-4 h-4 text-brand-silver" />
-          <h3 className="text-sm font-medium text-white">
-            7-Day Performance Trend
-          </h3>
+          <InfoTooltip text="Tracks CPA, CTR, and ROAS over the last 7 days. Each data point is captured during an optimization tick. Use this chart to spot trends, anomalies, and the impact of recent changes.">
+            <h3 className="text-sm font-medium text-white cursor-default">
+              7-Day Performance Trend
+            </h3>
+          </InfoTooltip>
         </div>
-        <span className="text-xs text-brand-silver/40">
-          Updated every optimization tick
-        </span>
+        <InfoTooltip text="Performance data is refreshed each time the optimization engine runs a tick — either on schedule or when manually triggered.">
+          <span className="text-xs text-brand-silver/40 cursor-default">
+            Updated every optimization tick
+          </span>
+        </InfoTooltip>
       </div>
 
       {loading ? (

--- a/ai-brand-automator-frontend/src/components/optimization/CampaignSelector.tsx
+++ b/ai-brand-automator-frontend/src/components/optimization/CampaignSelector.tsx
@@ -2,6 +2,7 @@
 
 import { ChevronDown, Clock, Bell } from 'lucide-react';
 import type { CampaignRegistry } from '@/types/optimization';
+import Tooltip from './Tooltip';
 
 interface CampaignSelectorProps {
   campaigns: CampaignRegistry[];
@@ -51,40 +52,48 @@ export default function CampaignSelector({
         {selected && (
           <div className="flex items-center gap-3">
             {/* Status badge */}
-            <span
-              className={`px-2.5 py-1 text-xs font-medium rounded-full ${
-                selected.status === 'active'
-                  ? 'bg-emerald-500/20 text-emerald-400'
-                  : selected.status === 'paused'
-                    ? 'bg-amber-500/20 text-amber-400'
-                    : selected.status === 'completed'
-                      ? 'bg-blue-500/20 text-blue-400'
-                      : 'bg-white/10 text-brand-silver'
-              }`}
-            >
-              {selected.status.charAt(0).toUpperCase() +
-                selected.status.slice(1)}
-            </span>
+            <Tooltip text="Current campaign delivery status on Meta Ads. Active means ads are running, Paused means delivery is stopped, Completed means the campaign has ended.">
+              <span
+                className={`px-2.5 py-1 text-xs font-medium rounded-full ${
+                  selected.status === 'active'
+                    ? 'bg-emerald-500/20 text-emerald-400'
+                    : selected.status === 'paused'
+                      ? 'bg-amber-500/20 text-amber-400'
+                      : selected.status === 'completed'
+                        ? 'bg-blue-500/20 text-blue-400'
+                        : 'bg-white/10 text-brand-silver'
+                }`}
+              >
+                {selected.status.charAt(0).toUpperCase() +
+                  selected.status.slice(1)}
+              </span>
+            </Tooltip>
 
             {/* Age badge */}
-            <span className="flex items-center gap-1 text-xs text-brand-silver">
-              <Clock className="w-3.5 h-3.5" />
-              {selected.age_days}d old
-            </span>
+            <Tooltip text="Number of days since the campaign started running. Younger campaigns may need more time before optimization patterns emerge.">
+              <span className="flex items-center gap-1 text-xs text-brand-silver">
+                <Clock className="w-3.5 h-3.5" />
+                {selected.age_days}d old
+              </span>
+            </Tooltip>
 
             {/* Pending recommendations badge */}
             {selected.pending_recommendations_count > 0 && (
-              <span className="flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-full bg-brand-electric/20 text-brand-electric">
-                <Bell className="w-3.5 h-3.5" />
-                {selected.pending_recommendations_count} pending
-              </span>
+              <Tooltip text="AI-generated optimization recommendations waiting for your review. Approve or reject each to guide the optimization engine.">
+                <span className="flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-full bg-brand-electric/20 text-brand-electric">
+                  <Bell className="w-3.5 h-3.5" />
+                  {selected.pending_recommendations_count} pending
+                </span>
+              </Tooltip>
             )}
 
             {/* Sandbox badge */}
             {selected.sandbox_mode && (
-              <span className="px-2.5 py-1 text-xs font-medium rounded-full bg-amber-500/20 text-amber-400">
-                Sandbox
-              </span>
+              <Tooltip text="This campaign is in sandbox mode. All optimization actions are simulated and not applied to real Meta Ads.">
+                <span className="px-2.5 py-1 text-xs font-medium rounded-full bg-amber-500/20 text-amber-400">
+                  Sandbox
+                </span>
+              </Tooltip>
             )}
           </div>
         )}

--- a/ai-brand-automator-frontend/src/components/optimization/OptimizationSettings.tsx
+++ b/ai-brand-automator-frontend/src/components/optimization/OptimizationSettings.tsx
@@ -11,6 +11,7 @@ import {
 } from 'lucide-react';
 import type { CampaignRegistry } from '@/types/optimization';
 import { updateCampaignSettings } from '@/lib/optimization';
+import Tooltip from './Tooltip';
 
 interface OptimizationSettingsProps {
   campaign: CampaignRegistry;
@@ -45,9 +46,11 @@ export default function OptimizationSettings({
     <div className="glass-card p-6 space-y-5">
       <div className="flex items-center gap-2">
         <Settings className="w-4 h-4 text-brand-silver" />
-        <h3 className="text-sm font-medium text-white">
-          Optimization Settings
-        </h3>
+        <Tooltip text="Configure how the AI optimization engine manages this campaign. Control automation level, review budget settings, and set guardrail boundaries.">
+          <h3 className="text-sm font-medium text-white cursor-default">
+            Optimization Settings
+          </h3>
+        </Tooltip>
       </div>
 
       {/* Sandbox Warning */}
@@ -65,9 +68,11 @@ export default function OptimizationSettings({
 
       {/* Mode Toggle */}
       <div className="space-y-2">
-        <p className="text-xs font-medium text-brand-silver/60 uppercase tracking-wider">
-          Optimization Mode
-        </p>
+        <Tooltip text="In Autonomous mode, the AI auto-applies recommendations within guardrail limits. In Manual mode, every recommendation requires your explicit approval before execution.">
+          <p className="text-xs font-medium text-brand-silver/60 uppercase tracking-wider cursor-default">
+            Optimization Mode
+          </p>
+        </Tooltip>
         <div className="flex items-center gap-3">
           <button
             onClick={handleModeToggle}
@@ -101,9 +106,11 @@ export default function OptimizationSettings({
 
       {/* Campaign Info */}
       <div className="space-y-3 pt-2 border-t border-white/5">
-        <p className="text-xs font-medium text-brand-silver/60 uppercase tracking-wider">
-          Campaign Info
-        </p>
+        <Tooltip text="Key campaign configuration from Meta Ads including dates, budget allocations, and performance targets.">
+          <p className="text-xs font-medium text-brand-silver/60 uppercase tracking-wider cursor-default">
+            Campaign Info
+          </p>
+        </Tooltip>
 
         <div className="space-y-2">
           <div className="flex items-center gap-2 text-xs">
@@ -160,9 +167,11 @@ export default function OptimizationSettings({
         <div className="space-y-3 pt-2 border-t border-white/5">
           <div className="flex items-center gap-2">
             <Shield className="w-3.5 h-3.5 text-brand-silver/60" />
-            <p className="text-xs font-medium text-brand-silver/60 uppercase tracking-wider">
-              Guardrail Config
-            </p>
+            <Tooltip text="Safety limits that constrain AI optimization decisions. Guardrails prevent the optimizer from making changes that exceed these boundaries, even in autonomous mode.">
+              <p className="text-xs font-medium text-brand-silver/60 uppercase tracking-wider cursor-default">
+                Guardrail Config
+              </p>
+            </Tooltip>
           </div>
           <div className="space-y-1.5">
             {guardrailEntries.map(([key, value]) => (
@@ -185,18 +194,22 @@ export default function OptimizationSettings({
       {/* Ad Sets & Ads count */}
       <div className="pt-2 border-t border-white/5">
         <div className="grid grid-cols-2 gap-3">
-          <div className="bg-white/5 rounded-lg p-3 text-center">
-            <p className="text-lg font-heading font-bold text-white">
-              {campaign.ad_sets?.length ?? 0}
-            </p>
-            <p className="text-xs text-brand-silver/60">Ad Sets</p>
-          </div>
-          <div className="bg-white/5 rounded-lg p-3 text-center">
-            <p className="text-lg font-heading font-bold text-white">
-              {campaign.ads?.length ?? 0}
-            </p>
-            <p className="text-xs text-brand-silver/60">Ads</p>
-          </div>
+          <Tooltip text="Number of ad sets in this campaign. Ad sets define targeting, budget, and schedule for a group of ads.">
+            <div className="bg-white/5 rounded-lg p-3 text-center cursor-default">
+              <p className="text-lg font-heading font-bold text-white">
+                {campaign.ad_sets?.length ?? 0}
+              </p>
+              <p className="text-xs text-brand-silver/60">Ad Sets</p>
+            </div>
+          </Tooltip>
+          <Tooltip text="Total number of individual ads across all ad sets. Each ad is a creative unit with its own copy, image, and performance metrics.">
+            <div className="bg-white/5 rounded-lg p-3 text-center cursor-default">
+              <p className="text-lg font-heading font-bold text-white">
+                {campaign.ads?.length ?? 0}
+              </p>
+              <p className="text-xs text-brand-silver/60">Ads</p>
+            </div>
+          </Tooltip>
         </div>
       </div>
     </div>

--- a/ai-brand-automator-frontend/src/components/optimization/RecentActionsList.tsx
+++ b/ai-brand-automator-frontend/src/components/optimization/RecentActionsList.tsx
@@ -2,6 +2,7 @@
 
 import { CheckCircle2, XCircle, History } from 'lucide-react';
 import type { OptimizationAction } from '@/types/optimization';
+import Tooltip from './Tooltip';
 
 interface RecentActionsListProps {
   actions: OptimizationAction[];
@@ -43,7 +44,9 @@ export default function RecentActionsList({
     <div className="glass-card p-6">
       <div className="flex items-center gap-2 mb-4">
         <History className="w-4 h-4 text-brand-silver" />
-        <h3 className="text-sm font-medium text-white">Recent Actions</h3>
+        <Tooltip text="Log of optimization actions executed on this campaign. Includes both autonomous (auto-applied) and manual (human-approved) actions. Shows the most recent 20 actions.">
+          <h3 className="text-sm font-medium text-white cursor-default">Recent Actions</h3>
+        </Tooltip>
         <span className="text-xs text-brand-silver/60">
           ({recent.length} shown)
         </span>
@@ -61,13 +64,41 @@ export default function RecentActionsList({
           <table className="w-full text-sm">
             <thead>
               <tr className="text-brand-silver/60 border-b border-white/5">
-                <th className="text-left py-2 font-medium">Date</th>
-                <th className="text-left py-2 font-medium">Campaign</th>
-                <th className="text-left py-2 font-medium">Action</th>
-                <th className="text-left py-2 font-medium">Entity</th>
-                <th className="text-left py-2 font-medium">Mode</th>
-                <th className="text-center py-2 font-medium">Verified</th>
-                <th className="text-left py-2 font-medium">Rationale</th>
+                <th className="text-left py-2 font-medium">
+                  <Tooltip text="When the action was executed.">
+                    <span className="cursor-default">Date</span>
+                  </Tooltip>
+                </th>
+                <th className="text-left py-2 font-medium">
+                  <Tooltip text="The campaign this action was applied to.">
+                    <span className="cursor-default">Campaign</span>
+                  </Tooltip>
+                </th>
+                <th className="text-left py-2 font-medium">
+                  <Tooltip text="The type of optimization action taken (e.g., Pause, Scale, Reallocate, Adjust Bid).">
+                    <span className="cursor-default">Action</span>
+                  </Tooltip>
+                </th>
+                <th className="text-left py-2 font-medium">
+                  <Tooltip text="The specific entity (campaign, ad set, or ad) the action was applied to.">
+                    <span className="cursor-default">Entity</span>
+                  </Tooltip>
+                </th>
+                <th className="text-left py-2 font-medium">
+                  <Tooltip text="How the action was applied. Autonomous means auto-applied by the AI; Manual means a human approved it first.">
+                    <span className="cursor-default">Mode</span>
+                  </Tooltip>
+                </th>
+                <th className="text-center py-2 font-medium">
+                  <Tooltip text="Whether the action was verified as successfully applied on Meta Ads after execution.">
+                    <span className="cursor-default">Verified</span>
+                  </Tooltip>
+                </th>
+                <th className="text-left py-2 font-medium">
+                  <Tooltip text="The AI-generated explanation for why this action was recommended and executed.">
+                    <span className="cursor-default">Rationale</span>
+                  </Tooltip>
+                </th>
               </tr>
             </thead>
             <tbody>

--- a/ai-brand-automator-frontend/src/components/optimization/RecommendationCard.tsx
+++ b/ai-brand-automator-frontend/src/components/optimization/RecommendationCard.tsx
@@ -15,6 +15,7 @@ import {
   AlertTriangle,
 } from 'lucide-react';
 import type { OptimizationRecommendation } from '@/types/optimization';
+import Tooltip from './Tooltip';
 
 interface RecommendationCardProps {
   recommendation: OptimizationRecommendation;
@@ -123,20 +124,24 @@ export default function RecommendationCard({
           </div>
         </div>
         <div className="flex items-center gap-2">
-          <span
-            className={`px-2 py-0.5 text-xs font-medium rounded-full ${priorityStyle.bg} ${priorityStyle.text}`}
-          >
-            {rec.priority}
-          </span>
-          {rec.expires_at && (
+          <Tooltip text="Priority level set by the AI based on potential impact and urgency. Critical items need immediate attention; Low items are minor optimizations.">
             <span
-              className={`text-xs ${
-                rec.is_expired ? 'text-red-400' : 'text-brand-silver/60'
-              }`}
+              className={`px-2 py-0.5 text-xs font-medium rounded-full ${priorityStyle.bg} ${priorityStyle.text}`}
             >
-              <Clock className="w-3 h-3 inline mr-1" />
-              {formatTimeRemaining(rec.expires_at)}
+              {rec.priority}
             </span>
+          </Tooltip>
+          {rec.expires_at && (
+            <Tooltip text="Recommendations expire after a set window. Once expired, the underlying data may no longer be relevant and the recommendation cannot be approved.">
+              <span
+                className={`text-xs ${
+                  rec.is_expired ? 'text-red-400' : 'text-brand-silver/60'
+                }`}
+              >
+                <Clock className="w-3 h-3 inline mr-1" />
+                {formatTimeRemaining(rec.expires_at)}
+              </span>
+            </Tooltip>
           )}
         </div>
       </div>
@@ -147,9 +152,11 @@ export default function RecommendationCard({
       {/* Current vs Proposed */}
       <div className="grid grid-cols-2 gap-3 mb-3">
         <div className="bg-white/5 rounded-lg p-3">
-          <p className="text-xs font-medium text-brand-silver/60 mb-1.5 uppercase tracking-wider">
-            Current
-          </p>
+          <Tooltip text="The current values of the settings that the AI is recommending to change.">
+            <p className="text-xs font-medium text-brand-silver/60 mb-1.5 uppercase tracking-wider cursor-default">
+              Current
+            </p>
+          </Tooltip>
           {currentValues.map((v, i) => (
             <p key={i} className="text-xs text-brand-silver">
               {v}
@@ -157,9 +164,11 @@ export default function RecommendationCard({
           ))}
         </div>
         <div className="bg-brand-electric/5 rounded-lg p-3 border border-brand-electric/10">
-          <p className="text-xs font-medium text-brand-electric/60 mb-1.5 uppercase tracking-wider">
-            Proposed
-          </p>
+          <Tooltip text="The new values that the AI recommends applying. Compare these against the current values to assess the change.">
+            <p className="text-xs font-medium text-brand-electric/60 mb-1.5 uppercase tracking-wider cursor-default">
+              Proposed
+            </p>
+          </Tooltip>
           {proposedValues.map((v, i) => (
             <p key={i} className="text-xs text-brand-electric">
               {v}
@@ -171,9 +180,11 @@ export default function RecommendationCard({
       {/* Projected impact */}
       {Object.keys(rec.projected_impact).length > 0 && (
         <div className="bg-white/5 rounded-lg p-3 mb-3">
-          <p className="text-xs font-medium text-brand-silver/60 mb-1.5 uppercase tracking-wider">
-            Projected Impact
-          </p>
+          <Tooltip text="AI-estimated impact if this recommendation is approved. These are projections based on historical data and may vary from actual results.">
+            <p className="text-xs font-medium text-brand-silver/60 mb-1.5 uppercase tracking-wider cursor-default">
+              Projected Impact
+            </p>
+          </Tooltip>
           <div className="flex flex-wrap gap-2">
             {Object.entries(rec.projected_impact ?? {}).map(([key, val]) => (
               <span

--- a/ai-brand-automator-frontend/src/components/optimization/RecommendationsList.tsx
+++ b/ai-brand-automator-frontend/src/components/optimization/RecommendationsList.tsx
@@ -9,6 +9,7 @@ import {
   batchApproveRecommendations,
 } from '@/lib/optimization';
 import RecommendationCard from './RecommendationCard';
+import Tooltip from './Tooltip';
 
 interface RecommendationsListProps {
   campaignId: string | null;
@@ -83,9 +84,11 @@ export default function RecommendationsList({
     <div className="glass-card p-6">
       <div className="flex items-center justify-between mb-4">
         <div>
-          <h3 className="text-sm font-medium text-white">
-            Recommendations
-          </h3>
+          <Tooltip text="AI-generated suggestions to improve campaign performance. Each recommendation includes a proposed change, its rationale, and projected impact. Review and approve or reject each one.">
+            <h3 className="text-sm font-medium text-white cursor-default">
+              Recommendations
+            </h3>
+          </Tooltip>
           <p className="text-xs text-brand-silver/60 mt-0.5">
             {recommendations.length} recommendation
             {recommendations.length !== 1 ? 's' : ''}
@@ -94,14 +97,16 @@ export default function RecommendationsList({
           </p>
         </div>
         {recommendations.length > 1 && (
-          <button
-            onClick={handleBatchApprove}
-            disabled={batchApproving}
-            className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg bg-brand-electric/20 text-brand-electric hover:bg-brand-electric/30 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            <CheckCheck className="w-3.5 h-3.5" />
-            {batchApproving ? 'Approving All...' : 'Approve All'}
-          </button>
+          <Tooltip text="Approve all pending recommendations at once. Expired recommendations will be skipped automatically.">
+            <button
+              onClick={handleBatchApprove}
+              disabled={batchApproving}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg bg-brand-electric/20 text-brand-electric hover:bg-brand-electric/30 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <CheckCheck className="w-3.5 h-3.5" />
+              {batchApproving ? 'Approving All...' : 'Approve All'}
+            </button>
+          </Tooltip>
         )}
       </div>
 

--- a/ai-brand-automator-frontend/src/components/optimization/Tooltip.tsx
+++ b/ai-brand-automator-frontend/src/components/optimization/Tooltip.tsx
@@ -1,0 +1,1 @@
+export { default } from '@/components/ui/Tooltip';

--- a/ai-brand-automator-frontend/src/components/ui/Tooltip.tsx
+++ b/ai-brand-automator-frontend/src/components/ui/Tooltip.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+interface TooltipProps {
+  text: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+/**
+ * Inline hover/focus tooltip.
+ * Wraps children in a group container and shows tooltip above on hover or focus.
+ */
+export default function Tooltip({ text, children, className = '' }: TooltipProps) {
+  return (
+    <span className={`group/tip relative inline-flex ${className}`} tabIndex={0}>
+      {children}
+      <span
+        role="tooltip"
+        className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-56 px-3 py-2 rounded-lg bg-brand-midnight border border-white/10 shadow-lg text-xs text-brand-silver leading-relaxed opacity-0 pointer-events-none group-hover/tip:opacity-100 group-focus-within/tip:opacity-100 transition-opacity duration-200 z-50"
+      >
+        {text}
+        <span className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-white/10" />
+      </span>
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds educational hover/focus tooltips to **every tile, badge, chart heading, and setting** across both the Optimization Dashboard and the Workflow Analytics Dashboard
- Creates a shared reusable `Tooltip` component at `src/components/ui/Tooltip.tsx` (optimization components re-export from it)
- **15 files changed** across 13 existing components + 2 new Tooltip files

### Optimization Dashboard (6 components)
- **CampaignSelector**: status, age, pending recommendations, sandbox badges
- **CampaignPerformanceChart**: chart title, update frequency label
- **RecommendationsList**: section heading, Approve All button
- **RecommendationCard**: priority badge, expiry timer, current/proposed labels, projected impact
- **RecentActionsList**: section heading + all 7 table column headers (Date, Campaign, Action, Entity, Mode, Verified, Rationale)
- **OptimizationSettings**: section heading, optimization mode, campaign info, guardrail config, ad sets count, ads count

### Analytics Dashboard (7 components)
- **AnalyticsDashboard**: Workflow Analytics heading, View All link
- **KpiScorecard**: metric name (with higher/lower-is-better context), trend icon, change %, sparkline
- **TrendChart**: dynamic chart title per metric
- **ComparisonBars**: Period Comparison heading
- **DistributionGauge**: Sentiment Distribution heading
- **AnalyticsCoverage**: coverage badge
- **TimeRangePicker**: time range selector

## Test plan
- [ ] Hover over each tile/badge/heading on the Optimization Dashboard — tooltip appears above with explanation
- [ ] Hover over each tile/chart/heading on the Analytics Dashboard — tooltip appears above with explanation
- [ ] Tab through elements — tooltips appear on focus for keyboard accessibility
- [ ] Verify tooltips don't overlap or clip on mobile viewports
- [ ] Run `npx tsc --noEmit` — passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)