### PR TITLE
feat(gepa): maintain context variable registry for all 15 agents (US-031)

### DIFF
--- a/prompt-optimization-svc/app/api/routes.py
+++ b/prompt-optimization-svc/app/api/routes.py
@@ -131,6 +131,25 @@ async def register_prompt(
             message="Prompt registered (MLflow not connected — stub mode)",
         )
     try:
+        # AC-3: Validate placeholders against context variable registry
+        agent_code = request.metadata.get("agent_code", "")
+        warning_msg = ""
+        if agent_code:
+            from app.registries.context_variables import (
+                validate_template_against_registry,
+            )
+
+            violations = validate_template_against_registry(
+                request.template, agent_code
+            )
+            if violations:
+                warning_msg = f"Registry warnings: {'; '.join(violations)}"
+                logger.warning(
+                    "Prompt %s has undeclared placeholders: %s",
+                    request.name,
+                    violations,
+                )
+
         info = mlflow_registry.register_prompt(
             name=request.name,
             template=request.template,
@@ -140,6 +159,7 @@ async def register_prompt(
             name=info.name,
             version=info.version,
             status="registered",
+            message=warning_msg if warning_msg else None,
         )
     except Exception as exc:
         logger.error("Failed to register prompt %s: %s", request.name, exc)

--- a/prompt-optimization-svc/app/api/routes.py
+++ b/prompt-optimization-svc/app/api/routes.py
@@ -159,7 +159,7 @@ async def register_prompt(
             name=info.name,
             version=info.version,
             status="registered",
-            message=warning_msg if warning_msg else None,
+            message=warning_msg,
         )
     except Exception as exc:
         logger.error("Failed to register prompt %s: %s", request.name, exc)

--- a/prompt-optimization-svc/app/main.py
+++ b/prompt-optimization-svc/app/main.py
@@ -68,7 +68,15 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         "prompt-optimization-svc starting on %s:%d", settings.HOST, settings.PORT
     )
 
-    # 0. Run database migrations
+    # 0. Load context variable registry into memory
+    from app.registries.context_variables import CONTEXT_REGISTRY
+
+    logger.info(
+        "Context variable registry loaded: %d variables across all agents",
+        len(CONTEXT_REGISTRY),
+    )
+
+    # 0b. Run database migrations
     _run_migrations()
 
     # 1. Redis (general cache)

--- a/prompt-optimization-svc/app/registries/context_variables.py
+++ b/prompt-optimization-svc/app/registries/context_variables.py
@@ -24,23 +24,30 @@ class ContextVariable:
 # Shared across all agents (onboarding data)
 SHARED_VARIABLES = [
     ContextVariable(
-        "context.brand_name", source="onboarding", required=True,
+        "context.brand_name",
+        source="onboarding",
+        required=True,
         description="Company/brand name from onboarding",
     ),
     ContextVariable(
-        "context.industry", source="onboarding", required=True,
+        "context.industry",
+        source="onboarding",
+        required=True,
         description="Industry classification from onboarding",
     ),
     ContextVariable(
-        "context.target_audience", source="onboarding",
+        "context.target_audience",
+        source="onboarding",
         description="Target audience description from onboarding",
     ),
     ContextVariable(
-        "context.brand_voice", source="onboarding",
+        "context.brand_voice",
+        source="onboarding",
         description="Brand voice/tone from onboarding",
     ),
     ContextVariable(
-        "context.product_description", source="onboarding",
+        "context.product_description",
+        source="onboarding",
         description="Product/service description from onboarding",
     ),
 ]
@@ -48,32 +55,39 @@ SHARED_VARIABLES = [
 # WF1 agent-specific variables
 WF1_VARIABLES = [
     ContextVariable(
-        "context.query", source="runtime", required=True,
+        "context.query",
+        source="runtime",
+        required=True,
         description="User's research query",
         agents=("mra", "cia", "apa", "tcia", "voca"),
     ),
     ContextVariable(
-        "context.competitors", source="runtime",
+        "context.competitors",
+        source="runtime",
         description="Known competitors list",
         agents=("cia",),
     ),
     ContextVariable(
-        "context.audience_data", source="runtime",
+        "context.audience_data",
+        source="runtime",
         description="Audience data for segmentation",
         agents=("apa",),
     ),
     ContextVariable(
-        "context.trends", source="runtime",
+        "context.trends",
+        source="runtime",
         description="Trends to score for brand relevance",
         agents=("tcia",),
     ),
     ContextVariable(
-        "context.feedback_data", source="runtime",
+        "context.feedback_data",
+        source="runtime",
         description="Customer feedback for VoC analysis",
         agents=("voca",),
     ),
     ContextVariable(
-        "context.raw_findings", source="upstream",
+        "context.raw_findings",
+        source="upstream",
         description="Raw research findings for synthesis",
         agents=("mra",),
     ),
@@ -82,52 +96,62 @@ WF1_VARIABLES = [
 # WF2 agent-specific variables
 WF2_VARIABLES = [
     ContextVariable(
-        "context.market_research", source="upstream",
+        "context.market_research",
+        source="upstream",
         description="MRA output for positioning context",
         agents=("bpa", "baa", "bpv", "nta", "bsa"),
     ),
     ContextVariable(
-        "context.positioning", source="upstream",
+        "context.positioning",
+        source="upstream",
         description="BPA positioning output",
         agents=("baa", "bpv", "nta", "bsa"),
     ),
     ContextVariable(
-        "context.personality", source="upstream",
+        "context.personality",
+        source="upstream",
         description="BPV personality output",
         agents=("nta", "bsa"),
     ),
     ContextVariable(
-        "context.voice", source="upstream",
+        "context.voice",
+        source="upstream",
         description="BPV voice matrix output",
         agents=("nta", "bsa"),
     ),
     ContextVariable(
-        "context.portfolio", source="upstream",
+        "context.portfolio",
+        source="upstream",
         description="Current brand portfolio",
         agents=("baa",),
     ),
     ContextVariable(
-        "context.market_data", source="upstream",
+        "context.market_data",
+        source="upstream",
         description="Market data for portfolio growth strategy",
         agents=("baa",),
     ),
     ContextVariable(
-        "context.architecture", source="upstream",
+        "context.architecture",
+        source="upstream",
         description="BAA architecture output",
         agents=("baa",),
     ),
     ContextVariable(
-        "context.values", source="upstream",
+        "context.values",
+        source="upstream",
         description="Brand values from BPV",
         agents=("bsa",),
     ),
     ContextVariable(
-        "context.brand_story", source="upstream",
+        "context.brand_story",
+        source="upstream",
         description="Brand story context",
         agents=("bsa",),
     ),
     ContextVariable(
-        "context.founder_info", source="onboarding",
+        "context.founder_info",
+        source="onboarding",
         description="Founder context for origin story",
         agents=("bsa",),
     ),
@@ -136,92 +160,110 @@ WF2_VARIABLES = [
 # WF3 agent-specific variables
 WF3_VARIABLES = [
     ContextVariable(
-        "context.objective", source="runtime",
+        "context.objective",
+        source="runtime",
         description="Campaign objective",
         agents=("caa",),
     ),
     ContextVariable(
-        "context.budget", source="runtime",
+        "context.budget",
+        source="runtime",
         description="Campaign budget",
         agents=("caa", "coa"),
     ),
     ContextVariable(
-        "context.personas", source="upstream",
+        "context.personas",
+        source="upstream",
         description="Audience personas from APA",
         agents=("caa",),
     ),
     ContextVariable(
-        "context.campaign_blueprint", source="upstream",
+        "context.campaign_blueprint",
+        source="upstream",
         description="CAA campaign architecture output",
         agents=("cga", "adpub"),
     ),
     ContextVariable(
-        "context.creative_profiles", source="upstream",
+        "context.creative_profiles",
+        source="upstream",
         description="CGA creative profiles output",
         agents=("cga",),
     ),
     ContextVariable(
-        "context.ad_units", source="upstream",
+        "context.ad_units",
+        source="upstream",
         description="CGA ad units for compliance review",
         agents=("cga",),
     ),
     ContextVariable(
-        "context.creative_packages", source="upstream",
+        "context.creative_packages",
+        source="upstream",
         description="CGA creative packages for publishing",
         agents=("adpub",),
     ),
     ContextVariable(
-        "context.campaign_name", source="upstream",
+        "context.campaign_name",
+        source="upstream",
         description="Campaign name for approval summary",
         agents=("adpub",),
     ),
     ContextVariable(
-        "context.ad_set_count", source="upstream",
+        "context.ad_set_count",
+        source="upstream",
         description="Number of ad sets",
         agents=("adpub",),
     ),
     ContextVariable(
-        "context.creative_count", source="upstream",
+        "context.creative_count",
+        source="upstream",
         description="Number of creatives",
         agents=("adpub",),
     ),
     ContextVariable(
-        "context.campaign_metrics", source="upstream",
+        "context.campaign_metrics",
+        source="upstream",
         description="Campaign performance metrics",
         agents=("coa",),
     ),
     ContextVariable(
-        "context.performance_data", source="upstream",
+        "context.performance_data",
+        source="upstream",
         description="Performance data for recommendations",
         agents=("coa",),
     ),
     ContextVariable(
-        "context.guardrails", source="runtime",
+        "context.guardrails",
+        source="runtime",
         description="Optimization guardrails config",
         agents=("coa",),
     ),
     ContextVariable(
-        "context.campaign_state", source="upstream",
+        "context.campaign_state",
+        source="upstream",
         description="Current campaign state for planner",
         agents=("coa",),
     ),
     ContextVariable(
-        "context.budget_remaining", source="upstream",
+        "context.budget_remaining",
+        source="upstream",
         description="Remaining budget for planner",
         agents=("coa",),
     ),
     ContextVariable(
-        "context.optimization_data", source="upstream",
+        "context.optimization_data",
+        source="upstream",
         description="Optimization data for learning extraction",
         agents=("ila",),
     ),
     ContextVariable(
-        "context.learning_history", source="upstream",
+        "context.learning_history",
+        source="upstream",
         description="Historical learnings for synthesis",
         agents=("ila",),
     ),
     ContextVariable(
-        "context.recent_actions", source="upstream",
+        "context.recent_actions",
+        source="upstream",
         description="Recent optimization actions for planner",
         agents=("ila",),
     ),
@@ -234,3 +276,49 @@ for var in SHARED_VARIABLES + WF1_VARIABLES + WF2_VARIABLES + WF3_VARIABLES:
 
 # All valid placeholder names
 VALID_PLACEHOLDER_NAMES: set[str] = set(CONTEXT_REGISTRY.keys())
+
+
+def get_variables_for_agent(agent_code: str) -> list[ContextVariable]:
+    """Get all context variables applicable to an agent.
+
+    Returns shared variables (agents=None) plus agent-specific variables.
+    """
+    agent = agent_code.lower()
+    return [
+        v for v in CONTEXT_REGISTRY.values() if v.agents is None or agent in v.agents
+    ]
+
+
+def get_required_variables(agent_code: str) -> list[ContextVariable]:
+    """Get only required context variables for an agent."""
+    return [v for v in get_variables_for_agent(agent_code) if v.required]
+
+
+def get_agent_variable_names(agent_code: str) -> set[str]:
+    """Get the set of valid placeholder names for an agent."""
+    return {v.name for v in get_variables_for_agent(agent_code)}
+
+
+def validate_template_against_registry(template: str, agent_code: str) -> list[str]:
+    """Validate that all placeholders in a template are declared in the registry.
+
+    Args:
+        template: Prompt template text.
+        agent_code: Agent code (e.g., "cga").
+
+    Returns:
+        List of violation messages (empty = valid).
+    """
+    from app.logic.placeholder_validator import extract_placeholders
+
+    placeholders = extract_placeholders(template)
+    valid_names = get_agent_variable_names(agent_code)
+    violations = []
+
+    for ph in sorted(placeholders):
+        if ph not in valid_names:
+            violations.append(
+                f"Placeholder '{{{ph}}}' not declared in registry for agent '{agent_code}'"
+            )
+
+    return violations

--- a/prompt-optimization-svc/tests/integration/test_context_registry.py
+++ b/prompt-optimization-svc/tests/integration/test_context_registry.py
@@ -1,0 +1,33 @@
+"""Integration tests for context variable registry (US-031)."""
+
+from app.registries.context_variables import (
+    CONTEXT_REGISTRY,
+    validate_template_against_registry,
+)
+from app.registries.prompt_catalog import PROMPT_CATALOG
+
+
+class TestCatalogRegistryValidation:
+    """All 48 catalog templates should pass registry validation."""
+
+    def test_all_templates_pass_validation(self):
+        for entry in PROMPT_CATALOG:
+            agent_code = entry.tags.get("agent_code", "")
+            violations = validate_template_against_registry(entry.template, agent_code)
+            assert violations == [], (
+                f"Template {entry.name} (agent={agent_code}) has "
+                f"undeclared placeholders: {violations}"
+            )
+
+    def test_registry_loaded_at_import(self):
+        assert len(CONTEXT_REGISTRY) >= 39
+
+    def test_all_catalog_agents_in_registry(self):
+        from app.registries.context_variables import get_variables_for_agent
+
+        agents_seen = {entry.tags["agent_code"] for entry in PROMPT_CATALOG}
+        for agent in agents_seen:
+            vars_for = get_variables_for_agent(agent)
+            assert (
+                len(vars_for) >= 5
+            ), f"Agent {agent} has too few variables: {len(vars_for)}"

--- a/prompt-optimization-svc/tests/test_context_registry_properties.py
+++ b/prompt-optimization-svc/tests/test_context_registry_properties.py
@@ -1,0 +1,41 @@
+"""Hypothesis property tests for context variable registry (US-031)."""
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from app.registries.context_variables import (
+    SHARED_VARIABLES,
+    get_agent_variable_names,
+    get_variables_for_agent,
+    validate_template_against_registry,
+)
+from app.registries.prompt_catalog import AGENT_PORTS
+
+
+class TestRegistryProperties:
+    @given(st.sampled_from(sorted(AGENT_PORTS.keys())))
+    @settings(max_examples=15, deadline=None)
+    def test_every_agent_has_at_least_5_vars(self, agent):
+        vars_for = get_variables_for_agent(agent)
+        assert len(vars_for) >= 5
+
+    @given(st.sampled_from(sorted(AGENT_PORTS.keys())))
+    @settings(max_examples=15, deadline=None)
+    def test_all_var_names_start_with_context(self, agent):
+        names = get_agent_variable_names(agent)
+        for name in names:
+            assert name.startswith("context.")
+
+    @given(st.sampled_from(sorted(AGENT_PORTS.keys())))
+    @settings(max_examples=15, deadline=None)
+    def test_always_includes_shared_variables(self, agent):
+        vars_for = get_variables_for_agent(agent)
+        agent_names = {v.name for v in vars_for}
+        shared_names = {v.name for v in SHARED_VARIABLES}
+        assert shared_names.issubset(agent_names)
+
+    @given(st.text(max_size=200))
+    @settings(max_examples=50, deadline=None)
+    def test_validate_never_raises(self, template):
+        violations = validate_template_against_registry(template, "mra")
+        assert isinstance(violations, list)

--- a/prompt-optimization-svc/tests/test_context_variable_registry.py
+++ b/prompt-optimization-svc/tests/test_context_variable_registry.py
@@ -1,0 +1,141 @@
+"""Unit tests for context variable registry (US-031)."""
+
+from app.registries.context_variables import (
+    CONTEXT_REGISTRY,
+    SHARED_VARIABLES,
+    VALID_PLACEHOLDER_NAMES,
+    ContextVariable,
+    get_agent_variable_names,
+    get_required_variables,
+    get_variables_for_agent,
+    validate_template_against_registry,
+)
+from app.registries.prompt_catalog import AGENT_PORTS
+
+
+class TestRegistryCompleteness:
+    """AC-1: Registry populated for all 15 agents."""
+
+    def test_registry_has_at_least_39_variables(self):
+        assert len(CONTEXT_REGISTRY) >= 39
+
+    def test_all_15_agents_have_variables(self):
+        for agent in AGENT_PORTS:
+            vars_for_agent = get_variables_for_agent(agent)
+            assert (
+                len(vars_for_agent) >= 5
+            ), f"Agent {agent} has only {len(vars_for_agent)} variables"
+
+    def test_valid_placeholder_names_matches_registry(self):
+        assert VALID_PLACEHOLDER_NAMES == set(CONTEXT_REGISTRY.keys())
+
+    def test_all_names_start_with_context(self):
+        for name in CONTEXT_REGISTRY:
+            assert name.startswith(
+                "context."
+            ), f"Variable '{name}' missing context. prefix"
+
+    def test_all_sources_valid(self):
+        valid_sources = {"onboarding", "runtime", "upstream"}
+        for var in CONTEXT_REGISTRY.values():
+            assert (
+                var.source in valid_sources
+            ), f"Variable {var.name} has invalid source '{var.source}'"
+
+    def test_context_variable_is_frozen(self):
+        var = ContextVariable("context.test", source="runtime")
+        try:
+            var.name = "changed"
+            assert False, "Should not be able to modify frozen dataclass"
+        except AttributeError:
+            pass  # Expected — frozen dataclass
+
+
+class TestGetVariablesForAgent:
+    def test_cga_includes_shared(self):
+        vars_for_cga = get_variables_for_agent("cga")
+        shared_names = {v.name for v in SHARED_VARIABLES}
+        agent_names = {v.name for v in vars_for_cga}
+        assert shared_names.issubset(agent_names)
+
+    def test_mra_includes_shared(self):
+        vars_for_mra = get_variables_for_agent("mra")
+        shared_names = {v.name for v in SHARED_VARIABLES}
+        agent_names = {v.name for v in vars_for_mra}
+        assert shared_names.issubset(agent_names)
+
+    def test_cga_has_campaign_blueprint(self):
+        names = get_agent_variable_names("cga")
+        assert "context.campaign_blueprint" in names
+
+    def test_coa_has_performance_data(self):
+        names = get_agent_variable_names("coa")
+        assert "context.performance_data" in names
+
+    def test_case_insensitive(self):
+        vars_lower = get_variables_for_agent("cga")
+        vars_upper = get_variables_for_agent("CGA")
+        assert len(vars_lower) == len(vars_upper)
+
+    def test_unknown_agent_gets_only_shared(self):
+        vars_for_unknown = get_variables_for_agent("nonexistent")
+        shared_count = len(SHARED_VARIABLES)
+        assert len(vars_for_unknown) == shared_count
+
+
+class TestGetRequiredVariables:
+    def test_brand_name_is_required(self):
+        required = get_required_variables("mra")
+        names = {v.name for v in required}
+        assert "context.brand_name" in names
+
+    def test_industry_is_required(self):
+        required = get_required_variables("cga")
+        names = {v.name for v in required}
+        assert "context.industry" in names
+
+    def test_required_subset_of_all(self):
+        all_vars = get_variables_for_agent("bpa")
+        required = get_required_variables("bpa")
+        assert len(required) <= len(all_vars)
+
+
+class TestGetAgentVariableNames:
+    def test_returns_set_of_strings(self):
+        names = get_agent_variable_names("cga")
+        assert isinstance(names, set)
+        for name in names:
+            assert isinstance(name, str)
+
+    def test_non_empty_for_all_agents(self):
+        for agent in AGENT_PORTS:
+            names = get_agent_variable_names(agent)
+            assert len(names) >= 5
+
+
+class TestValidateTemplateAgainstRegistry:
+    """AC-3: validate placeholders are declared."""
+
+    def test_valid_template_no_violations(self):
+        template = "Analyze {{context.brand_name}} in {{context.industry}}"
+        violations = validate_template_against_registry(template, "mra")
+        assert violations == []
+
+    def test_undeclared_placeholder_violation(self):
+        template = "Use {{context.nonexistent_var}} for analysis"
+        violations = validate_template_against_registry(template, "mra")
+        assert len(violations) == 1
+        assert "nonexistent_var" in violations[0]
+
+    def test_empty_template_no_violations(self):
+        violations = validate_template_against_registry("", "mra")
+        assert violations == []
+
+    def test_no_placeholders_no_violations(self):
+        violations = validate_template_against_registry("Plain text", "mra")
+        assert violations == []
+
+    def test_multiple_undeclared(self):
+        template = "{{context.foo}} and {{context.bar}}"
+        violations = validate_template_against_registry(template, "mra")
+        assert len(violations) == 2


### PR DESCRIPTION
## Summary

Final story in EPIC-8 (Template-Context Separation Guardrails). Adds helper functions, startup loading, and prompt registration validation to the existing context variable registry:

- **`get_variables_for_agent()`**: returns shared + agent-specific variables
- **`get_required_variables()`**: filters to `required=True` only
- **`validate_template_against_registry()`**: checks placeholders are declared in registry (AC-3)
- **Startup loading**: registry stats logged on service start (AC-2)
- **Prompt registration**: validates template placeholders, warns on undeclared vars
- Registry already covers all 15 agents with 39 variables (AC-1)

**Completes EPIC-8** — both stories (US-030 + US-031) implemented.

## Test plan

- [x] 22 unit tests (completeness, helpers, validation, frozen dataclass)
- [x] 4 Hypothesis property tests (agent coverage, prefix, shared subset)
- [x] 3 integration tests (all 48 catalog templates pass validation)
- [x] Full suite: 1333 passed, 38 skipped
- [x] Black formatting verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)