### PR TITLE
feat(gepa): Provide make_predict_fn factory for all agents (US-018)

### DIFF
--- a/prompt-optimization-svc/app/predict_fns/__init__.py
+++ b/prompt-optimization-svc/app/predict_fns/__init__.py
@@ -1,0 +1,5 @@
+"""Predict function factories for GEPA optimization."""
+
+from app.predict_fns.factory import make_predict_fn
+
+__all__ = ["make_predict_fn"]

--- a/prompt-optimization-svc/app/predict_fns/factory.py
+++ b/prompt-optimization-svc/app/predict_fns/factory.py
@@ -78,10 +78,15 @@ def make_predict_fn(
                 return ""
 
             # AC-2: Format template with kwargs
-            # Convert underscore keys to dot notation for {{context.brand_name}}
+            # Convert context_ prefix: context_brand_name → context.brand_name
             formatted_kwargs = {}
             for key, value in kwargs.items():
-                formatted_kwargs[key.replace("_", ".")] = str(value)
+                if key.startswith("context_"):
+                    # Only replace the first underscore after "context"
+                    dot_key = "context." + key[len("context_"):]
+                    formatted_kwargs[dot_key] = str(value)
+                else:
+                    formatted_kwargs[key] = str(value)
 
             formatted_prompt = prompt_version.format(**formatted_kwargs)
 

--- a/prompt-optimization-svc/app/predict_fns/factory.py
+++ b/prompt-optimization-svc/app/predict_fns/factory.py
@@ -1,0 +1,113 @@
+"""Universal predict_fn factory for GEPA optimization (§4.4).
+
+Creates a callable that:
+1. Loads a prompt from MLflow Prompt Registry
+2. Formats the template with provided kwargs
+3. Calls the Anthropic Messages API
+4. Returns the model's first content block text
+
+Usage:
+    predict = make_predict_fn("zorven-wf1-mra-system")
+    result = predict(context_brand_name="Nike", context_industry="sportswear")
+"""
+
+import logging
+from typing import Any, Callable, Optional
+
+import anthropic
+import mlflow
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+def make_predict_fn(
+    prompt_name: str,
+    model: str = "claude-sonnet-4-6",
+    mlflow_tracking_uri: Optional[str] = None,
+    anthropic_api_key: Optional[str] = None,
+    max_tokens: int = 4096,
+    temperature: float = 0.3,
+) -> Callable[..., str]:
+    """Create a predict function for GEPA optimization.
+
+    Args:
+        prompt_name: MLflow prompt name (§3.1 convention).
+        model: Anthropic model ID.
+        mlflow_tracking_uri: MLflow server URI (default from settings).
+        anthropic_api_key: Anthropic API key (default from settings).
+        max_tokens: Max tokens for Anthropic response.
+        temperature: Sampling temperature.
+
+    Returns:
+        A callable(**kwargs) -> str that loads the prompt, formats it,
+        calls Claude, and returns the first content block text.
+    """
+    tracking_uri = mlflow_tracking_uri or settings.MLFLOW_TRACKING_URI
+    api_key = anthropic_api_key or settings.ANTHROPIC_API_KEY
+
+    # Set tracking URI for MLflow prompt loading
+    mlflow.set_tracking_uri(tracking_uri)
+
+    # Create Anthropic client
+    client = anthropic.Anthropic(api_key=api_key)
+
+    def predict_fn(**kwargs: Any) -> str:
+        """Load prompt, format, call Claude, return text.
+
+        Args:
+            **kwargs: Template variables (context_brand_name, etc.).
+                      Underscores are converted to dots for {{context.brand_name}}.
+
+        Returns:
+            Model's first content block text, or empty string on error.
+        """
+        try:
+            # AC-1: Load prompt from MLflow registry
+            prompt_uri = f"prompts:/{prompt_name}/production"
+            prompt_version = mlflow.genai.load_prompt(
+                prompt_uri, allow_missing=True
+            )
+
+            if prompt_version is None:
+                logger.warning(
+                    "Prompt '%s' not found in MLflow — returning empty",
+                    prompt_name,
+                )
+                return ""
+
+            # AC-2: Format template with kwargs
+            # Convert underscore keys to dot notation for {{context.brand_name}}
+            formatted_kwargs = {}
+            for key, value in kwargs.items():
+                formatted_kwargs[key.replace("_", ".")] = str(value)
+
+            formatted_prompt = prompt_version.format(**formatted_kwargs)
+
+            # AC-2: Invoke Anthropic Messages API
+            message = client.messages.create(
+                model=model,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                messages=[{"role": "user", "content": formatted_prompt}],
+            )
+
+            # AC-3: Return the model's first content block text
+            if message.content and len(message.content) > 0:
+                return message.content[0].text
+
+            return ""
+
+        except Exception as exc:
+            logger.exception(
+                "predict_fn error for prompt '%s': %s", prompt_name, exc
+            )
+            return ""
+
+    # Attach metadata for introspection
+    predict_fn.prompt_name = prompt_name
+    predict_fn.model = model
+    predict_fn.mlflow_tracking_uri = tracking_uri
+
+    return predict_fn

--- a/prompt-optimization-svc/tests/integration/test_predict_fn.py
+++ b/prompt-optimization-svc/tests/integration/test_predict_fn.py
@@ -1,0 +1,117 @@
+"""Integration tests for make_predict_fn (US-018).
+
+Requires real MLflow and Anthropic API key.
+"""
+
+import os
+
+import pytest
+
+from app.predict_fns.factory import make_predict_fn
+
+from .conftest import MLFLOW_URI, requires_mlflow
+
+ANTHROPIC_API_KEY = os.environ.get("POI_ANTHROPIC_API_KEY", "")
+
+requires_anthropic = pytest.mark.skipif(
+    not ANTHROPIC_API_KEY,
+    reason="POI_ANTHROPIC_API_KEY not set",
+)
+
+
+@pytest.mark.integration
+@requires_mlflow
+class TestPredictFnWithRealMLflow:
+    """Test factory with real MLflow prompt registry."""
+
+    def test_factory_creates_callable(self):
+        fn = make_predict_fn(
+            "zorven-wf1-mra-system",
+            mlflow_tracking_uri=MLFLOW_URI,
+            anthropic_api_key=ANTHROPIC_API_KEY or "placeholder",
+        )
+        assert callable(fn)
+        assert fn.prompt_name == "zorven-wf1-mra-system"
+
+    def test_missing_prompt_returns_empty(self):
+        """Nonexistent prompt returns empty string."""
+        fn = make_predict_fn(
+            "__inttest_nonexistent_xyz",
+            mlflow_tracking_uri=MLFLOW_URI,
+            anthropic_api_key=ANTHROPIC_API_KEY or "placeholder",
+        )
+        result = fn()
+        assert result == ""
+
+
+@pytest.mark.integration
+@requires_mlflow
+@requires_anthropic
+class TestPredictFnEndToEnd:
+    """End-to-end: real MLflow prompt → real Anthropic → text response."""
+
+    @pytest.fixture
+    def registry(self):
+        from app.services.mlflow_registry import MLflowPromptRegistry
+
+        return MLflowPromptRegistry(MLFLOW_URI)
+
+    def test_end_to_end_with_registered_prompt(self, registry):
+        """Register a prompt, create predict_fn, get real Claude response."""
+        name = "__inttest_predict_fn_e2e"
+        registry.register_prompt(
+            name=name,
+            template="Say hello to {{context.name}} in one sentence.",
+        )
+
+        fn = make_predict_fn(
+            name,
+            model="claude-haiku-4-5-20251001",
+            mlflow_tracking_uri=MLFLOW_URI,
+            anthropic_api_key=ANTHROPIC_API_KEY,
+            max_tokens=50,
+        )
+        result = fn(context_name="World")
+
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_cga_prompt_returns_text(self, registry):
+        """AC-4: Factory works with CGA prompt."""
+        name = "__inttest_predict_cga"
+        registry.register_prompt(
+            name=name,
+            template="List one Meta Ads headline for {{context.brand_name}}.",
+        )
+
+        fn = make_predict_fn(
+            name,
+            model="claude-haiku-4-5-20251001",
+            mlflow_tracking_uri=MLFLOW_URI,
+            anthropic_api_key=ANTHROPIC_API_KEY,
+            max_tokens=50,
+        )
+        result = fn(context_brand_name="TestBrand")
+
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_mra_prompt_returns_text(self, registry):
+        """AC-4: Factory works with MRA prompt."""
+        name = "__inttest_predict_mra"
+        registry.register_prompt(
+            name=name,
+            template="Name one trend in the {{context.industry}} industry.",
+        )
+
+        fn = make_predict_fn(
+            name,
+            model="claude-haiku-4-5-20251001",
+            mlflow_tracking_uri=MLFLOW_URI,
+            anthropic_api_key=ANTHROPIC_API_KEY,
+            max_tokens=50,
+        )
+        result = fn(context_industry="tech")
+
+        assert isinstance(result, str)
+        assert len(result) > 0

--- a/prompt-optimization-svc/tests/test_predict_fn.py
+++ b/prompt-optimization-svc/tests/test_predict_fn.py
@@ -1,0 +1,217 @@
+"""Unit tests for make_predict_fn factory (US-018)."""
+
+from unittest.mock import MagicMock, patch
+
+from app.predict_fns.factory import make_predict_fn
+
+
+class TestMakePredictFnFactory:
+    """Test factory creation and configuration."""
+
+    @patch("app.predict_fns.factory.mlflow")
+    @patch("app.predict_fns.factory.anthropic")
+    def test_factory_returns_callable(self, mock_anthropic, mock_mlflow):
+        fn = make_predict_fn("zorven-wf1-mra-system")
+        assert callable(fn)
+
+    @patch("app.predict_fns.factory.mlflow")
+    @patch("app.predict_fns.factory.anthropic")
+    def test_factory_attaches_metadata(self, mock_anthropic, mock_mlflow):
+        fn = make_predict_fn("zorven-wf1-mra-system", model="claude-haiku-4-5")
+        assert fn.prompt_name == "zorven-wf1-mra-system"
+        assert fn.model == "claude-haiku-4-5"
+
+    @patch("app.predict_fns.factory.mlflow")
+    @patch("app.predict_fns.factory.anthropic")
+    def test_default_model(self, mock_anthropic, mock_mlflow):
+        fn = make_predict_fn("test")
+        assert fn.model == "claude-sonnet-4-6"
+
+
+class TestPredictFnExecution:
+    """Test predict_fn behavior."""
+
+    @patch("app.predict_fns.factory.anthropic")
+    @patch("app.predict_fns.factory.mlflow")
+    def test_loads_prompt_from_mlflow(self, mock_mlflow, mock_anthropic):
+        """AC-1: Factory loads prompt via mlflow.genai.load_prompt."""
+        mock_pv = MagicMock()
+        mock_pv.format.return_value = "Formatted prompt"
+        mock_mlflow.genai.load_prompt.return_value = mock_pv
+
+        mock_msg = MagicMock()
+        mock_msg.content = [MagicMock(text="Response")]
+        mock_anthropic.Anthropic.return_value.messages.create.return_value = (
+            mock_msg
+        )
+
+        fn = make_predict_fn("zorven-wf1-mra-system")
+        result = fn(context_brand_name="Nike")
+
+        mock_mlflow.genai.load_prompt.assert_called_once_with(
+            "prompts:/zorven-wf1-mra-system/production",
+            allow_missing=True,
+        )
+        assert result == "Response"
+
+    @patch("app.predict_fns.factory.anthropic")
+    @patch("app.predict_fns.factory.mlflow")
+    def test_formats_template_with_kwargs(self, mock_mlflow, mock_anthropic):
+        """AC-2: Factory formats with kwargs."""
+        mock_pv = MagicMock()
+        mock_pv.format.return_value = "Analyze Nike in sportswear"
+        mock_mlflow.genai.load_prompt.return_value = mock_pv
+
+        mock_msg = MagicMock()
+        mock_msg.content = [MagicMock(text="Analysis")]
+        mock_anthropic.Anthropic.return_value.messages.create.return_value = (
+            mock_msg
+        )
+
+        fn = make_predict_fn("zorven-wf1-mra-system")
+        fn(context_brand_name="Nike", context_industry="sportswear")
+
+        # Underscores converted to dots
+        mock_pv.format.assert_called_once()
+        call_kwargs = mock_pv.format.call_args[1]
+        assert call_kwargs["context.brand.name"] == "Nike" or \
+               call_kwargs.get("context_brand_name") == "Nike" or \
+               "Nike" in str(call_kwargs)
+
+    @patch("app.predict_fns.factory.anthropic")
+    @patch("app.predict_fns.factory.mlflow")
+    def test_calls_anthropic_api(self, mock_mlflow, mock_anthropic):
+        """AC-2: Factory invokes Anthropic Messages API."""
+        mock_pv = MagicMock()
+        mock_pv.format.return_value = "Formatted prompt"
+        mock_mlflow.genai.load_prompt.return_value = mock_pv
+
+        mock_client = MagicMock()
+        mock_msg = MagicMock()
+        mock_msg.content = [MagicMock(text="Claude response")]
+        mock_client.messages.create.return_value = mock_msg
+        mock_anthropic.Anthropic.return_value = mock_client
+
+        fn = make_predict_fn("test", model="claude-sonnet-4-6")
+        fn()
+
+        mock_client.messages.create.assert_called_once()
+        call_kwargs = mock_client.messages.create.call_args[1]
+        assert call_kwargs["model"] == "claude-sonnet-4-6"
+        assert call_kwargs["messages"][0]["content"] == "Formatted prompt"
+
+    @patch("app.predict_fns.factory.anthropic")
+    @patch("app.predict_fns.factory.mlflow")
+    def test_returns_first_content_block_text(
+        self, mock_mlflow, mock_anthropic
+    ):
+        """AC-3: Returns the model's first content block text."""
+        mock_pv = MagicMock()
+        mock_pv.format.return_value = "prompt"
+        mock_mlflow.genai.load_prompt.return_value = mock_pv
+
+        block1 = MagicMock()
+        block1.text = "First block text"
+        block2 = MagicMock()
+        block2.text = "Second block text"
+
+        mock_msg = MagicMock()
+        mock_msg.content = [block1, block2]
+        mock_anthropic.Anthropic.return_value.messages.create.return_value = (
+            mock_msg
+        )
+
+        fn = make_predict_fn("test")
+        result = fn()
+        assert result == "First block text"
+
+
+class TestPredictFnAgentPrompts:
+    """AC-4: Factory works with CGA and MRA prompts."""
+
+    @patch("app.predict_fns.factory.anthropic")
+    @patch("app.predict_fns.factory.mlflow")
+    def test_works_with_cga_prompt(self, mock_mlflow, mock_anthropic):
+        """AC-4: Factory works with CGA prompt name."""
+        mock_pv = MagicMock()
+        mock_pv.format.return_value = "CGA prompt"
+        mock_mlflow.genai.load_prompt.return_value = mock_pv
+
+        mock_msg = MagicMock()
+        mock_msg.content = [MagicMock(text="Creative output")]
+        mock_anthropic.Anthropic.return_value.messages.create.return_value = (
+            mock_msg
+        )
+
+        fn = make_predict_fn("zorven-wf3-cga-profiling")
+        result = fn(context_brand_name="TestBrand")
+        assert result == "Creative output"
+        assert fn.prompt_name == "zorven-wf3-cga-profiling"
+
+    @patch("app.predict_fns.factory.anthropic")
+    @patch("app.predict_fns.factory.mlflow")
+    def test_works_with_mra_prompt(self, mock_mlflow, mock_anthropic):
+        """AC-4: Factory works with MRA prompt name."""
+        mock_pv = MagicMock()
+        mock_pv.format.return_value = "MRA prompt"
+        mock_mlflow.genai.load_prompt.return_value = mock_pv
+
+        mock_msg = MagicMock()
+        mock_msg.content = [MagicMock(text="Market research")]
+        mock_anthropic.Anthropic.return_value.messages.create.return_value = (
+            mock_msg
+        )
+
+        fn = make_predict_fn("zorven-wf1-mra-planning")
+        result = fn(context_brand_name="Acme", context_industry="tech")
+        assert result == "Market research"
+        assert fn.prompt_name == "zorven-wf1-mra-planning"
+
+
+class TestPredictFnErrorHandling:
+    """Test graceful error handling."""
+
+    @patch("app.predict_fns.factory.anthropic")
+    @patch("app.predict_fns.factory.mlflow")
+    def test_mlflow_load_failure_returns_empty(
+        self, mock_mlflow, mock_anthropic
+    ):
+        mock_mlflow.genai.load_prompt.return_value = None
+
+        fn = make_predict_fn("nonexistent")
+        result = fn()
+        assert result == ""
+
+    @patch("app.predict_fns.factory.anthropic")
+    @patch("app.predict_fns.factory.mlflow")
+    def test_anthropic_failure_returns_empty(
+        self, mock_mlflow, mock_anthropic
+    ):
+        mock_pv = MagicMock()
+        mock_pv.format.return_value = "prompt"
+        mock_mlflow.genai.load_prompt.return_value = mock_pv
+
+        mock_anthropic.Anthropic.return_value.messages.create.side_effect = (
+            Exception("API error")
+        )
+
+        fn = make_predict_fn("test")
+        result = fn()
+        assert result == ""
+
+    @patch("app.predict_fns.factory.anthropic")
+    @patch("app.predict_fns.factory.mlflow")
+    def test_empty_content_returns_empty(self, mock_mlflow, mock_anthropic):
+        mock_pv = MagicMock()
+        mock_pv.format.return_value = "prompt"
+        mock_mlflow.genai.load_prompt.return_value = mock_pv
+
+        mock_msg = MagicMock()
+        mock_msg.content = []
+        mock_anthropic.Anthropic.return_value.messages.create.return_value = (
+            mock_msg
+        )
+
+        fn = make_predict_fn("test")
+        result = fn()
+        assert result == ""

--- a/prompt-optimization-svc/tests/test_predict_fn.py
+++ b/prompt-optimization-svc/tests/test_predict_fn.py
@@ -71,12 +71,11 @@ class TestPredictFnExecution:
         fn = make_predict_fn("zorven-wf1-mra-system")
         fn(context_brand_name="Nike", context_industry="sportswear")
 
-        # Underscores converted to dots
+        # context_ prefix converted to context. (preserving field name)
         mock_pv.format.assert_called_once()
         call_kwargs = mock_pv.format.call_args[1]
-        assert call_kwargs["context.brand.name"] == "Nike" or \
-               call_kwargs.get("context_brand_name") == "Nike" or \
-               "Nike" in str(call_kwargs)
+        assert call_kwargs["context.brand_name"] == "Nike"
+        assert call_kwargs["context.industry"] == "sportswear"
 
     @patch("app.predict_fns.factory.anthropic")
     @patch("app.predict_fns.factory.mlflow")

--- a/prompt-optimization-svc/tests/test_predict_fn_properties.py
+++ b/prompt-optimization-svc/tests/test_predict_fn_properties.py
@@ -1,0 +1,125 @@
+"""Hypothesis property tests for make_predict_fn (US-018)."""
+
+from unittest.mock import MagicMock, patch
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from app.predict_fns.factory import make_predict_fn
+
+
+# Strategy: valid prompt names matching §3.1
+_prompt_names = st.sampled_from([
+    "zorven-wf1-mra-system",
+    "zorven-wf1-cia-analysis",
+    "zorven-wf2-bpa-positioning",
+    "zorven-wf3-cga-profiling",
+    "zorven-wf3-coa-optimization",
+])
+
+# Strategy: context variable dicts with string keys/values
+_context_kwargs = st.dictionaries(
+    keys=st.sampled_from([
+        "context_brand_name",
+        "context_industry",
+        "context_target_audience",
+        "context_query",
+        "context_budget",
+    ]),
+    values=st.text(min_size=1, max_size=100),
+    min_size=0,
+    max_size=5,
+)
+
+
+class TestPredictFnProperties:
+    """Hypothesis property-based tests for predict_fn."""
+
+    @given(prompt_name=_prompt_names)
+    @settings(max_examples=10)
+    @patch("app.predict_fns.factory.anthropic")
+    @patch("app.predict_fns.factory.mlflow")
+    def test_factory_always_returns_callable(
+        self, mock_mlflow, mock_anthropic, prompt_name
+    ):
+        """For any valid prompt name, factory returns a callable."""
+        fn = make_predict_fn(prompt_name)
+        assert callable(fn)
+
+    @given(kwargs=_context_kwargs)
+    @settings(max_examples=20)
+    @patch("app.predict_fns.factory.anthropic")
+    @patch("app.predict_fns.factory.mlflow")
+    def test_predict_fn_always_returns_string(
+        self, mock_mlflow, mock_anthropic, kwargs
+    ):
+        """For any valid kwargs, predict_fn returns a string."""
+        mock_pv = MagicMock()
+        mock_pv.format.return_value = "formatted"
+        mock_mlflow.genai.load_prompt.return_value = mock_pv
+
+        mock_msg = MagicMock()
+        mock_msg.content = [MagicMock(text="response")]
+        mock_anthropic.Anthropic.return_value.messages.create.return_value = (
+            mock_msg
+        )
+
+        fn = make_predict_fn("zorven-wf1-mra-system")
+        result = fn(**kwargs)
+        assert isinstance(result, str)
+
+    @given(kwargs=_context_kwargs)
+    @settings(max_examples=10)
+    @patch("app.predict_fns.factory.anthropic")
+    @patch("app.predict_fns.factory.mlflow")
+    def test_predict_fn_returns_non_empty_on_success(
+        self, mock_mlflow, mock_anthropic, kwargs
+    ):
+        """When API succeeds, returned text is non-empty."""
+        mock_pv = MagicMock()
+        mock_pv.format.return_value = "formatted"
+        mock_mlflow.genai.load_prompt.return_value = mock_pv
+
+        mock_msg = MagicMock()
+        mock_msg.content = [MagicMock(text="non-empty response")]
+        mock_anthropic.Anthropic.return_value.messages.create.return_value = (
+            mock_msg
+        )
+
+        fn = make_predict_fn("zorven-wf1-mra-system")
+        result = fn(**kwargs)
+        assert len(result) > 0
+
+    @given(kwargs=_context_kwargs)
+    @settings(max_examples=10)
+    @patch("app.predict_fns.factory.anthropic")
+    @patch("app.predict_fns.factory.mlflow")
+    def test_predict_fn_returns_string_on_error(
+        self, mock_mlflow, mock_anthropic, kwargs
+    ):
+        """On any error, predict_fn still returns a string (empty)."""
+        mock_mlflow.genai.load_prompt.side_effect = Exception("fail")
+
+        fn = make_predict_fn("test")
+        result = fn(**kwargs)
+        assert isinstance(result, str)
+        assert result == ""
+
+    @given(
+        prompt_name=_prompt_names,
+        model=st.sampled_from([
+            "claude-sonnet-4-6",
+            "claude-haiku-4-5",
+            "claude-opus-4-6",
+        ]),
+    )
+    @settings(max_examples=10)
+    @patch("app.predict_fns.factory.anthropic")
+    @patch("app.predict_fns.factory.mlflow")
+    def test_factory_metadata_matches_inputs(
+        self, mock_mlflow, mock_anthropic, prompt_name, model
+    ):
+        """Factory metadata always matches the input parameters."""
+        fn = make_predict_fn(prompt_name, model=model)
+        assert fn.prompt_name == prompt_name
+        assert fn.model == model


### PR DESCRIPTION
## Summary

- Create universal `make_predict_fn(prompt_name, model)` factory for GEPA optimization
- Loads prompt from MLflow, formats with kwargs, calls Anthropic, returns text
- Three test types: unit (mocked), property (Hypothesis), integration (real services)

## Acceptance Criteria (US-018)

- [x] Factory loads prompt via `mlflow.genai.load_prompt('prompts:/<name>/production')` (AC-1)
- [x] Factory formats with kwargs and invokes Anthropic Messages API (AC-2)
- [x] Returns the model's first content block text (AC-3)
- [x] Works with CGA and MRA prompts (AC-4)

## Test Summary

| Type | Count | Framework | Requires |
|------|-------|-----------|----------|
| Unit | 12 | pytest + mock | Nothing |
| Property | 5 | Hypothesis | Nothing |
| Integration | 5 | pytest + real services | MLflow + Anthropic API |
| **Total** | **22** | | |

## Property Tests (Hypothesis)

- Factory always returns a callable for any valid prompt name
- predict_fn always returns a string for any valid kwargs
- Non-empty response on successful API call
- Empty string on any error (resilience)
- Factory metadata always matches input parameters

## Test plan

- [x] `pytest tests/test_predict_fn.py -v` — 12/12 unit tests pass
- [x] `pytest tests/test_predict_fn_properties.py -v` — 5/5 property tests pass
- [x] `pytest tests/integration/test_predict_fn.py -v -m integration` — 5 integration tests (skip locally, pass on Railway)
- [x] `pytest tests/ -m "not integration"` — 796 total pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)