### PR TITLE
feat(gepa): implement WF3 CAA scorers for campaign architecture evaluation (US-023)

### DIFF
--- a/prompt-optimization-svc/app/scorers/__init__.py
+++ b/prompt-optimization-svc/app/scorers/__init__.py
@@ -1,5 +1,12 @@
 """Scorer library for GEPA prompt optimization (§5.1, §5.2)."""
 
+from app.scorers.caa import (
+    CAA_SCORERS,
+    budget_rationality,
+    funnel_coverage,
+    structure_validity,
+    targeting_quality,
+)
 from app.scorers.cga import (
     CGA_SCORERS,
     brand_voice_match,
@@ -20,6 +27,7 @@ COMMON_SCORERS = [json_compliance, pii_safety, token_efficiency, brand_voice]
 __all__ = [
     "COMMON_SCORERS",
     "CGA_SCORERS",
+    "CAA_SCORERS",
     "json_compliance",
     "pii_safety",
     "token_efficiency",
@@ -29,4 +37,8 @@ __all__ = [
     "variant_diversity",
     "brand_voice_match",
     "cta_effectiveness",
+    "structure_validity",
+    "budget_rationality",
+    "funnel_coverage",
+    "targeting_quality",
 ]

--- a/prompt-optimization-svc/app/scorers/caa/__init__.py
+++ b/prompt-optimization-svc/app/scorers/caa/__init__.py
@@ -1,0 +1,21 @@
+"""CAA campaign architecture scorers (§5.2.2)."""
+
+from app.scorers.caa.budget_rationality import budget_rationality
+from app.scorers.caa.funnel_coverage import funnel_coverage
+from app.scorers.caa.structure_validity import structure_validity
+from app.scorers.caa.targeting_quality import targeting_quality
+
+CAA_SCORERS = [
+    structure_validity,
+    budget_rationality,
+    funnel_coverage,
+    targeting_quality,
+]
+
+__all__ = [
+    "CAA_SCORERS",
+    "structure_validity",
+    "budget_rationality",
+    "funnel_coverage",
+    "targeting_quality",
+]

--- a/prompt-optimization-svc/app/scorers/caa/budget_rationality.py
+++ b/prompt-optimization-svc/app/scorers/caa/budget_rationality.py
@@ -1,0 +1,107 @@
+"""Budget rationality scorer for CAA (§5.2.2, AC-2).
+
+Budget allocations must sum to 100% (±1% tolerance).
+"""
+
+import json
+import logging
+
+from mlflow.entities.assessment import Feedback
+from mlflow.genai.scorers import scorer
+
+logger = logging.getLogger(__name__)
+
+TOLERANCE = 1.0  # ±1% acceptable deviation
+MAX_DEVIATION = 10.0  # >10% off → score 0.0
+
+
+def _parse_output(outputs) -> dict | None:
+    if outputs is None:
+        return None
+    if isinstance(outputs, dict):
+        return outputs
+    try:
+        parsed = json.loads(str(outputs))
+        return parsed if isinstance(parsed, dict) else None
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+@scorer(name="budget_rationality")
+def budget_rationality(*, inputs, outputs, expectations=None):
+    """Score whether budget allocations sum to 100%.
+
+    Extracts budget_pct from funnel_map stages and validates
+    they sum to 100% within ±1% tolerance.
+
+    Returns:
+        Feedback with value 0.0–1.0.
+    """
+    data = _parse_output(outputs)
+    if data is None:
+        return Feedback(
+            name="budget_rationality",
+            value=0.0,
+            rationale="Invalid or missing output.",
+        )
+
+    funnel_map = data.get("funnel_map")
+    if not isinstance(funnel_map, dict):
+        return Feedback(
+            name="budget_rationality",
+            value=0.0,
+            rationale="Missing or invalid 'funnel_map' field.",
+        )
+
+    # Extract budget percentages from funnel stages
+    stages = funnel_map.get("stages")
+    if not stages:
+        # Try funnel_map directly as stage dict
+        stages = funnel_map
+
+    budget_pcts = []
+    if isinstance(stages, list):
+        for stage in stages:
+            if isinstance(stage, dict):
+                pct = stage.get("budget_pct", 0)
+                try:
+                    budget_pcts.append(float(pct))
+                except (TypeError, ValueError):
+                    pass
+    elif isinstance(stages, dict):
+        for key, val in stages.items():
+            if isinstance(val, dict):
+                pct = val.get("budget_pct", 0)
+                try:
+                    budget_pcts.append(float(pct))
+                except (TypeError, ValueError):
+                    pass
+            elif isinstance(val, (int, float)):
+                budget_pcts.append(float(val))
+
+    if not budget_pcts:
+        return Feedback(
+            name="budget_rationality",
+            value=0.0,
+            rationale="No budget percentages found in funnel_map.",
+        )
+
+    total = sum(budget_pcts)
+    deviation = abs(total - 100.0)
+
+    if deviation <= TOLERANCE:
+        score = 1.0
+    elif deviation >= MAX_DEVIATION:
+        score = 0.0
+    else:
+        score = round(1.0 - (deviation - TOLERANCE) / (MAX_DEVIATION - TOLERANCE), 4)
+
+    return Feedback(
+        name="budget_rationality",
+        value=score,
+        rationale=(
+            f"Budget sum: {total:.1f}% (deviation: {deviation:.1f}%). "
+            f"Stages: {len(budget_pcts)}. "
+            f"{'Within' if deviation <= TOLERANCE else 'Outside'} ±{TOLERANCE}% tolerance."
+        ),
+    )

--- a/prompt-optimization-svc/app/scorers/caa/funnel_coverage.py
+++ b/prompt-optimization-svc/app/scorers/caa/funnel_coverage.py
@@ -11,7 +11,7 @@ from mlflow.genai.scorers import scorer
 
 logger = logging.getLogger(__name__)
 
-EXPECTED_STAGES = {"tofu", "mofu", "bofu", "retention"}
+EXPECTED_STAGES = ("tofu", "mofu", "bofu", "retention")
 
 # Minimum budget percentage thresholds by brand maturity
 MATURITY_THRESHOLDS: dict[str, dict[str, float]] = {
@@ -100,7 +100,7 @@ def funnel_coverage(*, inputs, outputs, expectations=None):
         )
 
     # Stage presence score (50% weight)
-    present = set(stage_budgets.keys()) & EXPECTED_STAGES
+    present = set(stage_budgets.keys()) & set(EXPECTED_STAGES)
     presence_score = len(present) / len(EXPECTED_STAGES)
 
     # Maturity-appropriate allocation score (50% weight)

--- a/prompt-optimization-svc/app/scorers/caa/funnel_coverage.py
+++ b/prompt-optimization-svc/app/scorers/caa/funnel_coverage.py
@@ -1,0 +1,141 @@
+"""Funnel coverage scorer for CAA (§5.2.2, AC-3).
+
+New brands score lower if TOFU < 50%; established brands if BOFU < 30%.
+"""
+
+import json
+import logging
+
+from mlflow.entities.assessment import Feedback
+from mlflow.genai.scorers import scorer
+
+logger = logging.getLogger(__name__)
+
+EXPECTED_STAGES = {"tofu", "mofu", "bofu", "retention"}
+
+# Minimum budget percentage thresholds by brand maturity
+MATURITY_THRESHOLDS: dict[str, dict[str, float]] = {
+    "new": {"tofu": 50.0},
+    "emerging": {"tofu": 35.0},
+    "established": {"bofu": 30.0},
+}
+
+
+def _parse_output(outputs) -> dict | None:
+    if outputs is None:
+        return None
+    if isinstance(outputs, dict):
+        return outputs
+    try:
+        parsed = json.loads(str(outputs))
+        return parsed if isinstance(parsed, dict) else None
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+def _extract_stage_budgets(funnel_map: dict) -> dict[str, float]:
+    """Extract stage → budget_pct mapping from funnel_map."""
+    budgets: dict[str, float] = {}
+
+    stages = funnel_map.get("stages", funnel_map)
+
+    if isinstance(stages, list):
+        for stage in stages:
+            if isinstance(stage, dict):
+                name = stage.get("stage", "").lower()
+                try:
+                    budgets[name] = float(stage.get("budget_pct", 0))
+                except (TypeError, ValueError):
+                    pass
+    elif isinstance(stages, dict):
+        for key, val in stages.items():
+            if isinstance(val, dict):
+                try:
+                    budgets[key.lower()] = float(val.get("budget_pct", 0))
+                except (TypeError, ValueError):
+                    pass
+
+    return budgets
+
+
+@scorer(name="funnel_coverage")
+def funnel_coverage(*, inputs, outputs, expectations=None):
+    """Score funnel stage coverage based on brand maturity.
+
+    Checks that all 4 funnel stages are present and that budget
+    allocation matches maturity-appropriate thresholds.
+
+    Args:
+        inputs: Model input (unused).
+        outputs: CAA response JSON with funnel_map.
+        expectations: Dict with optional "brand_maturity" key
+            ("new", "emerging", "established"). Defaults to "new".
+
+    Returns:
+        Feedback with value 0.0–1.0.
+    """
+    data = _parse_output(outputs)
+    if data is None:
+        return Feedback(
+            name="funnel_coverage",
+            value=0.0,
+            rationale="Invalid or missing output.",
+        )
+
+    funnel_map = data.get("funnel_map")
+    if not isinstance(funnel_map, dict):
+        return Feedback(
+            name="funnel_coverage",
+            value=0.0,
+            rationale="Missing or invalid 'funnel_map' field.",
+        )
+
+    stage_budgets = _extract_stage_budgets(funnel_map)
+
+    if not stage_budgets:
+        return Feedback(
+            name="funnel_coverage",
+            value=0.0,
+            rationale="No funnel stages found in funnel_map.",
+        )
+
+    # Stage presence score (50% weight)
+    present = set(stage_budgets.keys()) & EXPECTED_STAGES
+    presence_score = len(present) / len(EXPECTED_STAGES)
+
+    # Maturity-appropriate allocation score (50% weight)
+    maturity = "new"
+    if expectations and isinstance(expectations, dict):
+        maturity = expectations.get("brand_maturity", "new").lower()
+
+    thresholds = MATURITY_THRESHOLDS.get(maturity, MATURITY_THRESHOLDS["new"])
+    allocation_score = 1.0
+
+    threshold_issues = []
+    for stage, min_pct in thresholds.items():
+        actual = stage_budgets.get(stage, 0.0)
+        if actual < min_pct:
+            # Linear penalty: how far below threshold
+            penalty = (min_pct - actual) / min_pct
+            allocation_score -= penalty
+            threshold_issues.append(f"{stage}={actual:.0f}% (need ≥{min_pct:.0f}%)")
+
+    allocation_score = max(0.0, allocation_score)
+
+    score = round(0.5 * presence_score + 0.5 * allocation_score, 4)
+
+    stage_detail = ", ".join(
+        f"{s}={stage_budgets.get(s, 0):.0f}%" for s in EXPECTED_STAGES
+    )
+    rationale = (
+        f"Maturity: {maturity}. Stages: {len(present)}/4 present. "
+        f"Distribution: {stage_detail}."
+    )
+    if threshold_issues:
+        rationale += f" Below threshold: {', '.join(threshold_issues)}."
+
+    return Feedback(
+        name="funnel_coverage",
+        value=score,
+        rationale=rationale,
+    )

--- a/prompt-optimization-svc/app/scorers/caa/structure_validity.py
+++ b/prompt-optimization-svc/app/scorers/caa/structure_validity.py
@@ -11,8 +11,8 @@ from mlflow.genai.scorers import scorer
 
 logger = logging.getLogger(__name__)
 
-BLUEPRINT_REQUIRED = {"campaign_name", "campaign_objective", "ad_sets"}
-AD_SET_REQUIRED = {"name", "funnel_stage", "targeting"}
+BLUEPRINT_REQUIRED = ("campaign_name", "campaign_objective")
+AD_SET_REQUIRED = ("name", "funnel_stage", "targeting")
 
 
 def _parse_output(outputs) -> dict | None:
@@ -54,20 +54,26 @@ def structure_validity(*, inputs, outputs, expectations=None):
             rationale="Missing or invalid 'blueprint' field.",
         )
 
-    # Check blueprint-level required fields
+    # Check blueprint-level required fields (presence, not truthiness)
     checks_passed = 0
     checks_total = 0
     issues = []
 
     for field in BLUEPRINT_REQUIRED:
         checks_total += 1
-        if field in blueprint and blueprint[field]:
+        if field in blueprint:
             checks_passed += 1
         else:
             issues.append(f"blueprint.{field} missing")
 
-    # Validate ad_sets
+    # Validate ad_sets — check presence, type, and non-empty separately
+    checks_total += 1  # presence check
     ad_sets = blueprint.get("ad_sets")
+    if ad_sets is not None:
+        checks_passed += 1
+    else:
+        issues.append("blueprint.ad_sets missing")
+
     if not isinstance(ad_sets, list):
         checks_total += 1
         issues.append("ad_sets is not a list")
@@ -78,6 +84,7 @@ def structure_validity(*, inputs, outputs, expectations=None):
             rationale=f"{checks_passed}/{checks_total} checks passed. Issues: {', '.join(issues)}",
         )
 
+    checks_total += 1  # non-empty check
     if not ad_sets:
         issues.append("ad_sets is empty")
         score = round(checks_passed / max(checks_total, 1), 4)
@@ -86,6 +93,8 @@ def structure_validity(*, inputs, outputs, expectations=None):
             value=score,
             rationale=f"{checks_passed}/{checks_total} checks passed. Issues: {', '.join(issues)}",
         )
+
+    checks_passed += 1  # ad_sets is non-empty
 
     # Validate each ad set
     for i, ad_set in enumerate(ad_sets):

--- a/prompt-optimization-svc/app/scorers/caa/structure_validity.py
+++ b/prompt-optimization-svc/app/scorers/caa/structure_validity.py
@@ -1,0 +1,115 @@
+"""Structure validity scorer for CAA (§5.2.2, AC-1).
+
+Validates campaign → ad set → ad hierarchy in JSON output.
+"""
+
+import json
+import logging
+
+from mlflow.entities.assessment import Feedback
+from mlflow.genai.scorers import scorer
+
+logger = logging.getLogger(__name__)
+
+BLUEPRINT_REQUIRED = {"campaign_name", "campaign_objective", "ad_sets"}
+AD_SET_REQUIRED = {"name", "funnel_stage", "targeting"}
+
+
+def _parse_output(outputs) -> dict | None:
+    if outputs is None:
+        return None
+    if isinstance(outputs, dict):
+        return outputs
+    try:
+        parsed = json.loads(str(outputs))
+        return parsed if isinstance(parsed, dict) else None
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+@scorer(name="structure_validity")
+def structure_validity(*, inputs, outputs, expectations=None):
+    """Score campaign blueprint structural validity.
+
+    Validates the campaign → ad set hierarchy: blueprint must contain
+    campaign_name, campaign_objective, and a non-empty ad_sets list
+    where each ad set has name, funnel_stage, and targeting.
+
+    Returns:
+        Feedback with value 0.0–1.0.
+    """
+    data = _parse_output(outputs)
+    if data is None:
+        return Feedback(
+            name="structure_validity",
+            value=0.0,
+            rationale="Invalid or missing output — cannot parse as JSON.",
+        )
+
+    blueprint = data.get("blueprint")
+    if not isinstance(blueprint, dict):
+        return Feedback(
+            name="structure_validity",
+            value=0.0,
+            rationale="Missing or invalid 'blueprint' field.",
+        )
+
+    # Check blueprint-level required fields
+    checks_passed = 0
+    checks_total = 0
+    issues = []
+
+    for field in BLUEPRINT_REQUIRED:
+        checks_total += 1
+        if field in blueprint and blueprint[field]:
+            checks_passed += 1
+        else:
+            issues.append(f"blueprint.{field} missing")
+
+    # Validate ad_sets
+    ad_sets = blueprint.get("ad_sets")
+    if not isinstance(ad_sets, list):
+        checks_total += 1
+        issues.append("ad_sets is not a list")
+        score = round(checks_passed / max(checks_total, 1), 4)
+        return Feedback(
+            name="structure_validity",
+            value=score,
+            rationale=f"{checks_passed}/{checks_total} checks passed. Issues: {', '.join(issues)}",
+        )
+
+    if not ad_sets:
+        issues.append("ad_sets is empty")
+        score = round(checks_passed / max(checks_total, 1), 4)
+        return Feedback(
+            name="structure_validity",
+            value=score,
+            rationale=f"{checks_passed}/{checks_total} checks passed. Issues: {', '.join(issues)}",
+        )
+
+    # Validate each ad set
+    for i, ad_set in enumerate(ad_sets):
+        if not isinstance(ad_set, dict):
+            checks_total += 1
+            issues.append(f"ad_sets[{i}] is not a dict")
+            continue
+        for field in AD_SET_REQUIRED:
+            checks_total += 1
+            if field in ad_set and ad_set[field]:
+                checks_passed += 1
+            else:
+                issues.append(f"ad_sets[{i}].{field} missing")
+
+    score = round(checks_passed / max(checks_total, 1), 4)
+
+    rationale = f"{checks_passed}/{checks_total} structural checks passed."
+    if issues:
+        rationale += f" Issues: {', '.join(issues[:5])}"
+        if len(issues) > 5:
+            rationale += f" (+{len(issues) - 5} more)"
+
+    return Feedback(
+        name="structure_validity",
+        value=score,
+        rationale=rationale,
+    )

--- a/prompt-optimization-svc/app/scorers/caa/targeting_quality.py
+++ b/prompt-optimization-svc/app/scorers/caa/targeting_quality.py
@@ -1,0 +1,116 @@
+"""Targeting quality scorer for CAA (§5.2.2, AC-4).
+
+Targeting must include demographics, interests, and a custom/lookalike audience.
+"""
+
+import json
+import logging
+
+from mlflow.entities.assessment import Feedback
+from mlflow.genai.scorers import scorer
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_output(outputs) -> dict | None:
+    if outputs is None:
+        return None
+    if isinstance(outputs, dict):
+        return outputs
+    try:
+        parsed = json.loads(str(outputs))
+        return parsed if isinstance(parsed, dict) else None
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+def _has_demographics(spec: dict) -> bool:
+    """Check for non-empty demographics dict."""
+    demo = spec.get("demographics")
+    return isinstance(demo, dict) and len(demo) > 0
+
+
+def _has_interests(spec: dict) -> bool:
+    """Check for non-empty interests list."""
+    interests = spec.get("interests")
+    return isinstance(interests, list) and len(interests) > 0
+
+
+def _has_custom_or_lookalike(spec: dict) -> bool:
+    """Check for at least one custom or lookalike audience."""
+    custom = spec.get("custom_audiences")
+    lookalike = spec.get("lookalike_audiences")
+    has_custom = isinstance(custom, list) and len(custom) > 0
+    has_lookalike = isinstance(lookalike, list) and len(lookalike) > 0
+    return has_custom or has_lookalike
+
+
+@scorer(name="targeting_quality")
+def targeting_quality(*, inputs, outputs, expectations=None):
+    """Score audience targeting completeness.
+
+    Each targeting spec is checked for demographics, interests,
+    and custom/lookalike audiences. Score = ratio of specs
+    meeting all 3 criteria.
+
+    Returns:
+        Feedback with value 0.0–1.0.
+    """
+    data = _parse_output(outputs)
+    if data is None:
+        return Feedback(
+            name="targeting_quality",
+            value=0.0,
+            rationale="Invalid or missing output.",
+        )
+
+    specs = data.get("targeting_specs")
+    if not isinstance(specs, list):
+        return Feedback(
+            name="targeting_quality",
+            value=0.0,
+            rationale="Missing or invalid 'targeting_specs' field.",
+        )
+
+    specs = [s for s in specs if isinstance(s, dict)]
+    if not specs:
+        return Feedback(
+            name="targeting_quality",
+            value=0.0,
+            rationale="No valid targeting specs found.",
+        )
+
+    complete = 0
+    issues = []
+
+    for i, spec in enumerate(specs):
+        has_demo = _has_demographics(spec)
+        has_int = _has_interests(spec)
+        has_aud = _has_custom_or_lookalike(spec)
+
+        if has_demo and has_int and has_aud:
+            complete += 1
+        else:
+            missing = []
+            if not has_demo:
+                missing.append("demographics")
+            if not has_int:
+                missing.append("interests")
+            if not has_aud:
+                missing.append("custom/lookalike")
+            name = spec.get("ad_set_name", f"spec[{i}]")
+            issues.append(f"{name}: missing {', '.join(missing)}")
+
+    score = round(complete / len(specs), 4)
+
+    rationale = f"{complete}/{len(specs)} targeting specs fully complete."
+    if issues:
+        rationale += f" Issues: {'; '.join(issues[:3])}"
+        if len(issues) > 3:
+            rationale += f" (+{len(issues) - 3} more)"
+
+    return Feedback(
+        name="targeting_quality",
+        value=score,
+        rationale=rationale,
+    )

--- a/prompt-optimization-svc/tests/integration/test_caa_scorers.py
+++ b/prompt-optimization-svc/tests/integration/test_caa_scorers.py
@@ -1,0 +1,26 @@
+"""Integration tests for CAA scorers (US-023)."""
+
+from tests.conftest import requires_mlflow
+
+
+@requires_mlflow
+class TestCaaScorerMlflowCompatibility:
+    def test_all_are_scorer_instances(self):
+        from mlflow.genai.scorers import Scorer
+
+        from app.scorers.caa import CAA_SCORERS
+
+        for s in CAA_SCORERS:
+            assert isinstance(s, Scorer), f"{s.name} is not a Scorer"
+
+    def test_caa_scorers_list_has_four(self):
+        from app.scorers.caa import CAA_SCORERS
+
+        assert len(CAA_SCORERS) == 4
+        names = {s.name for s in CAA_SCORERS}
+        assert names == {
+            "structure_validity",
+            "budget_rationality",
+            "funnel_coverage",
+            "targeting_quality",
+        }

--- a/prompt-optimization-svc/tests/test_caa_scorers.py
+++ b/prompt-optimization-svc/tests/test_caa_scorers.py
@@ -1,0 +1,518 @@
+"""Unit tests for CAA scorers (US-023).
+
+10+ tests per scorer covering perfect, partial, invalid, and edge inputs.
+"""
+
+import json
+
+from app.scorers.caa.budget_rationality import budget_rationality
+from app.scorers.caa.funnel_coverage import funnel_coverage
+from app.scorers.caa.structure_validity import structure_validity
+from app.scorers.caa.targeting_quality import targeting_quality
+
+
+def _caa_output(**overrides) -> str:
+    """Build a minimal valid CAA output JSON string."""
+    data = {
+        "blueprint": overrides.get(
+            "blueprint",
+            {
+                "campaign_name": "Test Campaign",
+                "campaign_objective": "AWARENESS",
+                "ad_sets": [
+                    {
+                        "name": "TOFU - Broad",
+                        "funnel_stage": "tofu",
+                        "targeting": {"demographics": {"age_min": 18}},
+                        "daily_budget": 50.0,
+                    },
+                    {
+                        "name": "BOFU - Converters",
+                        "funnel_stage": "bofu",
+                        "targeting": {"demographics": {"age_min": 25}},
+                        "daily_budget": 50.0,
+                    },
+                ],
+            },
+        ),
+        "funnel_map": overrides.get(
+            "funnel_map",
+            {
+                "stages": [
+                    {"stage": "tofu", "budget_pct": 50},
+                    {"stage": "mofu", "budget_pct": 25},
+                    {"stage": "bofu", "budget_pct": 20},
+                    {"stage": "retention", "budget_pct": 5},
+                ]
+            },
+        ),
+        "targeting_specs": overrides.get(
+            "targeting_specs",
+            [
+                {
+                    "ad_set_name": "TOFU",
+                    "demographics": {"age_min": 18, "age_max": 65, "genders": ["ALL"]},
+                    "interests": ["Technology", "Software"],
+                    "custom_audiences": ["repeat_buyers"],
+                    "lookalike_audiences": [],
+                },
+                {
+                    "ad_set_name": "BOFU",
+                    "demographics": {"age_min": 25, "age_max": 55, "genders": ["ALL"]},
+                    "interests": ["SaaS", "Startups"],
+                    "custom_audiences": [],
+                    "lookalike_audiences": ["lookalike_buyers_1pct"],
+                },
+            ],
+        ),
+        "placement_budget": overrides.get("placement_budget", {}),
+    }
+    data.update({k: v for k, v in overrides.items() if k not in data})
+    return json.dumps(data)
+
+
+# ── structure_validity tests (AC-1) ──
+
+
+class TestStructureValidity:
+    def test_valid_blueprint(self):
+        result = structure_validity(
+            inputs="test", outputs=_caa_output(), expectations=None
+        )
+        assert result.value == 1.0
+
+    def test_missing_blueprint(self):
+        result = structure_validity(
+            inputs="test", outputs='{"other": 1}', expectations=None
+        )
+        assert result.value == 0.0
+
+    def test_missing_ad_sets(self):
+        bp = {"campaign_name": "Test", "campaign_objective": "AWARENESS"}
+        result = structure_validity(
+            inputs="test", outputs=_caa_output(blueprint=bp), expectations=None
+        )
+        assert result.value < 1.0
+
+    def test_empty_ad_sets(self):
+        bp = {"campaign_name": "Test", "campaign_objective": "AWARENESS", "ad_sets": []}
+        result = structure_validity(
+            inputs="test", outputs=_caa_output(blueprint=bp), expectations=None
+        )
+        assert result.value < 1.0
+
+    def test_ad_set_missing_name(self):
+        bp = {
+            "campaign_name": "Test",
+            "campaign_objective": "AWARENESS",
+            "ad_sets": [{"funnel_stage": "tofu", "targeting": {}}],
+        }
+        result = structure_validity(
+            inputs="test", outputs=_caa_output(blueprint=bp), expectations=None
+        )
+        assert result.value < 1.0
+
+    def test_ad_set_missing_targeting(self):
+        bp = {
+            "campaign_name": "Test",
+            "campaign_objective": "AWARENESS",
+            "ad_sets": [{"name": "TOFU", "funnel_stage": "tofu"}],
+        }
+        result = structure_validity(
+            inputs="test", outputs=_caa_output(blueprint=bp), expectations=None
+        )
+        assert result.value < 1.0
+
+    def test_invalid_json(self):
+        result = structure_validity(
+            inputs="test", outputs="not json", expectations=None
+        )
+        assert result.value == 0.0
+
+    def test_none_output(self):
+        result = structure_validity(inputs="test", outputs=None, expectations=None)
+        assert result.value == 0.0
+
+    def test_dict_input(self):
+        data = json.loads(_caa_output())
+        result = structure_validity(inputs="test", outputs=data, expectations=None)
+        assert result.value == 1.0
+
+    def test_non_list_ad_sets(self):
+        bp = {
+            "campaign_name": "Test",
+            "campaign_objective": "AWARENESS",
+            "ad_sets": "bad",
+        }
+        result = structure_validity(
+            inputs="test", outputs=_caa_output(blueprint=bp), expectations=None
+        )
+        assert result.value < 1.0
+
+    def test_feedback_name(self):
+        result = structure_validity(
+            inputs="test", outputs=_caa_output(), expectations=None
+        )
+        assert result.name == "structure_validity"
+
+    def test_non_dict_ad_set_entries(self):
+        bp = {
+            "campaign_name": "Test",
+            "campaign_objective": "AWARENESS",
+            "ad_sets": ["bad", 42],
+        }
+        result = structure_validity(
+            inputs="test", outputs=_caa_output(blueprint=bp), expectations=None
+        )
+        assert result.value < 1.0
+
+
+# ── budget_rationality tests (AC-2) ──
+
+
+class TestBudgetRationality:
+    def test_sums_to_100(self):
+        result = budget_rationality(
+            inputs="test", outputs=_caa_output(), expectations=None
+        )
+        assert result.value == 1.0
+
+    def test_sums_to_99(self):
+        out = _caa_output(
+            funnel_map={
+                "stages": [
+                    {"stage": "tofu", "budget_pct": 49},
+                    {"stage": "mofu", "budget_pct": 25},
+                    {"stage": "bofu", "budget_pct": 20},
+                    {"stage": "retention", "budget_pct": 5},
+                ]
+            }
+        )
+        result = budget_rationality(inputs="test", outputs=out, expectations=None)
+        assert result.value == 1.0  # within ±1% tolerance
+
+    def test_sums_to_95(self):
+        out = _caa_output(
+            funnel_map={
+                "stages": [
+                    {"stage": "tofu", "budget_pct": 45},
+                    {"stage": "mofu", "budget_pct": 25},
+                    {"stage": "bofu", "budget_pct": 20},
+                    {"stage": "retention", "budget_pct": 5},
+                ]
+            }
+        )
+        result = budget_rationality(inputs="test", outputs=out, expectations=None)
+        assert 0.0 < result.value < 1.0
+
+    def test_sums_to_80(self):
+        out = _caa_output(
+            funnel_map={
+                "stages": [
+                    {"stage": "tofu", "budget_pct": 30},
+                    {"stage": "mofu", "budget_pct": 25},
+                    {"stage": "bofu", "budget_pct": 20},
+                    {"stage": "retention", "budget_pct": 5},
+                ]
+            }
+        )
+        result = budget_rationality(inputs="test", outputs=out, expectations=None)
+        assert result.value < 0.2
+
+    def test_missing_funnel_map(self):
+        out = json.dumps({"blueprint": {}, "targeting_specs": []})
+        result = budget_rationality(inputs="test", outputs=out, expectations=None)
+        assert result.value == 0.0
+
+    def test_empty_stages(self):
+        out = _caa_output(funnel_map={"stages": []})
+        result = budget_rationality(inputs="test", outputs=out, expectations=None)
+        assert result.value == 0.0
+
+    def test_none_output(self):
+        result = budget_rationality(inputs="test", outputs=None, expectations=None)
+        assert result.value == 0.0
+
+    def test_single_stage_100(self):
+        out = _caa_output(funnel_map={"stages": [{"stage": "tofu", "budget_pct": 100}]})
+        result = budget_rationality(inputs="test", outputs=out, expectations=None)
+        assert result.value == 1.0
+
+    def test_feedback_name(self):
+        result = budget_rationality(
+            inputs="test", outputs=_caa_output(), expectations=None
+        )
+        assert result.name == "budget_rationality"
+
+    def test_non_numeric_budget(self):
+        out = _caa_output(
+            funnel_map={"stages": [{"stage": "tofu", "budget_pct": "bad"}]}
+        )
+        result = budget_rationality(inputs="test", outputs=out, expectations=None)
+        assert result.value == 0.0
+
+    def test_dict_format_stages(self):
+        """funnel_map as dict of stage dicts."""
+        out = _caa_output(
+            funnel_map={
+                "tofu": {"budget_pct": 50},
+                "mofu": {"budget_pct": 25},
+                "bofu": {"budget_pct": 20},
+                "retention": {"budget_pct": 5},
+            }
+        )
+        result = budget_rationality(inputs="test", outputs=out, expectations=None)
+        assert result.value == 1.0
+
+
+# ── funnel_coverage tests (AC-3) ──
+
+
+class TestFunnelCoverage:
+    def test_new_brand_tofu_50(self):
+        result = funnel_coverage(
+            inputs="test", outputs=_caa_output(), expectations={"brand_maturity": "new"}
+        )
+        assert result.value >= 0.9
+
+    def test_new_brand_tofu_below_50(self):
+        out = _caa_output(
+            funnel_map={
+                "stages": [
+                    {"stage": "tofu", "budget_pct": 30},
+                    {"stage": "mofu", "budget_pct": 30},
+                    {"stage": "bofu", "budget_pct": 30},
+                    {"stage": "retention", "budget_pct": 10},
+                ]
+            }
+        )
+        result = funnel_coverage(
+            inputs="test", outputs=out, expectations={"brand_maturity": "new"}
+        )
+        assert result.value < 0.9
+
+    def test_established_brand_bofu_30(self):
+        out = _caa_output(
+            funnel_map={
+                "stages": [
+                    {"stage": "tofu", "budget_pct": 20},
+                    {"stage": "mofu", "budget_pct": 25},
+                    {"stage": "bofu", "budget_pct": 40},
+                    {"stage": "retention", "budget_pct": 15},
+                ]
+            }
+        )
+        result = funnel_coverage(
+            inputs="test", outputs=out, expectations={"brand_maturity": "established"}
+        )
+        assert result.value >= 0.9
+
+    def test_established_brand_bofu_below_30(self):
+        out = _caa_output(
+            funnel_map={
+                "stages": [
+                    {"stage": "tofu", "budget_pct": 40},
+                    {"stage": "mofu", "budget_pct": 35},
+                    {"stage": "bofu", "budget_pct": 15},
+                    {"stage": "retention", "budget_pct": 10},
+                ]
+            }
+        )
+        result = funnel_coverage(
+            inputs="test", outputs=out, expectations={"brand_maturity": "established"}
+        )
+        assert result.value < 0.9
+
+    def test_all_4_stages_present(self):
+        result = funnel_coverage(
+            inputs="test", outputs=_caa_output(), expectations=None
+        )
+        assert result.value > 0.5
+
+    def test_missing_stages(self):
+        out = _caa_output(funnel_map={"stages": [{"stage": "tofu", "budget_pct": 100}]})
+        result = funnel_coverage(inputs="test", outputs=out, expectations=None)
+        assert result.value < 0.9
+
+    def test_default_new_brand(self):
+        result = funnel_coverage(
+            inputs="test", outputs=_caa_output(), expectations=None
+        )
+        r2 = funnel_coverage(
+            inputs="test", outputs=_caa_output(), expectations={"brand_maturity": "new"}
+        )
+        assert result.value == r2.value
+
+    def test_none_output(self):
+        result = funnel_coverage(inputs="test", outputs=None, expectations=None)
+        assert result.value == 0.0
+
+    def test_malformed_funnel_map(self):
+        out = _caa_output(funnel_map="bad")
+        result = funnel_coverage(inputs="test", outputs=out, expectations=None)
+        assert result.value == 0.0
+
+    def test_emerging_brand(self):
+        out = _caa_output(
+            funnel_map={
+                "stages": [
+                    {"stage": "tofu", "budget_pct": 35},
+                    {"stage": "mofu", "budget_pct": 30},
+                    {"stage": "bofu", "budget_pct": 25},
+                    {"stage": "retention", "budget_pct": 10},
+                ]
+            }
+        )
+        result = funnel_coverage(
+            inputs="test", outputs=out, expectations={"brand_maturity": "emerging"}
+        )
+        assert result.value >= 0.9
+
+    def test_feedback_name(self):
+        result = funnel_coverage(
+            inputs="test", outputs=_caa_output(), expectations=None
+        )
+        assert result.name == "funnel_coverage"
+
+
+# ── targeting_quality tests (AC-4) ──
+
+
+class TestTargetingQuality:
+    def test_full_targeting(self):
+        result = targeting_quality(
+            inputs="test", outputs=_caa_output(), expectations=None
+        )
+        assert result.value == 1.0
+
+    def test_missing_demographics(self):
+        out = _caa_output(
+            targeting_specs=[
+                {
+                    "ad_set_name": "TOFU",
+                    "interests": ["Tech"],
+                    "custom_audiences": ["buyers"],
+                    "lookalike_audiences": [],
+                }
+            ]
+        )
+        result = targeting_quality(inputs="test", outputs=out, expectations=None)
+        assert result.value == 0.0
+
+    def test_missing_interests(self):
+        out = _caa_output(
+            targeting_specs=[
+                {
+                    "ad_set_name": "TOFU",
+                    "demographics": {"age_min": 18},
+                    "interests": [],
+                    "custom_audiences": ["buyers"],
+                    "lookalike_audiences": [],
+                }
+            ]
+        )
+        result = targeting_quality(inputs="test", outputs=out, expectations=None)
+        assert result.value == 0.0
+
+    def test_no_custom_or_lookalike(self):
+        out = _caa_output(
+            targeting_specs=[
+                {
+                    "ad_set_name": "TOFU",
+                    "demographics": {"age_min": 18},
+                    "interests": ["Tech"],
+                    "custom_audiences": [],
+                    "lookalike_audiences": [],
+                }
+            ]
+        )
+        result = targeting_quality(inputs="test", outputs=out, expectations=None)
+        assert result.value == 0.0
+
+    def test_lookalike_only(self):
+        out = _caa_output(
+            targeting_specs=[
+                {
+                    "ad_set_name": "TOFU",
+                    "demographics": {"age_min": 18},
+                    "interests": ["Tech"],
+                    "custom_audiences": [],
+                    "lookalike_audiences": ["lookalike_1pct"],
+                }
+            ]
+        )
+        result = targeting_quality(inputs="test", outputs=out, expectations=None)
+        assert result.value == 1.0
+
+    def test_empty_targeting_specs(self):
+        out = _caa_output(targeting_specs=[])
+        result = targeting_quality(inputs="test", outputs=out, expectations=None)
+        assert result.value == 0.0
+
+    def test_mixed_quality(self):
+        out = _caa_output(
+            targeting_specs=[
+                {
+                    "ad_set_name": "good",
+                    "demographics": {"age_min": 18},
+                    "interests": ["Tech"],
+                    "custom_audiences": ["buyers"],
+                    "lookalike_audiences": [],
+                },
+                {
+                    "ad_set_name": "bad",
+                    "demographics": {},
+                    "interests": [],
+                    "custom_audiences": [],
+                    "lookalike_audiences": [],
+                },
+            ]
+        )
+        result = targeting_quality(inputs="test", outputs=out, expectations=None)
+        assert result.value == 0.5
+
+    def test_none_output(self):
+        result = targeting_quality(inputs="test", outputs=None, expectations=None)
+        assert result.value == 0.0
+
+    def test_non_list_targeting_specs(self):
+        out = _caa_output(targeting_specs="bad")
+        result = targeting_quality(inputs="test", outputs=out, expectations=None)
+        assert result.value == 0.0
+
+    def test_non_dict_entries(self):
+        out = _caa_output(targeting_specs=["bad", 42])
+        result = targeting_quality(inputs="test", outputs=out, expectations=None)
+        assert result.value == 0.0
+
+    def test_feedback_name(self):
+        result = targeting_quality(
+            inputs="test", outputs=_caa_output(), expectations=None
+        )
+        assert result.name == "targeting_quality"
+
+
+# ── Scorer conformance ──
+
+
+class TestCaaScorerConformance:
+    def test_all_are_scorer_instances(self):
+        from mlflow.genai.scorers import Scorer
+
+        for s in [
+            structure_validity,
+            budget_rationality,
+            funnel_coverage,
+            targeting_quality,
+        ]:
+            assert isinstance(s, Scorer), f"{s.name} is not a Scorer"
+
+    def test_all_accept_keyword_args(self):
+        for s in [
+            structure_validity,
+            budget_rationality,
+            funnel_coverage,
+            targeting_quality,
+        ]:
+            result = s(inputs="test", outputs=_caa_output(), expectations=None)
+            assert result is not None

--- a/prompt-optimization-svc/tests/test_caa_scorers_properties.py
+++ b/prompt-optimization-svc/tests/test_caa_scorers_properties.py
@@ -1,0 +1,111 @@
+"""Hypothesis property tests for CAA scorers (US-023)."""
+
+import json
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from app.scorers.caa.budget_rationality import budget_rationality
+from app.scorers.caa.funnel_coverage import funnel_coverage
+from app.scorers.caa.structure_validity import structure_validity
+from app.scorers.caa.targeting_quality import targeting_quality
+
+
+class TestStructureValidityProperties:
+    @given(st.text())
+    @settings(max_examples=50, deadline=None)
+    def test_always_returns_float_in_range(self, text):
+        result = structure_validity(inputs="test", outputs=text, expectations=None)
+        assert 0.0 <= float(result.value) <= 1.0
+
+    @given(st.text())
+    @settings(max_examples=50, deadline=None)
+    def test_never_raises(self, text):
+        result = structure_validity(inputs=text, outputs=text, expectations=None)
+        assert result is not None
+
+    def test_deterministic(self):
+        out = json.dumps(
+            {
+                "blueprint": {
+                    "campaign_name": "Test",
+                    "campaign_objective": "AWARENESS",
+                    "ad_sets": [{"name": "X", "funnel_stage": "tofu", "targeting": {}}],
+                }
+            }
+        )
+        r1 = structure_validity(inputs="test", outputs=out, expectations=None)
+        r2 = structure_validity(inputs="test", outputs=out, expectations=None)
+        assert r1.value == r2.value
+
+
+class TestBudgetRationalityProperties:
+    @given(st.text())
+    @settings(max_examples=50, deadline=None)
+    def test_always_returns_float_in_range(self, text):
+        result = budget_rationality(inputs="test", outputs=text, expectations=None)
+        assert 0.0 <= float(result.value) <= 1.0
+
+    @given(
+        st.lists(
+            st.floats(
+                min_value=0, max_value=100, allow_nan=False, allow_infinity=False
+            ),
+            min_size=1,
+            max_size=4,
+        )
+    )
+    @settings(max_examples=30, deadline=None)
+    def test_exact_100_scores_1(self, pcts):
+        # Normalize to sum to exactly 100
+        total = sum(pcts)
+        if total == 0:
+            return
+        normalized = [p / total * 100 for p in pcts]
+        stages = [{"stage": f"s{i}", "budget_pct": p} for i, p in enumerate(normalized)]
+        out = json.dumps({"funnel_map": {"stages": stages}})
+        result = budget_rationality(inputs="test", outputs=out, expectations=None)
+        assert result.value >= 0.99
+
+
+class TestFunnelCoverageProperties:
+    @given(st.text())
+    @settings(max_examples=50, deadline=None)
+    def test_always_returns_float_in_range(self, text):
+        result = funnel_coverage(inputs="test", outputs=text, expectations=None)
+        assert 0.0 <= float(result.value) <= 1.0
+
+    @given(st.text())
+    @settings(max_examples=50, deadline=None)
+    def test_never_raises(self, text):
+        result = funnel_coverage(inputs=text, outputs=text, expectations=None)
+        assert result is not None
+
+
+class TestTargetingQualityProperties:
+    @given(st.text())
+    @settings(max_examples=50, deadline=None)
+    def test_always_returns_float_in_range(self, text):
+        result = targeting_quality(inputs="test", outputs=text, expectations=None)
+        assert 0.0 <= float(result.value) <= 1.0
+
+    @given(
+        st.lists(
+            st.fixed_dictionaries(
+                {
+                    "ad_set_name": st.text(min_size=1, max_size=10),
+                    "demographics": st.just({"age_min": 18}),
+                    "interests": st.just(["Tech"]),
+                    "custom_audiences": st.just(["buyers"]),
+                    "lookalike_audiences": st.just([]),
+                }
+            ),
+            min_size=1,
+            max_size=3,
+        )
+    )
+    @settings(max_examples=30, deadline=None)
+    def test_full_targeting_always_1(self, specs):
+        out = json.dumps({"targeting_specs": specs})
+        result = targeting_quality(inputs="test", outputs=out, expectations=None)
+        assert result.value == 1.0


### PR DESCRIPTION
## Summary

- Implements four CAA-specific scorers under `app/scorers/caa/` for EPIC-6 (Custom Scorer Library)
- **structure_validity**: validates campaign → ad set → ad hierarchy with required fields (AC-1)
- **budget_rationality**: checks funnel budget percentages sum to 100% with ±1% tolerance (AC-2)
- **funnel_coverage**: evaluates maturity-appropriate allocation — new brands TOFU≥50%, established BOFU≥30% (AC-3)
- **targeting_quality**: verifies demographics, interests, and custom/lookalike audiences per spec (AC-4)
- Exports `CAA_SCORERS` list for consumption by `ZorvenGepaOptimizer`

## Test plan

- [x] 46 unit tests (10+ per scorer: perfect, partial, invalid, edge inputs)
- [x] 9 Hypothesis property tests (score ranges, invariants, determinism)
- [x] 2 integration tests (MLflow compatibility)
- [x] Full suite: 903 passed, 29 skipped
- [x] Black formatting verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)