### PR TITLE
feat(gepa): configurable golden dataset size min=3/max=50/default=10 (US-029)

### DIFF
--- a/prompt-optimization-svc/app/api/routes.py
+++ b/prompt-optimization-svc/app/api/routes.py
@@ -499,3 +499,66 @@ async def generate_synthetic_datasets(request: SyntheticGenerateRequest):
         ],
         total=len(examples),
     )
+
+
+@router.get("/v1/config/dataset-size", response_model=None)
+async def get_dataset_size(
+    x_tenant_id: str = Header(default=None, alias="X-Tenant-ID"),
+):
+    """Get the golden dataset size limit for a tenant."""
+    from app.api.schemas import DatasetSizeConfigResponse
+    from app.cache.prompt_cache import PromptCacheManager
+    from app.cache.tenant_config import (
+        MAX_DATASET_SIZE,
+        MIN_DATASET_SIZE,
+        TenantConfigManager,
+    )
+    from app.core.config import settings
+
+    cache = PromptCacheManager(redis_url=settings.PROMPT_CACHE_REDIS_URL)
+    await cache.connect()
+    try:
+        mgr = TenantConfigManager(cache)
+        size = await mgr.get_golden_dataset_size(x_tenant_id)
+        return DatasetSizeConfigResponse(
+            tenant_id=x_tenant_id or "default",
+            size=size,
+            min_size=MIN_DATASET_SIZE,
+            max_size=MAX_DATASET_SIZE,
+        )
+    finally:
+        await cache.close()
+
+
+@router.put("/v1/config/dataset-size", response_model=None)
+async def set_dataset_size(
+    request: "DatasetSizeConfigRequest",
+    x_tenant_id: str = Header(default="default", alias="X-Tenant-ID"),
+):
+    """Set the golden dataset size limit for a tenant (AC-3: validates [3, 50])."""
+    from app.api.schemas import (
+        DatasetSizeConfigRequest,
+        DatasetSizeConfigResponse,
+    )
+    from app.cache.prompt_cache import PromptCacheManager
+    from app.cache.tenant_config import (
+        MAX_DATASET_SIZE,
+        MIN_DATASET_SIZE,
+        TenantConfigManager,
+    )
+    from app.core.config import settings
+
+    cache = PromptCacheManager(redis_url=settings.PROMPT_CACHE_REDIS_URL)
+    await cache.connect()
+    try:
+        mgr = TenantConfigManager(cache)
+        await mgr.set_golden_dataset_size(x_tenant_id, request.size)
+        size = await mgr.get_golden_dataset_size(x_tenant_id)
+        return DatasetSizeConfigResponse(
+            tenant_id=x_tenant_id,
+            size=size,
+            min_size=MIN_DATASET_SIZE,
+            max_size=MAX_DATASET_SIZE,
+        )
+    finally:
+        await cache.close()

--- a/prompt-optimization-svc/app/api/schemas.py
+++ b/prompt-optimization-svc/app/api/schemas.py
@@ -267,3 +267,18 @@ class SyntheticGenerateResponse(BaseModel):
 
     examples: list[dict[str, Any]] = Field(default_factory=list)
     total: int = 0
+
+
+class DatasetSizeConfigRequest(BaseModel):
+    """Request for PUT /v1/config/dataset-size."""
+
+    size: int = Field(..., ge=3, le=50, description="Dataset size [3, 50]")
+
+
+class DatasetSizeConfigResponse(BaseModel):
+    """Response for dataset size configuration."""
+
+    tenant_id: str = ""
+    size: int = 10
+    min_size: int = 3
+    max_size: int = 50

--- a/prompt-optimization-svc/app/cache/tenant_config.py
+++ b/prompt-optimization-svc/app/cache/tenant_config.py
@@ -15,23 +15,31 @@ DEFAULT_TTL = 300
 MIN_TTL = 10
 MAX_TTL = 3600
 
+DEFAULT_DATASET_SIZE = 10
+MIN_DATASET_SIZE = 3
+MAX_DATASET_SIZE = 50
+
 
 def clamp_ttl(ttl: int) -> int:
     """Clamp TTL to [MIN_TTL, MAX_TTL] inclusive."""
     return max(MIN_TTL, min(MAX_TTL, ttl))
 
 
+def clamp_dataset_size(size: int) -> int:
+    """Clamp dataset size to [MIN_DATASET_SIZE, MAX_DATASET_SIZE] inclusive."""
+    return max(MIN_DATASET_SIZE, min(MAX_DATASET_SIZE, size))
+
+
 class TenantConfigManager:
     """Read/write per-tenant configuration from Redis."""
 
     CONFIG_KEY_TEMPLATE = "tenant:{tenant_id}:config.prompt_cache_ttl_seconds"
+    DATASET_SIZE_KEY_TEMPLATE = "tenant:{tenant_id}:config.golden_dataset_default_size"
 
     def __init__(self, prompt_cache: PromptCacheManager) -> None:
         self.prompt_cache = prompt_cache
 
-    async def get_prompt_cache_ttl(
-        self, tenant_id: Optional[str] = None
-    ) -> int:
+    async def get_prompt_cache_ttl(self, tenant_id: Optional[str] = None) -> int:
         """Get the prompt cache TTL for a tenant.
 
         Returns the tenant-specific TTL clamped to [10, 3600],
@@ -55,9 +63,7 @@ class TenantConfigManager:
             )
             return DEFAULT_TTL
 
-    async def set_prompt_cache_ttl(
-        self, tenant_id: str, ttl: int
-    ) -> None:
+    async def set_prompt_cache_ttl(self, tenant_id: str, ttl: int) -> None:
         """Set the prompt cache TTL for a tenant.
 
         Value is clamped to [10, 3600] before storing (AC-1).
@@ -76,6 +82,53 @@ class TenantConfigManager:
         except Exception as exc:
             logger.warning(
                 "Failed to set tenant TTL config for %s: %s",
+                tenant_id,
+                exc,
+            )
+
+    async def get_golden_dataset_size(self, tenant_id: Optional[str] = None) -> int:
+        """Get the golden dataset size limit for a tenant.
+
+        Returns the tenant-specific size clamped to [3, 50],
+        or 10 if no tenant config exists.
+        """
+        if not tenant_id:
+            return DEFAULT_DATASET_SIZE
+
+        try:
+            r = await self.prompt_cache.connect()
+            key = self.DATASET_SIZE_KEY_TEMPLATE.format(tenant_id=tenant_id)
+            value = await r.get(key)
+            if value is None:
+                return DEFAULT_DATASET_SIZE
+            return clamp_dataset_size(int(value))
+        except Exception as exc:
+            logger.warning(
+                "Failed to read tenant dataset size for %s: %s",
+                tenant_id,
+                exc,
+            )
+            return DEFAULT_DATASET_SIZE
+
+    async def set_golden_dataset_size(self, tenant_id: str, size: int) -> None:
+        """Set the golden dataset size limit for a tenant.
+
+        Value is clamped to [3, 50] before storing (AC-3).
+        """
+        clamped = clamp_dataset_size(size)
+        try:
+            r = await self.prompt_cache.connect()
+            key = self.DATASET_SIZE_KEY_TEMPLATE.format(tenant_id=tenant_id)
+            await r.set(key, str(clamped))
+            logger.info(
+                "Tenant dataset size set: %s = %d (requested %d)",
+                tenant_id,
+                clamped,
+                size,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Failed to set tenant dataset size for %s: %s",
                 tenant_id,
                 exc,
             )

--- a/prompt-optimization-svc/app/datasets/sampler.py
+++ b/prompt-optimization-svc/app/datasets/sampler.py
@@ -1,0 +1,90 @@
+"""Golden dataset sampler with stratified selection and size validation.
+
+When dataset > max, stratified sampling preserves diversity.
+When dataset < min, raises InsufficientDatasetError.
+"""
+
+import logging
+from collections import defaultdict
+
+from app.datasets.golden_seed import GoldenExample
+
+logger = logging.getLogger(__name__)
+
+
+class InsufficientDatasetError(Exception):
+    """Raised when the dataset has fewer examples than the minimum required."""
+
+    def __init__(self, actual: int, minimum: int):
+        self.actual = actual
+        self.minimum = minimum
+        super().__init__(
+            f"Insufficient golden dataset: {actual} examples available, "
+            f"minimum {minimum} required. Add more examples before "
+            f"running optimization."
+        )
+
+
+def validate_dataset_size(examples: list, min_size: int) -> None:
+    """Validate that the dataset meets the minimum size requirement.
+
+    Args:
+        examples: List of golden examples.
+        min_size: Minimum required count.
+
+    Raises:
+        InsufficientDatasetError: If len(examples) < min_size (AC-1).
+    """
+    if len(examples) < min_size:
+        raise InsufficientDatasetError(actual=len(examples), minimum=min_size)
+
+
+def select_golden_examples(
+    examples: list[GoldenExample],
+    max_size: int,
+) -> list[GoldenExample]:
+    """Select up to max_size examples using stratified sampling.
+
+    When len(examples) <= max_size, returns all examples.
+    When len(examples) > max_size, performs stratified sampling by
+    (industry, brand_maturity) to preserve diversity (AC-2).
+
+    Args:
+        examples: Full list of golden examples.
+        max_size: Maximum number to return.
+
+    Returns:
+        List of at most max_size GoldenExamples.
+    """
+    if not examples:
+        return []
+
+    if len(examples) <= max_size:
+        return list(examples)
+
+    # Group by (industry, brand_maturity) for stratified sampling
+    groups: dict[tuple[str, str], list[GoldenExample]] = defaultdict(list)
+    for ex in examples:
+        industry = ex.metadata_extra.get("industry", "unknown")
+        maturity = ex.metadata_extra.get("brand_maturity", "unknown")
+        groups[(industry, maturity)].append(ex)
+
+    # Round-robin select from each group
+    selected: list[GoldenExample] = []
+    group_keys = sorted(groups.keys())
+    group_indices = {k: 0 for k in group_keys}
+
+    while len(selected) < max_size:
+        added_this_round = False
+        for key in group_keys:
+            if len(selected) >= max_size:
+                break
+            idx = group_indices[key]
+            if idx < len(groups[key]):
+                selected.append(groups[key][idx])
+                group_indices[key] = idx + 1
+                added_this_round = True
+        if not added_this_round:
+            break
+
+    return selected

--- a/prompt-optimization-svc/tests/integration/test_dataset_size_config.py
+++ b/prompt-optimization-svc/tests/integration/test_dataset_size_config.py
@@ -1,0 +1,72 @@
+"""Integration tests for dataset size configuration (US-029).
+
+Requires real Redis.
+"""
+
+import pytest
+
+from .conftest import REDIS_URL, requires_redis
+
+
+@requires_redis
+class TestDatasetSizeRedis:
+    """Dataset size config with real Redis."""
+
+    async def test_get_default_without_config(self, real_redis):
+        from app.cache.prompt_cache import PromptCacheManager
+        from app.cache.tenant_config import DEFAULT_DATASET_SIZE, TenantConfigManager
+
+        cache = PromptCacheManager(redis_url=REDIS_URL)
+        await cache.connect()
+        try:
+            mgr = TenantConfigManager(cache)
+            size = await mgr.get_golden_dataset_size("__test_no_config")
+            assert size == DEFAULT_DATASET_SIZE
+        finally:
+            await cache.close()
+
+    async def test_set_and_get(self, real_redis):
+        from app.cache.prompt_cache import PromptCacheManager
+        from app.cache.tenant_config import TenantConfigManager
+
+        cache = PromptCacheManager(redis_url=REDIS_URL)
+        await cache.connect()
+        try:
+            mgr = TenantConfigManager(cache)
+            await mgr.set_golden_dataset_size("__test_ds_size", 25)
+            size = await mgr.get_golden_dataset_size("__test_ds_size")
+            assert size == 25
+        finally:
+            # Cleanup
+            r = await cache.connect()
+            await r.delete("tenant:__test_ds_size:config.golden_dataset_default_size")
+            await cache.close()
+
+    async def test_clamped_value_stored(self, real_redis):
+        from app.cache.prompt_cache import PromptCacheManager
+        from app.cache.tenant_config import MAX_DATASET_SIZE, TenantConfigManager
+
+        cache = PromptCacheManager(redis_url=REDIS_URL)
+        await cache.connect()
+        try:
+            mgr = TenantConfigManager(cache)
+            await mgr.set_golden_dataset_size("__test_ds_clamp", 999)
+            size = await mgr.get_golden_dataset_size("__test_ds_clamp")
+            assert size == MAX_DATASET_SIZE
+        finally:
+            r = await cache.connect()
+            await r.delete("tenant:__test_ds_clamp:config.golden_dataset_default_size")
+            await cache.close()
+
+    async def test_no_tenant_returns_default(self, real_redis):
+        from app.cache.prompt_cache import PromptCacheManager
+        from app.cache.tenant_config import DEFAULT_DATASET_SIZE, TenantConfigManager
+
+        cache = PromptCacheManager(redis_url=REDIS_URL)
+        await cache.connect()
+        try:
+            mgr = TenantConfigManager(cache)
+            size = await mgr.get_golden_dataset_size(None)
+            assert size == DEFAULT_DATASET_SIZE
+        finally:
+            await cache.close()

--- a/prompt-optimization-svc/tests/test_dataset_size_config.py
+++ b/prompt-optimization-svc/tests/test_dataset_size_config.py
@@ -1,0 +1,144 @@
+"""Unit tests for configurable golden dataset size (US-029)."""
+
+import pytest
+
+from app.cache.tenant_config import (
+    DEFAULT_DATASET_SIZE,
+    MAX_DATASET_SIZE,
+    MIN_DATASET_SIZE,
+    clamp_dataset_size,
+)
+from app.datasets.golden_seed import GoldenExample
+from app.datasets.sampler import (
+    InsufficientDatasetError,
+    select_golden_examples,
+    validate_dataset_size,
+)
+
+
+def _make_example(industry="SaaS/Technology", maturity="new", idx=0):
+    return GoldenExample(
+        prompt_name=f"zorven-wf1-mra-system",
+        agent_code="mra",
+        input_context={"context_brand_name": f"Brand{idx}"},
+        expected_output=f"Output {idx}",
+        source="manual",
+        metadata_extra={"industry": industry, "brand_maturity": maturity},
+    )
+
+
+class TestClampDatasetSize:
+    def test_below_min(self):
+        assert clamp_dataset_size(1) == MIN_DATASET_SIZE
+
+    def test_above_max(self):
+        assert clamp_dataset_size(100) == MAX_DATASET_SIZE
+
+    def test_in_range(self):
+        assert clamp_dataset_size(25) == 25
+
+    def test_at_min_boundary(self):
+        assert clamp_dataset_size(3) == 3
+
+    def test_at_max_boundary(self):
+        assert clamp_dataset_size(50) == 50
+
+    def test_zero(self):
+        assert clamp_dataset_size(0) == MIN_DATASET_SIZE
+
+    def test_negative(self):
+        assert clamp_dataset_size(-5) == MIN_DATASET_SIZE
+
+
+class TestConstants:
+    def test_default_size(self):
+        assert DEFAULT_DATASET_SIZE == 10
+
+    def test_min_size(self):
+        assert MIN_DATASET_SIZE == 3
+
+    def test_max_size(self):
+        assert MAX_DATASET_SIZE == 50
+
+
+class TestValidateDatasetSize:
+    """AC-1: Optimization run aborts when dataset < min."""
+
+    def test_below_min_raises(self):
+        with pytest.raises(InsufficientDatasetError) as exc_info:
+            validate_dataset_size([1, 2], min_size=3)
+        assert exc_info.value.actual == 2
+        assert exc_info.value.minimum == 3
+
+    def test_at_min_passes(self):
+        validate_dataset_size([1, 2, 3], min_size=3)  # Should not raise
+
+    def test_above_min_passes(self):
+        validate_dataset_size([1, 2, 3, 4, 5], min_size=3)
+
+    def test_empty_raises(self):
+        with pytest.raises(InsufficientDatasetError):
+            validate_dataset_size([], min_size=3)
+
+    def test_error_message_clear(self):
+        with pytest.raises(
+            InsufficientDatasetError, match="Insufficient golden dataset"
+        ):
+            validate_dataset_size([1], min_size=3)
+
+    def test_error_includes_counts(self):
+        with pytest.raises(InsufficientDatasetError, match="1 examples.*minimum 3"):
+            validate_dataset_size([1], min_size=3)
+
+
+class TestSelectGoldenExamples:
+    """AC-2: When dataset > max, stratified sampling selects max."""
+
+    def test_below_max_returns_all(self):
+        examples = [_make_example(idx=i) for i in range(5)]
+        result = select_golden_examples(examples, max_size=10)
+        assert len(result) == 5
+
+    def test_at_max_returns_all(self):
+        examples = [_make_example(idx=i) for i in range(10)]
+        result = select_golden_examples(examples, max_size=10)
+        assert len(result) == 10
+
+    def test_above_max_returns_exactly_max(self):
+        examples = [_make_example(idx=i) for i in range(60)]
+        result = select_golden_examples(examples, max_size=50)
+        assert len(result) == 50
+
+    def test_stratified_preserves_diversity(self):
+        industries = ["SaaS/Technology", "Healthcare/Wellness", "Financial Services"]
+        examples = []
+        for i, ind in enumerate(industries):
+            for j in range(20):
+                examples.append(_make_example(industry=ind, idx=i * 20 + j))
+        result = select_golden_examples(examples, max_size=9)
+        result_industries = {e.metadata_extra["industry"] for e in result}
+        # All 3 industries should be represented
+        assert len(result_industries) == 3
+
+    def test_empty_list_returns_empty(self):
+        result = select_golden_examples([], max_size=10)
+        assert result == []
+
+    def test_single_example(self):
+        examples = [_make_example()]
+        result = select_golden_examples(examples, max_size=10)
+        assert len(result) == 1
+
+    def test_stratified_by_maturity(self):
+        examples = []
+        for maturity in ["new", "emerging", "established"]:
+            for i in range(10):
+                examples.append(_make_example(maturity=maturity, idx=i))
+        result = select_golden_examples(examples, max_size=6)
+        maturities = {e.metadata_extra["brand_maturity"] for e in result}
+        assert len(maturities) >= 2  # At least 2 maturities represented
+
+    def test_returns_list_not_generator(self):
+        examples = [_make_example(idx=i) for i in range(5)]
+        result = select_golden_examples(examples, max_size=10)
+        assert isinstance(result, list)

--- a/prompt-optimization-svc/tests/test_dataset_size_properties.py
+++ b/prompt-optimization-svc/tests/test_dataset_size_properties.py
@@ -1,0 +1,65 @@
+"""Hypothesis property tests for dataset size configuration (US-029)."""
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from app.cache.tenant_config import (
+    MAX_DATASET_SIZE,
+    MIN_DATASET_SIZE,
+    clamp_dataset_size,
+)
+from app.datasets.golden_seed import GoldenExample
+from app.datasets.sampler import (
+    InsufficientDatasetError,
+    select_golden_examples,
+    validate_dataset_size,
+)
+
+
+def _make_example(idx=0):
+    return GoldenExample(
+        prompt_name="zorven-wf1-mra-system",
+        agent_code="mra",
+        input_context={"context_brand_name": f"Brand{idx}"},
+        expected_output=f"Output {idx}",
+        source="manual",
+        metadata_extra={"industry": "SaaS/Technology", "brand_maturity": "new"},
+    )
+
+
+class TestClampProperties:
+    @given(st.integers(min_value=-1000, max_value=1000))
+    @settings(max_examples=100, deadline=None)
+    def test_always_in_range(self, size):
+        result = clamp_dataset_size(size)
+        assert MIN_DATASET_SIZE <= result <= MAX_DATASET_SIZE
+
+    @given(st.integers(min_value=MIN_DATASET_SIZE, max_value=MAX_DATASET_SIZE))
+    @settings(max_examples=50, deadline=None)
+    def test_in_range_unchanged(self, size):
+        assert clamp_dataset_size(size) == size
+
+
+class TestSelectProperties:
+    @given(st.integers(min_value=1, max_value=100))
+    @settings(max_examples=50, deadline=None)
+    def test_never_exceeds_max(self, max_size):
+        examples = [_make_example(idx=i) for i in range(200)]
+        result = select_golden_examples(examples, max_size=max_size)
+        assert len(result) <= max_size
+
+    @given(st.integers(min_value=1, max_value=100))
+    @settings(max_examples=50, deadline=None)
+    def test_never_exceeds_input(self, max_size):
+        examples = [_make_example(idx=i) for i in range(5)]
+        result = select_golden_examples(examples, max_size=max_size)
+        assert len(result) <= len(examples)
+
+
+class TestValidateProperties:
+    @given(st.integers(min_value=3, max_value=100))
+    @settings(max_examples=50, deadline=None)
+    def test_at_or_above_min_never_raises(self, count):
+        examples = list(range(count))
+        validate_dataset_size(examples, min_size=3)  # Should not raise


### PR DESCRIPTION
## Summary

Final story in EPIC-7 (Golden Evaluation Datasets). Exposes tenant-configurable golden dataset size via Redis:

- **tenant_config.py**: `clamp_dataset_size()` + `get/set_golden_dataset_size()` with Redis key `tenant:{tid}:config.golden_dataset_default_size`
- **sampler.py**: `validate_dataset_size()` raises `InsufficientDatasetError` when dataset < 3 (AC-1); `select_golden_examples()` performs stratified sampling by (industry, brand_maturity) when > 50 (AC-2)
- **Schema**: `DatasetSizeConfigRequest` with `ge=3, le=50` Pydantic validation (AC-3)
- **API**: `GET/PUT /v1/config/dataset-size` with X-Tenant-ID header

**Completes EPIC-7** — all 4 stories (US-026 through US-029) implemented.

## Test plan

- [x] 24 unit tests (clamp, validate, select, stratified sampling, error messages)
- [x] 5 Hypothesis property tests (clamp range, select max, validate threshold)
- [x] 4 integration tests (Redis get/set/clamp/default)
- [x] Full suite: 1284 passed, 38 skipped
- [x] Black formatting verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)