### PR TITLE
feat(gepa): validate optimized candidates against held-out set (US-032)

### DIFF
--- a/prompt-optimization-svc/app/core/config.py
+++ b/prompt-optimization-svc/app/core/config.py
@@ -43,6 +43,11 @@ class Settings(BaseSettings):
     MINING_QUALITY_THRESHOLD: float = 0.8
     MINING_LOOKBACK_DAYS: int = 7
 
+    # Validation (OPT-03/OPT-04)
+    VALIDATION_HOLDOUT_PCT: float = 0.2
+    VALIDATION_IMPROVEMENT_THRESHOLD: float = 0.05  # 5% minimum improvement
+    VALIDATION_REGRESSION_THRESHOLD: float = 0.03  # 3% max individual regression
+
     # Logging
     LOG_LEVEL: str = "INFO"
 

--- a/prompt-optimization-svc/app/logic/candidate_validator.py
+++ b/prompt-optimization-svc/app/logic/candidate_validator.py
@@ -1,0 +1,157 @@
+"""Candidate validation against held-out golden dataset (§4.1 Step 5).
+
+Compares GEPA candidate aggregate scorer scores to current PRODUCTION
+prompt. Only candidates exceeding OPT-03 (5% improvement) proceed
+to canary. Individual scorer regressions > OPT-04 (3%) trigger
+PENDING_APPROVAL for human review.
+"""
+
+import logging
+import random
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+VALID_DECISIONS = ("CANARY", "REJECTED", "PENDING_APPROVAL")
+
+
+@dataclass
+class ValidationResult:
+    """Result of candidate validation against production."""
+
+    passed: bool = False
+    decision: str = "REJECTED"
+    aggregate_improvement: float = 0.0
+    scorer_regressions: dict[str, float] = field(default_factory=dict)
+    candidate_scores: dict[str, float] = field(default_factory=dict)
+    production_scores: dict[str, float] = field(default_factory=dict)
+    held_out_count: int = 0
+
+
+def split_holdout(
+    examples: list,
+    holdout_pct: float = 0.2,
+    seed: int = 42,
+) -> tuple[list, list]:
+    """Split examples into train and holdout sets.
+
+    Uses a deterministic shuffle for reproducibility.
+
+    Args:
+        examples: Full list of examples.
+        holdout_pct: Fraction to hold out (default 20%, AC-1).
+        seed: Random seed for reproducibility.
+
+    Returns:
+        Tuple of (train, holdout) lists.
+    """
+    if not examples:
+        return [], []
+
+    shuffled = list(examples)
+    rng = random.Random(seed)
+    rng.shuffle(shuffled)
+
+    holdout_count = max(1, int(len(shuffled) * holdout_pct))
+    holdout = shuffled[:holdout_count]
+    train = shuffled[holdout_count:]
+
+    return train, holdout
+
+
+def compute_aggregate_score(scores: dict[str, float]) -> float:
+    """Compute mean aggregate score across all scorers.
+
+    Args:
+        scores: Dict of scorer_name → score (0.0-1.0).
+
+    Returns:
+        Mean score, or 0.0 if empty.
+    """
+    if not scores:
+        return 0.0
+    return sum(scores.values()) / len(scores)
+
+
+def validate_candidate(
+    candidate_scores: dict[str, float],
+    production_scores: dict[str, float],
+    improvement_threshold: float = 0.05,
+    regression_threshold: float = 0.03,
+) -> ValidationResult:
+    """Validate a GEPA candidate against current production scores.
+
+    Args:
+        candidate_scores: Per-scorer scores for the candidate.
+        production_scores: Per-scorer scores for current production.
+        improvement_threshold: Min aggregate improvement (OPT-03, default 5%).
+        regression_threshold: Max individual regression (OPT-04, default 3%).
+
+    Returns:
+        ValidationResult with decision: CANARY, REJECTED, or PENDING_APPROVAL.
+    """
+    candidate_agg = compute_aggregate_score(candidate_scores)
+    production_agg = compute_aggregate_score(production_scores)
+
+    # Compute aggregate improvement
+    if production_agg > 0:
+        improvement = (candidate_agg - production_agg) / production_agg
+    elif candidate_agg > 0:
+        improvement = 1.0  # Infinite improvement from zero
+    else:
+        improvement = 0.0
+
+    # AC-2: Check aggregate improvement threshold (OPT-03)
+    if improvement < improvement_threshold:
+        logger.info(
+            "Candidate REJECTED: aggregate improvement %.2f%% < %.2f%% threshold",
+            improvement * 100,
+            improvement_threshold * 100,
+        )
+        return ValidationResult(
+            passed=False,
+            decision="REJECTED",
+            aggregate_improvement=improvement,
+            candidate_scores=candidate_scores,
+            production_scores=production_scores,
+        )
+
+    # AC-3: Check individual scorer regressions (OPT-04)
+    regressions: dict[str, float] = {}
+    common_scorers = set(candidate_scores.keys()) & set(production_scores.keys())
+    for scorer_name in common_scorers:
+        prod_score = production_scores[scorer_name]
+        cand_score = candidate_scores[scorer_name]
+        if prod_score > 0:
+            regression = (prod_score - cand_score) / prod_score
+            if regression > regression_threshold:
+                regressions[scorer_name] = regression
+
+    if regressions:
+        logger.warning(
+            "Candidate PENDING_APPROVAL: %d scorer regressions > %.0f%% — %s",
+            len(regressions),
+            regression_threshold * 100,
+            ", ".join(f"{k}: -{v * 100:.1f}%" for k, v in sorted(regressions.items())),
+        )
+        return ValidationResult(
+            passed=False,
+            decision="PENDING_APPROVAL",
+            aggregate_improvement=improvement,
+            scorer_regressions=regressions,
+            candidate_scores=candidate_scores,
+            production_scores=production_scores,
+        )
+
+    # Passed all checks — proceed to canary
+    logger.info(
+        "Candidate approved for CANARY: aggregate improvement %.2f%%",
+        improvement * 100,
+    )
+    return ValidationResult(
+        passed=True,
+        decision="CANARY",
+        aggregate_improvement=improvement,
+        candidate_scores=candidate_scores,
+        production_scores=production_scores,
+    )

--- a/prompt-optimization-svc/app/logic/candidate_validator.py
+++ b/prompt-optimization-svc/app/logic/candidate_validator.py
@@ -9,10 +9,15 @@ PENDING_APPROVAL for human review.
 import logging
 import random
 from dataclasses import dataclass, field
+from typing import Optional, TypeVar
+
+from app.core.config import settings
 
 logger = logging.getLogger(__name__)
 
 VALID_DECISIONS = ("CANARY", "REJECTED", "PENDING_APPROVAL")
+
+T = TypeVar("T")
 
 
 @dataclass
@@ -29,22 +34,25 @@ class ValidationResult:
 
 
 def split_holdout(
-    examples: list,
-    holdout_pct: float = 0.2,
+    examples: list[T],
+    holdout_pct: Optional[float] = None,
     seed: int = 42,
-) -> tuple[list, list]:
+) -> tuple[list[T], list[T]]:
     """Split examples into train and holdout sets.
 
     Uses a deterministic shuffle for reproducibility.
 
     Args:
         examples: Full list of examples.
-        holdout_pct: Fraction to hold out (default 20%, AC-1).
+        holdout_pct: Fraction to hold out. Defaults to settings.VALIDATION_HOLDOUT_PCT.
         seed: Random seed for reproducibility.
 
     Returns:
         Tuple of (train, holdout) lists.
     """
+    if holdout_pct is None:
+        holdout_pct = settings.VALIDATION_HOLDOUT_PCT
+
     if not examples:
         return [], []
 
@@ -76,22 +84,44 @@ def compute_aggregate_score(scores: dict[str, float]) -> float:
 def validate_candidate(
     candidate_scores: dict[str, float],
     production_scores: dict[str, float],
-    improvement_threshold: float = 0.05,
-    regression_threshold: float = 0.03,
+    improvement_threshold: Optional[float] = None,
+    regression_threshold: Optional[float] = None,
 ) -> ValidationResult:
     """Validate a GEPA candidate against current production scores.
+
+    Requires matching scorer keys — missing candidate scorers are
+    treated as regressions (score=0.0), and missing production scorers
+    are excluded from the comparison.
 
     Args:
         candidate_scores: Per-scorer scores for the candidate.
         production_scores: Per-scorer scores for current production.
-        improvement_threshold: Min aggregate improvement (OPT-03, default 5%).
-        regression_threshold: Max individual regression (OPT-04, default 3%).
+        improvement_threshold: Min aggregate improvement (OPT-03).
+            Defaults to settings.VALIDATION_IMPROVEMENT_THRESHOLD.
+        regression_threshold: Max individual regression (OPT-04).
+            Defaults to settings.VALIDATION_REGRESSION_THRESHOLD.
 
     Returns:
         ValidationResult with decision: CANARY, REJECTED, or PENDING_APPROVAL.
     """
-    candidate_agg = compute_aggregate_score(candidate_scores)
-    production_agg = compute_aggregate_score(production_scores)
+    if improvement_threshold is None:
+        improvement_threshold = settings.VALIDATION_IMPROVEMENT_THRESHOLD
+    if regression_threshold is None:
+        regression_threshold = settings.VALIDATION_REGRESSION_THRESHOLD
+
+    # Ensure candidate has all production scorers — treat missing as 0.0
+    all_scorers = set(production_scores.keys())
+    normalized_candidate = dict(candidate_scores)
+    for scorer_name in all_scorers:
+        if scorer_name not in normalized_candidate:
+            normalized_candidate[scorer_name] = 0.0
+
+    # Compute aggregates over production scorer set only
+    prod_subset = {k: production_scores[k] for k in all_scorers}
+    cand_subset = {k: normalized_candidate[k] for k in all_scorers}
+
+    candidate_agg = compute_aggregate_score(cand_subset) if cand_subset else 0.0
+    production_agg = compute_aggregate_score(prod_subset) if prod_subset else 0.0
 
     # Compute aggregate improvement
     if production_agg > 0:
@@ -118,10 +148,9 @@ def validate_candidate(
 
     # AC-3: Check individual scorer regressions (OPT-04)
     regressions: dict[str, float] = {}
-    common_scorers = set(candidate_scores.keys()) & set(production_scores.keys())
-    for scorer_name in common_scorers:
+    for scorer_name in all_scorers:
         prod_score = production_scores[scorer_name]
-        cand_score = candidate_scores[scorer_name]
+        cand_score = normalized_candidate[scorer_name]
         if prod_score > 0:
             regression = (prod_score - cand_score) / prod_score
             if regression > regression_threshold:

--- a/prompt-optimization-svc/tests/integration/test_candidate_validator.py
+++ b/prompt-optimization-svc/tests/integration/test_candidate_validator.py
@@ -1,0 +1,38 @@
+"""Integration tests for candidate validation (US-032)."""
+
+from app.datasets.golden_seed import GOLDEN_EXAMPLES
+from app.logic.candidate_validator import split_holdout, validate_candidate
+
+
+class TestHoldoutOnRealData:
+    def test_split_golden_examples(self):
+        train, holdout = split_holdout(GOLDEN_EXAMPLES)
+        assert len(train) + len(holdout) == len(GOLDEN_EXAMPLES)
+        # ~20% holdout
+        expected_holdout = int(len(GOLDEN_EXAMPLES) * 0.2)
+        assert abs(len(holdout) - expected_holdout) <= 1
+
+    def test_holdout_non_empty(self):
+        _, holdout = split_holdout(GOLDEN_EXAMPLES)
+        assert len(holdout) > 0
+
+
+class TestRealisticValidation:
+    def test_clear_improvement_passes(self):
+        prod = {"json_compliance": 0.7, "pii_safety": 0.8, "brand_voice": 0.6}
+        cand = {"json_compliance": 0.85, "pii_safety": 0.9, "brand_voice": 0.75}
+        result = validate_candidate(cand, prod)
+        assert result.decision == "CANARY"
+
+    def test_marginal_improvement_rejected(self):
+        prod = {"json_compliance": 0.80, "pii_safety": 0.90, "brand_voice": 0.85}
+        cand = {"json_compliance": 0.81, "pii_safety": 0.91, "brand_voice": 0.86}
+        result = validate_candidate(cand, prod)
+        assert result.decision == "REJECTED"
+
+    def test_mixed_results_pending(self):
+        prod = {"json_compliance": 0.70, "pii_safety": 0.90, "brand_voice": 0.80}
+        cand = {"json_compliance": 0.90, "pii_safety": 0.82, "brand_voice": 0.85}
+        result = validate_candidate(cand, prod)
+        # pii_safety regressed ~8.9% (>3%) but aggregate improved
+        assert result.decision == "PENDING_APPROVAL"

--- a/prompt-optimization-svc/tests/test_candidate_validator.py
+++ b/prompt-optimization-svc/tests/test_candidate_validator.py
@@ -1,5 +1,6 @@
 """Unit tests for candidate validation (US-032, OPT-03/OPT-04)."""
 
+from app.core.config import settings
 from app.logic.candidate_validator import (
     ValidationResult,
     compute_aggregate_score,
@@ -174,18 +175,56 @@ class TestValidateCandidate:
         assert len(result.scorer_regressions) == 2
 
 
+class TestMissingScorerKeys:
+    """Missing candidate scorers treated as regressions."""
+
+    def test_missing_candidate_scorer_treated_as_zero(self):
+        """Missing scorer drops aggregate → REJECTED."""
+        prod = {"s1": 0.50, "s2": 0.80}
+        cand = {"s1": 0.90}  # s2 missing → treated as 0.0, aggregate drops
+        result = validate_candidate(cand, prod)
+        assert result.decision == "REJECTED"
+
+    def test_missing_candidate_scorer_regression_detected(self):
+        """When aggregate still passes, missing scorer triggers PENDING_APPROVAL."""
+        prod = {"s1": 0.30, "s2": 0.10}
+        cand = {"s1": 0.90}  # s2 missing=0.0, but aggregate improves vastly
+        result = validate_candidate(cand, prod)
+        # s2 regressed from 0.10 to 0.0 = 100% regression
+        assert result.decision == "PENDING_APPROVAL"
+        assert "s2" in result.scorer_regressions
+
+    def test_extra_candidate_scorer_ignored(self):
+        prod = {"s1": 0.70}
+        cand = {"s1": 0.80, "s2": 0.90}  # s2 extra, not in production
+        result = validate_candidate(cand, prod)
+        # Aggregate computed over production keys only
+        assert result.decision == "CANARY"
+
+
+class TestDefaultsFromSettings:
+    """Defaults should come from settings, not hardcoded."""
+
+    def test_split_holdout_uses_settings_default(self):
+        examples = list(range(100))
+        train, holdout = split_holdout(examples)
+        expected = int(100 * settings.VALIDATION_HOLDOUT_PCT)
+        assert len(holdout) == expected
+
+    def test_validate_uses_settings_thresholds(self):
+        # Verify defaults match settings
+        prod = {"s1": 0.80}
+        cand = {"s1": 0.85}  # 6.25% > 5%
+        result = validate_candidate(cand, prod)
+        assert result.decision == "CANARY"
+
+
 class TestConfigConstants:
     def test_holdout_pct(self):
-        from app.core.config import settings
-
         assert settings.VALIDATION_HOLDOUT_PCT == 0.2
 
     def test_improvement_threshold(self):
-        from app.core.config import settings
-
         assert settings.VALIDATION_IMPROVEMENT_THRESHOLD == 0.05
 
     def test_regression_threshold(self):
-        from app.core.config import settings
-
         assert settings.VALIDATION_REGRESSION_THRESHOLD == 0.03

--- a/prompt-optimization-svc/tests/test_candidate_validator.py
+++ b/prompt-optimization-svc/tests/test_candidate_validator.py
@@ -1,0 +1,191 @@
+"""Unit tests for candidate validation (US-032, OPT-03/OPT-04)."""
+
+from app.logic.candidate_validator import (
+    ValidationResult,
+    compute_aggregate_score,
+    split_holdout,
+    validate_candidate,
+)
+
+
+class TestSplitHoldout:
+    """AC-1: Validation uses a held-out 20% slice."""
+
+    def test_100_examples_80_20_split(self):
+        examples = list(range(100))
+        train, holdout = split_holdout(examples)
+        assert len(train) == 80
+        assert len(holdout) == 20
+
+    def test_deterministic(self):
+        examples = list(range(50))
+        t1, h1 = split_holdout(examples, seed=42)
+        t2, h2 = split_holdout(examples, seed=42)
+        assert t1 == t2
+        assert h1 == h2
+
+    def test_different_seed_different_split(self):
+        examples = list(range(50))
+        _, h1 = split_holdout(examples, seed=42)
+        _, h2 = split_holdout(examples, seed=99)
+        assert h1 != h2
+
+    def test_empty_list(self):
+        train, holdout = split_holdout([])
+        assert train == []
+        assert holdout == []
+
+    def test_small_list_at_least_1_holdout(self):
+        examples = list(range(3))
+        train, holdout = split_holdout(examples)
+        assert len(holdout) >= 1
+
+    def test_preserves_all_elements(self):
+        examples = list(range(50))
+        train, holdout = split_holdout(examples)
+        assert sorted(train + holdout) == examples
+
+    def test_custom_holdout_pct(self):
+        examples = list(range(100))
+        train, holdout = split_holdout(examples, holdout_pct=0.3)
+        assert len(holdout) == 30
+        assert len(train) == 70
+
+
+class TestComputeAggregateScore:
+    def test_simple_mean(self):
+        scores = {"scorer_a": 0.8, "scorer_b": 0.6}
+        assert compute_aggregate_score(scores) == 0.7
+
+    def test_empty_dict(self):
+        assert compute_aggregate_score({}) == 0.0
+
+    def test_single_scorer(self):
+        assert compute_aggregate_score({"s1": 0.9}) == 0.9
+
+    def test_all_perfect(self):
+        scores = {"a": 1.0, "b": 1.0, "c": 1.0}
+        assert compute_aggregate_score(scores) == 1.0
+
+    def test_all_zero(self):
+        scores = {"a": 0.0, "b": 0.0}
+        assert compute_aggregate_score(scores) == 0.0
+
+
+class TestValidateCandidate:
+    """AC-2 (OPT-03) and AC-3 (OPT-04)."""
+
+    def test_10pct_improvement_canary(self):
+        prod = {"s1": 0.70, "s2": 0.70}
+        cand = {"s1": 0.80, "s2": 0.75}
+        result = validate_candidate(cand, prod)
+        assert result.decision == "CANARY"
+        assert result.passed is True
+
+    def test_3pct_improvement_rejected(self):
+        """AC-2: < 5% → REJECTED."""
+        prod = {"s1": 0.80, "s2": 0.80}
+        cand = {"s1": 0.82, "s2": 0.82}  # ~2.5% improvement
+        result = validate_candidate(cand, prod)
+        assert result.decision == "REJECTED"
+        assert result.passed is False
+
+    def test_0pct_improvement_rejected(self):
+        prod = {"s1": 0.80, "s2": 0.80}
+        cand = {"s1": 0.80, "s2": 0.80}
+        result = validate_candidate(cand, prod)
+        assert result.decision == "REJECTED"
+
+    def test_negative_improvement_rejected(self):
+        prod = {"s1": 0.80, "s2": 0.80}
+        cand = {"s1": 0.70, "s2": 0.70}
+        result = validate_candidate(cand, prod)
+        assert result.decision == "REJECTED"
+
+    def test_6pct_improvement_with_4pct_regression_pending(self):
+        """AC-3: individual regression > 3% → PENDING_APPROVAL."""
+        prod = {"s1": 0.70, "s2": 0.80}
+        cand = {"s1": 0.85, "s2": 0.76}  # s2 regresses 5%
+        result = validate_candidate(cand, prod)
+        assert result.decision == "PENDING_APPROVAL"
+        assert "s2" in result.scorer_regressions
+
+    def test_6pct_improvement_no_regressions_canary(self):
+        prod = {"s1": 0.70, "s2": 0.70}
+        cand = {"s1": 0.76, "s2": 0.76}  # ~8.6% improvement, no regression
+        result = validate_candidate(cand, prod)
+        assert result.decision == "CANARY"
+
+    def test_just_above_5pct_threshold_canary(self):
+        """Just above 5% improvement should pass."""
+        prod = {"s1": 0.80}
+        cand = {"s1": 0.85}  # 6.25% improvement
+        result = validate_candidate(cand, prod)
+        assert result.decision == "CANARY"
+
+    def test_just_below_5pct_threshold_rejected(self):
+        """Just below 5% improvement should fail."""
+        prod = {"s1": 0.80}
+        cand = {"s1": 0.838}  # 4.75% improvement
+        result = validate_candidate(cand, prod)
+        assert result.decision == "REJECTED"
+
+    def test_2pct_regression_no_flag(self):
+        """2% regression should NOT flag (>3% needed)."""
+        prod = {"s1": 0.50, "s2": 1.00}
+        cand = {"s1": 0.80, "s2": 0.98}  # s2 regresses 2%, s1 improves 60%
+        result = validate_candidate(cand, prod)
+        assert "s2" not in result.scorer_regressions
+
+    def test_result_has_all_fields(self):
+        prod = {"s1": 0.80}
+        cand = {"s1": 0.90}
+        result = validate_candidate(cand, prod)
+        assert isinstance(result, ValidationResult)
+        assert isinstance(result.aggregate_improvement, float)
+        assert isinstance(result.scorer_regressions, dict)
+        assert isinstance(result.candidate_scores, dict)
+        assert isinstance(result.production_scores, dict)
+
+    def test_production_zero_candidate_positive(self):
+        prod = {"s1": 0.0}
+        cand = {"s1": 0.5}
+        result = validate_candidate(cand, prod)
+        assert result.decision == "CANARY"
+
+    def test_both_zero(self):
+        prod = {"s1": 0.0}
+        cand = {"s1": 0.0}
+        result = validate_candidate(cand, prod)
+        assert result.decision == "REJECTED"
+
+    def test_custom_thresholds(self):
+        prod = {"s1": 0.80}
+        cand = {"s1": 0.82}  # 2.5% improvement
+        # With 2% threshold, should pass
+        result = validate_candidate(cand, prod, improvement_threshold=0.02)
+        assert result.decision == "CANARY"
+
+    def test_multiple_regressions(self):
+        prod = {"s1": 0.60, "s2": 0.80, "s3": 0.80}
+        cand = {"s1": 0.95, "s2": 0.70, "s3": 0.70}  # agg improves ~7%, s2/s3 regress
+        result = validate_candidate(cand, prod)
+        assert result.decision == "PENDING_APPROVAL"
+        assert len(result.scorer_regressions) == 2
+
+
+class TestConfigConstants:
+    def test_holdout_pct(self):
+        from app.core.config import settings
+
+        assert settings.VALIDATION_HOLDOUT_PCT == 0.2
+
+    def test_improvement_threshold(self):
+        from app.core.config import settings
+
+        assert settings.VALIDATION_IMPROVEMENT_THRESHOLD == 0.05
+
+    def test_regression_threshold(self):
+        from app.core.config import settings
+
+        assert settings.VALIDATION_REGRESSION_THRESHOLD == 0.03

--- a/prompt-optimization-svc/tests/test_candidate_validator_properties.py
+++ b/prompt-optimization-svc/tests/test_candidate_validator_properties.py
@@ -1,0 +1,73 @@
+"""Hypothesis property tests for candidate validation (US-032)."""
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from app.logic.candidate_validator import (
+    VALID_DECISIONS,
+    compute_aggregate_score,
+    split_holdout,
+    validate_candidate,
+)
+
+
+class TestSplitHoldoutProperties:
+    @given(st.lists(st.integers(), min_size=0, max_size=200))
+    @settings(max_examples=50, deadline=None)
+    def test_preserves_total_length(self, examples):
+        train, holdout = split_holdout(examples)
+        assert len(train) + len(holdout) == len(examples)
+
+    @given(st.lists(st.integers(), min_size=10, max_size=200))
+    @settings(max_examples=50, deadline=None)
+    def test_holdout_approximately_20pct(self, examples):
+        _, holdout = split_holdout(examples)
+        expected = int(len(examples) * 0.2)
+        assert abs(len(holdout) - expected) <= 1
+
+
+class TestAggregateScoreProperties:
+    @given(
+        st.dictionaries(
+            st.text(min_size=1, max_size=5),
+            st.floats(min_value=0.0, max_value=1.0, allow_nan=False),
+            min_size=1,
+            max_size=10,
+        )
+    )
+    @settings(max_examples=50, deadline=None)
+    def test_always_in_range(self, scores):
+        result = compute_aggregate_score(scores)
+        assert 0.0 <= result <= 1.0
+
+
+class TestValidateCandidateProperties:
+    @given(
+        st.dictionaries(
+            st.text(min_size=1, max_size=5),
+            st.floats(min_value=0.0, max_value=1.0, allow_nan=False),
+            min_size=1,
+            max_size=5,
+        ),
+        st.dictionaries(
+            st.text(min_size=1, max_size=5),
+            st.floats(min_value=0.0, max_value=1.0, allow_nan=False),
+            min_size=1,
+            max_size=5,
+        ),
+    )
+    @settings(max_examples=50, deadline=None)
+    def test_always_valid_decision(self, cand, prod):
+        result = validate_candidate(cand, prod)
+        assert result.decision in VALID_DECISIONS
+
+    @given(
+        st.floats(min_value=0.01, max_value=0.99, allow_nan=False),
+    )
+    @settings(max_examples=30, deadline=None)
+    def test_below_5pct_always_rejected(self, base):
+        prod = {"s1": base}
+        # 4% improvement
+        cand = {"s1": base * 1.04}
+        result = validate_candidate(cand, prod)
+        assert result.decision == "REJECTED"


### PR DESCRIPTION
## Summary

First story in EPIC-9 (Validation, Canary & Promotion). Validates GEPA candidates against current production using a held-out golden dataset slice:

- **`split_holdout()`**: deterministic 80/20 split of golden dataset (AC-1)
- **`validate_candidate()`**: compares candidate vs production scorer scores
  - Aggregate improvement < 5% → **REJECTED** (OPT-03, AC-2)
  - Individual scorer regression > 3% → **PENDING_APPROVAL** (OPT-04, AC-3)
  - Otherwise → **CANARY** (proceed to canary phase)
- Config: `VALIDATION_HOLDOUT_PCT=0.2`, `IMPROVEMENT_THRESHOLD=0.05`, `REGRESSION_THRESHOLD=0.03`

## Test plan

- [x] 22 unit tests (split, aggregate, validation decisions, thresholds, config)
- [x] 5 Hypothesis property tests (length preservation, range, decision validity)
- [x] 5 integration tests (real golden examples, realistic scorer scenarios)
- [x] Full suite: 1367 passed, 38 skipped
- [x] Black formatting verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)