### PR TITLE
feat(loader): Support tenant-configurable cache TTL 10s-3600s (US-011)

### DIFF
--- a/prompt-optimization-svc/app/cache/tenant_config.py
+++ b/prompt-optimization-svc/app/cache/tenant_config.py
@@ -1,0 +1,81 @@
+"""Tenant-configurable prompt cache TTL (§10.2).
+
+Redis key: tenant:<tid>:config.prompt_cache_ttl_seconds
+Clamped to [10, 3600] with 300s default.
+"""
+
+import logging
+from typing import Optional
+
+from app.cache.prompt_cache import PromptCacheManager
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TTL = 300
+MIN_TTL = 10
+MAX_TTL = 3600
+
+
+def clamp_ttl(ttl: int) -> int:
+    """Clamp TTL to [MIN_TTL, MAX_TTL] inclusive."""
+    return max(MIN_TTL, min(MAX_TTL, ttl))
+
+
+class TenantConfigManager:
+    """Read/write per-tenant configuration from Redis."""
+
+    CONFIG_KEY_TEMPLATE = "tenant:{tenant_id}:config.prompt_cache_ttl_seconds"
+
+    def __init__(self, prompt_cache: PromptCacheManager) -> None:
+        self.prompt_cache = prompt_cache
+
+    async def get_prompt_cache_ttl(
+        self, tenant_id: Optional[str] = None
+    ) -> int:
+        """Get the prompt cache TTL for a tenant.
+
+        Returns the tenant-specific TTL clamped to [10, 3600],
+        or 300s if no tenant config exists (AC-2).
+        """
+        if not tenant_id:
+            return DEFAULT_TTL
+
+        try:
+            r = await self.prompt_cache.connect()
+            key = self.CONFIG_KEY_TEMPLATE.format(tenant_id=tenant_id)
+            value = await r.get(key)
+            if value is None:
+                return DEFAULT_TTL
+            return clamp_ttl(int(value))
+        except Exception as exc:
+            logger.warning(
+                "Failed to read tenant TTL config for %s: %s",
+                tenant_id,
+                exc,
+            )
+            return DEFAULT_TTL
+
+    async def set_prompt_cache_ttl(
+        self, tenant_id: str, ttl: int
+    ) -> None:
+        """Set the prompt cache TTL for a tenant.
+
+        Value is clamped to [10, 3600] before storing (AC-1).
+        """
+        clamped = clamp_ttl(ttl)
+        try:
+            r = await self.prompt_cache.connect()
+            key = self.CONFIG_KEY_TEMPLATE.format(tenant_id=tenant_id)
+            await r.set(key, str(clamped))
+            logger.info(
+                "Tenant TTL config set: %s = %ds (requested %ds)",
+                tenant_id,
+                clamped,
+                ttl,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Failed to set tenant TTL config for %s: %s",
+                tenant_id,
+                exc,
+            )

--- a/prompt-optimization-svc/app/services/prompt_loader.py
+++ b/prompt-optimization-svc/app/services/prompt_loader.py
@@ -12,7 +12,7 @@ import re
 from typing import Any, Optional
 
 from app.cache.prompt_cache import PromptCacheManager
-from app.cache.tenant_config import TenantConfigManager
+from app.cache.tenant_config import DEFAULT_TTL, TenantConfigManager
 from app.services.mlflow_registry import MLflowPromptRegistry
 
 logger = logging.getLogger(__name__)
@@ -67,13 +67,6 @@ class ZorvenPromptLoader:
         Returns:
             Formatted prompt string.
         """
-        # Resolve TTL from tenant config if not explicitly provided
-        if ttl is None:
-            if self.tenant_config is not None:
-                ttl = await self.tenant_config.get_prompt_cache_ttl(tenant_id)
-            else:
-                ttl = 300
-
         template = await self._resolve(name, tenant_id, ttl)
 
         if template is None:
@@ -89,7 +82,7 @@ class ZorvenPromptLoader:
         self,
         name: str,
         tenant_id: Optional[str],
-        ttl: int,
+        ttl: Optional[int],
     ) -> Optional[str]:
         """Resolve prompt template through three tiers."""
         # --- Tier 1: Redis cache (AC-1: tenant override first) ---
@@ -116,11 +109,12 @@ class ZorvenPromptLoader:
                 )
                 if template is not None:
                     logger.debug("Tier 2 HIT (MLflow): %s", name)
-                    # Cache under the correct key (AC-3)
+                    # Resolve TTL lazily — only needed for cache write
+                    resolved_ttl = await self._resolve_ttl(ttl, tenant_id)
                     await self.prompt_cache.set_prompt(
                         name,
                         template,
-                        ttl=ttl,
+                        ttl=resolved_ttl,
                         tenant_id=resolved_tenant,
                     )
                     return template
@@ -132,6 +126,16 @@ class ZorvenPromptLoader:
 
         # --- Tier 3: fallback (handled by caller) ---
         return None
+
+    async def _resolve_ttl(
+        self, ttl: Optional[int], tenant_id: Optional[str]
+    ) -> int:
+        """Resolve cache TTL: explicit > tenant config > default."""
+        if ttl is not None:
+            return ttl
+        if self.tenant_config is not None:
+            return await self.tenant_config.get_prompt_cache_ttl(tenant_id)
+        return DEFAULT_TTL
 
     def _mlflow_resolve(
         self, name: str, tenant_id: Optional[str]

--- a/prompt-optimization-svc/app/services/prompt_loader.py
+++ b/prompt-optimization-svc/app/services/prompt_loader.py
@@ -12,6 +12,7 @@ import re
 from typing import Any, Optional
 
 from app.cache.prompt_cache import PromptCacheManager
+from app.cache.tenant_config import TenantConfigManager
 from app.services.mlflow_registry import MLflowPromptRegistry
 
 logger = logging.getLogger(__name__)
@@ -39,9 +40,11 @@ class ZorvenPromptLoader:
         self,
         prompt_cache: PromptCacheManager,
         mlflow_registry: Optional[MLflowPromptRegistry] = None,
+        tenant_config: Optional[TenantConfigManager] = None,
     ) -> None:
         self.prompt_cache = prompt_cache
         self.mlflow_registry = mlflow_registry
+        self.tenant_config = tenant_config
 
     async def load(
         self,
@@ -49,7 +52,7 @@ class ZorvenPromptLoader:
         tenant_id: Optional[str] = None,
         variables: Optional[dict[str, Any]] = None,
         fallback_template: str = "",
-        ttl: int = 300,
+        ttl: Optional[int] = None,
     ) -> str:
         """Load, format, and return a prompt template.
 
@@ -58,11 +61,19 @@ class ZorvenPromptLoader:
             tenant_id: Optional tenant for override resolution (AC-1).
             variables: Template variables for formatting (AC-4).
             fallback_template: Hardcoded fallback if all tiers fail (AC-2).
-            ttl: Cache TTL in seconds for setex (AC-3).
+            ttl: Cache TTL in seconds. If None, resolved from tenant config
+                 (US-011: clamped to [10, 3600], default 300s).
 
         Returns:
             Formatted prompt string.
         """
+        # Resolve TTL from tenant config if not explicitly provided
+        if ttl is None:
+            if self.tenant_config is not None:
+                ttl = await self.tenant_config.get_prompt_cache_ttl(tenant_id)
+            else:
+                ttl = 300
+
         template = await self._resolve(name, tenant_id, ttl)
 
         if template is None:

--- a/prompt-optimization-svc/tests/test_tenant_config.py
+++ b/prompt-optimization-svc/tests/test_tenant_config.py
@@ -173,16 +173,14 @@ class TestSetTTL:
 
 
 class TestSetThenGet:
-    """AC-3: Updating config takes effect within one load cycle."""
+    """Unit tests for set-then-get TTL consistency."""
 
     async def test_get_after_set_returns_updated_value(
         self, config, mock_redis
     ):
-        """AC-3: Set TTL, then get returns the new value."""
-        # Set TTL to 120s
+        """Set TTL, then get returns the new value."""
         await config.set_prompt_cache_ttl("tenant-1", 120)
 
-        # Simulate Redis returning the stored value on next get
         mock_redis.get.return_value = "120"
         ttl = await config.get_prompt_cache_ttl("tenant-1")
         assert ttl == 120
@@ -190,14 +188,122 @@ class TestSetThenGet:
     async def test_update_takes_effect_immediately(
         self, config, mock_redis
     ):
-        """AC-3: Change from 300 to 60, next read returns 60."""
-        # Initial state: 300
+        """Change from 300 to 60, next read returns 60."""
         mock_redis.get.return_value = "300"
         assert await config.get_prompt_cache_ttl("t-1") == 300
 
-        # Update to 60
         await config.set_prompt_cache_ttl("t-1", 60)
 
-        # Next read returns 60
         mock_redis.get.return_value = "60"
         assert await config.get_prompt_cache_ttl("t-1") == 60
+
+
+# ------------------------------------------------------------------
+# Loader-level integration: tenant TTL in ZorvenPromptLoader (AC-3)
+# ------------------------------------------------------------------
+
+from unittest.mock import MagicMock
+
+from app.services.mlflow_registry import PromptInfo
+from app.services.prompt_loader import ZorvenPromptLoader
+
+
+class TestLoaderTenantTTL:
+    """AC-3: Tenant TTL change takes effect within one load cycle."""
+
+    async def test_loader_uses_tenant_ttl_on_cache_miss(self):
+        """ZorvenPromptLoader resolves TTL from tenant config on Tier 2."""
+        mock_cache = AsyncMock()
+        mock_cache.get_prompt = AsyncMock(return_value=None)
+        mock_cache.set_prompt = AsyncMock()
+        mock_cache.connect = AsyncMock()
+
+        mock_registry = MagicMock()
+        mock_registry.get_prompt_by_state.return_value = None
+        mock_registry.load_prompt_template.return_value = "Template"
+
+        mock_tenant_config = AsyncMock()
+        mock_tenant_config.get_prompt_cache_ttl = AsyncMock(
+            return_value=120
+        )
+
+        loader = ZorvenPromptLoader(
+            mock_cache, mock_registry, tenant_config=mock_tenant_config
+        )
+        await loader.load("test", tenant_id="t-1")
+
+        # TTL resolved from tenant config (120s), not default (300s)
+        mock_cache.set_prompt.assert_called_once()
+        assert mock_cache.set_prompt.call_args[1]["ttl"] == 120
+
+    async def test_loader_uses_explicit_ttl_over_tenant_config(self):
+        """Explicit ttl parameter takes precedence over tenant config."""
+        mock_cache = AsyncMock()
+        mock_cache.get_prompt = AsyncMock(return_value=None)
+        mock_cache.set_prompt = AsyncMock()
+
+        mock_registry = MagicMock()
+        mock_registry.get_prompt_by_state.return_value = None
+        mock_registry.load_prompt_template.return_value = "T"
+
+        mock_tenant_config = AsyncMock()
+        mock_tenant_config.get_prompt_cache_ttl = AsyncMock(
+            return_value=120
+        )
+
+        loader = ZorvenPromptLoader(
+            mock_cache, mock_registry, tenant_config=mock_tenant_config
+        )
+        await loader.load("test", tenant_id="t-1", ttl=600)
+
+        # Explicit 600s used, not tenant config 120s
+        assert mock_cache.set_prompt.call_args[1]["ttl"] == 600
+        mock_tenant_config.get_prompt_cache_ttl.assert_not_called()
+
+    async def test_loader_skips_ttl_resolution_on_cache_hit(self):
+        """TTL resolution skipped on Tier 1 cache hit (no extra Redis call)."""
+        mock_cache = AsyncMock()
+        mock_cache.get_prompt = AsyncMock(return_value="Cached prompt")
+
+        mock_tenant_config = AsyncMock()
+        mock_tenant_config.get_prompt_cache_ttl = AsyncMock()
+
+        loader = ZorvenPromptLoader(
+            mock_cache, tenant_config=mock_tenant_config
+        )
+        result = await loader.load("test", tenant_id="t-1")
+
+        assert result == "Cached prompt"
+        mock_tenant_config.get_prompt_cache_ttl.assert_not_called()
+
+    async def test_tenant_ttl_change_affects_next_load(self):
+        """AC-3: Updating tenant TTL takes effect on the next load cycle."""
+        mock_cache = AsyncMock()
+        mock_cache.get_prompt = AsyncMock(return_value=None)
+        mock_cache.set_prompt = AsyncMock()
+
+        mock_registry = MagicMock()
+        mock_registry.get_prompt_by_state.return_value = None
+        mock_registry.load_prompt_template.return_value = "T"
+
+        mock_tenant_config = AsyncMock()
+
+        loader = ZorvenPromptLoader(
+            mock_cache, mock_registry, tenant_config=mock_tenant_config
+        )
+
+        # First load: TTL = 300
+        mock_tenant_config.get_prompt_cache_ttl = AsyncMock(
+            return_value=300
+        )
+        await loader.load("test", tenant_id="t-1")
+        assert mock_cache.set_prompt.call_args[1]["ttl"] == 300
+
+        mock_cache.set_prompt.reset_mock()
+
+        # Tenant updates TTL to 60 — next load uses 60
+        mock_tenant_config.get_prompt_cache_ttl = AsyncMock(
+            return_value=60
+        )
+        await loader.load("test", tenant_id="t-1")
+        assert mock_cache.set_prompt.call_args[1]["ttl"] == 60

--- a/prompt-optimization-svc/tests/test_tenant_config.py
+++ b/prompt-optimization-svc/tests/test_tenant_config.py
@@ -1,0 +1,203 @@
+"""Tests for tenant-configurable cache TTL (§10.2)."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.cache.tenant_config import (
+    DEFAULT_TTL,
+    MAX_TTL,
+    MIN_TTL,
+    TenantConfigManager,
+    clamp_ttl,
+)
+
+
+@pytest.fixture
+def mock_redis():
+    """Mock Redis client."""
+    r = AsyncMock()
+    r.get.return_value = None
+    r.set.return_value = True
+    return r
+
+
+@pytest.fixture
+def mock_cache(mock_redis):
+    """Mock PromptCacheManager with Redis client."""
+    cache = AsyncMock()
+    cache.connect.return_value = mock_redis
+    return cache
+
+
+@pytest.fixture
+def config(mock_cache):
+    """TenantConfigManager with mocked cache."""
+    return TenantConfigManager(mock_cache)
+
+
+# ------------------------------------------------------------------
+# clamp_ttl (AC-1)
+# ------------------------------------------------------------------
+
+
+class TestClampTTL:
+    """TTL is clamped to [10, 3600] inclusive (AC-1)."""
+
+    def test_below_min_clamped_to_10(self):
+        assert clamp_ttl(5) == MIN_TTL
+
+    def test_zero_clamped_to_10(self):
+        assert clamp_ttl(0) == MIN_TTL
+
+    def test_negative_clamped_to_10(self):
+        assert clamp_ttl(-100) == MIN_TTL
+
+    def test_above_max_clamped_to_3600(self):
+        assert clamp_ttl(5000) == MAX_TTL
+
+    def test_exactly_min_accepted(self):
+        assert clamp_ttl(10) == 10
+
+    def test_exactly_max_accepted(self):
+        assert clamp_ttl(3600) == 3600
+
+    def test_within_range_passes_through(self):
+        assert clamp_ttl(600) == 600
+
+    def test_default_value(self):
+        assert clamp_ttl(300) == 300
+
+    def test_constants(self):
+        assert MIN_TTL == 10
+        assert MAX_TTL == 3600
+        assert DEFAULT_TTL == 300
+
+
+# ------------------------------------------------------------------
+# get_prompt_cache_ttl (AC-2)
+# ------------------------------------------------------------------
+
+
+class TestGetTTL:
+    """Get tenant TTL with default fallback (AC-2)."""
+
+    async def test_missing_config_returns_default(self, config, mock_redis):
+        """AC-2: Missing tenant config falls back to 300s."""
+        mock_redis.get.return_value = None
+        ttl = await config.get_prompt_cache_ttl("tenant-1")
+        assert ttl == DEFAULT_TTL
+
+    async def test_none_tenant_returns_default(self, config):
+        """None tenant_id returns default without Redis call."""
+        ttl = await config.get_prompt_cache_ttl(None)
+        assert ttl == DEFAULT_TTL
+
+    async def test_empty_tenant_returns_default(self, config):
+        ttl = await config.get_prompt_cache_ttl("")
+        assert ttl == DEFAULT_TTL
+
+    async def test_stored_value_returned(self, config, mock_redis):
+        mock_redis.get.return_value = "600"
+        ttl = await config.get_prompt_cache_ttl("tenant-1")
+        assert ttl == 600
+
+    async def test_stored_value_clamped_below_min(self, config, mock_redis):
+        """AC-1: Stored value below 10 is clamped."""
+        mock_redis.get.return_value = "5"
+        ttl = await config.get_prompt_cache_ttl("tenant-1")
+        assert ttl == MIN_TTL
+
+    async def test_stored_value_clamped_above_max(self, config, mock_redis):
+        """AC-1: Stored value above 3600 is clamped."""
+        mock_redis.get.return_value = "9999"
+        ttl = await config.get_prompt_cache_ttl("tenant-1")
+        assert ttl == MAX_TTL
+
+    async def test_redis_error_returns_default(self, config, mock_redis):
+        mock_redis.get.side_effect = ConnectionError("refused")
+        ttl = await config.get_prompt_cache_ttl("tenant-1")
+        assert ttl == DEFAULT_TTL
+
+    async def test_correct_redis_key_used(self, config, mock_redis):
+        await config.get_prompt_cache_ttl("t-42")
+        mock_redis.get.assert_called_once_with(
+            "tenant:t-42:config.prompt_cache_ttl_seconds"
+        )
+
+
+# ------------------------------------------------------------------
+# set_prompt_cache_ttl
+# ------------------------------------------------------------------
+
+
+class TestSetTTL:
+    """Set tenant TTL with clamping."""
+
+    async def test_set_within_range(self, config, mock_redis):
+        await config.set_prompt_cache_ttl("tenant-1", 600)
+        mock_redis.set.assert_called_once_with(
+            "tenant:tenant-1:config.prompt_cache_ttl_seconds", "600"
+        )
+
+    async def test_set_below_min_clamped(self, config, mock_redis):
+        """AC-1: Value below 10 stored as 10."""
+        await config.set_prompt_cache_ttl("tenant-1", 5)
+        mock_redis.set.assert_called_once_with(
+            "tenant:tenant-1:config.prompt_cache_ttl_seconds", "10"
+        )
+
+    async def test_set_above_max_clamped(self, config, mock_redis):
+        """AC-1: Value above 3600 stored as 3600."""
+        await config.set_prompt_cache_ttl("tenant-1", 5000)
+        mock_redis.set.assert_called_once_with(
+            "tenant:tenant-1:config.prompt_cache_ttl_seconds", "3600"
+        )
+
+    async def test_set_boundary_min(self, config, mock_redis):
+        await config.set_prompt_cache_ttl("t-1", 10)
+        mock_redis.set.assert_called_once_with(
+            "tenant:t-1:config.prompt_cache_ttl_seconds", "10"
+        )
+
+    async def test_set_boundary_max(self, config, mock_redis):
+        await config.set_prompt_cache_ttl("t-1", 3600)
+        mock_redis.set.assert_called_once_with(
+            "tenant:t-1:config.prompt_cache_ttl_seconds", "3600"
+        )
+
+
+# ------------------------------------------------------------------
+# Integration: set then get (AC-3)
+# ------------------------------------------------------------------
+
+
+class TestSetThenGet:
+    """AC-3: Updating config takes effect within one load cycle."""
+
+    async def test_get_after_set_returns_updated_value(
+        self, config, mock_redis
+    ):
+        """AC-3: Set TTL, then get returns the new value."""
+        # Set TTL to 120s
+        await config.set_prompt_cache_ttl("tenant-1", 120)
+
+        # Simulate Redis returning the stored value on next get
+        mock_redis.get.return_value = "120"
+        ttl = await config.get_prompt_cache_ttl("tenant-1")
+        assert ttl == 120
+
+    async def test_update_takes_effect_immediately(
+        self, config, mock_redis
+    ):
+        """AC-3: Change from 300 to 60, next read returns 60."""
+        # Initial state: 300
+        mock_redis.get.return_value = "300"
+        assert await config.get_prompt_cache_ttl("t-1") == 300
+
+        # Update to 60
+        await config.set_prompt_cache_ttl("t-1", 60)
+
+        # Next read returns 60
+        mock_redis.get.return_value = "60"
+        assert await config.get_prompt_cache_ttl("t-1") == 60


### PR DESCRIPTION
## Summary

- Add per-tenant prompt cache TTL stored in Redis, clamped to [10, 3600] with 300s default
- Integrate into ZorvenPromptLoader for automatic TTL resolution per tenant

## Acceptance Criteria (US-011)

- [x] TTL is clamped to [10, 3600] inclusive (AC-1)
- [x] Missing tenant config falls back to 300s (AC-2)
- [x] Integration test verifies updating config takes effect within one load cycle (AC-3)

## Implementation

| Component | Detail |
|-----------|--------|
| Redis key | `tenant:<tid>:config.prompt_cache_ttl_seconds` |
| Default | 300s |
| Range | [10, 3600] — values outside are clamped |
| Integration | `ZorvenPromptLoader.load(ttl=None)` auto-resolves from tenant config |

## Test plan

- [x] `pytest tests/ -v` — 660/660 tests pass (24 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)