### PR TITLE
feat(infra): Configure Redis DB 2 as prompt cache (US-004)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,7 +246,7 @@ Schema-based via `django-tenants`. All models have a nullable `tenant` FK. Most 
 
 ### Redis Database Allocation
 
-DB 0: Django/Celery, DB 1: Orchestrator, DB 2: Discovery, DB 3: Intelligence, DB 4: Titling, DB 5: Content, DB 6: Social, DB 7: RAG Uploader, DB 8: Brand Equity, DB 9: Odoo MCP, DB 10: Odoo Worker, DB 11: Market Research, DB 12: Competitor Intel, DB 13: Audience Persona, DB 14: Trend Cultural, DB 15: VoC Agent, DB 16: Brand Positioning, DB 17: Brand Architecture, DB 18: Brand Personality, DB 19: Brand Naming, DB 20: Brand Story, DB 21: Campaign Architecture, DB 22: Creative Generation, DB 23: Ad Publishing, DB 24: Campaign Optimization, DB 25: Intelligence Loop Agent (WF3.5), DB 26: Prompt Optimization. Requires `databases 27` in redis.conf and `--databases 27` in docker-compose — if a service fails with `ERR DB index is out of range`, bump the Redis `databases` setting.
+DB 0: Django/Celery, DB 1: Orchestrator, DB 2: Discovery + Prompt Cache (shared, key-prefix isolated), DB 3: Intelligence, DB 4: Titling, DB 5: Content, DB 6: Social, DB 7: RAG Uploader, DB 8: Brand Equity, DB 9: Odoo MCP, DB 10: Odoo Worker, DB 11: Market Research, DB 12: Competitor Intel, DB 13: Audience Persona, DB 14: Trend Cultural, DB 15: VoC Agent, DB 16: Brand Positioning, DB 17: Brand Architecture, DB 18: Brand Personality, DB 19: Brand Naming, DB 20: Brand Story, DB 21: Campaign Architecture, DB 22: Creative Generation, DB 23: Ad Publishing, DB 24: Campaign Optimization, DB 25: Intelligence Loop Agent (WF3.5), DB 26: Prompt Optimization. Requires `databases 27` in redis.conf and `--databases 27` in docker-compose — if a service fails with `ERR DB index is out of range`, bump the Redis `databases` setting.
 
 ### Microservice Layout Convention
 

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -1693,6 +1693,7 @@ services:
     container_name: ai-brand-automator-prompt-optimization
     environment:
       - POI_REDIS_URL=redis://redis:6379/26
+      - POI_PROMPT_CACHE_REDIS_URL=redis://redis:6379/2
       - POI_KAFKA_BOOTSTRAP_SERVERS=${POI_KAFKA_BOOTSTRAP_SERVERS:-}
       - POI_ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       - POI_MLFLOW_TRACKING_URI=http://mlflow-server:5000

--- a/prompt-optimization-svc/CLAUDE.md
+++ b/prompt-optimization-svc/CLAUDE.md
@@ -31,6 +31,7 @@ app/
 POI_MLFLOW_TRACKING_URI=http://mlflow-server:5000
 POI_DATABASE_URL=postgresql://mlflow:mlflow@mlflow-db:5432/mlflow
 POI_REDIS_URL=redis://localhost:6379/26
+POI_PROMPT_CACHE_REDIS_URL=redis://localhost:6379/2
 POI_KAFKA_BOOTSTRAP_SERVERS=    # Empty = disabled
 POI_ANTHROPIC_API_KEY=
 POI_HOST=0.0.0.0

--- a/prompt-optimization-svc/app/cache/prompt_cache.py
+++ b/prompt-optimization-svc/app/cache/prompt_cache.py
@@ -141,25 +141,34 @@ class PromptCacheManager:
             logger.warning("Lock acquire error: %s", exc)
             return False
 
+    # Lua script for atomic compare-and-delete (lock release)
+    _RELEASE_LOCK_SCRIPT = """
+    if redis.call("GET", KEYS[1]) == ARGV[1] then
+        return redis.call("DEL", KEYS[1])
+    else
+        return 0
+    end
+    """
+
     async def release_optimization_lock(
         self, group: str, owner: str
     ) -> bool:
         """Release an optimization lock (only if held by the given owner).
+
+        Uses an atomic Lua script to compare-and-delete, preventing race
+        conditions where the lock expires and is re-acquired between
+        GET and DEL.
 
         Returns True if released, False if not held or held by another owner.
         """
         try:
             r = await self.connect()
             key = self._lock_key(group)
-            current_owner = await r.get(key)
-            if current_owner == owner:
-                await r.delete(key)
+            result = await r.eval(self._RELEASE_LOCK_SCRIPT, 1, key, owner)
+            if result:
                 logger.info("Lock released: %s (owner=%s)", group, owner)
                 return True
-            logger.debug(
-                "Lock release denied: %s (owner=%s, held_by=%s)",
-                group, owner, current_owner,
-            )
+            logger.debug("Lock release denied: %s (owner=%s)", group, owner)
             return False
         except Exception as exc:
             logger.warning("Lock release error: %s", exc)

--- a/prompt-optimization-svc/app/cache/prompt_cache.py
+++ b/prompt-optimization-svc/app/cache/prompt_cache.py
@@ -1,0 +1,236 @@
+"""Prompt cache manager — Redis DB 2 for prompt storage, locks, and progress.
+
+Key naming convention (§9.1):
+  prompt:<name>:production               — global production prompt
+  prompt:<name>:tenant:<tid>             — tenant-specific override
+  prompt:optimization:lock:<group>       — distributed optimization lock
+  prompt:optimization:progress:<run_id>  — optimization run progress hash
+"""
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import redis.asyncio as aioredis
+
+logger = logging.getLogger(__name__)
+
+# TTL defaults (seconds)
+DEFAULT_PROMPT_TTL = 300  # 5 minutes
+LOCK_TTL = 7200  # 2 hours
+PROGRESS_TTL = 86400  # 24 hours
+
+
+class PromptCacheManager:
+    """Redis DB 2 — prompt cache, optimization locks, and progress tracking."""
+
+    def __init__(self, redis_url: str) -> None:
+        self.redis_url = redis_url
+        self._redis: Optional[aioredis.Redis] = None
+
+    async def connect(self) -> aioredis.Redis:
+        """Initialize and return the Redis connection."""
+        if self._redis is None:
+            self._redis = aioredis.from_url(
+                self.redis_url, decode_responses=True
+            )
+        return self._redis
+
+    @property
+    def client(self) -> Optional[aioredis.Redis]:
+        """Return the raw Redis client (for health checks)."""
+        return self._redis
+
+    async def close(self) -> None:
+        """Close the Redis connection."""
+        if self._redis is not None:
+            await self._redis.aclose()
+            self._redis = None
+
+    # ------------------------------------------------------------------
+    # Prompt cache (AC-1)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _prompt_key(name: str, tenant_id: Optional[str] = None) -> str:
+        """Build the Redis key for a prompt.
+
+        Returns:
+            prompt:<name>:tenant:<tid>  if tenant_id is set
+            prompt:<name>:production    otherwise
+        """
+        if tenant_id:
+            return f"prompt:{name}:tenant:{tenant_id}"
+        return f"prompt:{name}:production"
+
+    async def get_prompt(
+        self, name: str, tenant_id: Optional[str] = None
+    ) -> Optional[str]:
+        """Get a cached prompt template. Returns None on miss or error."""
+        try:
+            r = await self.connect()
+            key = self._prompt_key(name, tenant_id)
+            return await r.get(key)
+        except Exception as exc:
+            logger.warning("Prompt cache get error: %s", exc)
+            return None
+
+    async def set_prompt(
+        self,
+        name: str,
+        template: str,
+        ttl: int = DEFAULT_PROMPT_TTL,
+        tenant_id: Optional[str] = None,
+    ) -> None:
+        """Cache a prompt template with TTL."""
+        try:
+            r = await self.connect()
+            key = self._prompt_key(name, tenant_id)
+            await r.set(key, template, ex=ttl)
+            logger.debug("Prompt cached: %s (ttl=%ds)", key, ttl)
+        except Exception as exc:
+            logger.warning("Prompt cache set error: %s", exc)
+
+    async def invalidate_prompt(self, name: str) -> int:
+        """Delete all cached versions of a prompt (production + tenant overrides).
+
+        Returns the number of keys deleted.
+        """
+        try:
+            r = await self.connect()
+            keys = []
+            async for key in r.scan_iter(match=f"prompt:{name}:*"):
+                keys.append(key)
+            if keys:
+                deleted = await r.delete(*keys)
+                logger.info("Prompt invalidated: %s (%d keys)", name, deleted)
+                return deleted
+            return 0
+        except Exception as exc:
+            logger.warning("Prompt cache invalidate error: %s", exc)
+            return 0
+
+    # ------------------------------------------------------------------
+    # Optimization lock (AC-2)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _lock_key(group: str) -> str:
+        """Build the Redis key for an optimization lock."""
+        return f"prompt:optimization:lock:{group}"
+
+    async def acquire_optimization_lock(
+        self, group: str, owner: str, ttl: int = LOCK_TTL
+    ) -> bool:
+        """Acquire a distributed optimization lock.
+
+        Uses SET NX EX for atomic acquire with 2-hour TTL.
+        Returns True if lock was acquired, False if already held.
+        """
+        try:
+            r = await self.connect()
+            key = self._lock_key(group)
+            acquired = await r.set(key, owner, nx=True, ex=ttl)
+            if acquired:
+                logger.info("Lock acquired: %s (owner=%s, ttl=%ds)", group, owner, ttl)
+            else:
+                logger.debug("Lock not acquired: %s (already held)", group)
+            return bool(acquired)
+        except Exception as exc:
+            logger.warning("Lock acquire error: %s", exc)
+            return False
+
+    async def release_optimization_lock(
+        self, group: str, owner: str
+    ) -> bool:
+        """Release an optimization lock (only if held by the given owner).
+
+        Returns True if released, False if not held or held by another owner.
+        """
+        try:
+            r = await self.connect()
+            key = self._lock_key(group)
+            current_owner = await r.get(key)
+            if current_owner == owner:
+                await r.delete(key)
+                logger.info("Lock released: %s (owner=%s)", group, owner)
+                return True
+            logger.debug(
+                "Lock release denied: %s (owner=%s, held_by=%s)",
+                group, owner, current_owner,
+            )
+            return False
+        except Exception as exc:
+            logger.warning("Lock release error: %s", exc)
+            return False
+
+    async def get_optimization_lock_info(
+        self, group: str
+    ) -> Optional[dict[str, Any]]:
+        """Get lock info (owner and remaining TTL)."""
+        try:
+            r = await self.connect()
+            key = self._lock_key(group)
+            owner = await r.get(key)
+            if owner is None:
+                return None
+            ttl = await r.ttl(key)
+            return {"group": group, "owner": owner, "ttl_seconds": ttl}
+        except Exception as exc:
+            logger.warning("Lock info error: %s", exc)
+            return None
+
+    # ------------------------------------------------------------------
+    # Optimization progress (AC-3)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _progress_key(run_id: str) -> str:
+        """Build the Redis key for optimization progress."""
+        return f"prompt:optimization:progress:{run_id}"
+
+    async def set_optimization_progress(
+        self,
+        run_id: str,
+        progress: dict[str, Any],
+        ttl: int = PROGRESS_TTL,
+    ) -> None:
+        """Set optimization progress as a Redis hash with 24-hour TTL."""
+        try:
+            r = await self.connect()
+            key = self._progress_key(run_id)
+            # Serialize complex values to JSON strings for Redis hash
+            flat = {
+                k: json.dumps(v) if isinstance(v, (dict, list)) else str(v)
+                for k, v in progress.items()
+            }
+            flat["updated_at"] = datetime.now(timezone.utc).isoformat()
+            await r.hset(key, mapping=flat)
+            await r.expire(key, ttl)
+            logger.debug("Progress updated: %s", run_id)
+        except Exception as exc:
+            logger.warning("Progress set error: %s", exc)
+
+    async def get_optimization_progress(
+        self, run_id: str
+    ) -> Optional[dict[str, str]]:
+        """Get optimization progress hash. Returns None if not found."""
+        try:
+            r = await self.connect()
+            key = self._progress_key(run_id)
+            data = await r.hgetall(key)
+            return data if data else None
+        except Exception as exc:
+            logger.warning("Progress get error: %s", exc)
+            return None
+
+    async def delete_optimization_progress(self, run_id: str) -> None:
+        """Delete optimization progress hash."""
+        try:
+            r = await self.connect()
+            key = self._progress_key(run_id)
+            await r.delete(key)
+            logger.debug("Progress deleted: %s", run_id)
+        except Exception as exc:
+            logger.warning("Progress delete error: %s", exc)

--- a/prompt-optimization-svc/app/core/config.py
+++ b/prompt-optimization-svc/app/core/config.py
@@ -21,8 +21,11 @@ class Settings(BaseSettings):
     # PostgreSQL (shared with MLflow backend store)
     DATABASE_URL: str = "postgresql://mlflow:mlflow@mlflow-db:5432/mlflow"
 
-    # Redis (DB 26)
+    # Redis (DB 26 — general service cache/rate-limiting)
     REDIS_URL: str = "redis://localhost:6379/26"
+
+    # Redis (DB 2 — prompt cache, optimization locks, progress tracking)
+    PROMPT_CACHE_REDIS_URL: str = "redis://localhost:6379/2"
 
     # Kafka
     KAFKA_BOOTSTRAP_SERVERS: str = ""

--- a/prompt-optimization-svc/app/main.py
+++ b/prompt-optimization-svc/app/main.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.routes import router
+from app.cache.prompt_cache import PromptCacheManager
 from app.cache.redis_manager import RedisManager
 from app.core.config import settings
 from app.core.logging_config import setup_logging
@@ -66,9 +67,13 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # 0. Run database migrations
     _run_migrations()
 
-    # 1. Redis
+    # 1. Redis (general cache)
     redis_manager = RedisManager(redis_url=settings.REDIS_URL)
     redis_client = await redis_manager.connect()
+
+    # 1b. Redis DB 2 (prompt cache, locks, progress)
+    prompt_cache = PromptCacheManager(redis_url=settings.PROMPT_CACHE_REDIS_URL)
+    await prompt_cache.connect()
 
     # 2. Kafka producers
     trace_producer = TraceProducer(settings.KAFKA_BOOTSTRAP_SERVERS)
@@ -85,9 +90,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     routes.health_checker = checker
 
     logger.info(
-        "Service initialized — MLflow=%s, Redis=%s, Kafka=%s",
+        "Service initialized — MLflow=%s, Redis=%s, PromptCache=%s, Kafka=%s",
         settings.MLFLOW_TRACKING_URI,
         settings.REDIS_URL,
+        settings.PROMPT_CACHE_REDIS_URL,
         settings.KAFKA_BOOTSTRAP_SERVERS or "disabled",
     )
     yield
@@ -95,6 +101,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # Shutdown
     await trace_producer.stop()
     await audit_producer.stop()
+    await prompt_cache.close()
     await redis_manager.close()
     routes.health_checker = None
     logger.info("prompt-optimization-svc shut down")

--- a/prompt-optimization-svc/tests/test_prompt_cache.py
+++ b/prompt-optimization-svc/tests/test_prompt_cache.py
@@ -1,0 +1,254 @@
+"""Tests for PromptCacheManager — Redis DB 2 prompt cache, locks, and progress."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.cache.prompt_cache import (
+    DEFAULT_PROMPT_TTL,
+    LOCK_TTL,
+    PROGRESS_TTL,
+    PromptCacheManager,
+)
+
+
+@pytest.fixture
+def mock_redis():
+    """Mock Redis client."""
+    r = AsyncMock()
+    r.get.return_value = None
+    r.set.return_value = True
+    r.delete.return_value = 1
+    r.hset.return_value = True
+    r.hgetall.return_value = {}
+    r.expire.return_value = True
+    r.ttl.return_value = 7200
+    r.aclose.return_value = None
+    return r
+
+
+@pytest.fixture
+def cache(mock_redis):
+    """PromptCacheManager with mocked Redis."""
+    mgr = PromptCacheManager(redis_url="redis://localhost:6379/2")
+    mgr._redis = mock_redis
+    return mgr
+
+
+# ------------------------------------------------------------------
+# Key naming convention (AC-1)
+# ------------------------------------------------------------------
+
+
+class TestKeyPatterns:
+    """Verify §9.1 key naming convention."""
+
+    def test_production_key(self):
+        key = PromptCacheManager._prompt_key("zorven-wf1-mra-landscape")
+        assert key == "prompt:zorven-wf1-mra-landscape:production"
+
+    def test_tenant_key(self):
+        key = PromptCacheManager._prompt_key("zorven-wf1-mra-landscape", "tenant-42")
+        assert key == "prompt:zorven-wf1-mra-landscape:tenant:tenant-42"
+
+    def test_lock_key(self):
+        key = PromptCacheManager._lock_key("wf3-creative-pipeline")
+        assert key == "prompt:optimization:lock:wf3-creative-pipeline"
+
+    def test_progress_key(self):
+        key = PromptCacheManager._progress_key("run-abc-123")
+        assert key == "prompt:optimization:progress:run-abc-123"
+
+
+# ------------------------------------------------------------------
+# Prompt cache (AC-1)
+# ------------------------------------------------------------------
+
+
+class TestPromptCache:
+    """Test prompt get/set/invalidate."""
+
+    async def test_set_production_prompt(self, cache, mock_redis):
+        await cache.set_prompt("zorven-wf1-mra-landscape", "You are a market researcher")
+        mock_redis.set.assert_called_once_with(
+            "prompt:zorven-wf1-mra-landscape:production",
+            "You are a market researcher",
+            ex=DEFAULT_PROMPT_TTL,
+        )
+
+    async def test_set_tenant_prompt(self, cache, mock_redis):
+        await cache.set_prompt("zorven-wf1-mra-landscape", "Custom prompt", tenant_id="t-99")
+        mock_redis.set.assert_called_once_with(
+            "prompt:zorven-wf1-mra-landscape:tenant:t-99",
+            "Custom prompt",
+            ex=DEFAULT_PROMPT_TTL,
+        )
+
+    async def test_set_prompt_custom_ttl(self, cache, mock_redis):
+        await cache.set_prompt("test", "template", ttl=600)
+        mock_redis.set.assert_called_once_with(
+            "prompt:test:production", "template", ex=600
+        )
+
+    async def test_get_production_prompt_hit(self, cache, mock_redis):
+        mock_redis.get.return_value = "cached template"
+        result = await cache.get_prompt("test-prompt")
+        assert result == "cached template"
+        mock_redis.get.assert_called_once_with("prompt:test-prompt:production")
+
+    async def test_get_prompt_miss(self, cache, mock_redis):
+        mock_redis.get.return_value = None
+        result = await cache.get_prompt("nonexistent")
+        assert result is None
+
+    async def test_get_tenant_prompt(self, cache, mock_redis):
+        mock_redis.get.return_value = "tenant template"
+        result = await cache.get_prompt("test", tenant_id="t-1")
+        mock_redis.get.assert_called_once_with("prompt:test:tenant:t-1")
+        assert result == "tenant template"
+
+    async def test_invalidate_prompt(self, cache, mock_redis):
+        async def fake_scan(*args, **kwargs):
+            for key in [
+                "prompt:test:production",
+                "prompt:test:tenant:t-1",
+            ]:
+                yield key
+
+        mock_redis.scan_iter = fake_scan
+        mock_redis.delete.return_value = 2
+        deleted = await cache.invalidate_prompt("test")
+        assert deleted == 2
+
+    async def test_invalidate_no_keys(self, cache, mock_redis):
+        async def empty_scan(*args, **kwargs):
+            return
+            yield  # noqa: make it an async generator
+
+        mock_redis.scan_iter = empty_scan
+        deleted = await cache.invalidate_prompt("nonexistent")
+        assert deleted == 0
+
+    async def test_get_prompt_redis_error_returns_none(self, cache, mock_redis):
+        mock_redis.get.side_effect = ConnectionError("refused")
+        result = await cache.get_prompt("test")
+        assert result is None
+
+
+# ------------------------------------------------------------------
+# Optimization lock (AC-2)
+# ------------------------------------------------------------------
+
+
+class TestOptimizationLock:
+    """Test distributed optimization lock."""
+
+    async def test_acquire_lock_success(self, cache, mock_redis):
+        mock_redis.set.return_value = True
+        acquired = await cache.acquire_optimization_lock("wf3-creative", "worker-1")
+        assert acquired is True
+        mock_redis.set.assert_called_once_with(
+            "prompt:optimization:lock:wf3-creative",
+            "worker-1",
+            nx=True,
+            ex=LOCK_TTL,
+        )
+
+    async def test_acquire_lock_already_held(self, cache, mock_redis):
+        mock_redis.set.return_value = None  # NX failed
+        acquired = await cache.acquire_optimization_lock("wf3-creative", "worker-2")
+        assert acquired is False
+
+    async def test_acquire_lock_custom_ttl(self, cache, mock_redis):
+        mock_redis.set.return_value = True
+        await cache.acquire_optimization_lock("grp", "owner", ttl=3600)
+        mock_redis.set.assert_called_once_with(
+            "prompt:optimization:lock:grp", "owner", nx=True, ex=3600
+        )
+
+    async def test_release_lock_by_owner(self, cache, mock_redis):
+        mock_redis.get.return_value = "worker-1"
+        released = await cache.release_optimization_lock("wf3-creative", "worker-1")
+        assert released is True
+        mock_redis.delete.assert_called_once_with(
+            "prompt:optimization:lock:wf3-creative"
+        )
+
+    async def test_release_lock_wrong_owner(self, cache, mock_redis):
+        mock_redis.get.return_value = "worker-1"
+        released = await cache.release_optimization_lock("wf3-creative", "worker-2")
+        assert released is False
+        mock_redis.delete.assert_not_called()
+
+    async def test_release_lock_not_held(self, cache, mock_redis):
+        mock_redis.get.return_value = None
+        released = await cache.release_optimization_lock("grp", "owner")
+        assert released is False
+
+    async def test_get_lock_info(self, cache, mock_redis):
+        mock_redis.get.return_value = "worker-1"
+        mock_redis.ttl.return_value = 5400
+        info = await cache.get_optimization_lock_info("wf3-creative")
+        assert info == {
+            "group": "wf3-creative",
+            "owner": "worker-1",
+            "ttl_seconds": 5400,
+        }
+
+    async def test_get_lock_info_not_held(self, cache, mock_redis):
+        mock_redis.get.return_value = None
+        info = await cache.get_optimization_lock_info("grp")
+        assert info is None
+
+    async def test_lock_ttl_is_2_hours(self):
+        assert LOCK_TTL == 7200
+
+
+# ------------------------------------------------------------------
+# Optimization progress (AC-3)
+# ------------------------------------------------------------------
+
+
+class TestOptimizationProgress:
+    """Test optimization progress hash."""
+
+    async def test_set_progress(self, cache, mock_redis):
+        progress = {"state": "OPTIMIZING", "percent": 45}
+        await cache.set_optimization_progress("run-123", progress)
+        mock_redis.hset.assert_called_once()
+        # Verify the key was passed (positional or keyword)
+        call_args = mock_redis.hset.call_args
+        key_arg = call_args[0][0] if call_args[0] else call_args[1].get("name", call_args[1].get("key"))
+        assert key_arg == "prompt:optimization:progress:run-123"
+        mock_redis.expire.assert_called_once_with(
+            "prompt:optimization:progress:run-123", PROGRESS_TTL
+        )
+
+    async def test_set_progress_ttl_is_24_hours(self):
+        assert PROGRESS_TTL == 86400
+
+    async def test_get_progress(self, cache, mock_redis):
+        mock_redis.hgetall.return_value = {
+            "state": "OPTIMIZING",
+            "percent": "45",
+            "updated_at": "2026-05-22T10:00:00+00:00",
+        }
+        result = await cache.get_optimization_progress("run-123")
+        assert result["state"] == "OPTIMIZING"
+        assert result["percent"] == "45"
+
+    async def test_get_progress_not_found(self, cache, mock_redis):
+        mock_redis.hgetall.return_value = {}
+        result = await cache.get_optimization_progress("nonexistent")
+        assert result is None
+
+    async def test_delete_progress(self, cache, mock_redis):
+        await cache.delete_optimization_progress("run-123")
+        mock_redis.delete.assert_called_once_with(
+            "prompt:optimization:progress:run-123"
+        )
+
+    async def test_progress_redis_error_returns_none(self, cache, mock_redis):
+        mock_redis.hgetall.side_effect = ConnectionError("refused")
+        result = await cache.get_optimization_progress("run-123")
+        assert result is None

--- a/prompt-optimization-svc/tests/test_prompt_cache.py
+++ b/prompt-optimization-svc/tests/test_prompt_cache.py
@@ -1,6 +1,6 @@
 """Tests for PromptCacheManager — Redis DB 2 prompt cache, locks, and progress."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -167,21 +167,18 @@ class TestOptimizationLock:
         )
 
     async def test_release_lock_by_owner(self, cache, mock_redis):
-        mock_redis.get.return_value = "worker-1"
+        mock_redis.eval.return_value = 1  # Lua script returns 1 (DEL succeeded)
         released = await cache.release_optimization_lock("wf3-creative", "worker-1")
         assert released is True
-        mock_redis.delete.assert_called_once_with(
-            "prompt:optimization:lock:wf3-creative"
-        )
+        mock_redis.eval.assert_called_once()
 
     async def test_release_lock_wrong_owner(self, cache, mock_redis):
-        mock_redis.get.return_value = "worker-1"
+        mock_redis.eval.return_value = 0  # Lua script returns 0 (owner mismatch)
         released = await cache.release_optimization_lock("wf3-creative", "worker-2")
         assert released is False
-        mock_redis.delete.assert_not_called()
 
     async def test_release_lock_not_held(self, cache, mock_redis):
-        mock_redis.get.return_value = None
+        mock_redis.eval.return_value = 0  # Lua script returns 0 (key doesn't exist)
         released = await cache.release_optimization_lock("grp", "owner")
         assert released is False
 


### PR DESCRIPTION
## Summary

- Add `PromptCacheManager` connecting to Redis DB 2 for prompt caching, distributed optimization locks, and progress tracking
- Implements §9.1 key naming convention for all prompt-related Redis keys
- Separate from general service cache (DB 26) to isolate prompt operations

## Acceptance Criteria (US-004)

- [x] All prompt keys follow §9.1 naming: `prompt:<name>:production`, `prompt:<name>:tenant:<tid>`
- [x] Distributed optimization lock: `prompt:optimization:lock:<group>` with 2-hour TTL
- [x] Optimization progress hash: `prompt:optimization:progress:<run_id>` with 24-hour TTL
- [x] Service connects via `PROMPT_CACHE_REDIS_URL=redis://redis:6379/2`

## Key Implementation Details

| Feature | Key Pattern | TTL | Semantics |
|---------|-------------|-----|-----------|
| Prompt cache | `prompt:<name>:production` / `prompt:<name>:tenant:<tid>` | 300s (configurable) | GET/SET/invalidate |
| Optimization lock | `prompt:optimization:lock:<group>` | 7200s (2h) | SET NX EX, owner-validated release |
| Progress tracking | `prompt:optimization:progress:<run_id>` | 86400s (24h) | Redis hash (HSET/HGETALL) |

## Test plan

- [x] `pytest tests/ -v` — 59/59 tests pass (28 new prompt cache tests)
- [ ] Service connects to Redis DB 2 on startup
- [ ] Health check shows both Redis connections up

🤖 Generated with [Claude Code](https://claude.com/claude-code)