### PR TITLE
feat(gepa): implement WF1 + WF2 + ILA domain scorers (US-025)

### DIFF
--- a/prompt-optimization-svc/app/scorers/__init__.py
+++ b/prompt-optimization-svc/app/scorers/__init__.py
@@ -1,5 +1,26 @@
 """Scorer library for GEPA prompt optimization (§5.1, §5.2)."""
 
+from app.scorers.ila import (
+    ILA_SCORERS,
+    learning_depth,
+    meta_policy,
+)
+from app.scorers.wf1 import (
+    WF1_SCORERS,
+    competitor_accuracy,
+    market_completeness,
+    persona_quality,
+    trend_relevance,
+    voca_sentiment,
+)
+from app.scorers.wf2 import (
+    WF2_SCORERS,
+    architecture_coherence,
+    name_quality,
+    narrative_engagement,
+    positioning_clarity,
+    voice_consistency,
+)
 from app.scorers.coa import (
     COA_SCORERS,
     data_grounding,
@@ -36,6 +57,9 @@ __all__ = [
     "CGA_SCORERS",
     "CAA_SCORERS",
     "COA_SCORERS",
+    "WF1_SCORERS",
+    "WF2_SCORERS",
+    "ILA_SCORERS",
     "json_compliance",
     "pii_safety",
     "token_efficiency",
@@ -53,4 +77,16 @@ __all__ = [
     "guardrail_compliance",
     "data_grounding",
     "prioritization_quality",
+    "market_completeness",
+    "competitor_accuracy",
+    "persona_quality",
+    "trend_relevance",
+    "voca_sentiment",
+    "positioning_clarity",
+    "architecture_coherence",
+    "voice_consistency",
+    "name_quality",
+    "narrative_engagement",
+    "learning_depth",
+    "meta_policy",
 ]

--- a/prompt-optimization-svc/app/scorers/ila/__init__.py
+++ b/prompt-optimization-svc/app/scorers/ila/__init__.py
@@ -1,0 +1,15 @@
+"""ILA intelligence loop scorers."""
+
+from app.scorers.ila.learning_depth import learning_depth
+from app.scorers.ila.meta_policy import meta_policy
+
+ILA_SCORERS = [
+    learning_depth,
+    meta_policy,
+]
+
+__all__ = [
+    "ILA_SCORERS",
+    "learning_depth",
+    "meta_policy",
+]

--- a/prompt-optimization-svc/app/scorers/ila/learning_depth.py
+++ b/prompt-optimization-svc/app/scorers/ila/learning_depth.py
@@ -1,0 +1,110 @@
+"""Learning depth scorer for ILA (Intelligence Loop Agent).
+
+Evaluates the depth and quality of extracted learnings by checking
+confidence thresholds and contradiction detection thoroughness.
+"""
+
+import json
+import logging
+
+from mlflow.entities.assessment import Feedback
+from mlflow.genai.scorers import scorer
+
+logger = logging.getLogger(__name__)
+
+VALID_IMPACT_VALUES = {"HIGH", "MEDIUM", "LOW"}
+
+
+def _parse_output(outputs) -> dict | None:
+    if outputs is None:
+        return None
+    if isinstance(outputs, dict):
+        return outputs
+    try:
+        parsed = json.loads(str(outputs))
+        return parsed if isinstance(parsed, dict) else None
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+@scorer(name="learning_depth")
+def learning_depth(*, inputs, outputs, expectations=None):
+    """Score the depth and quality of ILA learning extraction.
+
+    Checks `learnings` (list of dicts with `confidence` int 0-100 and
+    `impact` string HIGH/MEDIUM/LOW) and `contradictions` (list).
+
+    Score = ratio of learnings with confidence >= 50 to total learnings.
+    Contradiction detection is a bonus showing thoroughness.
+    Returns 0.0 if no learnings are present.
+
+    Returns:
+        Feedback with value 0.0-1.0.
+    """
+    data = _parse_output(outputs)
+    if data is None:
+        return Feedback(
+            name="learning_depth",
+            value=0.0,
+            rationale="Invalid or missing output.",
+        )
+
+    learnings = data.get("learnings")
+    if not isinstance(learnings, list):
+        return Feedback(
+            name="learning_depth",
+            value=0.0,
+            rationale="Missing or invalid 'learnings' field.",
+        )
+
+    if not learnings:
+        return Feedback(
+            name="learning_depth",
+            value=0.0,
+            rationale="Empty learnings list.",
+        )
+
+    # Count valid learnings with confidence >= 50
+    total = 0
+    confident = 0
+    for learning in learnings:
+        if not isinstance(learning, dict):
+            continue
+        total += 1
+
+        confidence = learning.get("confidence")
+        if not isinstance(confidence, int):
+            continue
+
+        impact = learning.get("impact")
+        if not isinstance(impact, str) or impact not in VALID_IMPACT_VALUES:
+            continue
+
+        if confidence >= 50:
+            confident += 1
+
+    if total == 0:
+        return Feedback(
+            name="learning_depth",
+            value=0.0,
+            rationale="No valid learning dicts found in learnings list.",
+        )
+
+    base_score = confident / total
+
+    # Contradiction detection bonus (shows thoroughness)
+    contradictions = data.get("contradictions")
+    bonus_note = ""
+    if isinstance(contradictions, list) and len(contradictions) > 0:
+        bonus_note = (
+            f" Contradictions detected ({len(contradictions)})"
+            " — shows analytical thoroughness."
+        )
+
+    return Feedback(
+        name="learning_depth",
+        value=round(base_score, 4),
+        rationale=(
+            f"{confident}/{total} learnings have confidence >= 50." f"{bonus_note}"
+        ),
+    )

--- a/prompt-optimization-svc/app/scorers/ila/meta_policy.py
+++ b/prompt-optimization-svc/app/scorers/ila/meta_policy.py
@@ -1,0 +1,86 @@
+"""Meta policy scorer for ILA (Intelligence Loop Agent).
+
+Evaluates ADPUB output for Meta Ads policy compliance:
+plan warnings count, published campaign presence, and sandbox mode flag.
+"""
+
+import json
+import logging
+
+from mlflow.entities.assessment import Feedback
+from mlflow.genai.scorers import scorer
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_output(outputs) -> dict | None:
+    if outputs is None:
+        return None
+    if isinstance(outputs, dict):
+        return outputs
+    try:
+        parsed = json.loads(str(outputs))
+        return parsed if isinstance(parsed, dict) else None
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+@scorer(name="meta_policy")
+def meta_policy(*, inputs, outputs, expectations=None):
+    """Score Meta Ads policy compliance from ADPUB output.
+
+    Three checks (each worth 1/3):
+    1. plan_warnings list has <= 2 entries (fewer is better).
+    2. published_campaign dict is present (required for production).
+    3. sandbox_mode is a bool (type validation).
+
+    Score = passes / 3.
+
+    Returns:
+        Feedback with value 0.0-1.0.
+    """
+    data = _parse_output(outputs)
+    if data is None:
+        return Feedback(
+            name="meta_policy",
+            value=0.0,
+            rationale="Invalid or missing output.",
+        )
+
+    passes = 0
+    details = []
+
+    # Check 1: plan_warnings <= 2
+    plan_warnings = data.get("plan_warnings")
+    if isinstance(plan_warnings, list):
+        if len(plan_warnings) <= 2:
+            passes += 1
+            details.append(f"plan_warnings={len(plan_warnings)} (<=2, pass)")
+        else:
+            details.append(f"plan_warnings={len(plan_warnings)} (>2, fail)")
+    else:
+        details.append("plan_warnings missing or not a list (fail)")
+
+    # Check 2: published_campaign is a dict
+    published_campaign = data.get("published_campaign")
+    if isinstance(published_campaign, dict):
+        passes += 1
+        details.append("published_campaign present (pass)")
+    else:
+        details.append("published_campaign missing or not a dict (fail)")
+
+    # Check 3: sandbox_mode is a bool
+    sandbox_mode = data.get("sandbox_mode")
+    if isinstance(sandbox_mode, bool):
+        passes += 1
+        details.append(f"sandbox_mode={sandbox_mode} is bool (pass)")
+    else:
+        details.append("sandbox_mode missing or not a bool (fail)")
+
+    score = round(passes / 3, 4)
+
+    return Feedback(
+        name="meta_policy",
+        value=score,
+        rationale=f"{passes}/3 checks passed: {'; '.join(details)}",
+    )

--- a/prompt-optimization-svc/app/scorers/wf1/__init__.py
+++ b/prompt-optimization-svc/app/scorers/wf1/__init__.py
@@ -1,0 +1,24 @@
+"""WF1 discovery & research scorers."""
+
+from app.scorers.wf1.competitor_accuracy import competitor_accuracy
+from app.scorers.wf1.market_completeness import market_completeness
+from app.scorers.wf1.persona_quality import persona_quality
+from app.scorers.wf1.trend_relevance import trend_relevance
+from app.scorers.wf1.voca_sentiment import voca_sentiment
+
+WF1_SCORERS = [
+    market_completeness,
+    competitor_accuracy,
+    persona_quality,
+    trend_relevance,
+    voca_sentiment,
+]
+
+__all__ = [
+    "WF1_SCORERS",
+    "market_completeness",
+    "competitor_accuracy",
+    "persona_quality",
+    "trend_relevance",
+    "voca_sentiment",
+]

--- a/prompt-optimization-svc/app/scorers/wf1/competitor_accuracy.py
+++ b/prompt-optimization-svc/app/scorers/wf1/competitor_accuracy.py
@@ -1,0 +1,93 @@
+"""Competitor accuracy scorer for CIA (WF1).
+
+Checks CIA output for competitors (list of dicts with market_position),
+positioning_gaps (non-empty list), and benchmarking_report (dict).
+Score = checks passed / 3.
+"""
+
+import json
+import logging
+
+from mlflow.entities.assessment import Feedback
+from mlflow.genai.scorers import scorer
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_output(outputs) -> dict | None:
+    if outputs is None:
+        return None
+    if isinstance(outputs, dict):
+        return outputs
+    try:
+        parsed = json.loads(str(outputs))
+        return parsed if isinstance(parsed, dict) else None
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+@scorer(name="competitor_accuracy")
+def competitor_accuracy(*, inputs, outputs, expectations=None):
+    """Score CIA output accuracy.
+
+    Checks for three key components: competitors (list of dicts each with
+    market_position), positioning_gaps (non-empty list), and
+    benchmarking_report (dict).
+
+    Returns:
+        Feedback with value 0.0-1.0 (checks passed / 3).
+    """
+    data = _parse_output(outputs)
+    if data is None:
+        return Feedback(
+            name="competitor_accuracy",
+            value=0.0,
+            rationale="Invalid or missing output.",
+        )
+
+    passed = 0
+    details = []
+
+    # Check competitors list with market_position in each
+    competitors = data.get("competitors")
+    if isinstance(competitors, list) and len(competitors) > 0:
+        with_position = sum(
+            1
+            for c in competitors
+            if isinstance(c, dict) and c.get("market_position") is not None
+        )
+        if with_position == len(competitors):
+            passed += 1
+            details.append(
+                f"competitors: {len(competitors)} entries, all have market_position"
+            )
+        else:
+            details.append(
+                f"competitors: {with_position}/{len(competitors)} have market_position"
+            )
+    else:
+        details.append("competitors: missing or empty")
+
+    # Check positioning_gaps
+    positioning_gaps = data.get("positioning_gaps")
+    if isinstance(positioning_gaps, list) and len(positioning_gaps) > 0:
+        passed += 1
+        details.append(f"positioning_gaps: {len(positioning_gaps)} items")
+    else:
+        details.append("positioning_gaps: missing or empty")
+
+    # Check benchmarking_report
+    benchmarking_report = data.get("benchmarking_report")
+    if isinstance(benchmarking_report, dict):
+        passed += 1
+        details.append("benchmarking_report: present")
+    else:
+        details.append("benchmarking_report: missing or not a dict")
+
+    score = passed / 3.0
+
+    return Feedback(
+        name="competitor_accuracy",
+        value=score,
+        rationale=f"{passed}/3 checks passed. {'; '.join(details)}",
+    )

--- a/prompt-optimization-svc/app/scorers/wf1/market_completeness.py
+++ b/prompt-optimization-svc/app/scorers/wf1/market_completeness.py
@@ -1,0 +1,94 @@
+"""Market completeness scorer for MRA (WF1).
+
+Checks MRA output for market_sizing (TAM/SAM/SOM), competitive_landscape,
+industry_trends, and findings. Score = present fields / 4.
+"""
+
+import json
+import logging
+
+from mlflow.entities.assessment import Feedback
+from mlflow.genai.scorers import scorer
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_output(outputs) -> dict | None:
+    if outputs is None:
+        return None
+    if isinstance(outputs, dict):
+        return outputs
+    try:
+        parsed = json.loads(str(outputs))
+        return parsed if isinstance(parsed, dict) else None
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+@scorer(name="market_completeness")
+def market_completeness(*, inputs, outputs, expectations=None):
+    """Score MRA output completeness.
+
+    Checks for four key fields: market_sizing (dict with TAM/SAM/SOM),
+    competitive_landscape (non-empty list), industry_trends (non-empty list),
+    and findings (non-empty list).
+
+    Returns:
+        Feedback with value 0.0-1.0 (present fields / 4).
+    """
+    data = _parse_output(outputs)
+    if data is None:
+        return Feedback(
+            name="market_completeness",
+            value=0.0,
+            rationale="Invalid or missing output.",
+        )
+
+    present = 0
+    details = []
+
+    # Check market_sizing with TAM/SAM/SOM
+    market_sizing = data.get("market_sizing")
+    if isinstance(market_sizing, dict):
+        tam_sam_som = all(
+            market_sizing.get(k) is not None for k in ("TAM", "SAM", "SOM")
+        )
+        if tam_sam_som:
+            present += 1
+            details.append("market_sizing: present with TAM/SAM/SOM")
+        else:
+            details.append("market_sizing: missing TAM, SAM, or SOM keys")
+    else:
+        details.append("market_sizing: missing or not a dict")
+
+    # Check competitive_landscape
+    competitive_landscape = data.get("competitive_landscape")
+    if isinstance(competitive_landscape, list) and len(competitive_landscape) > 0:
+        present += 1
+        details.append(f"competitive_landscape: {len(competitive_landscape)} items")
+    else:
+        details.append("competitive_landscape: missing or empty")
+
+    # Check industry_trends
+    industry_trends = data.get("industry_trends")
+    if isinstance(industry_trends, list) and len(industry_trends) > 0:
+        present += 1
+        details.append(f"industry_trends: {len(industry_trends)} items")
+    else:
+        details.append("industry_trends: missing or empty")
+
+    # Check findings
+    findings = data.get("findings")
+    if isinstance(findings, list) and len(findings) > 0:
+        present += 1
+        details.append(f"findings: {len(findings)} items")
+    else:
+        details.append("findings: missing or empty")
+
+    score = present / 4.0
+
+    return Feedback(
+        name="market_completeness",
+        value=score,
+        rationale=f"{present}/4 fields present. {'; '.join(details)}",
+    )

--- a/prompt-optimization-svc/app/scorers/wf1/persona_quality.py
+++ b/prompt-optimization-svc/app/scorers/wf1/persona_quality.py
@@ -1,0 +1,82 @@
+"""Persona quality scorer for APA (WF1).
+
+Checks APA output for personas (list of dicts with demographics and
+psychographics) and journey_maps (non-empty list).
+Score = 50% complete personas ratio + 50% journey map presence.
+"""
+
+import json
+import logging
+
+from mlflow.entities.assessment import Feedback
+from mlflow.genai.scorers import scorer
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_output(outputs) -> dict | None:
+    if outputs is None:
+        return None
+    if isinstance(outputs, dict):
+        return outputs
+    try:
+        parsed = json.loads(str(outputs))
+        return parsed if isinstance(parsed, dict) else None
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+@scorer(name="persona_quality")
+def persona_quality(*, inputs, outputs, expectations=None):
+    """Score APA output quality.
+
+    50% weight on complete persona ratio (each persona must have a
+    demographics dict and psychographics), 50% weight on journey_maps
+    presence.
+
+    Returns:
+        Feedback with value 0.0-1.0.
+    """
+    data = _parse_output(outputs)
+    if data is None:
+        return Feedback(
+            name="persona_quality",
+            value=0.0,
+            rationale="Invalid or missing output.",
+        )
+
+    details = []
+
+    # Check personas completeness (50% weight)
+    personas = data.get("personas")
+    persona_score = 0.0
+    if isinstance(personas, list) and len(personas) > 0:
+        complete = 0
+        for p in personas:
+            if not isinstance(p, dict):
+                continue
+            has_demographics = isinstance(p.get("demographics"), dict)
+            has_psychographics = p.get("psychographics") is not None
+            if has_demographics and has_psychographics:
+                complete += 1
+        persona_score = complete / len(personas)
+        details.append(f"personas: {complete}/{len(personas)} complete")
+    else:
+        details.append("personas: missing or empty")
+
+    # Check journey_maps presence (50% weight)
+    journey_maps = data.get("journey_maps")
+    journey_score = 0.0
+    if isinstance(journey_maps, list) and len(journey_maps) > 0:
+        journey_score = 1.0
+        details.append(f"journey_maps: {len(journey_maps)} items")
+    else:
+        details.append("journey_maps: missing or empty")
+
+    score = (persona_score * 0.5) + (journey_score * 0.5)
+
+    return Feedback(
+        name="persona_quality",
+        value=round(score, 4),
+        rationale=f"Persona ratio={persona_score:.2f}, journey_maps={'present' if journey_score else 'absent'}. {'; '.join(details)}",
+    )

--- a/prompt-optimization-svc/app/scorers/wf1/persona_quality.py
+++ b/prompt-optimization-svc/app/scorers/wf1/persona_quality.py
@@ -56,7 +56,7 @@ def persona_quality(*, inputs, outputs, expectations=None):
             if not isinstance(p, dict):
                 continue
             has_demographics = isinstance(p.get("demographics"), dict)
-            has_psychographics = p.get("psychographics") is not None
+            has_psychographics = isinstance(p.get("psychographics"), dict)
             if has_demographics and has_psychographics:
                 complete += 1
         persona_score = complete / len(personas)

--- a/prompt-optimization-svc/app/scorers/wf1/trend_relevance.py
+++ b/prompt-optimization-svc/app/scorers/wf1/trend_relevance.py
@@ -1,0 +1,87 @@
+"""Trend relevance scorer for TCIA (WF1).
+
+Checks TCIA output for trend_report (dict with trend_scorecard list of dicts
+having relevance_score 0-100) and opportunity_alerts (non-empty list).
+Score = valid scored trends / total + alerts bonus.
+"""
+
+import json
+import logging
+
+from mlflow.entities.assessment import Feedback
+from mlflow.genai.scorers import scorer
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_output(outputs) -> dict | None:
+    if outputs is None:
+        return None
+    if isinstance(outputs, dict):
+        return outputs
+    try:
+        parsed = json.loads(str(outputs))
+        return parsed if isinstance(parsed, dict) else None
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+@scorer(name="trend_relevance")
+def trend_relevance(*, inputs, outputs, expectations=None):
+    """Score TCIA output relevance.
+
+    Primary component (80%): ratio of trends with valid relevance_score
+    (0-100) in trend_report.trend_scorecard.
+    Bonus component (20%): presence of non-empty opportunity_alerts.
+
+    Returns:
+        Feedback with value 0.0-1.0.
+    """
+    data = _parse_output(outputs)
+    if data is None:
+        return Feedback(
+            name="trend_relevance",
+            value=0.0,
+            rationale="Invalid or missing output.",
+        )
+
+    details = []
+
+    # Check trend_report.trend_scorecard (80% weight)
+    trend_score = 0.0
+    trend_report = data.get("trend_report")
+    if isinstance(trend_report, dict):
+        scorecard = trend_report.get("trend_scorecard")
+        if isinstance(scorecard, list) and len(scorecard) > 0:
+            valid_count = 0
+            for entry in scorecard:
+                if not isinstance(entry, dict):
+                    continue
+                rel = entry.get("relevance_score")
+                if isinstance(rel, (int, float)) and 0 <= rel <= 100:
+                    valid_count += 1
+            trend_score = valid_count / len(scorecard)
+            details.append(
+                f"trend_scorecard: {valid_count}/{len(scorecard)} valid scores"
+            )
+        else:
+            details.append("trend_scorecard: missing or empty")
+    else:
+        details.append("trend_report: missing or not a dict")
+
+    # Check opportunity_alerts (20% weight)
+    alerts_score = 0.0
+    opportunity_alerts = data.get("opportunity_alerts")
+    if isinstance(opportunity_alerts, list) and len(opportunity_alerts) > 0:
+        alerts_score = 1.0
+        details.append(f"opportunity_alerts: {len(opportunity_alerts)} items")
+    else:
+        details.append("opportunity_alerts: missing or empty")
+
+    score = (trend_score * 0.8) + (alerts_score * 0.2)
+
+    return Feedback(
+        name="trend_relevance",
+        value=round(score, 4),
+        rationale=f"Trend validity={trend_score:.2f}, alerts={'present' if alerts_score else 'absent'}. {'; '.join(details)}",
+    )

--- a/prompt-optimization-svc/app/scorers/wf1/voca_sentiment.py
+++ b/prompt-optimization-svc/app/scorers/wf1/voca_sentiment.py
@@ -1,0 +1,85 @@
+"""VoCA sentiment scorer (WF1).
+
+Checks VoCA output for sentiment (dict with overall_sentiment),
+nps_analysis (dict), and pain_point_priority_matrix (dict or list).
+Score = components present / 3.
+"""
+
+import json
+import logging
+
+from mlflow.entities.assessment import Feedback
+from mlflow.genai.scorers import scorer
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_output(outputs) -> dict | None:
+    if outputs is None:
+        return None
+    if isinstance(outputs, dict):
+        return outputs
+    try:
+        parsed = json.loads(str(outputs))
+        return parsed if isinstance(parsed, dict) else None
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+@scorer(name="voca_sentiment")
+def voca_sentiment(*, inputs, outputs, expectations=None):
+    """Score VoCA output sentiment completeness.
+
+    Checks for three components: sentiment (dict with overall_sentiment),
+    nps_analysis (dict), and pain_point_priority_matrix (dict or list).
+
+    Returns:
+        Feedback with value 0.0-1.0 (components present / 3).
+    """
+    data = _parse_output(outputs)
+    if data is None:
+        return Feedback(
+            name="voca_sentiment",
+            value=0.0,
+            rationale="Invalid or missing output.",
+        )
+
+    present = 0
+    details = []
+
+    # Check sentiment with overall_sentiment
+    sentiment = data.get("sentiment")
+    if isinstance(sentiment, dict) and sentiment.get("overall_sentiment") is not None:
+        present += 1
+        details.append(
+            f"sentiment: present, overall_sentiment={sentiment['overall_sentiment']}"
+        )
+    else:
+        details.append("sentiment: missing, not a dict, or lacks overall_sentiment")
+
+    # Check nps_analysis
+    nps_analysis = data.get("nps_analysis")
+    if isinstance(nps_analysis, dict):
+        present += 1
+        details.append("nps_analysis: present")
+    else:
+        details.append("nps_analysis: missing or not a dict")
+
+    # Check pain_point_priority_matrix (dict or list)
+    matrix = data.get("pain_point_priority_matrix")
+    if isinstance(matrix, (dict, list)):
+        if isinstance(matrix, list) and len(matrix) == 0:
+            details.append("pain_point_priority_matrix: empty list")
+        else:
+            present += 1
+            details.append("pain_point_priority_matrix: present")
+    else:
+        details.append("pain_point_priority_matrix: missing or invalid type")
+
+    score = present / 3.0
+
+    return Feedback(
+        name="voca_sentiment",
+        value=round(score, 4),
+        rationale=f"{present}/3 components present. {'; '.join(details)}",
+    )

--- a/prompt-optimization-svc/app/scorers/wf2/__init__.py
+++ b/prompt-optimization-svc/app/scorers/wf2/__init__.py
@@ -1,0 +1,24 @@
+"""WF2 brand strategy scorers."""
+
+from app.scorers.wf2.architecture_coherence import architecture_coherence
+from app.scorers.wf2.name_quality import name_quality
+from app.scorers.wf2.narrative_engagement import narrative_engagement
+from app.scorers.wf2.positioning_clarity import positioning_clarity
+from app.scorers.wf2.voice_consistency import voice_consistency
+
+WF2_SCORERS = [
+    positioning_clarity,
+    architecture_coherence,
+    voice_consistency,
+    name_quality,
+    narrative_engagement,
+]
+
+__all__ = [
+    "WF2_SCORERS",
+    "positioning_clarity",
+    "architecture_coherence",
+    "voice_consistency",
+    "name_quality",
+    "narrative_engagement",
+]

--- a/prompt-optimization-svc/app/scorers/wf2/architecture_coherence.py
+++ b/prompt-optimization-svc/app/scorers/wf2/architecture_coherence.py
@@ -93,10 +93,14 @@ def architecture_coherence(*, inputs, outputs, expectations=None):
     naming = data.get("naming_hierarchy")
     if isinstance(naming, dict):
         consistency = naming.get("consistency_score")
-        if isinstance(consistency, (int, float)) and 0.0 <= float(consistency) <= 1.0:
+        if isinstance(consistency, (int, float)) and float(consistency) >= 0:
+            # Normalize 0-100 to 0-1 (also accepts 0-1 directly)
+            val = float(consistency)
+            normalized = val / 100.0 if val > 1.0 else val
+            normalized = min(normalized, 1.0)
             valid_count += 1
             details.append(
-                f"naming_hierarchy valid (consistency_score={float(consistency):.2f})"
+                f"naming_hierarchy valid (consistency_score={normalized:.2f})"
             )
         else:
             details.append("naming_hierarchy.consistency_score invalid or out of range")

--- a/prompt-optimization-svc/app/scorers/wf2/architecture_coherence.py
+++ b/prompt-optimization-svc/app/scorers/wf2/architecture_coherence.py
@@ -1,0 +1,113 @@
+"""Architecture coherence scorer for BAA (brand-architecture-agent-svc).
+
+Checks recommendation, hierarchy, and naming_hierarchy components.
+Score = valid components present / 3.
+"""
+
+import json
+import logging
+
+from mlflow.entities.assessment import Feedback
+from mlflow.genai.scorers import scorer
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_output(outputs) -> dict | None:
+    if outputs is None:
+        return None
+    if isinstance(outputs, dict):
+        return outputs
+    try:
+        parsed = json.loads(str(outputs))
+        return parsed if isinstance(parsed, dict) else None
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+@scorer(name="architecture_coherence")
+def architecture_coherence(*, inputs, outputs, expectations=None):
+    """Score architecture coherence from BAA output.
+
+    Checks:
+    - recommendation: dict with 'recommended_model' and 'model_scores' list
+    - hierarchy: dict with 'root' and 'total_depth'
+    - naming_hierarchy: dict with 'consistency_score' 0-1
+
+    Returns:
+        Feedback with value 0.0-1.0 (valid components / 3).
+    """
+    data = _parse_output(outputs)
+    if data is None:
+        return Feedback(
+            name="architecture_coherence",
+            value=0.0,
+            rationale="Invalid or missing output.",
+        )
+
+    valid_count = 0
+    details = []
+
+    # 1. recommendation
+    rec = data.get("recommendation")
+    if isinstance(rec, dict):
+        has_model = (
+            isinstance(rec.get("recommended_model"), str)
+            and rec["recommended_model"].strip()
+        )
+        model_scores = rec.get("model_scores")
+        has_scores = isinstance(model_scores, list) and len(model_scores) > 0
+        if has_model and has_scores:
+            valid_count += 1
+            details.append("recommendation valid (recommended_model + model_scores)")
+        else:
+            missing = []
+            if not has_model:
+                missing.append("recommended_model")
+            if not has_scores:
+                missing.append("model_scores")
+            details.append(f"recommendation incomplete: missing {', '.join(missing)}")
+    else:
+        details.append("recommendation missing or not a dict")
+
+    # 2. hierarchy
+    hier = data.get("hierarchy")
+    if isinstance(hier, dict):
+        has_root = hier.get("root") is not None
+        total_depth = hier.get("total_depth")
+        has_depth = isinstance(total_depth, (int, float))
+        if has_root and has_depth:
+            valid_count += 1
+            details.append("hierarchy valid (root + total_depth)")
+        else:
+            missing = []
+            if not has_root:
+                missing.append("root")
+            if not has_depth:
+                missing.append("total_depth")
+            details.append(f"hierarchy incomplete: missing {', '.join(missing)}")
+    else:
+        details.append("hierarchy missing or not a dict")
+
+    # 3. naming_hierarchy
+    naming = data.get("naming_hierarchy")
+    if isinstance(naming, dict):
+        consistency = naming.get("consistency_score")
+        if isinstance(consistency, (int, float)) and 0.0 <= float(consistency) <= 1.0:
+            valid_count += 1
+            details.append(
+                f"naming_hierarchy valid (consistency_score={float(consistency):.2f})"
+            )
+        else:
+            details.append("naming_hierarchy.consistency_score invalid or out of range")
+    else:
+        details.append("naming_hierarchy missing or not a dict")
+
+    final_score = round(valid_count / 3.0, 4)
+
+    return Feedback(
+        name="architecture_coherence",
+        value=final_score,
+        rationale=f"Score {final_score:.2f} ({valid_count}/3 components valid): "
+        f"{'; '.join(details)}",
+    )

--- a/prompt-optimization-svc/app/scorers/wf2/name_quality.py
+++ b/prompt-optimization-svc/app/scorers/wf2/name_quality.py
@@ -1,0 +1,107 @@
+"""Name quality scorer for NTA (brand-naming-agent-svc).
+
+Checks name_candidates, shortlisted_names, and taglines components.
+Score = checks passed / 3.
+"""
+
+import json
+import logging
+
+from mlflow.entities.assessment import Feedback
+from mlflow.genai.scorers import scorer
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_output(outputs) -> dict | None:
+    if outputs is None:
+        return None
+    if isinstance(outputs, dict):
+        return outputs
+    try:
+        parsed = json.loads(str(outputs))
+        return parsed if isinstance(parsed, dict) else None
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+@scorer(name="name_quality")
+def name_quality(*, inputs, outputs, expectations=None):
+    """Score name quality from NTA output.
+
+    Checks:
+    - name_candidates: non-empty list of dicts with score fields
+    - shortlisted_names: non-empty list
+    - taglines: list with 'memorability_score'
+
+    Returns:
+        Feedback with value 0.0-1.0 (checks passed / 3).
+    """
+    data = _parse_output(outputs)
+    if data is None:
+        return Feedback(
+            name="name_quality",
+            value=0.0,
+            rationale="Invalid or missing output.",
+        )
+
+    checks_passed = 0
+    details = []
+
+    # 1. name_candidates
+    candidates = data.get("name_candidates")
+    if isinstance(candidates, list) and len(candidates) > 0:
+        has_scores = False
+        for c in candidates:
+            if not isinstance(c, dict):
+                continue
+            # Check for any score-like field
+            score_fields = [k for k in c.keys() if "score" in k.lower()]
+            if score_fields:
+                has_scores = True
+                break
+        if has_scores:
+            checks_passed += 1
+            details.append(
+                f"name_candidates valid ({len(candidates)} candidates with scores)"
+            )
+        else:
+            details.append("name_candidates present but no score fields found")
+    else:
+        details.append("name_candidates missing or empty")
+
+    # 2. shortlisted_names
+    shortlisted = data.get("shortlisted_names")
+    if isinstance(shortlisted, list) and len(shortlisted) > 0:
+        checks_passed += 1
+        details.append(f"shortlisted_names valid ({len(shortlisted)} names)")
+    else:
+        details.append("shortlisted_names missing or empty")
+
+    # 3. taglines
+    taglines = data.get("taglines")
+    if isinstance(taglines, list) and len(taglines) > 0:
+        has_memorability = False
+        for t in taglines:
+            if not isinstance(t, dict):
+                continue
+            mem_score = t.get("memorability_score")
+            if isinstance(mem_score, (int, float)):
+                has_memorability = True
+                break
+        if has_memorability:
+            checks_passed += 1
+            details.append("taglines valid (memorability_score present)")
+        else:
+            details.append("taglines present but no memorability_score found")
+    else:
+        details.append("taglines missing or empty")
+
+    final_score = round(checks_passed / 3.0, 4)
+
+    return Feedback(
+        name="name_quality",
+        value=final_score,
+        rationale=f"Score {final_score:.2f} ({checks_passed}/3 checks passed): "
+        f"{'; '.join(details)}",
+    )

--- a/prompt-optimization-svc/app/scorers/wf2/narrative_engagement.py
+++ b/prompt-optimization-svc/app/scorers/wf2/narrative_engagement.py
@@ -1,0 +1,91 @@
+"""Narrative engagement scorer for BSA (brand-story-agent-svc).
+
+Checks origin_story, mission_vision, pitches, and channel_narratives.
+Score = sections present / 4.
+"""
+
+import json
+import logging
+
+from mlflow.entities.assessment import Feedback
+from mlflow.genai.scorers import scorer
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_output(outputs) -> dict | None:
+    if outputs is None:
+        return None
+    if isinstance(outputs, dict):
+        return outputs
+    try:
+        parsed = json.loads(str(outputs))
+        return parsed if isinstance(parsed, dict) else None
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+@scorer(name="narrative_engagement")
+def narrative_engagement(*, inputs, outputs, expectations=None):
+    """Score narrative engagement from BSA output.
+
+    Checks presence of:
+    - origin_story: dict
+    - mission_vision: dict
+    - pitches: dict or list
+    - channel_narratives: dict
+
+    Returns:
+        Feedback with value 0.0-1.0 (sections present / 4).
+    """
+    data = _parse_output(outputs)
+    if data is None:
+        return Feedback(
+            name="narrative_engagement",
+            value=0.0,
+            rationale="Invalid or missing output.",
+        )
+
+    sections_present = 0
+    details = []
+
+    # 1. origin_story
+    origin = data.get("origin_story")
+    if isinstance(origin, dict):
+        sections_present += 1
+        details.append("origin_story present")
+    else:
+        details.append("origin_story missing or not a dict")
+
+    # 2. mission_vision
+    mission = data.get("mission_vision")
+    if isinstance(mission, dict):
+        sections_present += 1
+        details.append("mission_vision present")
+    else:
+        details.append("mission_vision missing or not a dict")
+
+    # 3. pitches (dict or list)
+    pitches = data.get("pitches")
+    if isinstance(pitches, (dict, list)):
+        sections_present += 1
+        details.append(f"pitches present ({type(pitches).__name__})")
+    else:
+        details.append("pitches missing or not a dict/list")
+
+    # 4. channel_narratives
+    narratives = data.get("channel_narratives")
+    if isinstance(narratives, dict):
+        sections_present += 1
+        details.append("channel_narratives present")
+    else:
+        details.append("channel_narratives missing or not a dict")
+
+    final_score = round(sections_present / 4.0, 4)
+
+    return Feedback(
+        name="narrative_engagement",
+        value=final_score,
+        rationale=f"Score {final_score:.2f} ({sections_present}/4 sections present): "
+        f"{'; '.join(details)}",
+    )

--- a/prompt-optimization-svc/app/scorers/wf2/positioning_clarity.py
+++ b/prompt-optimization-svc/app/scorers/wf2/positioning_clarity.py
@@ -1,0 +1,100 @@
+"""Positioning clarity scorer for BPA (brand-positioning-agent-svc).
+
+Checks recommended_positioning, canvas fit_score, and differentiation score.
+Score = weighted: 40% positioning + 30% canvas + 30% differentiation.
+"""
+
+import json
+import logging
+
+from mlflow.entities.assessment import Feedback
+from mlflow.genai.scorers import scorer
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_output(outputs) -> dict | None:
+    if outputs is None:
+        return None
+    if isinstance(outputs, dict):
+        return outputs
+    try:
+        parsed = json.loads(str(outputs))
+        return parsed if isinstance(parsed, dict) else None
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+@scorer(name="positioning_clarity")
+def positioning_clarity(*, inputs, outputs, expectations=None):
+    """Score positioning clarity from BPA output.
+
+    Checks:
+    - recommended_positioning: dict with non-empty 'statement' string (40%)
+    - canvas: dict with 'fit_score' float 0-1 (30%)
+    - differentiation: dict with 'overall_differentiation_score' (30%)
+
+    Returns:
+        Feedback with value 0.0-1.0.
+    """
+    data = _parse_output(outputs)
+    if data is None:
+        return Feedback(
+            name="positioning_clarity",
+            value=0.0,
+            rationale="Invalid or missing output.",
+        )
+
+    details = []
+    positioning_score = 0.0
+    canvas_score = 0.0
+    differentiation_score = 0.0
+
+    # 1. recommended_positioning (40%)
+    rec_pos = data.get("recommended_positioning")
+    if isinstance(rec_pos, dict):
+        statement = rec_pos.get("statement")
+        if isinstance(statement, str) and statement.strip():
+            positioning_score = 1.0
+            details.append("recommended_positioning.statement present")
+        else:
+            details.append("recommended_positioning.statement empty or not a string")
+    else:
+        details.append("recommended_positioning missing or not a dict")
+
+    # 2. canvas (30%)
+    canvas = data.get("canvas")
+    if isinstance(canvas, dict):
+        fit_score = canvas.get("fit_score")
+        if isinstance(fit_score, (int, float)) and 0.0 <= float(fit_score) <= 1.0:
+            canvas_score = float(fit_score)
+            details.append(f"canvas.fit_score={canvas_score:.2f}")
+        else:
+            details.append("canvas.fit_score invalid or out of range")
+    else:
+        details.append("canvas missing or not a dict")
+
+    # 3. differentiation (30%)
+    diff = data.get("differentiation")
+    if isinstance(diff, dict):
+        overall = diff.get("overall_differentiation_score")
+        if isinstance(overall, (int, float)):
+            differentiation_score = min(max(float(overall), 0.0), 1.0)
+            details.append(
+                f"differentiation.overall_differentiation_score={differentiation_score:.2f}"
+            )
+        else:
+            details.append("differentiation.overall_differentiation_score invalid")
+    else:
+        details.append("differentiation missing or not a dict")
+
+    final_score = round(
+        0.4 * positioning_score + 0.3 * canvas_score + 0.3 * differentiation_score,
+        4,
+    )
+
+    return Feedback(
+        name="positioning_clarity",
+        value=final_score,
+        rationale=f"Score {final_score:.2f}: {'; '.join(details)}",
+    )

--- a/prompt-optimization-svc/app/scorers/wf2/positioning_clarity.py
+++ b/prompt-optimization-svc/app/scorers/wf2/positioning_clarity.py
@@ -66,8 +66,11 @@ def positioning_clarity(*, inputs, outputs, expectations=None):
     canvas = data.get("canvas")
     if isinstance(canvas, dict):
         fit_score = canvas.get("fit_score")
-        if isinstance(fit_score, (int, float)) and 0.0 <= float(fit_score) <= 1.0:
-            canvas_score = float(fit_score)
+        if isinstance(fit_score, (int, float)) and float(fit_score) >= 0:
+            val = float(fit_score)
+            # Normalize 0-100 to 0-1 (also accepts 0-1 directly)
+            canvas_score = val / 100.0 if val > 1.0 else val
+            canvas_score = min(canvas_score, 1.0)
             details.append(f"canvas.fit_score={canvas_score:.2f}")
         else:
             details.append("canvas.fit_score invalid or out of range")
@@ -78,8 +81,11 @@ def positioning_clarity(*, inputs, outputs, expectations=None):
     diff = data.get("differentiation")
     if isinstance(diff, dict):
         overall = diff.get("overall_differentiation_score")
-        if isinstance(overall, (int, float)):
-            differentiation_score = min(max(float(overall), 0.0), 1.0)
+        if isinstance(overall, (int, float)) and float(overall) >= 0:
+            val = float(overall)
+            # Normalize 0-100 to 0-1 (also accepts 0-1 directly)
+            differentiation_score = val / 100.0 if val > 1.0 else val
+            differentiation_score = min(differentiation_score, 1.0)
             details.append(
                 f"differentiation.overall_differentiation_score={differentiation_score:.2f}"
             )

--- a/prompt-optimization-svc/app/scorers/wf2/voice_consistency.py
+++ b/prompt-optimization-svc/app/scorers/wf2/voice_consistency.py
@@ -1,0 +1,111 @@
+"""Voice consistency scorer for BPV (brand-personality-agent-svc).
+
+Checks aaker_profile, archetype, and values_hierarchy components.
+Score = valid components / 3.
+"""
+
+import json
+import logging
+
+from mlflow.entities.assessment import Feedback
+from mlflow.genai.scorers import scorer
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_output(outputs) -> dict | None:
+    if outputs is None:
+        return None
+    if isinstance(outputs, dict):
+        return outputs
+    try:
+        parsed = json.loads(str(outputs))
+        return parsed if isinstance(parsed, dict) else None
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+@scorer(name="voice_consistency")
+def voice_consistency(*, inputs, outputs, expectations=None):
+    """Score voice consistency from BPV output.
+
+    Checks:
+    - aaker_profile: dict with 'dimensions' list of dicts having 'score' 0-100
+    - archetype: dict with 'resonance_score' 0-1
+    - values_hierarchy: dict with 'authenticity_score'
+
+    Returns:
+        Feedback with value 0.0-1.0 (valid components / 3).
+    """
+    data = _parse_output(outputs)
+    if data is None:
+        return Feedback(
+            name="voice_consistency",
+            value=0.0,
+            rationale="Invalid or missing output.",
+        )
+
+    valid_count = 0
+    details = []
+
+    # 1. aaker_profile
+    aaker = data.get("aaker_profile")
+    if isinstance(aaker, dict):
+        dimensions = aaker.get("dimensions")
+        if isinstance(dimensions, list) and len(dimensions) > 0:
+            all_valid = True
+            for dim in dimensions:
+                if not isinstance(dim, dict):
+                    all_valid = False
+                    break
+                score = dim.get("score")
+                if not isinstance(score, (int, float)):
+                    all_valid = False
+                    break
+                if not (0 <= float(score) <= 100):
+                    all_valid = False
+                    break
+            if all_valid:
+                valid_count += 1
+                details.append(f"aaker_profile valid ({len(dimensions)} dimensions)")
+            else:
+                details.append("aaker_profile.dimensions contains invalid entries")
+        else:
+            details.append("aaker_profile.dimensions missing or empty")
+    else:
+        details.append("aaker_profile missing or not a dict")
+
+    # 2. archetype
+    archetype = data.get("archetype")
+    if isinstance(archetype, dict):
+        resonance = archetype.get("resonance_score")
+        if isinstance(resonance, (int, float)) and 0.0 <= float(resonance) <= 1.0:
+            valid_count += 1
+            details.append(f"archetype valid (resonance_score={float(resonance):.2f})")
+        else:
+            details.append("archetype.resonance_score invalid or out of range")
+    else:
+        details.append("archetype missing or not a dict")
+
+    # 3. values_hierarchy
+    values = data.get("values_hierarchy")
+    if isinstance(values, dict):
+        authenticity = values.get("authenticity_score")
+        if isinstance(authenticity, (int, float)):
+            valid_count += 1
+            details.append(
+                f"values_hierarchy valid (authenticity_score={float(authenticity):.2f})"
+            )
+        else:
+            details.append("values_hierarchy.authenticity_score invalid")
+    else:
+        details.append("values_hierarchy missing or not a dict")
+
+    final_score = round(valid_count / 3.0, 4)
+
+    return Feedback(
+        name="voice_consistency",
+        value=final_score,
+        rationale=f"Score {final_score:.2f} ({valid_count}/3 components valid): "
+        f"{'; '.join(details)}",
+    )

--- a/prompt-optimization-svc/tests/integration/test_domain_scorers.py
+++ b/prompt-optimization-svc/tests/integration/test_domain_scorers.py
@@ -1,0 +1,76 @@
+"""Integration tests for domain scorers (WF1 + WF2 + ILA).
+
+Verifies all 12 domain scorers are valid MLflow Scorer instances
+and that the grouped lists have the correct counts and names.
+"""
+
+from tests.conftest import requires_mlflow
+
+
+@requires_mlflow
+class TestWf1ScorerMlflowCompatibility:
+    def test_all_are_scorer_instances(self):
+        from mlflow.genai.scorers import Scorer
+
+        from app.scorers.wf1 import WF1_SCORERS
+
+        for s in WF1_SCORERS:
+            assert isinstance(s, Scorer), f"{s.name} is not a Scorer"
+
+    def test_wf1_scorers_list_has_five(self):
+        from app.scorers.wf1 import WF1_SCORERS
+
+        assert len(WF1_SCORERS) == 5
+        names = {s.name for s in WF1_SCORERS}
+        assert names == {
+            "market_completeness",
+            "competitor_accuracy",
+            "persona_quality",
+            "trend_relevance",
+            "voca_sentiment",
+        }
+
+
+@requires_mlflow
+class TestWf2ScorerMlflowCompatibility:
+    def test_all_are_scorer_instances(self):
+        from mlflow.genai.scorers import Scorer
+
+        from app.scorers.wf2 import WF2_SCORERS
+
+        for s in WF2_SCORERS:
+            assert isinstance(s, Scorer), f"{s.name} is not a Scorer"
+
+    def test_wf2_scorers_list_has_five(self):
+        from app.scorers.wf2 import WF2_SCORERS
+
+        assert len(WF2_SCORERS) == 5
+        names = {s.name for s in WF2_SCORERS}
+        assert names == {
+            "positioning_clarity",
+            "architecture_coherence",
+            "voice_consistency",
+            "name_quality",
+            "narrative_engagement",
+        }
+
+
+@requires_mlflow
+class TestIlaScorerMlflowCompatibility:
+    def test_all_are_scorer_instances(self):
+        from mlflow.genai.scorers import Scorer
+
+        from app.scorers.ila import ILA_SCORERS
+
+        for s in ILA_SCORERS:
+            assert isinstance(s, Scorer), f"{s.name} is not a Scorer"
+
+    def test_ila_scorers_list_has_two(self):
+        from app.scorers.ila import ILA_SCORERS
+
+        assert len(ILA_SCORERS) == 2
+        names = {s.name for s in ILA_SCORERS}
+        assert names == {
+            "learning_depth",
+            "meta_policy",
+        }

--- a/prompt-optimization-svc/tests/test_domain_scorers_properties.py
+++ b/prompt-optimization-svc/tests/test_domain_scorers_properties.py
@@ -1,0 +1,180 @@
+"""Hypothesis property tests for ALL 12 domain scorers (WF1 + WF2 + ILA).
+
+Verifies scorer invariants hold across random inputs:
+- Always returns a float in [0.0, 1.0]
+- Never raises on arbitrary text input
+"""
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from app.scorers.wf1.market_completeness import market_completeness
+from app.scorers.wf1.competitor_accuracy import competitor_accuracy
+from app.scorers.wf1.persona_quality import persona_quality
+from app.scorers.wf1.trend_relevance import trend_relevance
+from app.scorers.wf1.voca_sentiment import voca_sentiment
+
+from app.scorers.wf2.positioning_clarity import positioning_clarity
+from app.scorers.wf2.architecture_coherence import architecture_coherence
+from app.scorers.wf2.voice_consistency import voice_consistency
+from app.scorers.wf2.name_quality import name_quality
+from app.scorers.wf2.narrative_engagement import narrative_engagement
+
+from app.scorers.ila.learning_depth import learning_depth
+from app.scorers.ila.meta_policy import meta_policy
+
+
+class TestWf1Properties:
+    """Property-based tests for all 5 WF1 scorers."""
+
+    @given(st.text())
+    @settings(max_examples=50, deadline=None)
+    def test_market_completeness_range(self, text):
+        result = market_completeness(inputs="test", outputs=text, expectations=None)
+        assert 0.0 <= float(result.value) <= 1.0
+
+    @given(st.text())
+    @settings(max_examples=50, deadline=None)
+    def test_market_completeness_never_raises(self, text):
+        result = market_completeness(inputs=text, outputs=text, expectations=None)
+        assert result is not None
+
+    @given(st.text())
+    @settings(max_examples=50, deadline=None)
+    def test_competitor_accuracy_range(self, text):
+        result = competitor_accuracy(inputs="test", outputs=text, expectations=None)
+        assert 0.0 <= float(result.value) <= 1.0
+
+    @given(st.text())
+    @settings(max_examples=50, deadline=None)
+    def test_competitor_accuracy_never_raises(self, text):
+        result = competitor_accuracy(inputs=text, outputs=text, expectations=None)
+        assert result is not None
+
+    @given(st.text())
+    @settings(max_examples=50, deadline=None)
+    def test_persona_quality_range(self, text):
+        result = persona_quality(inputs="test", outputs=text, expectations=None)
+        assert 0.0 <= float(result.value) <= 1.0
+
+    @given(st.text())
+    @settings(max_examples=50, deadline=None)
+    def test_persona_quality_never_raises(self, text):
+        result = persona_quality(inputs=text, outputs=text, expectations=None)
+        assert result is not None
+
+    @given(st.text())
+    @settings(max_examples=50, deadline=None)
+    def test_trend_relevance_range(self, text):
+        result = trend_relevance(inputs="test", outputs=text, expectations=None)
+        assert 0.0 <= float(result.value) <= 1.0
+
+    @given(st.text())
+    @settings(max_examples=50, deadline=None)
+    def test_trend_relevance_never_raises(self, text):
+        result = trend_relevance(inputs=text, outputs=text, expectations=None)
+        assert result is not None
+
+    @given(st.text())
+    @settings(max_examples=50, deadline=None)
+    def test_voca_sentiment_range(self, text):
+        result = voca_sentiment(inputs="test", outputs=text, expectations=None)
+        assert 0.0 <= float(result.value) <= 1.0
+
+    @given(st.text())
+    @settings(max_examples=50, deadline=None)
+    def test_voca_sentiment_never_raises(self, text):
+        result = voca_sentiment(inputs=text, outputs=text, expectations=None)
+        assert result is not None
+
+
+class TestWf2Properties:
+    """Property-based tests for all 5 WF2 scorers."""
+
+    @given(st.text())
+    @settings(max_examples=50, deadline=None)
+    def test_positioning_clarity_range(self, text):
+        result = positioning_clarity(inputs="test", outputs=text, expectations=None)
+        assert 0.0 <= float(result.value) <= 1.0
+
+    @given(st.text())
+    @settings(max_examples=50, deadline=None)
+    def test_positioning_clarity_never_raises(self, text):
+        result = positioning_clarity(inputs=text, outputs=text, expectations=None)
+        assert result is not None
+
+    @given(st.text())
+    @settings(max_examples=50, deadline=None)
+    def test_architecture_coherence_range(self, text):
+        result = architecture_coherence(inputs="test", outputs=text, expectations=None)
+        assert 0.0 <= float(result.value) <= 1.0
+
+    @given(st.text())
+    @settings(max_examples=50, deadline=None)
+    def test_architecture_coherence_never_raises(self, text):
+        result = architecture_coherence(inputs=text, outputs=text, expectations=None)
+        assert result is not None
+
+    @given(st.text())
+    @settings(max_examples=50, deadline=None)
+    def test_voice_consistency_range(self, text):
+        result = voice_consistency(inputs="test", outputs=text, expectations=None)
+        assert 0.0 <= float(result.value) <= 1.0
+
+    @given(st.text())
+    @settings(max_examples=50, deadline=None)
+    def test_voice_consistency_never_raises(self, text):
+        result = voice_consistency(inputs=text, outputs=text, expectations=None)
+        assert result is not None
+
+    @given(st.text())
+    @settings(max_examples=50, deadline=None)
+    def test_name_quality_range(self, text):
+        result = name_quality(inputs="test", outputs=text, expectations=None)
+        assert 0.0 <= float(result.value) <= 1.0
+
+    @given(st.text())
+    @settings(max_examples=50, deadline=None)
+    def test_name_quality_never_raises(self, text):
+        result = name_quality(inputs=text, outputs=text, expectations=None)
+        assert result is not None
+
+    @given(st.text())
+    @settings(max_examples=50, deadline=None)
+    def test_narrative_engagement_range(self, text):
+        result = narrative_engagement(inputs="test", outputs=text, expectations=None)
+        assert 0.0 <= float(result.value) <= 1.0
+
+    @given(st.text())
+    @settings(max_examples=50, deadline=None)
+    def test_narrative_engagement_never_raises(self, text):
+        result = narrative_engagement(inputs=text, outputs=text, expectations=None)
+        assert result is not None
+
+
+class TestIlaProperties:
+    """Property-based tests for both ILA scorers."""
+
+    @given(st.text())
+    @settings(max_examples=50, deadline=None)
+    def test_learning_depth_range(self, text):
+        result = learning_depth(inputs="test", outputs=text, expectations=None)
+        assert 0.0 <= float(result.value) <= 1.0
+
+    @given(st.text())
+    @settings(max_examples=50, deadline=None)
+    def test_learning_depth_never_raises(self, text):
+        result = learning_depth(inputs=text, outputs=text, expectations=None)
+        assert result is not None
+
+    @given(st.text())
+    @settings(max_examples=50, deadline=None)
+    def test_meta_policy_range(self, text):
+        result = meta_policy(inputs="test", outputs=text, expectations=None)
+        assert 0.0 <= float(result.value) <= 1.0
+
+    @given(st.text())
+    @settings(max_examples=50, deadline=None)
+    def test_meta_policy_never_raises(self, text):
+        result = meta_policy(inputs=text, outputs=text, expectations=None)
+        assert result is not None

--- a/prompt-optimization-svc/tests/test_ila_scorers.py
+++ b/prompt-optimization-svc/tests/test_ila_scorers.py
@@ -1,0 +1,285 @@
+"""Unit tests for ILA scorers (US-026).
+
+10+ tests per scorer covering perfect, partial, invalid, and edge inputs.
+"""
+
+import json
+
+from app.scorers.ila.learning_depth import learning_depth
+from app.scorers.ila.meta_policy import meta_policy
+
+
+def _learning(**overrides) -> dict:
+    """Build a valid learning dict."""
+    base = {
+        "confidence": 75,
+        "impact": "HIGH",
+        "insight": "CPA decreased after audience narrowing.",
+    }
+    base.update(overrides)
+    return base
+
+
+def _ila_output(**overrides) -> str:
+    """Build a minimal valid ILA output JSON string."""
+    data = {
+        "learnings": overrides.get(
+            "learnings",
+            [_learning()],
+        ),
+        "contradictions": overrides.get("contradictions", []),
+    }
+    data.update({k: v for k, v in overrides.items() if k not in data})
+    return json.dumps(data)
+
+
+def _meta_output(**overrides) -> str:
+    """Build a minimal valid meta_policy output JSON string."""
+    data = {
+        "plan_warnings": overrides.get("plan_warnings", ["minor warning"]),
+        "published_campaign": overrides.get(
+            "published_campaign", {"id": "camp_123", "status": "ACTIVE"}
+        ),
+        "sandbox_mode": overrides.get("sandbox_mode", False),
+    }
+    data.update({k: v for k, v in overrides.items() if k not in data})
+    return json.dumps(data)
+
+
+# ── learning_depth tests ──
+
+
+class TestLearningDepth:
+    def test_single_confident_learning(self):
+        result = learning_depth(inputs="test", outputs=_ila_output(), expectations=None)
+        assert result.value == 1.0
+
+    def test_all_confident_learnings(self):
+        out = _ila_output(
+            learnings=[
+                _learning(confidence=80, impact="HIGH"),
+                _learning(confidence=60, impact="MEDIUM"),
+                _learning(confidence=50, impact="LOW"),
+            ]
+        )
+        result = learning_depth(inputs="test", outputs=out, expectations=None)
+        assert result.value == 1.0
+
+    def test_mixed_confidence(self):
+        out = _ila_output(
+            learnings=[
+                _learning(confidence=80, impact="HIGH"),
+                _learning(confidence=30, impact="LOW"),
+            ]
+        )
+        result = learning_depth(inputs="test", outputs=out, expectations=None)
+        assert result.value == 0.5
+
+    def test_all_low_confidence(self):
+        out = _ila_output(
+            learnings=[
+                _learning(confidence=10, impact="HIGH"),
+                _learning(confidence=20, impact="MEDIUM"),
+            ]
+        )
+        result = learning_depth(inputs="test", outputs=out, expectations=None)
+        assert result.value == 0.0
+
+    def test_empty_learnings(self):
+        out = _ila_output(learnings=[])
+        result = learning_depth(inputs="test", outputs=out, expectations=None)
+        assert result.value == 0.0
+
+    def test_missing_learnings_field(self):
+        out = json.dumps({"contradictions": []})
+        result = learning_depth(inputs="test", outputs=out, expectations=None)
+        assert result.value == 0.0
+
+    def test_none_output(self):
+        result = learning_depth(inputs="test", outputs=None, expectations=None)
+        assert result.value == 0.0
+
+    def test_malformed_json(self):
+        result = learning_depth(
+            inputs="test", outputs="not json at all", expectations=None
+        )
+        assert result.value == 0.0
+
+    def test_non_dict_learnings(self):
+        out = json.dumps({"learnings": "not_a_list"})
+        result = learning_depth(inputs="test", outputs=out, expectations=None)
+        assert result.value == 0.0
+
+    def test_non_dict_entries_in_learnings(self):
+        out = _ila_output(learnings=["bad", 42, None])
+        result = learning_depth(inputs="test", outputs=out, expectations=None)
+        assert result.value == 0.0
+        assert "No valid learning dicts" in result.rationale
+
+    def test_invalid_impact_value(self):
+        out = _ila_output(learnings=[_learning(confidence=80, impact="INVALID")])
+        result = learning_depth(inputs="test", outputs=out, expectations=None)
+        # Valid dict but impact not in {HIGH, MEDIUM, LOW} so not counted
+        assert result.value == 0.0
+
+    def test_non_int_confidence(self):
+        out = _ila_output(learnings=[_learning(confidence="high", impact="HIGH")])
+        result = learning_depth(inputs="test", outputs=out, expectations=None)
+        assert result.value == 0.0
+
+    def test_contradiction_bonus_noted(self):
+        out = _ila_output(
+            learnings=[_learning()],
+            contradictions=[{"old": "A", "new": "B"}],
+        )
+        result = learning_depth(inputs="test", outputs=out, expectations=None)
+        assert result.value == 1.0
+        assert "Contradictions detected" in result.rationale
+
+    def test_no_contradictions_no_bonus(self):
+        out = _ila_output(learnings=[_learning()], contradictions=[])
+        result = learning_depth(inputs="test", outputs=out, expectations=None)
+        assert "Contradictions detected" not in result.rationale
+
+    def test_dict_input_accepted(self):
+        data = json.loads(_ila_output())
+        result = learning_depth(inputs="test", outputs=data, expectations=None)
+        assert result.value == 1.0
+
+    def test_feedback_name(self):
+        result = learning_depth(inputs="test", outputs=_ila_output(), expectations=None)
+        assert result.name == "learning_depth"
+
+    def test_boundary_confidence_49(self):
+        out = _ila_output(learnings=[_learning(confidence=49, impact="HIGH")])
+        result = learning_depth(inputs="test", outputs=out, expectations=None)
+        assert result.value == 0.0
+
+    def test_boundary_confidence_50(self):
+        out = _ila_output(learnings=[_learning(confidence=50, impact="HIGH")])
+        result = learning_depth(inputs="test", outputs=out, expectations=None)
+        assert result.value == 1.0
+
+    def test_score_rounded(self):
+        out = _ila_output(
+            learnings=[
+                _learning(confidence=80, impact="HIGH"),
+                _learning(confidence=80, impact="MEDIUM"),
+                _learning(confidence=10, impact="LOW"),
+            ]
+        )
+        result = learning_depth(inputs="test", outputs=out, expectations=None)
+        assert result.value == round(2 / 3, 4)
+
+
+# ── meta_policy tests ──
+
+
+class TestMetaPolicy:
+    def test_all_checks_pass(self):
+        result = meta_policy(inputs="test", outputs=_meta_output(), expectations=None)
+        assert result.value == 1.0
+
+    def test_zero_warnings_pass(self):
+        out = _meta_output(plan_warnings=[])
+        result = meta_policy(inputs="test", outputs=out, expectations=None)
+        assert result.value == 1.0
+
+    def test_two_warnings_pass(self):
+        out = _meta_output(plan_warnings=["w1", "w2"])
+        result = meta_policy(inputs="test", outputs=out, expectations=None)
+        assert result.value == 1.0
+
+    def test_three_warnings_fail(self):
+        out = _meta_output(plan_warnings=["w1", "w2", "w3"])
+        result = meta_policy(inputs="test", outputs=out, expectations=None)
+        # plan_warnings fails, published_campaign + sandbox_mode pass = 2/3
+        assert result.value == round(2 / 3, 4)
+
+    def test_missing_published_campaign(self):
+        out = json.dumps(
+            {
+                "plan_warnings": [],
+                "sandbox_mode": True,
+            }
+        )
+        result = meta_policy(inputs="test", outputs=out, expectations=None)
+        assert result.value == round(2 / 3, 4)
+
+    def test_published_campaign_not_dict(self):
+        out = _meta_output(published_campaign="not_a_dict")
+        result = meta_policy(inputs="test", outputs=out, expectations=None)
+        assert result.value == round(2 / 3, 4)
+
+    def test_sandbox_mode_not_bool(self):
+        out = _meta_output(sandbox_mode="yes")
+        result = meta_policy(inputs="test", outputs=out, expectations=None)
+        assert result.value == round(2 / 3, 4)
+
+    def test_sandbox_mode_true_is_valid(self):
+        out = _meta_output(sandbox_mode=True)
+        result = meta_policy(inputs="test", outputs=out, expectations=None)
+        assert result.value == 1.0
+
+    def test_all_checks_fail(self):
+        out = json.dumps(
+            {
+                "plan_warnings": ["w1", "w2", "w3", "w4"],
+                "published_campaign": "bad",
+                "sandbox_mode": "not_bool",
+            }
+        )
+        result = meta_policy(inputs="test", outputs=out, expectations=None)
+        assert result.value == 0.0
+
+    def test_none_output(self):
+        result = meta_policy(inputs="test", outputs=None, expectations=None)
+        assert result.value == 0.0
+
+    def test_malformed_json(self):
+        result = meta_policy(inputs="test", outputs="not json", expectations=None)
+        assert result.value == 0.0
+
+    def test_empty_dict(self):
+        result = meta_policy(inputs="test", outputs=json.dumps({}), expectations=None)
+        assert result.value == 0.0
+
+    def test_dict_input_accepted(self):
+        data = json.loads(_meta_output())
+        result = meta_policy(inputs="test", outputs=data, expectations=None)
+        assert result.value == 1.0
+
+    def test_feedback_name(self):
+        result = meta_policy(inputs="test", outputs=_meta_output(), expectations=None)
+        assert result.name == "meta_policy"
+
+    def test_rationale_lists_details(self):
+        result = meta_policy(inputs="test", outputs=_meta_output(), expectations=None)
+        assert "3/3 checks passed" in result.rationale
+
+    def test_plan_warnings_not_list(self):
+        out = _meta_output()
+        data = json.loads(out)
+        data["plan_warnings"] = "not_a_list"
+        result = meta_policy(inputs="test", outputs=json.dumps(data), expectations=None)
+        # plan_warnings fails, other two pass = 2/3
+        assert result.value == round(2 / 3, 4)
+
+
+# ── Scorer conformance ──
+
+
+class TestIlaScorerConformance:
+    def test_all_are_scorer_instances(self):
+        from mlflow.genai.scorers import Scorer
+
+        for s in [learning_depth, meta_policy]:
+            assert isinstance(s, Scorer), f"{s.name} is not a Scorer"
+
+    def test_all_accept_keyword_args(self):
+        for s, out in [
+            (learning_depth, _ila_output()),
+            (meta_policy, _meta_output()),
+        ]:
+            result = s(inputs="test", outputs=out, expectations=None)
+            assert result is not None

--- a/prompt-optimization-svc/tests/test_wf1_scorers.py
+++ b/prompt-optimization-svc/tests/test_wf1_scorers.py
@@ -1,0 +1,682 @@
+"""Unit tests for WF1 discovery & research scorers.
+
+10+ tests per scorer covering perfect, partial, invalid, and edge inputs.
+"""
+
+import json
+
+from app.scorers.wf1.market_completeness import market_completeness
+from app.scorers.wf1.competitor_accuracy import competitor_accuracy
+from app.scorers.wf1.persona_quality import persona_quality
+from app.scorers.wf1.trend_relevance import trend_relevance
+from app.scorers.wf1.voca_sentiment import voca_sentiment
+
+
+# ── Helper builders ──
+
+
+def _mra_output(**overrides) -> str:
+    """Build a minimal valid MRA (market research) output JSON string."""
+    data = {
+        "market_sizing": overrides.get(
+            "market_sizing",
+            {"TAM": 1_000_000, "SAM": 500_000, "SOM": 100_000},
+        ),
+        "competitive_landscape": overrides.get(
+            "competitive_landscape",
+            [{"name": "Competitor A"}, {"name": "Competitor B"}],
+        ),
+        "industry_trends": overrides.get(
+            "industry_trends",
+            ["AI adoption", "Cloud migration"],
+        ),
+        "findings": overrides.get(
+            "findings",
+            ["Key insight 1", "Key insight 2"],
+        ),
+    }
+    data.update({k: v for k, v in overrides.items() if k not in data})
+    return json.dumps(data)
+
+
+def _cia_output(**overrides) -> str:
+    """Build a minimal valid CIA (competitor intel) output JSON string."""
+    data = {
+        "competitors": overrides.get(
+            "competitors",
+            [
+                {"name": "Rival A", "market_position": "leader"},
+                {"name": "Rival B", "market_position": "challenger"},
+            ],
+        ),
+        "positioning_gaps": overrides.get(
+            "positioning_gaps",
+            ["gap 1", "gap 2"],
+        ),
+        "benchmarking_report": overrides.get(
+            "benchmarking_report",
+            {"metric_a": 85, "metric_b": 90},
+        ),
+    }
+    data.update({k: v for k, v in overrides.items() if k not in data})
+    return json.dumps(data)
+
+
+def _apa_output(**overrides) -> str:
+    """Build a minimal valid APA (audience persona) output JSON string."""
+    data = {
+        "personas": overrides.get(
+            "personas",
+            [
+                {
+                    "name": "Tech Enthusiast",
+                    "demographics": {"age": "25-34", "gender": "mixed"},
+                    "psychographics": {"values": ["innovation"]},
+                },
+                {
+                    "name": "Budget Buyer",
+                    "demographics": {"age": "35-44", "income": "medium"},
+                    "psychographics": {"values": ["value"]},
+                },
+            ],
+        ),
+        "journey_maps": overrides.get(
+            "journey_maps",
+            [{"stage": "awareness", "touchpoints": ["social", "search"]}],
+        ),
+    }
+    data.update({k: v for k, v in overrides.items() if k not in data})
+    return json.dumps(data)
+
+
+def _tcia_output(**overrides) -> str:
+    """Build a minimal valid TCIA (trend cultural) output JSON string."""
+    data = {
+        "trend_report": overrides.get(
+            "trend_report",
+            {
+                "trend_scorecard": [
+                    {"trend": "AI", "relevance_score": 95},
+                    {"trend": "Sustainability", "relevance_score": 80},
+                    {"trend": "Remote work", "relevance_score": 70},
+                ]
+            },
+        ),
+        "opportunity_alerts": overrides.get(
+            "opportunity_alerts",
+            ["Alert 1: AI opportunity", "Alert 2: Green market"],
+        ),
+    }
+    data.update({k: v for k, v in overrides.items() if k not in data})
+    return json.dumps(data)
+
+
+def _voca_output(**overrides) -> str:
+    """Build a minimal valid VoCA (voice of customer) output JSON string."""
+    data = {
+        "sentiment": overrides.get(
+            "sentiment",
+            {"overall_sentiment": "positive", "confidence": 0.92},
+        ),
+        "nps_analysis": overrides.get(
+            "nps_analysis",
+            {"score": 45, "promoters": 60, "detractors": 15},
+        ),
+        "pain_point_priority_matrix": overrides.get(
+            "pain_point_priority_matrix",
+            {"high": ["pricing"], "medium": ["onboarding"]},
+        ),
+    }
+    data.update({k: v for k, v in overrides.items() if k not in data})
+    return json.dumps(data)
+
+
+# ── market_completeness tests ──
+
+
+class TestMarketCompleteness:
+    def test_valid_complete_output(self):
+        result = market_completeness(
+            inputs="test", outputs=_mra_output(), expectations=None
+        )
+        assert result.value == 1.0
+
+    def test_missing_market_sizing(self):
+        out = _mra_output(market_sizing=None)
+        result = market_completeness(inputs="test", outputs=out, expectations=None)
+        assert result.value == 0.75
+
+    def test_missing_competitive_landscape(self):
+        out = _mra_output(competitive_landscape=[])
+        result = market_completeness(inputs="test", outputs=out, expectations=None)
+        assert result.value == 0.75
+
+    def test_missing_industry_trends(self):
+        out = _mra_output(industry_trends=[])
+        result = market_completeness(inputs="test", outputs=out, expectations=None)
+        assert result.value == 0.75
+
+    def test_missing_findings(self):
+        out = _mra_output(findings=[])
+        result = market_completeness(inputs="test", outputs=out, expectations=None)
+        assert result.value == 0.75
+
+    def test_none_output(self):
+        result = market_completeness(inputs="test", outputs=None, expectations=None)
+        assert result.value == 0.0
+
+    def test_invalid_json(self):
+        result = market_completeness(
+            inputs="test", outputs="not json {{", expectations=None
+        )
+        assert result.value == 0.0
+
+    def test_dict_input(self):
+        data = json.loads(_mra_output())
+        result = market_completeness(inputs="test", outputs=data, expectations=None)
+        assert result.value == 1.0
+
+    def test_market_sizing_not_dict(self):
+        out = _mra_output(market_sizing="big market")
+        result = market_completeness(inputs="test", outputs=out, expectations=None)
+        assert result.value == 0.75
+
+    def test_market_sizing_missing_tam(self):
+        out = _mra_output(market_sizing={"SAM": 500_000, "SOM": 100_000})
+        result = market_completeness(inputs="test", outputs=out, expectations=None)
+        assert result.value == 0.75
+
+    def test_competitive_landscape_not_list(self):
+        out = _mra_output(competitive_landscape="some text")
+        result = market_completeness(inputs="test", outputs=out, expectations=None)
+        assert result.value == 0.75
+
+    def test_all_fields_missing(self):
+        result = market_completeness(
+            inputs="test", outputs=json.dumps({}), expectations=None
+        )
+        assert result.value == 0.0
+
+    def test_feedback_name(self):
+        result = market_completeness(
+            inputs="test", outputs=_mra_output(), expectations=None
+        )
+        assert result.name == "market_completeness"
+
+    def test_partial_two_fields(self):
+        out = _mra_output(market_sizing=None, competitive_landscape=[])
+        result = market_completeness(inputs="test", outputs=out, expectations=None)
+        assert result.value == 0.5
+
+
+# ── competitor_accuracy tests ──
+
+
+class TestCompetitorAccuracy:
+    def test_valid_complete_output(self):
+        result = competitor_accuracy(
+            inputs="test", outputs=_cia_output(), expectations=None
+        )
+        assert result.value == 1.0
+
+    def test_missing_competitors(self):
+        out = _cia_output(competitors=[])
+        result = competitor_accuracy(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_competitors_without_market_position(self):
+        out = _cia_output(
+            competitors=[
+                {"name": "Rival A"},
+                {"name": "Rival B", "market_position": "leader"},
+            ]
+        )
+        result = competitor_accuracy(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_all_competitors_missing_market_position(self):
+        out = _cia_output(competitors=[{"name": "A"}, {"name": "B"}])
+        result = competitor_accuracy(inputs="test", outputs=out, expectations=None)
+        # competitors present but none have market_position -> that check fails
+        assert result.value < 1.0
+
+    def test_missing_positioning_gaps(self):
+        out = _cia_output(positioning_gaps=[])
+        result = competitor_accuracy(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_missing_benchmarking_report(self):
+        out = _cia_output(benchmarking_report=None)
+        result = competitor_accuracy(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_none_output(self):
+        result = competitor_accuracy(inputs="test", outputs=None, expectations=None)
+        assert result.value == 0.0
+
+    def test_invalid_json(self):
+        result = competitor_accuracy(
+            inputs="test", outputs="bad json {{{", expectations=None
+        )
+        assert result.value == 0.0
+
+    def test_dict_input(self):
+        data = json.loads(_cia_output())
+        result = competitor_accuracy(inputs="test", outputs=data, expectations=None)
+        assert result.value == 1.0
+
+    def test_competitors_not_list(self):
+        out = _cia_output(competitors="not a list")
+        result = competitor_accuracy(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_benchmarking_report_not_dict(self):
+        out = _cia_output(benchmarking_report="just text")
+        result = competitor_accuracy(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_feedback_name(self):
+        result = competitor_accuracy(
+            inputs="test", outputs=_cia_output(), expectations=None
+        )
+        assert result.name == "competitor_accuracy"
+
+    def test_non_dict_competitor_entries(self):
+        out = _cia_output(competitors=["string entry", 42])
+        result = competitor_accuracy(inputs="test", outputs=out, expectations=None)
+        # entries are not dicts, so none have market_position
+        assert result.value < 1.0
+
+    def test_all_fields_missing(self):
+        result = competitor_accuracy(
+            inputs="test", outputs=json.dumps({}), expectations=None
+        )
+        assert result.value == 0.0
+
+    def test_empty_benchmarking_report_dict(self):
+        """Empty dict is still a dict -- should pass."""
+        out = _cia_output(benchmarking_report={})
+        result = competitor_accuracy(inputs="test", outputs=out, expectations=None)
+        # competitors + positioning_gaps pass, benchmarking_report is {} -> dict check passes
+        assert result.value == 1.0
+
+
+# ── persona_quality tests ──
+
+
+class TestPersonaQuality:
+    def test_valid_complete_output(self):
+        result = persona_quality(
+            inputs="test", outputs=_apa_output(), expectations=None
+        )
+        assert result.value == 1.0
+
+    def test_missing_personas(self):
+        out = _apa_output(personas=[])
+        result = persona_quality(inputs="test", outputs=out, expectations=None)
+        # persona_score=0 (empty), journey_maps present -> 0.5
+        assert result.value == 0.5
+
+    def test_missing_journey_maps(self):
+        out = _apa_output(journey_maps=[])
+        result = persona_quality(inputs="test", outputs=out, expectations=None)
+        # personas complete -> 0.5, journey absent -> 0
+        assert result.value == 0.5
+
+    def test_persona_missing_demographics(self):
+        out = _apa_output(
+            personas=[
+                {
+                    "name": "Incomplete",
+                    "psychographics": {"values": ["speed"]},
+                }
+            ]
+        )
+        result = persona_quality(inputs="test", outputs=out, expectations=None)
+        # 0 complete / 1 -> persona_score=0 -> 0 * 0.5 + journey 0.5
+        assert result.value == 0.5
+
+    def test_persona_missing_psychographics(self):
+        out = _apa_output(
+            personas=[
+                {
+                    "name": "Incomplete",
+                    "demographics": {"age": "25-34"},
+                }
+            ]
+        )
+        result = persona_quality(inputs="test", outputs=out, expectations=None)
+        assert result.value == 0.5
+
+    def test_mixed_persona_quality(self):
+        out = _apa_output(
+            personas=[
+                {
+                    "name": "Complete",
+                    "demographics": {"age": "25-34"},
+                    "psychographics": {"values": ["innovation"]},
+                },
+                {
+                    "name": "Incomplete",
+                    "demographics": {"age": "35-44"},
+                    # missing psychographics
+                },
+            ]
+        )
+        result = persona_quality(inputs="test", outputs=out, expectations=None)
+        # 1/2 complete -> 0.5 * 0.5 = 0.25 + journey 0.5 = 0.75
+        assert result.value == 0.75
+
+    def test_none_output(self):
+        result = persona_quality(inputs="test", outputs=None, expectations=None)
+        assert result.value == 0.0
+
+    def test_invalid_json(self):
+        result = persona_quality(
+            inputs="test", outputs="not valid json", expectations=None
+        )
+        assert result.value == 0.0
+
+    def test_dict_input(self):
+        data = json.loads(_apa_output())
+        result = persona_quality(inputs="test", outputs=data, expectations=None)
+        assert result.value == 1.0
+
+    def test_personas_not_list(self):
+        out = _apa_output(personas="not a list")
+        result = persona_quality(inputs="test", outputs=out, expectations=None)
+        # persona_score=0, journey present -> 0.5
+        assert result.value == 0.5
+
+    def test_journey_maps_not_list(self):
+        out = _apa_output(journey_maps="not a list")
+        result = persona_quality(inputs="test", outputs=out, expectations=None)
+        # personas complete -> 0.5, journey not list -> 0
+        assert result.value == 0.5
+
+    def test_non_dict_persona_entries(self):
+        out = _apa_output(personas=["string", 42, None])
+        result = persona_quality(inputs="test", outputs=out, expectations=None)
+        # 0 complete / 3 -> persona_score=0
+        assert result.value == 0.5
+
+    def test_feedback_name(self):
+        result = persona_quality(
+            inputs="test", outputs=_apa_output(), expectations=None
+        )
+        assert result.name == "persona_quality"
+
+    def test_all_missing(self):
+        result = persona_quality(
+            inputs="test", outputs=json.dumps({}), expectations=None
+        )
+        assert result.value == 0.0
+
+    def test_demographics_not_dict(self):
+        out = _apa_output(
+            personas=[
+                {
+                    "name": "Bad",
+                    "demographics": "age 25-34",
+                    "psychographics": {"values": ["x"]},
+                }
+            ]
+        )
+        result = persona_quality(inputs="test", outputs=out, expectations=None)
+        # demographics not dict -> incomplete
+        assert result.value == 0.5
+
+
+# ── trend_relevance tests ──
+
+
+class TestTrendRelevance:
+    def test_valid_complete_output(self):
+        result = trend_relevance(
+            inputs="test", outputs=_tcia_output(), expectations=None
+        )
+        assert result.value == 1.0
+
+    def test_missing_trend_report(self):
+        out = json.dumps({"opportunity_alerts": ["Alert 1"]})
+        result = trend_relevance(inputs="test", outputs=out, expectations=None)
+        # trend_score=0 -> 0*0.8 + 1*0.2 = 0.2
+        assert result.value == 0.2
+
+    def test_missing_opportunity_alerts(self):
+        out = _tcia_output(opportunity_alerts=[])
+        result = trend_relevance(inputs="test", outputs=out, expectations=None)
+        # trend_score=1.0 -> 1*0.8 + 0*0.2 = 0.8
+        assert result.value == 0.8
+
+    def test_empty_scorecard(self):
+        out = _tcia_output(trend_report={"trend_scorecard": []})
+        result = trend_relevance(inputs="test", outputs=out, expectations=None)
+        # scorecard empty -> trend_score=0 -> 0*0.8 + 0.2 = 0.2
+        assert result.value == 0.2
+
+    def test_invalid_relevance_scores(self):
+        out = _tcia_output(
+            trend_report={
+                "trend_scorecard": [
+                    {"trend": "AI", "relevance_score": -5},
+                    {"trend": "Cloud", "relevance_score": 150},
+                ]
+            }
+        )
+        result = trend_relevance(inputs="test", outputs=out, expectations=None)
+        # Both out of range -> 0/2 -> trend_score=0
+        assert result.value == 0.2
+
+    def test_mixed_valid_invalid_scores(self):
+        out = _tcia_output(
+            trend_report={
+                "trend_scorecard": [
+                    {"trend": "AI", "relevance_score": 85},
+                    {"trend": "Cloud", "relevance_score": -10},
+                ]
+            }
+        )
+        result = trend_relevance(inputs="test", outputs=out, expectations=None)
+        # 1/2 valid -> 0.5 * 0.8 + 0.2 = 0.6
+        assert result.value == 0.6
+
+    def test_none_output(self):
+        result = trend_relevance(inputs="test", outputs=None, expectations=None)
+        assert result.value == 0.0
+
+    def test_invalid_json(self):
+        result = trend_relevance(
+            inputs="test", outputs="broken json {{", expectations=None
+        )
+        assert result.value == 0.0
+
+    def test_dict_input(self):
+        data = json.loads(_tcia_output())
+        result = trend_relevance(inputs="test", outputs=data, expectations=None)
+        assert result.value == 1.0
+
+    def test_trend_report_not_dict(self):
+        out = _tcia_output(trend_report="not a dict")
+        result = trend_relevance(inputs="test", outputs=out, expectations=None)
+        # trend_report not dict -> trend_score=0
+        assert result.value == 0.2
+
+    def test_scorecard_not_list(self):
+        out = _tcia_output(trend_report={"trend_scorecard": "bad"})
+        result = trend_relevance(inputs="test", outputs=out, expectations=None)
+        assert result.value == 0.2
+
+    def test_non_dict_scorecard_entries(self):
+        out = _tcia_output(trend_report={"trend_scorecard": ["string", 42, None]})
+        result = trend_relevance(inputs="test", outputs=out, expectations=None)
+        # 0/3 valid -> trend_score=0
+        assert result.value == 0.2
+
+    def test_feedback_name(self):
+        result = trend_relevance(
+            inputs="test", outputs=_tcia_output(), expectations=None
+        )
+        assert result.name == "trend_relevance"
+
+    def test_relevance_score_non_numeric(self):
+        out = _tcia_output(
+            trend_report={
+                "trend_scorecard": [
+                    {"trend": "AI", "relevance_score": "high"},
+                ]
+            }
+        )
+        result = trend_relevance(inputs="test", outputs=out, expectations=None)
+        # string not numeric -> 0/1 valid
+        assert result.value == 0.2
+
+    def test_boundary_relevance_scores(self):
+        out = _tcia_output(
+            trend_report={
+                "trend_scorecard": [
+                    {"trend": "A", "relevance_score": 0},
+                    {"trend": "B", "relevance_score": 100},
+                ]
+            }
+        )
+        result = trend_relevance(inputs="test", outputs=out, expectations=None)
+        # Both valid (0 and 100 are within range)
+        assert result.value == 1.0
+
+
+# ── voca_sentiment tests ──
+
+
+class TestVocaSentiment:
+    def test_valid_complete_output(self):
+        result = voca_sentiment(
+            inputs="test", outputs=_voca_output(), expectations=None
+        )
+        assert result.value == 1.0
+
+    def test_missing_sentiment(self):
+        out = _voca_output(sentiment=None)
+        result = voca_sentiment(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_sentiment_missing_overall(self):
+        out = _voca_output(sentiment={"confidence": 0.9})
+        result = voca_sentiment(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_missing_nps_analysis(self):
+        out = _voca_output(nps_analysis=None)
+        result = voca_sentiment(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_missing_pain_point_matrix(self):
+        out = _voca_output(pain_point_priority_matrix=None)
+        result = voca_sentiment(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_empty_pain_point_list(self):
+        out = _voca_output(pain_point_priority_matrix=[])
+        result = voca_sentiment(inputs="test", outputs=out, expectations=None)
+        # empty list does not count as present
+        assert result.value < 1.0
+
+    def test_pain_point_as_list(self):
+        out = _voca_output(
+            pain_point_priority_matrix=[{"issue": "pricing", "priority": "high"}]
+        )
+        result = voca_sentiment(inputs="test", outputs=out, expectations=None)
+        assert result.value == 1.0
+
+    def test_none_output(self):
+        result = voca_sentiment(inputs="test", outputs=None, expectations=None)
+        assert result.value == 0.0
+
+    def test_invalid_json(self):
+        result = voca_sentiment(
+            inputs="test", outputs="not json at all", expectations=None
+        )
+        assert result.value == 0.0
+
+    def test_dict_input(self):
+        data = json.loads(_voca_output())
+        result = voca_sentiment(inputs="test", outputs=data, expectations=None)
+        assert result.value == 1.0
+
+    def test_sentiment_not_dict(self):
+        out = _voca_output(sentiment="positive")
+        result = voca_sentiment(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_nps_analysis_not_dict(self):
+        out = _voca_output(nps_analysis=[1, 2, 3])
+        result = voca_sentiment(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_feedback_name(self):
+        result = voca_sentiment(
+            inputs="test", outputs=_voca_output(), expectations=None
+        )
+        assert result.name == "voca_sentiment"
+
+    def test_all_fields_missing(self):
+        result = voca_sentiment(
+            inputs="test", outputs=json.dumps({}), expectations=None
+        )
+        assert result.value == 0.0
+
+    def test_pain_point_matrix_invalid_type(self):
+        out = _voca_output(pain_point_priority_matrix=42)
+        result = voca_sentiment(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+
+# ── Scorer conformance ──
+
+
+class TestWf1ScorerConformance:
+    def test_all_are_scorer_instances(self):
+        from mlflow.genai.scorers import Scorer
+
+        for s in [
+            market_completeness,
+            competitor_accuracy,
+            persona_quality,
+            trend_relevance,
+            voca_sentiment,
+        ]:
+            assert isinstance(s, Scorer), f"{s.name} is not a Scorer"
+
+    def test_all_accept_keyword_args(self):
+        pairs = [
+            (market_completeness, _mra_output()),
+            (competitor_accuracy, _cia_output()),
+            (persona_quality, _apa_output()),
+            (trend_relevance, _tcia_output()),
+            (voca_sentiment, _voca_output()),
+        ]
+        for s, out in pairs:
+            result = s(inputs="test", outputs=out, expectations=None)
+            assert result is not None, f"{s.name} returned None"
+
+    def test_all_return_zero_on_none(self):
+        for s in [
+            market_completeness,
+            competitor_accuracy,
+            persona_quality,
+            trend_relevance,
+            voca_sentiment,
+        ]:
+            result = s(inputs="test", outputs=None, expectations=None)
+            assert result.value == 0.0, f"{s.name} did not return 0.0 for None"
+
+    def test_all_handle_invalid_json(self):
+        for s in [
+            market_completeness,
+            competitor_accuracy,
+            persona_quality,
+            trend_relevance,
+            voca_sentiment,
+        ]:
+            result = s(inputs="test", outputs="{{bad", expectations=None)
+            assert result.value == 0.0, f"{s.name} did not return 0.0 for bad JSON"

--- a/prompt-optimization-svc/tests/test_wf2_scorers.py
+++ b/prompt-optimization-svc/tests/test_wf2_scorers.py
@@ -28,14 +28,14 @@ def _positioning_output(**overrides) -> str:
         "canvas": overrides.get(
             "canvas",
             {
-                "fit_score": 0.92,
+                "fit_score": 92,
                 "elements": ["value_prop", "differentiator"],
             },
         ),
         "differentiation": overrides.get(
             "differentiation",
             {
-                "overall_differentiation_score": 0.88,
+                "overall_differentiation_score": 72,
                 "factors": ["AI-native", "multi-tenant"],
             },
         ),
@@ -60,7 +60,7 @@ def _architecture_output(**overrides) -> str:
         "hierarchy": overrides.get(
             "hierarchy",
             {
-                "root": "Zorven",
+                "root": {"name": "Zorven", "type": "master_brand"},
                 "total_depth": 3,
                 "branches": ["Platform", "Services"],
             },
@@ -68,7 +68,7 @@ def _architecture_output(**overrides) -> str:
         "naming_hierarchy": overrides.get(
             "naming_hierarchy",
             {
-                "consistency_score": 0.85,
+                "consistency_score": 85,
                 "naming_pattern": "parent_endorsed",
             },
         ),
@@ -181,7 +181,7 @@ class TestPositioningClarity:
         result = positioning_clarity(
             inputs="test", outputs=_positioning_output(), expectations=None
         )
-        assert result.value >= 0.9
+        assert result.value >= 0.8
 
     def test_perfect_scores(self):
         out = _positioning_output(
@@ -231,7 +231,7 @@ class TestPositioningClarity:
     def test_dict_input(self):
         data = json.loads(_positioning_output())
         result = positioning_clarity(inputs="test", outputs=data, expectations=None)
-        assert result.value >= 0.9
+        assert result.value >= 0.8
 
     def test_non_dict_recommended_positioning(self):
         out = _positioning_output(recommended_positioning="just a string")
@@ -327,10 +327,18 @@ class TestArchitectureCoherence:
         result = architecture_coherence(inputs="test", outputs=out, expectations=None)
         assert result.value < 1.0
 
-    def test_naming_consistency_out_of_range(self):
-        out = _architecture_output(naming_hierarchy={"consistency_score": 1.5})
+    def test_naming_consistency_negative(self):
+        out = _architecture_output(naming_hierarchy={"consistency_score": -5})
         result = architecture_coherence(inputs="test", outputs=out, expectations=None)
         assert result.value < 1.0
+
+    def test_naming_consistency_100_scale(self):
+        """consistency_score on 0-100 scale should normalize to 0-1."""
+        out = _architecture_output(
+            naming_hierarchy={"consistency_score": 85, "naming_pattern": "endorsed"}
+        )
+        result = architecture_coherence(inputs="test", outputs=out, expectations=None)
+        assert result.value == 1.0  # valid component
 
     def test_none_output(self):
         result = architecture_coherence(inputs="test", outputs=None, expectations=None)

--- a/prompt-optimization-svc/tests/test_wf2_scorers.py
+++ b/prompt-optimization-svc/tests/test_wf2_scorers.py
@@ -1,0 +1,741 @@
+"""Unit tests for WF2 scorers (brand strategy pipeline).
+
+10+ tests per scorer covering perfect, partial, invalid, and edge inputs.
+"""
+
+import json
+
+from app.scorers.wf2.positioning_clarity import positioning_clarity
+from app.scorers.wf2.architecture_coherence import architecture_coherence
+from app.scorers.wf2.voice_consistency import voice_consistency
+from app.scorers.wf2.name_quality import name_quality
+from app.scorers.wf2.narrative_engagement import narrative_engagement
+
+
+# ── helpers ──
+
+
+def _positioning_output(**overrides) -> str:
+    """Build a minimal valid BPA positioning output JSON string."""
+    data = {
+        "recommended_positioning": overrides.get(
+            "recommended_positioning",
+            {
+                "statement": "We are the premium AI-first brand platform.",
+                "target_segment": "SMBs",
+            },
+        ),
+        "canvas": overrides.get(
+            "canvas",
+            {
+                "fit_score": 0.92,
+                "elements": ["value_prop", "differentiator"],
+            },
+        ),
+        "differentiation": overrides.get(
+            "differentiation",
+            {
+                "overall_differentiation_score": 0.88,
+                "factors": ["AI-native", "multi-tenant"],
+            },
+        ),
+    }
+    data.update({k: v for k, v in overrides.items() if k not in data})
+    return json.dumps(data)
+
+
+def _architecture_output(**overrides) -> str:
+    """Build a minimal valid BAA architecture output JSON string."""
+    data = {
+        "recommendation": overrides.get(
+            "recommendation",
+            {
+                "recommended_model": "branded_house",
+                "model_scores": [
+                    {"model": "branded_house", "score": 0.9},
+                    {"model": "house_of_brands", "score": 0.6},
+                ],
+            },
+        ),
+        "hierarchy": overrides.get(
+            "hierarchy",
+            {
+                "root": "Zorven",
+                "total_depth": 3,
+                "branches": ["Platform", "Services"],
+            },
+        ),
+        "naming_hierarchy": overrides.get(
+            "naming_hierarchy",
+            {
+                "consistency_score": 0.85,
+                "naming_pattern": "parent_endorsed",
+            },
+        ),
+    }
+    data.update({k: v for k, v in overrides.items() if k not in data})
+    return json.dumps(data)
+
+
+def _voice_output(**overrides) -> str:
+    """Build a minimal valid BPV voice/personality output JSON string."""
+    data = {
+        "aaker_profile": overrides.get(
+            "aaker_profile",
+            {
+                "dimensions": [
+                    {"name": "Sincerity", "score": 75},
+                    {"name": "Excitement", "score": 85},
+                    {"name": "Competence", "score": 90},
+                    {"name": "Sophistication", "score": 60},
+                    {"name": "Ruggedness", "score": 40},
+                ]
+            },
+        ),
+        "archetype": overrides.get(
+            "archetype",
+            {
+                "primary": "Creator",
+                "resonance_score": 0.91,
+            },
+        ),
+        "values_hierarchy": overrides.get(
+            "values_hierarchy",
+            {
+                "core_values": ["Innovation", "Trust"],
+                "authenticity_score": 0.87,
+            },
+        ),
+    }
+    data.update({k: v for k, v in overrides.items() if k not in data})
+    return json.dumps(data)
+
+
+def _naming_output(**overrides) -> str:
+    """Build a minimal valid NTA naming output JSON string."""
+    data = {
+        "name_candidates": overrides.get(
+            "name_candidates",
+            [
+                {"name": "Lumina", "linguistic_score": 0.9, "brand_fit_score": 0.85},
+                {"name": "Aethon", "linguistic_score": 0.8, "brand_fit_score": 0.75},
+            ],
+        ),
+        "shortlisted_names": overrides.get(
+            "shortlisted_names",
+            ["Lumina", "Aethon"],
+        ),
+        "taglines": overrides.get(
+            "taglines",
+            [
+                {"text": "Build brilliance.", "memorability_score": 0.88},
+                {"text": "Brand, amplified.", "memorability_score": 0.82},
+            ],
+        ),
+    }
+    data.update({k: v for k, v in overrides.items() if k not in data})
+    return json.dumps(data)
+
+
+def _narrative_output(**overrides) -> str:
+    """Build a minimal valid BSA narrative output JSON string."""
+    data = {
+        "origin_story": overrides.get(
+            "origin_story",
+            {
+                "narrative": "Founded in a garage with a vision to democratize AI.",
+                "tone": "inspirational",
+            },
+        ),
+        "mission_vision": overrides.get(
+            "mission_vision",
+            {
+                "mission": "Empower every brand with AI.",
+                "vision": "A world where every brand tells its story.",
+            },
+        ),
+        "pitches": overrides.get(
+            "pitches",
+            {
+                "elevator": "We turn brand chaos into AI-powered clarity.",
+                "investor": "AI brand platform, $50B TAM, 10x efficiency.",
+            },
+        ),
+        "channel_narratives": overrides.get(
+            "channel_narratives",
+            {
+                "social_media": "Short, punchy brand voice.",
+                "website": "Full brand story arc.",
+            },
+        ),
+    }
+    data.update({k: v for k, v in overrides.items() if k not in data})
+    return json.dumps(data)
+
+
+# ── positioning_clarity tests ──
+
+
+class TestPositioningClarity:
+    def test_valid_complete_output(self):
+        result = positioning_clarity(
+            inputs="test", outputs=_positioning_output(), expectations=None
+        )
+        assert result.value >= 0.9
+
+    def test_perfect_scores(self):
+        out = _positioning_output(
+            canvas={"fit_score": 1.0},
+            differentiation={"overall_differentiation_score": 1.0},
+        )
+        result = positioning_clarity(inputs="test", outputs=out, expectations=None)
+        assert result.value == 1.0
+
+    def test_missing_recommended_positioning(self):
+        out = _positioning_output(recommended_positioning={})
+        result = positioning_clarity(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_empty_statement(self):
+        out = _positioning_output(
+            recommended_positioning={"statement": "", "target_segment": "SMBs"}
+        )
+        result = positioning_clarity(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_missing_canvas(self):
+        out = _positioning_output(canvas={})
+        result = positioning_clarity(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_canvas_fit_score_out_of_range(self):
+        out = _positioning_output(canvas={"fit_score": 1.5})
+        result = positioning_clarity(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_missing_differentiation(self):
+        out = _positioning_output(differentiation={})
+        result = positioning_clarity(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_none_output(self):
+        result = positioning_clarity(inputs="test", outputs=None, expectations=None)
+        assert result.value == 0.0
+
+    def test_invalid_json(self):
+        result = positioning_clarity(
+            inputs="test", outputs="not json", expectations=None
+        )
+        assert result.value == 0.0
+
+    def test_dict_input(self):
+        data = json.loads(_positioning_output())
+        result = positioning_clarity(inputs="test", outputs=data, expectations=None)
+        assert result.value >= 0.9
+
+    def test_non_dict_recommended_positioning(self):
+        out = _positioning_output(recommended_positioning="just a string")
+        result = positioning_clarity(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_non_dict_canvas(self):
+        out = _positioning_output(canvas="bad")
+        result = positioning_clarity(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_feedback_name(self):
+        result = positioning_clarity(
+            inputs="test", outputs=_positioning_output(), expectations=None
+        )
+        assert result.name == "positioning_clarity"
+
+    def test_partial_only_positioning(self):
+        out = _positioning_output(canvas={}, differentiation={})
+        result = positioning_clarity(inputs="test", outputs=out, expectations=None)
+        # Only 40% (positioning) should score
+        assert result.value == 0.4
+
+    def test_zero_fit_score(self):
+        out = _positioning_output(
+            canvas={"fit_score": 0.0},
+            differentiation={"overall_differentiation_score": 0.0},
+        )
+        result = positioning_clarity(inputs="test", outputs=out, expectations=None)
+        # 0.4 * 1.0 + 0.3 * 0.0 + 0.3 * 0.0 = 0.4
+        assert result.value == 0.4
+
+    def test_empty_dict_output(self):
+        result = positioning_clarity(
+            inputs="test", outputs=json.dumps({}), expectations=None
+        )
+        assert result.value == 0.0
+
+    def test_non_numeric_fit_score(self):
+        out = _positioning_output(canvas={"fit_score": "high"})
+        result = positioning_clarity(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+
+# ── architecture_coherence tests ──
+
+
+class TestArchitectureCoherence:
+    def test_valid_complete_output(self):
+        result = architecture_coherence(
+            inputs="test", outputs=_architecture_output(), expectations=None
+        )
+        assert result.value == 1.0
+
+    def test_missing_recommendation(self):
+        out = _architecture_output(recommendation={})
+        result = architecture_coherence(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_missing_recommended_model(self):
+        out = _architecture_output(
+            recommendation={"model_scores": [{"model": "x", "score": 0.8}]}
+        )
+        result = architecture_coherence(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_empty_model_scores(self):
+        out = _architecture_output(
+            recommendation={"recommended_model": "branded_house", "model_scores": []}
+        )
+        result = architecture_coherence(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_missing_hierarchy(self):
+        out = _architecture_output(hierarchy={})
+        result = architecture_coherence(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_hierarchy_missing_root(self):
+        out = _architecture_output(hierarchy={"total_depth": 3})
+        result = architecture_coherence(inputs="test", outputs=out, expectations=None)
+        # hierarchy invalid because root is None via .get() -> None, but has_root checks not None
+        # Actually hier.get("root") returns None which is not not-None, so has_root = False
+        assert result.value < 1.0
+
+    def test_hierarchy_missing_depth(self):
+        out = _architecture_output(hierarchy={"root": "Zorven"})
+        result = architecture_coherence(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_missing_naming_hierarchy(self):
+        out = _architecture_output(naming_hierarchy={})
+        result = architecture_coherence(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_naming_consistency_out_of_range(self):
+        out = _architecture_output(naming_hierarchy={"consistency_score": 1.5})
+        result = architecture_coherence(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_none_output(self):
+        result = architecture_coherence(inputs="test", outputs=None, expectations=None)
+        assert result.value == 0.0
+
+    def test_invalid_json(self):
+        result = architecture_coherence(
+            inputs="test", outputs="not json", expectations=None
+        )
+        assert result.value == 0.0
+
+    def test_dict_input(self):
+        data = json.loads(_architecture_output())
+        result = architecture_coherence(inputs="test", outputs=data, expectations=None)
+        assert result.value == 1.0
+
+    def test_non_dict_recommendation(self):
+        out = _architecture_output(recommendation="bad")
+        result = architecture_coherence(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_non_list_model_scores(self):
+        out = _architecture_output(
+            recommendation={"recommended_model": "branded_house", "model_scores": "bad"}
+        )
+        result = architecture_coherence(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_feedback_name(self):
+        result = architecture_coherence(
+            inputs="test", outputs=_architecture_output(), expectations=None
+        )
+        assert result.name == "architecture_coherence"
+
+    def test_partial_one_component(self):
+        out = _architecture_output(recommendation={}, hierarchy={})
+        result = architecture_coherence(inputs="test", outputs=out, expectations=None)
+        # Only naming_hierarchy valid -> 1/3
+        assert result.value == round(1 / 3.0, 4)
+
+    def test_empty_dict_output(self):
+        result = architecture_coherence(
+            inputs="test", outputs=json.dumps({}), expectations=None
+        )
+        assert result.value == 0.0
+
+    def test_non_numeric_consistency_score(self):
+        out = _architecture_output(naming_hierarchy={"consistency_score": "high"})
+        result = architecture_coherence(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+
+# ── voice_consistency tests ──
+
+
+class TestVoiceConsistency:
+    def test_valid_complete_output(self):
+        result = voice_consistency(
+            inputs="test", outputs=_voice_output(), expectations=None
+        )
+        assert result.value == 1.0
+
+    def test_missing_aaker_profile(self):
+        out = _voice_output(aaker_profile={})
+        result = voice_consistency(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_empty_dimensions(self):
+        out = _voice_output(aaker_profile={"dimensions": []})
+        result = voice_consistency(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_dimensions_invalid_score(self):
+        out = _voice_output(
+            aaker_profile={"dimensions": [{"name": "Sincerity", "score": "high"}]}
+        )
+        result = voice_consistency(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_dimensions_score_out_of_range(self):
+        out = _voice_output(
+            aaker_profile={"dimensions": [{"name": "Sincerity", "score": 150}]}
+        )
+        result = voice_consistency(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_dimensions_non_dict_entry(self):
+        out = _voice_output(aaker_profile={"dimensions": ["bad", 42]})
+        result = voice_consistency(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_missing_archetype(self):
+        out = _voice_output(archetype={})
+        result = voice_consistency(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_archetype_resonance_out_of_range(self):
+        out = _voice_output(archetype={"primary": "Creator", "resonance_score": 1.5})
+        result = voice_consistency(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_missing_values_hierarchy(self):
+        out = _voice_output(values_hierarchy={})
+        result = voice_consistency(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_values_hierarchy_non_numeric_authenticity(self):
+        out = _voice_output(values_hierarchy={"authenticity_score": "very authentic"})
+        result = voice_consistency(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_none_output(self):
+        result = voice_consistency(inputs="test", outputs=None, expectations=None)
+        assert result.value == 0.0
+
+    def test_invalid_json(self):
+        result = voice_consistency(inputs="test", outputs="not json", expectations=None)
+        assert result.value == 0.0
+
+    def test_dict_input(self):
+        data = json.loads(_voice_output())
+        result = voice_consistency(inputs="test", outputs=data, expectations=None)
+        assert result.value == 1.0
+
+    def test_non_dict_aaker_profile(self):
+        out = _voice_output(aaker_profile="bad")
+        result = voice_consistency(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_non_dict_archetype(self):
+        out = _voice_output(archetype="bad")
+        result = voice_consistency(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_feedback_name(self):
+        result = voice_consistency(
+            inputs="test", outputs=_voice_output(), expectations=None
+        )
+        assert result.name == "voice_consistency"
+
+    def test_partial_one_component(self):
+        out = _voice_output(aaker_profile={}, archetype={})
+        result = voice_consistency(inputs="test", outputs=out, expectations=None)
+        # Only values_hierarchy valid -> 1/3
+        assert result.value == round(1 / 3.0, 4)
+
+    def test_empty_dict_output(self):
+        result = voice_consistency(
+            inputs="test", outputs=json.dumps({}), expectations=None
+        )
+        assert result.value == 0.0
+
+    def test_single_valid_dimension(self):
+        out = _voice_output(
+            aaker_profile={"dimensions": [{"name": "Sincerity", "score": 80}]}
+        )
+        result = voice_consistency(inputs="test", outputs=out, expectations=None)
+        assert result.value >= round(1 / 3.0, 4)
+
+
+# ── name_quality tests ──
+
+
+class TestNameQuality:
+    def test_valid_complete_output(self):
+        result = name_quality(
+            inputs="test", outputs=_naming_output(), expectations=None
+        )
+        assert result.value == 1.0
+
+    def test_missing_name_candidates(self):
+        out = _naming_output(name_candidates=[])
+        result = name_quality(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_candidates_no_score_fields(self):
+        out = _naming_output(name_candidates=[{"name": "Lumina", "meaning": "light"}])
+        result = name_quality(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_candidates_non_dict_entries(self):
+        out = _naming_output(name_candidates=["bad", 42])
+        result = name_quality(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_missing_shortlisted_names(self):
+        out = _naming_output(shortlisted_names=[])
+        result = name_quality(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_missing_taglines(self):
+        out = _naming_output(taglines=[])
+        result = name_quality(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_taglines_no_memorability(self):
+        out = _naming_output(taglines=[{"text": "Build brilliance.", "impact": "high"}])
+        result = name_quality(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_taglines_non_dict_entries(self):
+        out = _naming_output(taglines=["just a string"])
+        result = name_quality(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_none_output(self):
+        result = name_quality(inputs="test", outputs=None, expectations=None)
+        assert result.value == 0.0
+
+    def test_invalid_json(self):
+        result = name_quality(inputs="test", outputs="not json", expectations=None)
+        assert result.value == 0.0
+
+    def test_dict_input(self):
+        data = json.loads(_naming_output())
+        result = name_quality(inputs="test", outputs=data, expectations=None)
+        assert result.value == 1.0
+
+    def test_non_list_name_candidates(self):
+        out = _naming_output(name_candidates="bad")
+        result = name_quality(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_non_list_shortlisted(self):
+        out = _naming_output(shortlisted_names="bad")
+        result = name_quality(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_non_list_taglines(self):
+        out = _naming_output(taglines="bad")
+        result = name_quality(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_feedback_name(self):
+        result = name_quality(
+            inputs="test", outputs=_naming_output(), expectations=None
+        )
+        assert result.name == "name_quality"
+
+    def test_partial_only_shortlisted(self):
+        out = _naming_output(
+            name_candidates=[],
+            taglines=[],
+        )
+        result = name_quality(inputs="test", outputs=out, expectations=None)
+        # Only shortlisted_names valid -> 1/3
+        assert result.value == round(1 / 3.0, 4)
+
+    def test_empty_dict_output(self):
+        result = name_quality(inputs="test", outputs=json.dumps({}), expectations=None)
+        assert result.value == 0.0
+
+    def test_proportional_two_of_three(self):
+        out = _naming_output(taglines=[])
+        result = name_quality(inputs="test", outputs=out, expectations=None)
+        # name_candidates + shortlisted -> 2/3
+        assert result.value == round(2 / 3.0, 4)
+
+
+# ── narrative_engagement tests ──
+
+
+class TestNarrativeEngagement:
+    def test_valid_complete_output(self):
+        result = narrative_engagement(
+            inputs="test", outputs=_narrative_output(), expectations=None
+        )
+        assert result.value == 1.0
+
+    def test_missing_origin_story(self):
+        out = _narrative_output(origin_story=None)
+        result = narrative_engagement(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_missing_mission_vision(self):
+        out = _narrative_output(mission_vision=None)
+        result = narrative_engagement(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_missing_pitches(self):
+        out = _narrative_output(pitches=None)
+        result = narrative_engagement(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_missing_channel_narratives(self):
+        out = _narrative_output(channel_narratives=None)
+        result = narrative_engagement(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_pitches_as_list(self):
+        out = _narrative_output(pitches=["Elevator pitch here", "Investor pitch here"])
+        result = narrative_engagement(inputs="test", outputs=out, expectations=None)
+        assert result.value == 1.0
+
+    def test_non_dict_origin_story(self):
+        out = _narrative_output(origin_story="just a string")
+        result = narrative_engagement(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_non_dict_channel_narratives(self):
+        out = _narrative_output(channel_narratives="bad")
+        result = narrative_engagement(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_non_dict_or_list_pitches(self):
+        out = _narrative_output(pitches=42)
+        result = narrative_engagement(inputs="test", outputs=out, expectations=None)
+        assert result.value < 1.0
+
+    def test_none_output(self):
+        result = narrative_engagement(inputs="test", outputs=None, expectations=None)
+        assert result.value == 0.0
+
+    def test_invalid_json(self):
+        result = narrative_engagement(
+            inputs="test", outputs="not json", expectations=None
+        )
+        assert result.value == 0.0
+
+    def test_dict_input(self):
+        data = json.loads(_narrative_output())
+        result = narrative_engagement(inputs="test", outputs=data, expectations=None)
+        assert result.value == 1.0
+
+    def test_feedback_name(self):
+        result = narrative_engagement(
+            inputs="test", outputs=_narrative_output(), expectations=None
+        )
+        assert result.name == "narrative_engagement"
+
+    def test_partial_two_sections(self):
+        out = _narrative_output(origin_story=None, mission_vision=None)
+        result = narrative_engagement(inputs="test", outputs=out, expectations=None)
+        # pitches + channel_narratives -> 2/4
+        assert result.value == 0.5
+
+    def test_partial_one_section(self):
+        out = _narrative_output(origin_story=None, mission_vision=None, pitches=None)
+        result = narrative_engagement(inputs="test", outputs=out, expectations=None)
+        assert result.value == 0.25
+
+    def test_empty_dict_output(self):
+        result = narrative_engagement(
+            inputs="test", outputs=json.dumps({}), expectations=None
+        )
+        assert result.value == 0.0
+
+    def test_all_sections_missing(self):
+        out = _narrative_output(
+            origin_story=None,
+            mission_vision=None,
+            pitches=None,
+            channel_narratives=None,
+        )
+        result = narrative_engagement(inputs="test", outputs=out, expectations=None)
+        assert result.value == 0.0
+
+
+# ── WF2 Scorer conformance ──
+
+
+class TestWf2ScorerConformance:
+    def test_all_are_scorer_instances(self):
+        from mlflow.genai.scorers import Scorer
+
+        for s in [
+            positioning_clarity,
+            architecture_coherence,
+            voice_consistency,
+            name_quality,
+            narrative_engagement,
+        ]:
+            assert isinstance(s, Scorer), f"{s.name} is not a Scorer"
+
+    def test_all_accept_keyword_args(self):
+        pairs = [
+            (positioning_clarity, _positioning_output),
+            (architecture_coherence, _architecture_output),
+            (voice_consistency, _voice_output),
+            (name_quality, _naming_output),
+            (narrative_engagement, _narrative_output),
+        ]
+        for s, helper in pairs:
+            result = s(inputs="test", outputs=helper(), expectations=None)
+            assert result is not None, f"{s.name} returned None"
+
+    def test_all_return_correct_feedback_names(self):
+        pairs = [
+            (positioning_clarity, _positioning_output, "positioning_clarity"),
+            (architecture_coherence, _architecture_output, "architecture_coherence"),
+            (voice_consistency, _voice_output, "voice_consistency"),
+            (name_quality, _naming_output, "name_quality"),
+            (narrative_engagement, _narrative_output, "narrative_engagement"),
+        ]
+        for s, helper, expected in pairs:
+            result = s(inputs="test", outputs=helper(), expectations=None)
+            assert result.name == expected, f"Expected {expected}, got {result.name}"
+
+    def test_all_handle_none_output(self):
+        for s in [
+            positioning_clarity,
+            architecture_coherence,
+            voice_consistency,
+            name_quality,
+            narrative_engagement,
+        ]:
+            result = s(inputs="test", outputs=None, expectations=None)
+            assert result.value == 0.0, f"{s.name} did not return 0.0 for None output"


### PR DESCRIPTION
## Summary

Completes EPIC-6 (Custom Scorer Library) with 12 domain-specific scorers across all workflows:

**WF1 scorers** (`app/scorers/wf1/`):
- `market_completeness` — TAM/SAM/SOM, competitive landscape, industry trends
- `competitor_accuracy` — competitor profiles with SWOT, positioning gaps
- `persona_quality` — demographics+psychographics completeness, journey maps
- `trend_relevance` — scored trends (0-100 relevance), opportunity alerts
- `voca_sentiment` — sentiment analysis, NPS, pain point priority matrix

**WF2 scorers** (`app/scorers/wf2/`):
- `positioning_clarity` — positioning statement, VPC fit_score, differentiation
- `architecture_coherence` — model scores (4 dims), hierarchy, naming consistency
- `voice_consistency` — Aaker dimensions (0-100), archetype resonance, values authenticity
- `name_quality` — candidate scores, shortlist, tagline memorability
- `narrative_engagement` — origin story, mission/vision, pitches, channel narratives

**ILA scorers** (`app/scorers/ila/`):
- `learning_depth` — learning confidence (0-100), impact levels, contradictions
- `meta_policy` — plan warnings, published campaign, sandbox mode

All scorers conform to `mlflow.genai.scorer` signature (AC-3) and return `{score, justification}` Feedback (AC-2).

## Test plan

- [x] 208 unit tests (10+ per scorer: perfect/invalid/partial/edge) (AC-1)
- [x] 24 Hypothesis property tests (score ranges, never-raises)
- [x] 6 integration tests (MLflow Scorer instance checks, list counts)
- [x] Full suite: 1192 passed, 29 skipped
- [x] Black formatting verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)