### PR TITLE
feat(registry): Enforce standard prompt naming convention (US-006)

### DIFF
--- a/prompt-optimization-svc/app/api/routes.py
+++ b/prompt-optimization-svc/app/api/routes.py
@@ -3,10 +3,16 @@
 import logging
 from typing import Optional
 
-from fastapi import APIRouter, Header
+from fastapi import APIRouter, Header, Request
 from fastapi.responses import JSONResponse
 
-from app.api.schemas import ExecuteRequest, ExecuteResponse, HealthResponse
+from app.api.schemas import (
+    ExecuteRequest,
+    ExecuteResponse,
+    HealthResponse,
+    PromptRegistrationRequest,
+    PromptRegistrationResponse,
+)
 from app.services.health_checker import HealthChecker
 
 logger = logging.getLogger(__name__)
@@ -23,6 +29,20 @@ async def health() -> HealthResponse:
     if health_checker is not None:
         return await health_checker.check_all()
     return HealthResponse(status="unhealthy", dependencies=[])
+
+
+@router.post("/v1/prompts", response_model=PromptRegistrationResponse)
+async def register_prompt(
+    request: PromptRegistrationRequest,
+    x_tenant_id: str = Header(default="default", alias="X-Tenant-ID"),
+) -> PromptRegistrationResponse:
+    """Register a prompt template (stub — MLflow integration in US-007)."""
+    return PromptRegistrationResponse(
+        name=request.name,
+        version=1,
+        status="registered",
+        message="Prompt registered (stub — MLflow integration pending)",
+    )
 
 
 @router.post("/v1/execute", response_model=ExecuteResponse, status_code=501)

--- a/prompt-optimization-svc/app/api/schemas.py
+++ b/prompt-optimization-svc/app/api/schemas.py
@@ -2,7 +2,9 @@
 
 from typing import Any, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+from app.logic.prompt_naming import validate_prompt_name
 
 
 class DependencyStatus(BaseModel):
@@ -55,3 +57,31 @@ class ExecuteResponse(BaseModel):
 
     status: str = "not_implemented"
     message: str = "Prompt optimization endpoints will be available in EPIC-2+"
+
+
+class PromptRegistrationRequest(BaseModel):
+    """Request body for POST /v1/prompts — register a prompt template."""
+
+    name: str = Field(
+        ...,
+        description="Prompt name following §3.1: zorven-wf<n>-<agent_code>-<skill>[-<variant>]",
+    )
+    template: str = Field(..., description="Prompt template text")
+    metadata: dict[str, Any] = Field(
+        default_factory=dict, description="Optional metadata (workflow, model_target, etc.)"
+    )
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        validate_prompt_name(v)
+        return v
+
+
+class PromptRegistrationResponse(BaseModel):
+    """Response for POST /v1/prompts."""
+
+    name: str
+    version: int = 1
+    status: str = "registered"
+    message: str = ""

--- a/prompt-optimization-svc/app/logic/prompt_naming.py
+++ b/prompt-optimization-svc/app/logic/prompt_naming.py
@@ -1,0 +1,114 @@
+"""Prompt naming convention validator (§3.1).
+
+Pattern: zorven-wf<n>-<agent_code>-<skill>[-<variant>]
+
+Examples:
+    zorven-wf1-mra-landscape           # Standard skill prompt
+    zorven-wf1-mra-landscape-v2        # Variant
+    zorven-wf1-mra-system              # System prompt
+    zorven-wf1-mra-planner             # Planner prompt (PG-01)
+    zorven-wf3-cga-creative-v3         # WF3 variant
+"""
+
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+# Valid agent codes per workflow
+VALID_AGENT_CODES: dict[int, set[str]] = {
+    1: {"mra", "cia", "apa", "tcia", "voca"},
+    2: {"bpa", "baa", "bpv", "nta", "bsa"},
+    3: {"caa", "cga", "adpub", "coa", "ila"},
+}
+
+ALL_AGENT_CODES: set[str] = set()
+for codes in VALID_AGENT_CODES.values():
+    ALL_AGENT_CODES |= codes
+
+# Reserved skill names that are always valid
+RESERVED_SKILLS = {"system", "planner"}
+
+# Regex for structural validation
+_NAME_PATTERN = re.compile(
+    r"^zorven-wf([1-3])-([a-z][a-z0-9]*)-([a-z][a-z0-9_]*)(?:-([a-z0-9][a-z0-9_]*))?$"
+)
+
+EXPECTED_FORMAT = "zorven-wf<1|2|3>-<agent_code>-<skill>[-<variant>]"
+
+
+@dataclass(frozen=True)
+class PromptNameParts:
+    """Parsed components of a validated prompt name."""
+
+    workflow: int
+    agent_code: str
+    skill: str
+    variant: Optional[str] = None
+
+    @property
+    def is_system(self) -> bool:
+        return self.skill == "system"
+
+    @property
+    def is_planner(self) -> bool:
+        return self.skill == "planner"
+
+    @property
+    def base_name(self) -> str:
+        """Name without variant suffix."""
+        return f"zorven-wf{self.workflow}-{self.agent_code}-{self.skill}"
+
+    @property
+    def full_name(self) -> str:
+        """Full name including variant if present."""
+        if self.variant:
+            return f"{self.base_name}-{self.variant}"
+        return self.base_name
+
+
+def validate_prompt_name(name: str) -> PromptNameParts:
+    """Validate a prompt name against the §3.1 naming convention.
+
+    Args:
+        name: The prompt name to validate.
+
+    Returns:
+        Parsed PromptNameParts on success.
+
+    Raises:
+        ValueError: If the name is invalid, with a corrective message.
+    """
+    if not name:
+        raise ValueError(
+            f"Prompt name cannot be empty. Expected format: {EXPECTED_FORMAT}"
+        )
+
+    match = _NAME_PATTERN.match(name)
+    if not match:
+        raise ValueError(
+            f"Invalid prompt name '{name}'. "
+            f"Expected format: {EXPECTED_FORMAT}. "
+            f"Names must be lowercase with hyphens. "
+            f"Valid agent codes: {', '.join(sorted(ALL_AGENT_CODES))}"
+        )
+
+    workflow = int(match.group(1))
+    agent_code = match.group(2)
+    skill = match.group(3)
+    variant = match.group(4)
+
+    # Validate agent code belongs to the specified workflow
+    if agent_code not in VALID_AGENT_CODES[workflow]:
+        valid_for_wf = ", ".join(sorted(VALID_AGENT_CODES[workflow]))
+        raise ValueError(
+            f"Agent code '{agent_code}' is not valid for workflow {workflow}. "
+            f"Valid WF{workflow} agent codes: {valid_for_wf}. "
+            f"Use the correct workflow number for this agent."
+        )
+
+    return PromptNameParts(
+        workflow=workflow,
+        agent_code=agent_code,
+        skill=skill,
+        variant=variant,
+    )

--- a/prompt-optimization-svc/app/main.py
+++ b/prompt-optimization-svc/app/main.py
@@ -6,8 +6,10 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import AsyncGenerator
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 
 from app.api.routes import router
 from app.cache.prompt_cache import PromptCacheManager
@@ -125,5 +127,20 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(
+    request: Request, exc: RequestValidationError
+) -> JSONResponse:
+    """Return 400 (not 422) for validation errors with corrective messages."""
+    errors = []
+    for error in exc.errors():
+        field = ".".join(str(loc) for loc in error["loc"] if loc != "body")
+        errors.append({"field": field, "message": error["msg"]})
+    return JSONResponse(
+        status_code=400,
+        content={"detail": "Validation error", "errors": errors},
+    )
+
 
 app.include_router(router)

--- a/prompt-optimization-svc/tests/test_prompt_naming.py
+++ b/prompt-optimization-svc/tests/test_prompt_naming.py
@@ -1,0 +1,188 @@
+"""Tests for prompt naming convention validator (§3.1)."""
+
+import re
+
+import pytest
+
+from app.logic.prompt_naming import (
+    ALL_AGENT_CODES,
+    EXPECTED_FORMAT,
+    VALID_AGENT_CODES,
+    PromptNameParts,
+    validate_prompt_name,
+)
+
+
+class TestValidNames:
+    """Test valid prompt names are accepted."""
+
+    def test_standard_wf1_prompt(self):
+        parts = validate_prompt_name("zorven-wf1-mra-landscape")
+        assert parts.workflow == 1
+        assert parts.agent_code == "mra"
+        assert parts.skill == "landscape"
+        assert parts.variant is None
+
+    def test_standard_wf2_prompt(self):
+        parts = validate_prompt_name("zorven-wf2-bpa-positioning")
+        assert parts.workflow == 2
+        assert parts.agent_code == "bpa"
+        assert parts.skill == "positioning"
+
+    def test_standard_wf3_prompt(self):
+        parts = validate_prompt_name("zorven-wf3-cga-creative")
+        assert parts.workflow == 3
+        assert parts.agent_code == "cga"
+
+    def test_variant_suffix(self):
+        """AC-2: Variant suffix supported."""
+        parts = validate_prompt_name("zorven-wf3-cga-creative-v2")
+        assert parts.variant == "v2"
+        assert parts.full_name == "zorven-wf3-cga-creative-v2"
+        assert parts.base_name == "zorven-wf3-cga-creative"
+
+    def test_variant_with_numbers(self):
+        parts = validate_prompt_name("zorven-wf1-mra-landscape-v3")
+        assert parts.variant == "v3"
+
+    def test_system_prompt(self):
+        """AC-3: System prompts use zorven-wf<n>-<agent_code>-system."""
+        parts = validate_prompt_name("zorven-wf1-mra-system")
+        assert parts.skill == "system"
+        assert parts.is_system is True
+        assert parts.is_planner is False
+
+    def test_planner_prompt(self):
+        """AC-4: Planner prompts use zorven-wf<n>-<agent_code>-planner."""
+        parts = validate_prompt_name("zorven-wf1-mra-planner")
+        assert parts.skill == "planner"
+        assert parts.is_planner is True
+        assert parts.is_system is False
+
+    def test_system_prompt_wf2(self):
+        parts = validate_prompt_name("zorven-wf2-bpv-system")
+        assert parts.is_system is True
+
+    def test_planner_prompt_wf3(self):
+        parts = validate_prompt_name("zorven-wf3-coa-planner")
+        assert parts.is_planner is True
+
+    def test_skill_with_underscore(self):
+        parts = validate_prompt_name("zorven-wf1-mra-market_sizing")
+        assert parts.skill == "market_sizing"
+
+    def test_adpub_agent_code(self):
+        """Multi-char agent code (4 chars)."""
+        parts = validate_prompt_name("zorven-wf3-adpub-publish")
+        assert parts.agent_code == "adpub"
+
+    def test_tcia_agent_code(self):
+        """4-char agent code."""
+        parts = validate_prompt_name("zorven-wf1-tcia-trends")
+        assert parts.agent_code == "tcia"
+
+    def test_voca_agent_code(self):
+        parts = validate_prompt_name("zorven-wf1-voca-sentiment")
+        assert parts.agent_code == "voca"
+
+
+class TestAllAgentCodes:
+    """Verify all 15 agent codes are accepted in their correct workflow."""
+
+    @pytest.mark.parametrize(
+        "wf,code",
+        [
+            (1, "mra"), (1, "cia"), (1, "apa"), (1, "tcia"), (1, "voca"),
+            (2, "bpa"), (2, "baa"), (2, "bpv"), (2, "nta"), (2, "bsa"),
+            (3, "caa"), (3, "cga"), (3, "adpub"), (3, "coa"), (3, "ila"),
+        ],
+    )
+    def test_agent_code_accepted(self, wf, code):
+        name = f"zorven-wf{wf}-{code}-test"
+        parts = validate_prompt_name(name)
+        assert parts.agent_code == code
+        assert parts.workflow == wf
+
+    def test_all_15_codes_covered(self):
+        assert len(ALL_AGENT_CODES) == 15
+
+
+class TestInvalidNames:
+    """Test invalid prompt names are rejected with corrective messages."""
+
+    def test_empty_name(self):
+        with pytest.raises(ValueError, match="cannot be empty"):
+            validate_prompt_name("")
+
+    def test_missing_prefix(self):
+        with pytest.raises(ValueError, match="Invalid prompt name"):
+            validate_prompt_name("wf1-mra-landscape")
+
+    def test_wrong_workflow_number(self):
+        with pytest.raises(ValueError, match="Invalid prompt name"):
+            validate_prompt_name("zorven-wf4-mra-landscape")
+
+    def test_workflow_zero(self):
+        with pytest.raises(ValueError, match="Invalid prompt name"):
+            validate_prompt_name("zorven-wf0-mra-landscape")
+
+    def test_unknown_agent_code(self):
+        with pytest.raises(ValueError, match="not valid for workflow"):
+            validate_prompt_name("zorven-wf1-xyz-landscape")
+
+    def test_agent_code_wrong_workflow(self):
+        """WF2 agent code used with WF1 prefix."""
+        with pytest.raises(ValueError, match="not valid for workflow 1"):
+            validate_prompt_name("zorven-wf1-bpa-positioning")
+
+    def test_uppercase_rejected(self):
+        with pytest.raises(ValueError, match="Invalid prompt name"):
+            validate_prompt_name("zorven-WF1-MRA-landscape")
+
+    def test_missing_skill(self):
+        with pytest.raises(ValueError, match="Invalid prompt name"):
+            validate_prompt_name("zorven-wf1-mra")
+
+    def test_trailing_hyphen(self):
+        with pytest.raises(ValueError, match="Invalid prompt name"):
+            validate_prompt_name("zorven-wf1-mra-")
+
+    def test_special_characters(self):
+        with pytest.raises(ValueError, match="Invalid prompt name"):
+            validate_prompt_name("zorven-wf1-mra-land@scape")
+
+    def test_spaces(self):
+        with pytest.raises(ValueError, match="Invalid prompt name"):
+            validate_prompt_name("zorven-wf1-mra-land scape")
+
+    def test_corrective_message_includes_format(self):
+        """AC-5: Error includes the expected format."""
+        with pytest.raises(ValueError, match=re.escape(EXPECTED_FORMAT)):
+            validate_prompt_name("bad-name")
+
+    def test_corrective_message_includes_agent_codes(self):
+        with pytest.raises(ValueError, match="agent codes"):
+            validate_prompt_name("bad-name")
+
+
+class TestPromptNameParts:
+    """Test PromptNameParts dataclass."""
+
+    def test_base_name(self):
+        parts = PromptNameParts(workflow=1, agent_code="mra", skill="landscape")
+        assert parts.base_name == "zorven-wf1-mra-landscape"
+
+    def test_full_name_no_variant(self):
+        parts = PromptNameParts(workflow=2, agent_code="bpa", skill="positioning")
+        assert parts.full_name == "zorven-wf2-bpa-positioning"
+
+    def test_full_name_with_variant(self):
+        parts = PromptNameParts(
+            workflow=3, agent_code="cga", skill="creative", variant="v2"
+        )
+        assert parts.full_name == "zorven-wf3-cga-creative-v2"
+
+    def test_frozen(self):
+        parts = PromptNameParts(workflow=1, agent_code="mra", skill="test")
+        with pytest.raises(AttributeError):
+            parts.workflow = 2  # type: ignore

--- a/prompt-optimization-svc/tests/test_prompt_registration.py
+++ b/prompt-optimization-svc/tests/test_prompt_registration.py
@@ -1,0 +1,128 @@
+"""Tests for POST /v1/prompts registration endpoint."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest.fixture
+async def client():
+    """Async test client for the FastAPI app."""
+    with patch("app.cache.redis_manager.aioredis") as mock_aioredis:
+        mock_redis = AsyncMock()
+        mock_redis.ping.return_value = True
+        mock_redis.aclose.return_value = None
+        mock_aioredis.from_url.return_value = mock_redis
+
+        from app.main import app
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as c:
+            yield c
+
+
+class TestPromptRegistration:
+    """Test POST /v1/prompts endpoint."""
+
+    async def test_register_valid_prompt(self, client):
+        resp = await client.post(
+            "/v1/prompts",
+            json={
+                "name": "zorven-wf1-mra-landscape",
+                "template": "You are a market researcher...",
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["name"] == "zorven-wf1-mra-landscape"
+        assert data["status"] == "registered"
+
+    async def test_register_system_prompt(self, client):
+        """AC-3: System prompts accepted."""
+        resp = await client.post(
+            "/v1/prompts",
+            json={
+                "name": "zorven-wf2-bpa-system",
+                "template": "System prompt template",
+            },
+        )
+        assert resp.status_code == 200
+
+    async def test_register_planner_prompt(self, client):
+        """AC-4: Planner prompts accepted."""
+        resp = await client.post(
+            "/v1/prompts",
+            json={
+                "name": "zorven-wf3-coa-planner",
+                "template": "Planner prompt template",
+            },
+        )
+        assert resp.status_code == 200
+
+    async def test_register_variant_prompt(self, client):
+        """AC-2: Variant suffix accepted."""
+        resp = await client.post(
+            "/v1/prompts",
+            json={
+                "name": "zorven-wf3-cga-creative-v2",
+                "template": "Variant template",
+            },
+        )
+        assert resp.status_code == 200
+
+    async def test_register_with_metadata(self, client):
+        resp = await client.post(
+            "/v1/prompts",
+            json={
+                "name": "zorven-wf1-mra-landscape",
+                "template": "Template",
+                "metadata": {"model_target": "claude-sonnet-4"},
+            },
+        )
+        assert resp.status_code == 200
+
+    async def test_invalid_name_returns_400(self, client):
+        """AC-5: Invalid names rejected with 400 and corrective message."""
+        resp = await client.post(
+            "/v1/prompts",
+            json={
+                "name": "bad-name",
+                "template": "Template",
+            },
+        )
+        assert resp.status_code == 400
+        data = resp.json()
+        assert "errors" in data
+        assert any("name" in e["field"] for e in data["errors"])
+
+    async def test_invalid_name_corrective_message(self, client):
+        """AC-5: Response includes corrective guidance."""
+        resp = await client.post(
+            "/v1/prompts",
+            json={
+                "name": "wf1-mra-landscape",
+                "template": "Template",
+            },
+        )
+        assert resp.status_code == 400
+        data = resp.json()
+        error_msg = data["errors"][0]["message"]
+        assert "zorven-wf" in error_msg.lower() or "format" in error_msg.lower()
+
+    async def test_wrong_workflow_agent_returns_400(self, client):
+        resp = await client.post(
+            "/v1/prompts",
+            json={
+                "name": "zorven-wf1-bpa-positioning",
+                "template": "Template",
+            },
+        )
+        assert resp.status_code == 400
+
+    async def test_missing_template_returns_400(self, client):
+        resp = await client.post(
+            "/v1/prompts",
+            json={"name": "zorven-wf1-mra-landscape"},
+        )
+        assert resp.status_code == 400


### PR DESCRIPTION
## Summary

- Implement §3.1 prompt naming convention: `zorven-wf<n>-<agent_code>-<skill>[-<variant>]`
- Pydantic validation at registration time with 400 response + corrective messages
- First endpoint in EPIC-2 (Prompt Registry): `POST /v1/prompts`

## Acceptance Criteria (US-006)

- [x] Naming validated via Pydantic at registration time
- [x] Variant suffix supported: `zorven-wf<n>-<agent_code>-<skill>-<variant>`
- [x] System prompts: `zorven-wf<n>-<agent_code>-system`
- [x] Planner prompts: `zorven-wf<n>-<agent_code>-planner` (PG-01)
- [x] Invalid names rejected with 400 + corrective message

## Valid Agent Codes (all 15)

| Workflow | Agent Codes |
|----------|------------|
| WF1 | `mra`, `cia`, `apa`, `tcia`, `voca` |
| WF2 | `bpa`, `baa`, `bpv`, `nta`, `bsa` |
| WF3 | `caa`, `cga`, `adpub`, `coa`, `ila` |

## Files Changed

| Area | Files |
|------|-------|
| Naming validator | `app/logic/prompt_naming.py` — regex + agent code validation |
| API schemas | `app/api/schemas.py` — `PromptRegistrationRequest` with `@field_validator` |
| API routes | `app/api/routes.py` — `POST /v1/prompts` endpoint |
| Error handling | `app/main.py` — Custom 400 exception handler |
| Tests | `tests/test_prompt_naming.py` (40 tests), `tests/test_prompt_registration.py` (9 tests) |

## Test plan

- [x] `pytest tests/ -v` — 114/114 tests pass (55 new)
- [ ] `POST /v1/prompts` with `zorven-wf1-mra-landscape` → 200
- [ ] `POST /v1/prompts` with `bad-name` → 400 with corrective message

🤖 Generated with [Claude Code](https://claude.com/claude-code)