### PR TITLE
fix(dashboard): use allSettled for overview cards to prevent all-or-nothing failure

### DIFF
--- a/ai-brand-automator-frontend/src/components/dashboard/OverviewCards.tsx
+++ b/ai-brand-automator-frontend/src/components/dashboard/OverviewCards.tsx
@@ -66,11 +66,19 @@ export function OverviewCards() {
   useEffect(() => {
     const fetchDashboardData = async () => {
       try {
-        const responses = await Promise.all(
-          CARD_CONFIGS.map((cfg) => apiClient.get(cfg.endpoint))
+        // Use allSettled so one failing endpoint doesn't blank all cards
+        const results = await Promise.allSettled(
+          CARD_CONFIGS.map(async (cfg) => {
+            const response = await apiClient.get(cfg.endpoint);
+            if (!response.ok) return 0;
+            const data = await response.json();
+            return extractCount(data);
+          })
         );
-        const dataList = await Promise.all(responses.map((r) => r.json()));
-        const counts = dataList.map(extractCount);
+
+        const counts = results.map((r) =>
+          r.status === 'fulfilled' ? r.value : 0
+        );
 
         setCardStates(
           counts.map((count, i) => ({
@@ -79,9 +87,9 @@ export function OverviewCards() {
             changeType: count > 0 ? ('positive' as const) : ('neutral' as const),
           }))
         );
-        setLoading(false);
       } catch (error) {
         console.error('Error fetching dashboard data:', error);
+      } finally {
         setLoading(false);
       }
     };


### PR DESCRIPTION
## Summary
- **Root cause**: `OverviewCards` used `Promise.all` to fetch 4 endpoints (`/assets/`, `/ai/generations/`, `/orchestration/jobs/`, `/ai/chat-sessions/`) in parallel. If any single request failed (network error, 500, auth issue), the entire `Promise.all` rejected and all four tiles showed 0.
- **Fix**: Switched to `Promise.allSettled` so each tile fetches independently. A failing endpoint only blanks its own card — the other three still display correct counts. Also added `response.ok` check to handle non-200 responses gracefully instead of trying to parse error bodies.

## Test plan
- [ ] Verify all four overview tiles (Total Assets, AI Interactions, Workflows Run, Chat Sessions) show correct counts
- [ ] Verify that if one endpoint is temporarily unavailable, only that tile shows 0 while others still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)