### PR TITLE
feat(gepa): implement OPT-11 placeholder invariance guardrail (US-030)

### DIFF
--- a/prompt-optimization-svc/app/logic/gepa_guardrails.py
+++ b/prompt-optimization-svc/app/logic/gepa_guardrails.py
@@ -1,0 +1,48 @@
+"""GEPA mutation guardrails (OPT-11).
+
+Validates GEPA candidate templates against the original to ensure
+placeholder invariance and template-context separation.
+"""
+
+import logging
+
+from app.logic.placeholder_validator import (
+    PlaceholderInvarianceResult,
+    validate_placeholder_invariance,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def check_gepa_mutation(
+    original_template: str,
+    candidate_template: str,
+) -> tuple[bool, PlaceholderInvarianceResult]:
+    """Check whether a GEPA mutation candidate should be accepted.
+
+    A candidate is rejected if it removes any placeholder from the
+    original template. New placeholders flag the candidate for
+    human review but do not cause rejection.
+
+    Args:
+        original_template: The original prompt template.
+        candidate_template: The GEPA-generated candidate template.
+
+    Returns:
+        Tuple of (accepted, result). accepted=False if placeholders removed.
+    """
+    result = validate_placeholder_invariance(original_template, candidate_template)
+
+    if not result.valid:
+        logger.error(
+            "OPT-11: GEPA candidate REJECTED — removed placeholders: %s",
+            ", ".join(sorted(result.removed)),
+        )
+    elif result.needs_review:
+        logger.warning(
+            "OPT-11: GEPA candidate accepted but FLAGGED FOR REVIEW — "
+            "new placeholders: %s",
+            ", ".join(sorted(result.added)),
+        )
+
+    return result.valid, result

--- a/prompt-optimization-svc/app/logic/placeholder_validator.py
+++ b/prompt-optimization-svc/app/logic/placeholder_validator.py
@@ -1,15 +1,22 @@
-"""Template placeholder validation (AC-2).
+"""Template placeholder validation (AC-2) and invariance guardrail (OPT-11).
 
 Ensures prompt templates only contain {context.*} placeholders,
 preventing PII from being baked into optimization snapshots.
 
+Also validates placeholder invariance across GEPA mutations — rejecting
+candidates that drop original placeholders and flagging new ones.
+
 Handles both Python {var} and MLflow {{var}} placeholder syntax.
 """
 
+import logging
 import re
+from dataclasses import dataclass, field
 from typing import Optional
 
 from app.registries.context_variables import VALID_PLACEHOLDER_NAMES
+
+logger = logging.getLogger(__name__)
 
 # Match {word.word} (single brace)
 _SINGLE_BRACE_PATTERN = re.compile(r"(?<!\{)\{([\w.]+)\}(?!\})")
@@ -61,3 +68,59 @@ def validate_template_placeholders(
             )
 
     return violations
+
+
+@dataclass
+class PlaceholderInvarianceResult:
+    """Result of placeholder invariance validation (OPT-11)."""
+
+    valid: bool = True
+    removed: set[str] = field(default_factory=set)
+    added: set[str] = field(default_factory=set)
+    needs_review: bool = False
+    original_count: int = 0
+    mutated_count: int = 0
+
+
+def validate_placeholder_invariance(
+    original: str,
+    mutated: str,
+) -> PlaceholderInvarianceResult:
+    """Validate that a GEPA mutation preserves all original placeholders.
+
+    Args:
+        original: The original prompt template.
+        mutated: The GEPA-mutated candidate template.
+
+    Returns:
+        PlaceholderInvarianceResult with:
+        - valid=False if any placeholder was removed (AC-2)
+        - needs_review=True if new placeholders were added (AC-3)
+    """
+    original_ph = extract_placeholders(original)
+    mutated_ph = extract_placeholders(mutated)
+
+    removed = original_ph - mutated_ph
+    added = mutated_ph - original_ph
+
+    if removed:
+        logger.error(
+            "OPT-11: GEPA mutation removed placeholders: %s",
+            ", ".join(sorted(removed)),
+        )
+
+    if added:
+        logger.warning(
+            "OPT-11: GEPA mutation introduced new placeholders "
+            "(flagged for review): %s",
+            ", ".join(sorted(added)),
+        )
+
+    return PlaceholderInvarianceResult(
+        valid=len(removed) == 0,
+        removed=removed,
+        added=added,
+        needs_review=len(added) > 0,
+        original_count=len(original_ph),
+        mutated_count=len(mutated_ph),
+    )

--- a/prompt-optimization-svc/tests/integration/test_placeholder_invariance.py
+++ b/prompt-optimization-svc/tests/integration/test_placeholder_invariance.py
@@ -1,0 +1,58 @@
+"""Integration tests for placeholder invariance (US-030).
+
+Validates against real prompt catalog templates.
+"""
+
+from app.logic.gepa_guardrails import check_gepa_mutation
+from app.logic.placeholder_validator import validate_placeholder_invariance
+from app.registries.prompt_catalog import PROMPT_CATALOG
+
+
+class TestCatalogInvariance:
+    """Each catalog template should be invariant with itself."""
+
+    def test_all_48_templates_self_invariant(self):
+        for entry in PROMPT_CATALOG:
+            result = validate_placeholder_invariance(entry.template, entry.template)
+            assert (
+                result.valid is True
+            ), f"Template {entry.name} failed self-invariance check"
+            assert result.removed == set()
+            assert result.added == set()
+
+    def test_catalog_template_mutation_removal_detected(self):
+        """Simulate a GEPA mutation that strips a placeholder."""
+        entry = PROMPT_CATALOG[0]
+        # Remove all placeholder tokens from template
+        mutated = entry.template
+        import re
+
+        mutated = re.sub(r"\{\{[\w.]+\}\}", "REMOVED", mutated)
+        mutated = re.sub(r"(?<!\{)\{([\w.]+)\}(?!\})", "REMOVED", mutated)
+
+        result = validate_placeholder_invariance(entry.template, mutated)
+        # Only fail if the original actually had placeholders
+        from app.logic.placeholder_validator import extract_placeholders
+
+        original_ph = extract_placeholders(entry.template)
+        if original_ph:
+            assert result.valid is False
+            assert len(result.removed) > 0
+
+    def test_gepa_guardrail_on_catalog_template(self):
+        """GEPA mutation check on a real template."""
+        entry = PROMPT_CATALOG[0]
+        accepted, result = check_gepa_mutation(entry.template, entry.template)
+        assert accepted is True
+
+    def test_all_templates_have_placeholders(self):
+        """Verify catalog templates actually contain placeholders."""
+        from app.logic.placeholder_validator import extract_placeholders
+
+        templates_with_ph = 0
+        for entry in PROMPT_CATALOG:
+            ph = extract_placeholders(entry.template)
+            if ph:
+                templates_with_ph += 1
+        # Most templates should have placeholders
+        assert templates_with_ph >= len(PROMPT_CATALOG) * 0.5

--- a/prompt-optimization-svc/tests/test_placeholder_invariance.py
+++ b/prompt-optimization-svc/tests/test_placeholder_invariance.py
@@ -1,0 +1,139 @@
+"""Unit tests for placeholder invariance guardrail (US-030, OPT-11).
+
+AC-4: cover removal, addition, and identical templates.
+"""
+
+from app.logic.gepa_guardrails import check_gepa_mutation
+from app.logic.placeholder_validator import (
+    PlaceholderInvarianceResult,
+    validate_placeholder_invariance,
+)
+
+
+class TestValidatePlaceholderInvariance:
+    """Core invariance validation tests."""
+
+    def test_identical_templates(self):
+        t = "Hello {{context.brand_name}}, welcome to {{context.industry}}."
+        result = validate_placeholder_invariance(t, t)
+        assert result.valid is True
+        assert result.removed == set()
+        assert result.added == set()
+        assert result.needs_review is False
+
+    def test_removed_placeholder(self):
+        original = "Brand: {{context.brand_name}} in {{context.industry}}."
+        mutated = "Brand overview for the industry."
+        result = validate_placeholder_invariance(original, mutated)
+        assert result.valid is False
+        assert "context.brand_name" in result.removed
+        assert "context.industry" in result.removed
+
+    def test_added_placeholder(self):
+        original = "Brand: {{context.brand_name}}."
+        mutated = "Brand: {{context.brand_name}} in {{context.industry}}."
+        result = validate_placeholder_invariance(original, mutated)
+        assert result.valid is True
+        assert result.needs_review is True
+        assert "context.industry" in result.added
+
+    def test_both_removed_and_added(self):
+        original = "Brand: {{context.brand_name}}."
+        mutated = "Industry: {{context.industry}}."
+        result = validate_placeholder_invariance(original, mutated)
+        assert result.valid is False
+        assert "context.brand_name" in result.removed
+        assert "context.industry" in result.added
+        assert result.needs_review is True
+
+    def test_empty_original(self):
+        result = validate_placeholder_invariance("", "Hello {{context.brand_name}}")
+        assert result.valid is True
+        assert result.needs_review is True
+        assert result.original_count == 0
+
+    def test_empty_mutated_with_placeholders(self):
+        result = validate_placeholder_invariance("{{context.brand_name}}", "")
+        assert result.valid is False
+        assert "context.brand_name" in result.removed
+
+    def test_multiple_placeholders_one_removed(self):
+        original = "{{context.brand_name}} in {{context.industry}} for {{context.target_audience}}"
+        mutated = "{{context.brand_name}} in {{context.industry}} for everyone"
+        result = validate_placeholder_invariance(original, mutated)
+        assert result.valid is False
+        assert result.removed == {"context.target_audience"}
+        assert result.added == set()
+
+    def test_dotted_placeholders(self):
+        original = "Use {context.brand_name} for {context.product_description}"
+        mutated = "Use {context.brand_name} for {context.product_description}"
+        result = validate_placeholder_invariance(original, mutated)
+        assert result.valid is True
+
+    def test_double_brace_placeholders(self):
+        original = "{{context.brand_name}} is great"
+        mutated = "{{context.brand_name}} is amazing"
+        result = validate_placeholder_invariance(original, mutated)
+        assert result.valid is True
+
+    def test_mixed_single_and_double(self):
+        original = "{context.brand_name} and {{context.industry}}"
+        mutated = "{context.brand_name} and {{context.industry}}"
+        result = validate_placeholder_invariance(original, mutated)
+        assert result.valid is True
+
+    def test_no_placeholders_in_either(self):
+        result = validate_placeholder_invariance("Hello world", "Goodbye world")
+        assert result.valid is True
+        assert result.needs_review is False
+        assert result.original_count == 0
+        assert result.mutated_count == 0
+
+    def test_counts_correct(self):
+        original = "{{context.brand_name}} {{context.industry}}"
+        mutated = "{{context.brand_name}} {{context.voice}}"
+        result = validate_placeholder_invariance(original, mutated)
+        assert result.original_count == 2
+        assert result.mutated_count == 2
+
+    def test_result_is_dataclass(self):
+        result = validate_placeholder_invariance("test", "test")
+        assert isinstance(result, PlaceholderInvarianceResult)
+
+
+class TestCheckGepaMutation:
+    """GEPA guardrail hook tests."""
+
+    def test_accepted_identical(self):
+        t = "Analyze {{context.brand_name}} in {{context.industry}}"
+        accepted, result = check_gepa_mutation(t, t)
+        assert accepted is True
+        assert result.valid is True
+
+    def test_rejected_removal(self):
+        original = "{{context.brand_name}} in {{context.industry}}"
+        candidate = "Brand analysis report"
+        accepted, result = check_gepa_mutation(original, candidate)
+        assert accepted is False
+        assert result.valid is False
+
+    def test_accepted_with_review_flag(self):
+        original = "{{context.brand_name}}"
+        candidate = "{{context.brand_name}} targeting {{context.target_audience}}"
+        accepted, result = check_gepa_mutation(original, candidate)
+        assert accepted is True
+        assert result.needs_review is True
+
+    def test_returns_tuple(self):
+        accepted, result = check_gepa_mutation("test", "test")
+        assert isinstance(accepted, bool)
+        assert isinstance(result, PlaceholderInvarianceResult)
+
+    def test_text_changes_without_placeholder_changes(self):
+        original = "Analyze the brand {{context.brand_name}} thoroughly."
+        candidate = "Perform deep analysis on {{context.brand_name}} with precision."
+        accepted, result = check_gepa_mutation(original, candidate)
+        assert accepted is True
+        assert result.removed == set()
+        assert result.added == set()

--- a/prompt-optimization-svc/tests/test_placeholder_invariance_properties.py
+++ b/prompt-optimization-svc/tests/test_placeholder_invariance_properties.py
@@ -1,0 +1,48 @@
+"""Hypothesis property tests for placeholder invariance (US-030)."""
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from app.logic.placeholder_validator import validate_placeholder_invariance
+
+
+class TestInvarianceProperties:
+    @given(st.text(max_size=200))
+    @settings(max_examples=50, deadline=None)
+    def test_identical_always_valid(self, template):
+        result = validate_placeholder_invariance(template, template)
+        assert result.valid is True
+        assert result.removed == set()
+        assert result.added == set()
+
+    @given(st.text(max_size=100), st.text(max_size=100))
+    @settings(max_examples=50, deadline=None)
+    def test_removed_union_added_equals_symmetric_diff(self, t1, t2):
+        from app.logic.placeholder_validator import extract_placeholders
+
+        result = validate_placeholder_invariance(t1, t2)
+        orig = extract_placeholders(t1)
+        mut = extract_placeholders(t2)
+        assert result.removed == orig - mut
+        assert result.added == mut - orig
+
+    @given(st.text(max_size=100))
+    @settings(max_examples=50, deadline=None)
+    def test_superset_always_valid(self, extra_text):
+        original = "Use {{context.brand_name}} for analysis."
+        mutated = f"Use {{{{context.brand_name}}}} for analysis. {extra_text}"
+        result = validate_placeholder_invariance(original, mutated)
+        assert result.valid is True
+
+    @given(st.text(max_size=200))
+    @settings(max_examples=50, deadline=None)
+    def test_never_raises(self, template):
+        result = validate_placeholder_invariance(template, "")
+        assert isinstance(result.valid, bool)
+
+    @given(st.text(max_size=200))
+    @settings(max_examples=50, deadline=None)
+    def test_counts_non_negative(self, template):
+        result = validate_placeholder_invariance(template, template)
+        assert result.original_count >= 0
+        assert result.mutated_count >= 0


### PR DESCRIPTION
## Summary

First story in EPIC-8 (Template-Context Separation Guardrails). Implements the OPT-11 placeholder invariance guardrail for GEPA mutations:

- **`validate_placeholder_invariance(original, mutated)`**: compares placeholder sets between original and mutated templates
- **Removal = rejection** (AC-2): mutations that drop any `{context.*}` placeholder are rejected with ERROR logging
- **Addition = review flag** (AC-3): mutations that introduce new placeholders are accepted but flagged with `needs_review=True`
- **`check_gepa_mutation()`**: GEPA hook returning `(accepted, result)` tuple for integration with optimization pipeline
- Reuses existing `extract_placeholders()` supporting both `{var}` and `{{var}}` syntax (AC-1)

## Test plan

- [x] 18 unit tests: removal, addition, identical, mixed, empty, dotted, double-brace (AC-4)
- [x] 5 Hypothesis property tests: identity invariance, symmetric difference, never-raises
- [x] 4 integration tests: all 48 catalog templates self-invariant, mutation detection
- [x] Full suite: 1307 passed, 38 skipped
- [x] Black formatting verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)