### PR TITLE
feat(registry): Implement prompt version lifecycle state machine (US-008)

### DIFF
--- a/prompt-optimization-svc/app/api/routes.py
+++ b/prompt-optimization-svc/app/api/routes.py
@@ -10,9 +10,17 @@ from app.api.schemas import (
     ExecuteRequest,
     ExecuteResponse,
     HealthResponse,
+    ProductionPromptResponse,
     PromptRegistrationRequest,
     PromptRegistrationResponse,
+    PromptTransitionRequest,
+    PromptTransitionResponse,
     SeedResponse,
+)
+from app.logic.lifecycle import (
+    InvalidTransitionError,
+    PromptLifecycleManager,
+    PromptState,
 )
 from app.services.health_checker import HealthChecker
 from app.services.mlflow_registry import MLflowPromptRegistry
@@ -24,6 +32,7 @@ router = APIRouter()
 # Module-level dependencies — initialized in main.py lifespan
 health_checker: Optional[HealthChecker] = None
 mlflow_registry: Optional[MLflowPromptRegistry] = None
+lifecycle_manager: Optional[PromptLifecycleManager] = None
 
 
 @router.get("/health", response_model=HealthResponse)
@@ -81,6 +90,124 @@ async def seed_prompts() -> SeedResponse:
         skipped=result.skipped,
         errors=result.errors,
         details=result.details,
+    )
+
+
+@router.put("/v1/prompts/{name}/versions/{version}/promote")
+async def promote_prompt(
+    name: str,
+    version: int,
+    request: PromptTransitionRequest,
+    x_tenant_id: str = Header(default="default", alias="X-Tenant-ID"),
+) -> PromptTransitionResponse:
+    """Promote a prompt version to the next lifecycle state."""
+    if lifecycle_manager is None:
+        return PromptTransitionResponse(
+            name=name, version=version, from_state="unknown",
+            to_state=request.target_state, success=False,
+            message="Lifecycle manager not initialized",
+        )
+    try:
+        current = mlflow_registry.get_prompt(name) if mlflow_registry else None
+        current_state = (current.tags.get("state", "DRAFT") if current else "DRAFT")
+
+        from_state = PromptState(current_state)
+        to_state = PromptState(request.target_state)
+
+        if to_state == PromptState.PRODUCTION:
+            lifecycle_manager.promote_to_production(
+                name, version, tenant_id=request.tenant_id
+            )
+        else:
+            lifecycle_manager.transition(
+                name, version, from_state, to_state,
+                tenant_id=request.tenant_id,
+            )
+
+        return PromptTransitionResponse(
+            name=name, version=version, from_state=from_state.value,
+            to_state=to_state.value, success=True,
+        )
+    except (InvalidTransitionError, ValueError) as exc:
+        return PromptTransitionResponse(
+            name=name, version=version, from_state="unknown",
+            to_state=request.target_state, success=False, message=str(exc),
+        )
+
+
+@router.put("/v1/prompts/{name}/versions/{version}/reject")
+async def reject_prompt(name: str, version: int) -> PromptTransitionResponse:
+    """Reject a STAGING prompt version (AC-3: never hard-deleted)."""
+    if lifecycle_manager is None:
+        return PromptTransitionResponse(
+            name=name, version=version, from_state="STAGING",
+            to_state="REJECTED", success=False,
+            message="Lifecycle manager not initialized",
+        )
+    try:
+        lifecycle_manager.reject(name, version)
+        return PromptTransitionResponse(
+            name=name, version=version, from_state="STAGING",
+            to_state="REJECTED", success=True,
+        )
+    except InvalidTransitionError as exc:
+        return PromptTransitionResponse(
+            name=name, version=version, from_state="STAGING",
+            to_state="REJECTED", success=False, message=str(exc),
+        )
+
+
+@router.put("/v1/prompts/{name}/versions/{version}/rollback")
+async def rollback_prompt(
+    name: str,
+    version: int,
+    x_tenant_id: str = Header(default=None, alias="X-Tenant-ID"),
+) -> PromptTransitionResponse:
+    """Roll back a CANARY or PRODUCTION version."""
+    if lifecycle_manager is None:
+        return PromptTransitionResponse(
+            name=name, version=version, from_state="unknown",
+            to_state="ROLLED_BACK", success=False,
+            message="Lifecycle manager not initialized",
+        )
+    try:
+        current = mlflow_registry.get_prompt(name) if mlflow_registry else None
+        current_state = PromptState(
+            current.tags.get("state", "PRODUCTION") if current else "PRODUCTION"
+        )
+        lifecycle_manager.rollback(name, version, current_state, tenant_id=x_tenant_id)
+        return PromptTransitionResponse(
+            name=name, version=version, from_state=current_state.value,
+            to_state="ROLLED_BACK", success=True,
+        )
+    except InvalidTransitionError as exc:
+        return PromptTransitionResponse(
+            name=name, version=version, from_state="unknown",
+            to_state="ROLLED_BACK", success=False, message=str(exc),
+        )
+
+
+@router.get("/v1/prompts/{name}/production", response_model=None)
+async def get_production_prompt(
+    name: str,
+    x_tenant_id: str = Header(default=None, alias="X-Tenant-ID"),
+):
+    """Get the current production version (AC-4, AC-5: tenant override first)."""
+    if lifecycle_manager is None:
+        return JSONResponse(status_code=503, content={"detail": "Not initialized"})
+    prod = lifecycle_manager.get_production_version(name, tenant_id=x_tenant_id)
+    if prod is None:
+        return JSONResponse(
+            status_code=404,
+            content={"detail": f"No production version found for '{name}'"},
+        )
+    return ProductionPromptResponse(
+        name=prod.name,
+        version=prod.version,
+        template=prod.template,
+        state=prod.tags.get("state", "PRODUCTION"),
+        tenant_id=prod.tags.get("tenant_id"),
+        tags=prod.tags,
     )
 
 

--- a/prompt-optimization-svc/app/api/schemas.py
+++ b/prompt-optimization-svc/app/api/schemas.py
@@ -87,6 +87,35 @@ class PromptRegistrationResponse(BaseModel):
     message: str = ""
 
 
+class PromptTransitionRequest(BaseModel):
+    """Request body for lifecycle transitions."""
+
+    target_state: str = Field(..., description="Target state: STAGING, CANARY, PRODUCTION, etc.")
+    tenant_id: Optional[str] = Field(default=None, description="Tenant ID for scoped transitions")
+
+
+class PromptTransitionResponse(BaseModel):
+    """Response for lifecycle transition endpoints."""
+
+    name: str
+    version: int
+    from_state: str
+    to_state: str
+    success: bool
+    message: str = ""
+
+
+class ProductionPromptResponse(BaseModel):
+    """Response for GET /v1/prompts/{name}/production."""
+
+    name: str
+    version: int
+    template: str
+    state: str
+    tenant_id: Optional[str] = None
+    tags: dict[str, str] = Field(default_factory=dict)
+
+
 class SeedResponse(BaseModel):
     """Response for POST /v1/prompts/seed."""
 

--- a/prompt-optimization-svc/app/kafka/producer.py
+++ b/prompt-optimization-svc/app/kafka/producer.py
@@ -4,7 +4,7 @@ import json
 import logging
 from typing import Any, Optional
 
-from app.kafka.schemas import AuditEvent, TraceEvent
+from app.kafka.schemas import AuditEvent, PromptLifecycleEvent, TraceEvent
 
 logger = logging.getLogger(__name__)
 
@@ -145,3 +145,84 @@ class AuditProducer:
             )
         except Exception as exc:
             logger.warning("Failed to send audit event: %s", exc)
+
+
+class LifecycleProducer:
+    """Emits prompt lifecycle events to prompt-lifecycle-events topic (AC-6)."""
+
+    TOPIC = "prompt-lifecycle-events"
+
+    def __init__(self, bootstrap_servers: str) -> None:
+        self.bootstrap_servers = bootstrap_servers
+        self._producer: Any = None
+        self._connected = False
+
+    @property
+    def is_connected(self) -> bool:
+        return self._connected
+
+    async def start(self) -> None:
+        """Start the Kafka producer."""
+        if not self.bootstrap_servers:
+            logger.info("Kafka disabled — LifecycleProducer in no-op mode")
+            return
+        try:
+            from aiokafka import AIOKafkaProducer
+
+            producer = AIOKafkaProducer(
+                bootstrap_servers=self.bootstrap_servers,
+                value_serializer=lambda v: json.dumps(v).encode("utf-8"),
+            )
+            await producer.start()
+            self._producer = producer
+            self._connected = True
+            logger.info("LifecycleProducer connected to %s", self.bootstrap_servers)
+        except Exception as exc:
+            self._producer = None
+            logger.warning("LifecycleProducer failed: %s — no-op mode", exc)
+
+    async def stop(self) -> None:
+        """Stop the producer."""
+        if self._producer is not None:
+            try:
+                await self._producer.stop()
+            except Exception as exc:
+                logger.warning("Error stopping LifecycleProducer: %s", exc)
+            self._producer = None
+            self._connected = False
+
+    def send_lifecycle_event_sync(
+        self,
+        event_type: str,
+        prompt_name: str,
+        version: int,
+        from_state: str,
+        to_state: str,
+        tenant_id: Optional[str] = None,
+    ) -> None:
+        """Emit a lifecycle event (fire-and-forget, sync wrapper)."""
+        if self._producer is None:
+            logger.debug("LifecycleProducer not connected, skipping: %s", event_type)
+            return
+        event = PromptLifecycleEvent(
+            event_type=event_type,
+            prompt_name=prompt_name,
+            version=version,
+            from_state=from_state,
+            to_state=to_state,
+            tenant_id=tenant_id,
+        )
+        try:
+            import asyncio
+
+            loop = asyncio.get_event_loop()
+            if loop.is_running():
+                loop.create_task(
+                    self._producer.send_and_wait(self.TOPIC, event.model_dump())
+                )
+            else:
+                loop.run_until_complete(
+                    self._producer.send_and_wait(self.TOPIC, event.model_dump())
+                )
+        except Exception as exc:
+            logger.warning("Failed to send lifecycle event: %s", exc)

--- a/prompt-optimization-svc/app/kafka/schemas.py
+++ b/prompt-optimization-svc/app/kafka/schemas.py
@@ -19,6 +19,20 @@ class TraceEvent(BaseModel):
     )
 
 
+class PromptLifecycleEvent(BaseModel):
+    """Lifecycle event for prompt-lifecycle-events topic."""
+
+    event_type: str = Field(..., description="e.g. prompt.promoted, prompt.rejected")
+    prompt_name: str = Field(...)
+    version: int = Field(...)
+    from_state: str = Field(...)
+    to_state: str = Field(...)
+    tenant_id: str | None = Field(default=None)
+    timestamp: str = Field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+
+
 class AuditEvent(BaseModel):
     """Audit event for poi-optimization-audit-topic."""
 

--- a/prompt-optimization-svc/app/logic/lifecycle.py
+++ b/prompt-optimization-svc/app/logic/lifecycle.py
@@ -1,0 +1,223 @@
+"""Prompt version lifecycle state machine (§3.3).
+
+States:
+    DRAFT → STAGING → CANARY → PRODUCTION → ARCHIVED
+    STAGING → REJECTED (optimization didn't improve)
+    CANARY → ROLLED_BACK (regression detected)
+    PRODUCTION → ROLLED_BACK (manual rollback)
+    DRAFT → TENANT_OVERRIDE → ARCHIVED (tenant-specific path)
+"""
+
+import logging
+from enum import Enum
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class PromptState(str, Enum):
+    """Prompt version lifecycle states."""
+
+    DRAFT = "DRAFT"
+    STAGING = "STAGING"
+    CANARY = "CANARY"
+    PRODUCTION = "PRODUCTION"
+    ARCHIVED = "ARCHIVED"
+    REJECTED = "REJECTED"
+    ROLLED_BACK = "ROLLED_BACK"
+    TENANT_OVERRIDE = "TENANT_OVERRIDE"
+
+
+# Valid state transitions: from_state -> set of allowed to_states
+VALID_TRANSITIONS: dict[PromptState, set[PromptState]] = {
+    PromptState.DRAFT: {PromptState.STAGING, PromptState.TENANT_OVERRIDE},
+    PromptState.STAGING: {PromptState.CANARY, PromptState.REJECTED},
+    PromptState.CANARY: {PromptState.PRODUCTION, PromptState.ROLLED_BACK},
+    PromptState.PRODUCTION: {PromptState.ARCHIVED, PromptState.ROLLED_BACK},
+    PromptState.ARCHIVED: set(),
+    PromptState.REJECTED: set(),
+    PromptState.ROLLED_BACK: set(),
+    PromptState.TENANT_OVERRIDE: {PromptState.ARCHIVED},
+}
+
+# States that are served to production agents
+SERVABLE_STATES = {PromptState.PRODUCTION, PromptState.TENANT_OVERRIDE, PromptState.CANARY}
+
+# Event type names for Kafka
+STATE_EVENT_MAP: dict[PromptState, str] = {
+    PromptState.STAGING: "prompt.staged",
+    PromptState.CANARY: "prompt.canary_started",
+    PromptState.PRODUCTION: "prompt.promoted",
+    PromptState.ARCHIVED: "prompt.archived",
+    PromptState.REJECTED: "prompt.rejected",
+    PromptState.ROLLED_BACK: "prompt.rolled_back",
+    PromptState.TENANT_OVERRIDE: "prompt.tenant_override",
+}
+
+
+class InvalidTransitionError(Exception):
+    """Raised when a state transition is not allowed."""
+
+    def __init__(self, from_state: PromptState, to_state: PromptState):
+        self.from_state = from_state
+        self.to_state = to_state
+        super().__init__(
+            f"Invalid transition: {from_state.value} → {to_state.value}. "
+            f"Allowed from {from_state.value}: "
+            f"{', '.join(s.value for s in VALID_TRANSITIONS.get(from_state, set())) or 'none'}"
+        )
+
+
+class PromptLifecycleManager:
+    """Manages prompt version lifecycle transitions.
+
+    Delegates state persistence to MLflowPromptRegistry and emits
+    Kafka events via LifecycleProducer.
+    """
+
+    def __init__(self, registry, lifecycle_producer=None):
+        """
+        Args:
+            registry: MLflowPromptRegistry instance for state persistence.
+            lifecycle_producer: Optional LifecycleProducer for Kafka events.
+        """
+        self.registry = registry
+        self.producer = lifecycle_producer
+
+    def validate_transition(
+        self, from_state: PromptState, to_state: PromptState
+    ) -> bool:
+        """Check if a state transition is valid.
+
+        Returns True if valid, raises InvalidTransitionError otherwise.
+        """
+        allowed = VALID_TRANSITIONS.get(from_state, set())
+        if to_state not in allowed:
+            raise InvalidTransitionError(from_state, to_state)
+        return True
+
+    def transition(
+        self,
+        name: str,
+        version: int,
+        from_state: PromptState,
+        to_state: PromptState,
+        tenant_id: Optional[str] = None,
+    ) -> bool:
+        """Execute a state transition with validation and event emission.
+
+        Args:
+            name: Prompt name.
+            version: Prompt version number.
+            from_state: Current state.
+            to_state: Target state.
+            tenant_id: Optional tenant for scoping.
+
+        Returns:
+            True on success.
+
+        Raises:
+            InvalidTransitionError: If the transition is not allowed.
+        """
+        self.validate_transition(from_state, to_state)
+
+        # Persist state change
+        self.registry.set_prompt_state(name, version, to_state.value)
+
+        # Emit Kafka event (AC-6)
+        event_type = STATE_EVENT_MAP.get(to_state, f"prompt.state_changed")
+        if self.producer:
+            self.producer.send_lifecycle_event_sync(
+                event_type=event_type,
+                prompt_name=name,
+                version=version,
+                from_state=from_state.value,
+                to_state=to_state.value,
+                tenant_id=tenant_id,
+            )
+
+        logger.info(
+            "Lifecycle transition: %s v%d %s → %s (tenant=%s)",
+            name, version, from_state.value, to_state.value, tenant_id,
+        )
+        return True
+
+    def promote_to_production(
+        self,
+        name: str,
+        version: int,
+        tenant_id: Optional[str] = None,
+    ) -> bool:
+        """Promote a CANARY version to PRODUCTION.
+
+        AC-1: Only one PRODUCTION per prompt per tenant.
+        AC-2: Auto-archives the previous PRODUCTION version.
+        """
+        # Find and archive current PRODUCTION (AC-2)
+        current_prod = self.registry.get_prompt_by_state(
+            name, PromptState.PRODUCTION.value, tenant_id=tenant_id
+        )
+        if current_prod is not None:
+            self.transition(
+                name,
+                current_prod.version,
+                PromptState.PRODUCTION,
+                PromptState.ARCHIVED,
+                tenant_id=tenant_id,
+            )
+
+        # Promote new version
+        return self.transition(
+            name, version, PromptState.CANARY, PromptState.PRODUCTION,
+            tenant_id=tenant_id,
+        )
+
+    def reject(self, name: str, version: int) -> bool:
+        """Reject a STAGING version. AC-3: Never hard-deleted."""
+        return self.transition(
+            name, version, PromptState.STAGING, PromptState.REJECTED
+        )
+
+    def rollback(
+        self,
+        name: str,
+        version: int,
+        current_state: PromptState,
+        tenant_id: Optional[str] = None,
+    ) -> bool:
+        """Roll back a CANARY or PRODUCTION version."""
+        return self.transition(
+            name, version, current_state, PromptState.ROLLED_BACK,
+            tenant_id=tenant_id,
+        )
+
+    def get_production_version(
+        self,
+        name: str,
+        tenant_id: Optional[str] = None,
+    ):
+        """Get the current production version.
+
+        AC-5: TENANT_OVERRIDE takes precedence over global PRODUCTION.
+        AC-4: STAGING versions are never returned.
+        """
+        if tenant_id:
+            # Check tenant override first
+            override = self.registry.get_prompt_by_state(
+                name, PromptState.TENANT_OVERRIDE.value, tenant_id=tenant_id
+            )
+            if override is not None:
+                return override
+
+        # Fall back to global PRODUCTION
+        return self.registry.get_prompt_by_state(
+            name, PromptState.PRODUCTION.value, tenant_id=None
+        )
+
+    @staticmethod
+    def is_servable(state: PromptState) -> bool:
+        """Check if a state is served to production agents.
+
+        AC-4: STAGING is NOT servable.
+        """
+        return state in SERVABLE_STATES

--- a/prompt-optimization-svc/app/main.py
+++ b/prompt-optimization-svc/app/main.py
@@ -16,7 +16,8 @@ from app.cache.prompt_cache import PromptCacheManager
 from app.cache.redis_manager import RedisManager
 from app.core.config import settings
 from app.core.logging_config import setup_logging
-from app.kafka.producer import AuditProducer, TraceProducer
+from app.kafka.producer import AuditProducer, LifecycleProducer, TraceProducer
+from app.logic.lifecycle import PromptLifecycleManager
 from app.services.health_checker import HealthChecker
 from app.services.mlflow_registry import MLflowPromptRegistry
 
@@ -83,6 +84,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     await trace_producer.start()
     audit_producer = AuditProducer(settings.KAFKA_BOOTSTRAP_SERVERS)
     await audit_producer.start()
+    lifecycle_producer = LifecycleProducer(settings.KAFKA_BOOTSTRAP_SERVERS)
+    await lifecycle_producer.start()
 
     # 3. MLflow Prompt Registry
     registry: MLflowPromptRegistry | None = None
@@ -92,14 +95,20 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     except Exception as exc:
         logger.warning("MLflow prompt registry unavailable: %s", exc)
 
-    # 4. Health checker
+    # 4. Lifecycle manager
+    lcm = None
+    if registry:
+        lcm = PromptLifecycleManager(registry, lifecycle_producer)
+
+    # 5. Health checker
     checker = HealthChecker(redis_client=redis_client)
 
-    # 5. Assign to routes module
+    # 6. Assign to routes module
     from app.api import routes
 
     routes.health_checker = checker
     routes.mlflow_registry = registry
+    routes.lifecycle_manager = lcm
 
     logger.info(
         "Service initialized — MLflow=%s, Redis=%s, PromptCache=%s, Kafka=%s",
@@ -111,11 +120,13 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     yield
 
     # Shutdown
+    await lifecycle_producer.stop()
     await trace_producer.stop()
     await audit_producer.stop()
     await prompt_cache.close()
     await redis_manager.close()
     routes.health_checker = None
+    routes.lifecycle_manager = None
     logger.info("prompt-optimization-svc shut down")
 
 

--- a/prompt-optimization-svc/app/services/mlflow_registry.py
+++ b/prompt-optimization-svc/app/services/mlflow_registry.py
@@ -87,3 +87,40 @@ class MLflowPromptRegistry:
             return pv.template
         except Exception:
             return None
+
+    def set_prompt_state(
+        self, name: str, version: int, state: str
+    ) -> None:
+        """Update the state tag on a prompt version."""
+        self.client.set_prompt_version_tag(name, version, "state", state)
+        logger.info("State updated: %s v%d → %s", name, version, state)
+
+    def get_prompt_by_state(
+        self,
+        name: str,
+        state: str,
+        tenant_id: Optional[str] = None,
+    ) -> Optional[PromptInfo]:
+        """Find a prompt version with a specific state tag.
+
+        Searches versions from latest to earliest.
+        """
+        try:
+            versions = self.client.search_prompt_versions(name)
+            for pv in versions:
+                tags = pv.tags or {}
+                if tags.get("state") != state:
+                    continue
+                if tenant_id and tags.get("tenant_id") != tenant_id:
+                    continue
+                if not tenant_id and tags.get("tenant_id"):
+                    continue
+                return PromptInfo(
+                    name=name,
+                    version=pv.version,
+                    template=pv.template,
+                    tags=tags,
+                )
+            return None
+        except Exception:
+            return None

--- a/prompt-optimization-svc/tests/test_lifecycle.py
+++ b/prompt-optimization-svc/tests/test_lifecycle.py
@@ -1,0 +1,297 @@
+"""Tests for prompt version lifecycle state machine (§3.3)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.logic.lifecycle import (
+    InvalidTransitionError,
+    PromptLifecycleManager,
+    PromptState,
+    SERVABLE_STATES,
+    VALID_TRANSITIONS,
+)
+from app.services.mlflow_registry import PromptInfo
+
+
+@pytest.fixture
+def mock_registry():
+    """Mock MLflowPromptRegistry."""
+    reg = MagicMock()
+    reg.set_prompt_state = MagicMock()
+    reg.get_prompt_by_state = MagicMock(return_value=None)
+    return reg
+
+
+@pytest.fixture
+def mock_producer():
+    """Mock LifecycleProducer."""
+    prod = MagicMock()
+    prod.send_lifecycle_event_sync = MagicMock()
+    return prod
+
+
+@pytest.fixture
+def manager(mock_registry, mock_producer):
+    """PromptLifecycleManager with mocked dependencies."""
+    return PromptLifecycleManager(mock_registry, mock_producer)
+
+
+class TestValidTransitions:
+    """Test all valid lifecycle transitions."""
+
+    def test_draft_to_staging(self, manager, mock_registry):
+        result = manager.transition("test", 1, PromptState.DRAFT, PromptState.STAGING)
+        assert result is True
+        mock_registry.set_prompt_state.assert_called_with("test", 1, "STAGING")
+
+    def test_staging_to_canary(self, manager, mock_registry):
+        result = manager.transition("test", 1, PromptState.STAGING, PromptState.CANARY)
+        assert result is True
+        mock_registry.set_prompt_state.assert_called_with("test", 1, "CANARY")
+
+    def test_canary_to_production(self, manager, mock_registry):
+        result = manager.transition("test", 1, PromptState.CANARY, PromptState.PRODUCTION)
+        assert result is True
+
+    def test_production_to_archived(self, manager, mock_registry):
+        result = manager.transition("test", 1, PromptState.PRODUCTION, PromptState.ARCHIVED)
+        assert result is True
+
+    def test_staging_to_rejected(self, manager, mock_registry):
+        result = manager.transition("test", 1, PromptState.STAGING, PromptState.REJECTED)
+        assert result is True
+
+    def test_canary_to_rolled_back(self, manager, mock_registry):
+        result = manager.transition("test", 1, PromptState.CANARY, PromptState.ROLLED_BACK)
+        assert result is True
+
+    def test_production_to_rolled_back(self, manager, mock_registry):
+        result = manager.transition("test", 1, PromptState.PRODUCTION, PromptState.ROLLED_BACK)
+        assert result is True
+
+    def test_draft_to_tenant_override(self, manager, mock_registry):
+        result = manager.transition("test", 1, PromptState.DRAFT, PromptState.TENANT_OVERRIDE, tenant_id="t-1")
+        assert result is True
+
+    def test_tenant_override_to_archived(self, manager, mock_registry):
+        result = manager.transition("test", 1, PromptState.TENANT_OVERRIDE, PromptState.ARCHIVED)
+        assert result is True
+
+
+class TestInvalidTransitions:
+    """Test that invalid transitions are rejected."""
+
+    def test_draft_to_production_invalid(self, manager):
+        """Cannot skip stages."""
+        with pytest.raises(InvalidTransitionError):
+            manager.transition("test", 1, PromptState.DRAFT, PromptState.PRODUCTION)
+
+    def test_draft_to_canary_invalid(self, manager):
+        with pytest.raises(InvalidTransitionError):
+            manager.transition("test", 1, PromptState.DRAFT, PromptState.CANARY)
+
+    def test_archived_to_anything_invalid(self, manager):
+        with pytest.raises(InvalidTransitionError):
+            manager.transition("test", 1, PromptState.ARCHIVED, PromptState.DRAFT)
+
+    def test_rejected_to_anything_invalid(self, manager):
+        """AC-3: Rejected versions are terminal."""
+        with pytest.raises(InvalidTransitionError):
+            manager.transition("test", 1, PromptState.REJECTED, PromptState.STAGING)
+
+    def test_rolled_back_to_anything_invalid(self, manager):
+        with pytest.raises(InvalidTransitionError):
+            manager.transition("test", 1, PromptState.ROLLED_BACK, PromptState.DRAFT)
+
+    def test_error_message_includes_allowed_states(self):
+        try:
+            PromptLifecycleManager(MagicMock()).validate_transition(
+                PromptState.DRAFT, PromptState.PRODUCTION
+            )
+        except InvalidTransitionError as e:
+            assert "STAGING" in str(e)
+            assert "TENANT_OVERRIDE" in str(e)
+
+
+class TestPromoteToProduction:
+    """Test promotion with auto-archiving (AC-1, AC-2)."""
+
+    def test_promote_archives_previous_production(self, manager, mock_registry):
+        """AC-2: Previous PRODUCTION version is auto-archived."""
+        # Existing production version
+        mock_registry.get_prompt_by_state.return_value = PromptInfo(
+            name="test", version=1, template="old", tags={"state": "PRODUCTION"}
+        )
+        manager.promote_to_production("test", 2)
+
+        # Should archive v1 then promote v2
+        calls = mock_registry.set_prompt_state.call_args_list
+        assert len(calls) == 2
+        assert calls[0] == (("test", 1, "ARCHIVED"),)
+        assert calls[1] == (("test", 2, "PRODUCTION"),)
+
+    def test_promote_no_previous_production(self, manager, mock_registry):
+        """AC-1: Works when no previous PRODUCTION exists."""
+        mock_registry.get_prompt_by_state.return_value = None
+        manager.promote_to_production("test", 1)
+        mock_registry.set_prompt_state.assert_called_once_with("test", 1, "PRODUCTION")
+
+    def test_only_one_production_per_prompt(self, manager, mock_registry):
+        """AC-1: After promotion, only one PRODUCTION version exists."""
+        mock_registry.get_prompt_by_state.return_value = PromptInfo(
+            name="test", version=1, template="old", tags={"state": "PRODUCTION"}
+        )
+        manager.promote_to_production("test", 2)
+        # v1 archived, v2 promoted — only v2 is PRODUCTION
+        archive_call = mock_registry.set_prompt_state.call_args_list[0]
+        assert archive_call == (("test", 1, "ARCHIVED"),)
+
+
+class TestReject:
+    """Test rejection (AC-3)."""
+
+    def test_reject_moves_to_rejected(self, manager, mock_registry):
+        manager.reject("test", 1)
+        mock_registry.set_prompt_state.assert_called_once_with("test", 1, "REJECTED")
+
+    def test_reject_never_deletes(self, manager, mock_registry):
+        """AC-3: Rejected versions retain traces, never hard-deleted."""
+        manager.reject("test", 1)
+        # No delete calls on the registry
+        assert not hasattr(mock_registry, 'delete_prompt') or \
+               not mock_registry.delete_prompt.called
+
+
+class TestGetProductionVersion:
+    """Test production version resolution (AC-4, AC-5)."""
+
+    def test_tenant_override_takes_precedence(self, manager, mock_registry):
+        """AC-5: TENANT_OVERRIDE takes precedence over global PRODUCTION."""
+        tenant_override = PromptInfo(
+            name="test", version=3, template="tenant",
+            tags={"state": "TENANT_OVERRIDE", "tenant_id": "t-1"},
+        )
+        global_prod = PromptInfo(
+            name="test", version=2, template="global",
+            tags={"state": "PRODUCTION"},
+        )
+
+        def side_effect(name, state, tenant_id=None):
+            if state == "TENANT_OVERRIDE" and tenant_id == "t-1":
+                return tenant_override
+            if state == "PRODUCTION" and tenant_id is None:
+                return global_prod
+            return None
+
+        mock_registry.get_prompt_by_state.side_effect = side_effect
+
+        result = manager.get_production_version("test", tenant_id="t-1")
+        assert result.version == 3
+        assert result.template == "tenant"
+
+    def test_falls_back_to_global_production(self, manager, mock_registry):
+        """When no tenant override, returns global PRODUCTION."""
+        global_prod = PromptInfo(
+            name="test", version=2, template="global",
+            tags={"state": "PRODUCTION"},
+        )
+
+        def side_effect(name, state, tenant_id=None):
+            if state == "TENANT_OVERRIDE":
+                return None
+            if state == "PRODUCTION":
+                return global_prod
+            return None
+
+        mock_registry.get_prompt_by_state.side_effect = side_effect
+
+        result = manager.get_production_version("test", tenant_id="t-1")
+        assert result.version == 2
+
+    def test_no_production_returns_none(self, manager, mock_registry):
+        mock_registry.get_prompt_by_state.return_value = None
+        result = manager.get_production_version("test")
+        assert result is None
+
+    def test_staging_not_served(self):
+        """AC-4: STAGING versions are not served to production agents."""
+        assert not PromptLifecycleManager.is_servable(PromptState.STAGING)
+        assert not PromptLifecycleManager.is_servable(PromptState.DRAFT)
+        assert not PromptLifecycleManager.is_servable(PromptState.REJECTED)
+
+    def test_production_is_servable(self):
+        assert PromptLifecycleManager.is_servable(PromptState.PRODUCTION)
+        assert PromptLifecycleManager.is_servable(PromptState.TENANT_OVERRIDE)
+        assert PromptLifecycleManager.is_servable(PromptState.CANARY)
+
+
+class TestKafkaEvents:
+    """Test lifecycle transitions emit Kafka events (AC-6)."""
+
+    def test_transition_emits_event(self, manager, mock_producer):
+        manager.transition("test", 1, PromptState.DRAFT, PromptState.STAGING)
+        mock_producer.send_lifecycle_event_sync.assert_called_once_with(
+            event_type="prompt.staged",
+            prompt_name="test",
+            version=1,
+            from_state="DRAFT",
+            to_state="STAGING",
+            tenant_id=None,
+        )
+
+    def test_promotion_emits_promoted_event(self, manager, mock_registry, mock_producer):
+        mock_registry.get_prompt_by_state.return_value = None
+        manager.promote_to_production("test", 1)
+        mock_producer.send_lifecycle_event_sync.assert_called_once_with(
+            event_type="prompt.promoted",
+            prompt_name="test",
+            version=1,
+            from_state="CANARY",
+            to_state="PRODUCTION",
+            tenant_id=None,
+        )
+
+    def test_rejection_emits_rejected_event(self, manager, mock_producer):
+        manager.reject("test", 1)
+        mock_producer.send_lifecycle_event_sync.assert_called_once_with(
+            event_type="prompt.rejected",
+            prompt_name="test",
+            version=1,
+            from_state="STAGING",
+            to_state="REJECTED",
+            tenant_id=None,
+        )
+
+    def test_rollback_emits_event(self, manager, mock_producer):
+        manager.rollback("test", 1, PromptState.CANARY)
+        mock_producer.send_lifecycle_event_sync.assert_called_once_with(
+            event_type="prompt.rolled_back",
+            prompt_name="test",
+            version=1,
+            from_state="CANARY",
+            to_state="ROLLED_BACK",
+            tenant_id=None,
+        )
+
+    def test_no_event_without_producer(self, mock_registry):
+        """Works without Kafka producer (graceful degradation)."""
+        mgr = PromptLifecycleManager(mock_registry, lifecycle_producer=None)
+        result = mgr.transition("test", 1, PromptState.DRAFT, PromptState.STAGING)
+        assert result is True
+
+
+class TestRollback:
+    """Test rollback from various states."""
+
+    def test_rollback_from_canary(self, manager, mock_registry):
+        manager.rollback("test", 1, PromptState.CANARY)
+        mock_registry.set_prompt_state.assert_called_with("test", 1, "ROLLED_BACK")
+
+    def test_rollback_from_production(self, manager, mock_registry):
+        manager.rollback("test", 1, PromptState.PRODUCTION)
+        mock_registry.set_prompt_state.assert_called_with("test", 1, "ROLLED_BACK")
+
+    def test_rollback_from_staging_invalid(self, manager):
+        with pytest.raises(InvalidTransitionError):
+            manager.rollback("test", 1, PromptState.STAGING)


### PR DESCRIPTION
## Summary

- Implement DRAFT → STAGING → CANARY → PRODUCTION → ARCHIVED lifecycle with REJECTED and ROLLED_BACK side states
- PromptLifecycleManager enforces valid transitions, auto-archives previous PRODUCTION, and emits Kafka events
- API endpoints for promote, reject, rollback, and get production version

## Acceptance Criteria (US-008)

- [x] Only one PRODUCTION version per prompt name per tenant (AC-1)
- [x] Promotion to PRODUCTION automatically archives previous PRODUCTION (AC-2)
- [x] Rejected versions retain traces, never hard-deleted (AC-3)
- [x] STAGING versions not served to production agents (AC-4)
- [x] TENANT_OVERRIDE takes precedence over global PRODUCTION (AC-5)
- [x] Lifecycle transitions emit Kafka events (AC-6)

## State Machine

```
DRAFT → STAGING → CANARY → PRODUCTION → ARCHIVED
                     ↓           ↓
STAGING → REJECTED   CANARY/PRODUCTION → ROLLED_BACK
DRAFT → TENANT_OVERRIDE → ARCHIVED
```

## New API Endpoints

| Method | Path | Purpose |
|--------|------|---------|
| PUT | `/v1/prompts/{name}/versions/{version}/promote` | Promote to next state |
| PUT | `/v1/prompts/{name}/versions/{version}/reject` | Reject STAGING version |
| PUT | `/v1/prompts/{name}/versions/{version}/rollback` | Rollback CANARY/PRODUCTION |
| GET | `/v1/prompts/{name}/production` | Get current production (tenant override first) |

## Test plan

- [x] `pytest tests/ -v` — 407/407 tests pass (33 new lifecycle tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)