### PR TITLE
feat(gepa): enforce mandatory 24-hour canary at 10% traffic (US-033)

### DIFF
--- a/prompt-optimization-svc/app/core/config.py
+++ b/prompt-optimization-svc/app/core/config.py
@@ -43,6 +43,10 @@ class Settings(BaseSettings):
     MINING_QUALITY_THRESHOLD: float = 0.8
     MINING_LOOKBACK_DAYS: int = 7
 
+    # Canary
+    CANARY_REGRESSION_THRESHOLD: float = 0.05
+    CANARY_METRICS_TTL_DAYS: int = 30
+
     # Validation (OPT-03/OPT-04)
     VALIDATION_HOLDOUT_PCT: float = 0.2
     VALIDATION_IMPROVEMENT_THRESHOLD: float = 0.05  # 5% minimum improvement

--- a/prompt-optimization-svc/app/logic/canary_manager.py
+++ b/prompt-optimization-svc/app/logic/canary_manager.py
@@ -5,7 +5,6 @@ Auto-rollbacks on >5% scorer regression. Covers all 15 agents.
 """
 
 import hashlib
-import json
 import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -204,11 +203,12 @@ class CanaryManager:
         if regression > threshold:
             logger.error(
                 "ADMIN ALERT: Canary regression detected for %s: "
-                "%.2f%% > %.2f%% threshold. Triggering rollback.",
+                "%.2f%% > %.2f%% threshold. Triggering auto-rollback.",
                 prompt_name,
                 regression * 100,
                 threshold * 100,
             )
+            await self.rollback_canary(prompt_name)
             return regression
 
         return None
@@ -216,15 +216,36 @@ class CanaryManager:
     async def rollback_canary(self, prompt_name: str) -> bool:
         """Roll back a canary deployment (AC-3).
 
-        Clears canary state and logs ADMIN alert.
+        Transitions the prompt version to ROLLED_BACK via the lifecycle
+        manager, clears canary state from Redis, and logs ADMIN alert.
         """
-        r = await self.prompt_cache.connect()
-        key = CANARY_STATE_KEY.format(name=prompt_name)
-
         state = await self.get_canary_state(prompt_name)
         if state is None:
             return False
 
+        # Transition prompt lifecycle to ROLLED_BACK
+        try:
+            from app.logic.lifecycle import PromptLifecycleManager, PromptState
+
+            lifecycle = PromptLifecycleManager(
+                mlflow_registry=None, prompt_cache=self.prompt_cache
+            )
+            lifecycle.rollback(
+                prompt_name,
+                state.canary_version,
+                PromptState.CANARY,
+            )
+        except Exception as exc:
+            logger.error(
+                "Failed to transition %s v%d to ROLLED_BACK: %s",
+                prompt_name,
+                state.canary_version,
+                exc,
+            )
+
+        # Clear canary state from Redis
+        r = await self.prompt_cache.connect()
+        key = CANARY_STATE_KEY.format(name=prompt_name)
         await r.delete(key)
 
         logger.error(

--- a/prompt-optimization-svc/app/logic/canary_manager.py
+++ b/prompt-optimization-svc/app/logic/canary_manager.py
@@ -1,0 +1,237 @@
+"""Canary deployment manager (§3.3, §18.2).
+
+Routes 10% of agent invocations to a candidate prompt for 24 hours.
+Auto-rollbacks on >5% scorer regression. Covers all 15 agents.
+"""
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Non-configurable canary parameters (AC-2)
+CANARY_TRAFFIC_PCT = 0.10
+CANARY_DURATION_HOURS = 24
+CANARY_PROMOTION_ENABLED = True  # Hardcoded, non-configurable
+
+# Redis key templates
+CANARY_STATE_KEY = "prompt:canary:{name}"
+CANARY_METRICS_KEY = "prompt:metrics:{name}:v{version}"
+
+
+def is_canary_request(tenant_id: str, canary_pct: float = CANARY_TRAFFIC_PCT) -> bool:
+    """Determine if a request should be routed to the canary prompt.
+
+    Deterministic via stable hash of tenant_id (AC-1). Same tenant
+    always gets the same routing decision for a given canary_pct.
+
+    Args:
+        tenant_id: Tenant identifier.
+        canary_pct: Fraction of traffic to route to canary (default 10%).
+
+    Returns:
+        True if request should use the canary prompt.
+    """
+    if not tenant_id:
+        return False
+    # Use SHA-256 for deterministic, uniform distribution (not Python hash())
+    digest = hashlib.sha256(tenant_id.encode()).hexdigest()
+    bucket = int(digest[:8], 16) % 100
+    return bucket < int(canary_pct * 100)
+
+
+@dataclass
+class CanaryState:
+    """State of an active canary deployment."""
+
+    prompt_name: str
+    canary_version: int
+    production_version: int
+    started_at: datetime
+    expires_at: datetime
+    agent_code: str
+    active: bool = True
+
+
+class CanaryManager:
+    """Manages canary deployments for prompt optimization.
+
+    Stores canary state and metrics in Redis (DB 2).
+    """
+
+    def __init__(self, prompt_cache) -> None:
+        self.prompt_cache = prompt_cache
+
+    async def start_canary(
+        self,
+        prompt_name: str,
+        canary_version: int,
+        production_version: int,
+        agent_code: str,
+    ) -> CanaryState:
+        """Start a 24-hour canary deployment.
+
+        Args:
+            prompt_name: Prompt being canary-tested.
+            canary_version: New candidate version.
+            production_version: Current production version.
+            agent_code: Agent code (covers all 15, AC-4).
+
+        Returns:
+            CanaryState with start/expiry times.
+        """
+        now = datetime.now(timezone.utc)
+        expires_at = now + timedelta(hours=CANARY_DURATION_HOURS)
+
+        state = CanaryState(
+            prompt_name=prompt_name,
+            canary_version=canary_version,
+            production_version=production_version,
+            started_at=now,
+            expires_at=expires_at,
+            agent_code=agent_code,
+            active=True,
+        )
+
+        r = await self.prompt_cache.connect()
+        key = CANARY_STATE_KEY.format(name=prompt_name)
+        state_data = {
+            "prompt_name": prompt_name,
+            "canary_version": str(canary_version),
+            "production_version": str(production_version),
+            "started_at": now.isoformat(),
+            "expires_at": expires_at.isoformat(),
+            "agent_code": agent_code,
+            "active": "true",
+        }
+        await r.hset(key, mapping=state_data)
+        await r.expire(key, CANARY_DURATION_HOURS * 3600)
+
+        logger.info(
+            "Canary started: %s v%d (production v%d) for %s, expires %s",
+            prompt_name,
+            canary_version,
+            production_version,
+            agent_code,
+            expires_at.isoformat(),
+        )
+        return state
+
+    async def get_canary_state(self, prompt_name: str) -> Optional[CanaryState]:
+        """Get active canary state, or None if expired/not found."""
+        r = await self.prompt_cache.connect()
+        key = CANARY_STATE_KEY.format(name=prompt_name)
+        data = await r.hgetall(key)
+
+        if not data:
+            return None
+
+        return CanaryState(
+            prompt_name=data.get("prompt_name", prompt_name),
+            canary_version=int(data.get("canary_version", 0)),
+            production_version=int(data.get("production_version", 0)),
+            started_at=datetime.fromisoformat(data["started_at"]),
+            expires_at=datetime.fromisoformat(data["expires_at"]),
+            agent_code=data.get("agent_code", ""),
+            active=data.get("active", "true") == "true",
+        )
+
+    async def record_canary_metric(
+        self,
+        prompt_name: str,
+        version: int,
+        scorer_name: str,
+        score: float,
+    ) -> None:
+        """Record a scorer metric for a canary or production version (AC-5).
+
+        Stored in prompt:metrics:<name>:v<version> with 30-day TTL.
+        """
+        r = await self.prompt_cache.connect()
+        key = CANARY_METRICS_KEY.format(name=prompt_name, version=version)
+        await r.hset(key, scorer_name, str(score))
+        ttl_seconds = settings.CANARY_METRICS_TTL_DAYS * 86400
+        await r.expire(key, ttl_seconds)
+
+    async def get_canary_metrics(
+        self, prompt_name: str, version: int
+    ) -> dict[str, float]:
+        """Get all scorer metrics for a version."""
+        r = await self.prompt_cache.connect()
+        key = CANARY_METRICS_KEY.format(name=prompt_name, version=version)
+        data = await r.hgetall(key)
+        return {k: float(v) for k, v in data.items()}
+
+    async def check_canary_regression(self, prompt_name: str) -> Optional[float]:
+        """Check if canary version has regressed vs production (AC-3).
+
+        Returns regression percentage if > 5%, None otherwise.
+        """
+        state = await self.get_canary_state(prompt_name)
+        if state is None:
+            return None
+
+        canary_metrics = await self.get_canary_metrics(
+            prompt_name, state.canary_version
+        )
+        prod_metrics = await self.get_canary_metrics(
+            prompt_name, state.production_version
+        )
+
+        if not canary_metrics or not prod_metrics:
+            return None
+
+        # Compute aggregate regression
+        common = set(canary_metrics.keys()) & set(prod_metrics.keys())
+        if not common:
+            return None
+
+        canary_agg = sum(canary_metrics[k] for k in common) / len(common)
+        prod_agg = sum(prod_metrics[k] for k in common) / len(common)
+
+        if prod_agg <= 0:
+            return None
+
+        regression = (prod_agg - canary_agg) / prod_agg
+        threshold = settings.CANARY_REGRESSION_THRESHOLD
+
+        if regression > threshold:
+            logger.error(
+                "ADMIN ALERT: Canary regression detected for %s: "
+                "%.2f%% > %.2f%% threshold. Triggering rollback.",
+                prompt_name,
+                regression * 100,
+                threshold * 100,
+            )
+            return regression
+
+        return None
+
+    async def rollback_canary(self, prompt_name: str) -> bool:
+        """Roll back a canary deployment (AC-3).
+
+        Clears canary state and logs ADMIN alert.
+        """
+        r = await self.prompt_cache.connect()
+        key = CANARY_STATE_KEY.format(name=prompt_name)
+
+        state = await self.get_canary_state(prompt_name)
+        if state is None:
+            return False
+
+        await r.delete(key)
+
+        logger.error(
+            "ADMIN ALERT: Canary ROLLED_BACK for %s v%d "
+            "(reverted to production v%d)",
+            prompt_name,
+            state.canary_version,
+            state.production_version,
+        )
+        return True

--- a/prompt-optimization-svc/tests/integration/test_canary_manager.py
+++ b/prompt-optimization-svc/tests/integration/test_canary_manager.py
@@ -1,0 +1,93 @@
+"""Integration tests for canary manager (US-033).
+
+Requires real Redis.
+"""
+
+from .conftest import REDIS_URL, requires_redis
+
+
+@requires_redis
+class TestCanaryManagerRedis:
+    """Canary state and metrics with real Redis."""
+
+    async def test_start_and_get_canary(self, real_redis):
+        from app.cache.prompt_cache import PromptCacheManager
+        from app.logic.canary_manager import CanaryManager
+
+        cache = PromptCacheManager(redis_url=REDIS_URL)
+        await cache.connect()
+        try:
+            mgr = CanaryManager(cache)
+            state = await mgr.start_canary(
+                prompt_name="__test_canary_prompt",
+                canary_version=2,
+                production_version=1,
+                agent_code="mra",
+            )
+            assert state.active is True
+            assert state.canary_version == 2
+
+            retrieved = await mgr.get_canary_state("__test_canary_prompt")
+            assert retrieved is not None
+            assert retrieved.canary_version == 2
+            assert retrieved.agent_code == "mra"
+        finally:
+            r = await cache.connect()
+            await r.delete("prompt:canary:__test_canary_prompt")
+            await cache.close()
+
+    async def test_record_and_get_metrics(self, real_redis):
+        from app.cache.prompt_cache import PromptCacheManager
+        from app.logic.canary_manager import CanaryManager
+
+        cache = PromptCacheManager(redis_url=REDIS_URL)
+        await cache.connect()
+        try:
+            mgr = CanaryManager(cache)
+            await mgr.record_canary_metric(
+                "__test_metrics_prompt", 5, "json_compliance", 0.95
+            )
+            await mgr.record_canary_metric(
+                "__test_metrics_prompt", 5, "pii_safety", 0.88
+            )
+
+            metrics = await mgr.get_canary_metrics("__test_metrics_prompt", 5)
+            assert metrics["json_compliance"] == 0.95
+            assert metrics["pii_safety"] == 0.88
+        finally:
+            r = await cache.connect()
+            await r.delete("prompt:metrics:__test_metrics_prompt:v5")
+            await cache.close()
+
+    async def test_rollback_clears_state(self, real_redis):
+        from app.cache.prompt_cache import PromptCacheManager
+        from app.logic.canary_manager import CanaryManager
+
+        cache = PromptCacheManager(redis_url=REDIS_URL)
+        await cache.connect()
+        try:
+            mgr = CanaryManager(cache)
+            await mgr.start_canary("__test_rollback", 3, 2, "cga")
+
+            rolled_back = await mgr.rollback_canary("__test_rollback")
+            assert rolled_back is True
+
+            state = await mgr.get_canary_state("__test_rollback")
+            assert state is None
+        finally:
+            r = await cache.connect()
+            await r.delete("prompt:canary:__test_rollback")
+            await cache.close()
+
+    async def test_nonexistent_canary_returns_none(self, real_redis):
+        from app.cache.prompt_cache import PromptCacheManager
+        from app.logic.canary_manager import CanaryManager
+
+        cache = PromptCacheManager(redis_url=REDIS_URL)
+        await cache.connect()
+        try:
+            mgr = CanaryManager(cache)
+            state = await mgr.get_canary_state("__test_nonexistent")
+            assert state is None
+        finally:
+            await cache.close()

--- a/prompt-optimization-svc/tests/test_canary_manager.py
+++ b/prompt-optimization-svc/tests/test_canary_manager.py
@@ -1,0 +1,133 @@
+"""Unit tests for canary manager (US-033)."""
+
+from datetime import datetime, timedelta, timezone
+
+from app.logic.canary_manager import (
+    CANARY_DURATION_HOURS,
+    CANARY_METRICS_KEY,
+    CANARY_PROMOTION_ENABLED,
+    CANARY_STATE_KEY,
+    CANARY_TRAFFIC_PCT,
+    CanaryState,
+    is_canary_request,
+)
+from app.registries.prompt_catalog import AGENT_PORTS
+
+
+class TestIsCanaryRequest:
+    """AC-1: Deterministic via hash(tenant_id)."""
+
+    def test_deterministic_same_tenant(self):
+        r1 = is_canary_request("tenant-abc")
+        r2 = is_canary_request("tenant-abc")
+        assert r1 == r2
+
+    def test_deterministic_across_calls(self):
+        results = [is_canary_request("tenant-xyz") for _ in range(100)]
+        assert all(r == results[0] for r in results)
+
+    def test_approximately_10pct_routing(self):
+        total = 1000
+        canary_count = sum(is_canary_request(f"tenant-{i}") for i in range(total))
+        # 10% ± 5% tolerance
+        assert 50 <= canary_count <= 150, f"Got {canary_count}/1000"
+
+    def test_different_tenants_differ(self):
+        results = {is_canary_request(f"t-{i}") for i in range(100)}
+        assert True in results
+        assert False in results
+
+    def test_empty_tenant_returns_false(self):
+        assert is_canary_request("") is False
+
+    def test_custom_pct(self):
+        # With 100% canary, all should route
+        assert is_canary_request("any-tenant", canary_pct=1.0) is True
+
+    def test_zero_pct(self):
+        assert is_canary_request("any-tenant", canary_pct=0.0) is False
+
+
+class TestCanaryConstants:
+    """AC-2: Non-configurable canary parameters."""
+
+    def test_traffic_pct(self):
+        assert CANARY_TRAFFIC_PCT == 0.10
+
+    def test_duration_hours(self):
+        assert CANARY_DURATION_HOURS == 24
+
+    def test_promotion_enabled_hardcoded(self):
+        assert CANARY_PROMOTION_ENABLED is True
+
+    def test_regression_threshold(self):
+        from app.core.config import settings
+
+        assert settings.CANARY_REGRESSION_THRESHOLD == 0.05
+
+    def test_metrics_ttl_days(self):
+        from app.core.config import settings
+
+        assert settings.CANARY_METRICS_TTL_DAYS == 30
+
+
+class TestCanaryState:
+    def test_dataclass_fields(self):
+        now = datetime.now(timezone.utc)
+        state = CanaryState(
+            prompt_name="zorven-wf3-cga-system",
+            canary_version=5,
+            production_version=4,
+            started_at=now,
+            expires_at=now + timedelta(hours=24),
+            agent_code="cga",
+        )
+        assert state.prompt_name == "zorven-wf3-cga-system"
+        assert state.canary_version == 5
+        assert state.production_version == 4
+        assert state.active is True
+
+    def test_expires_after_24h(self):
+        now = datetime.now(timezone.utc)
+        expires = now + timedelta(hours=CANARY_DURATION_HOURS)
+        state = CanaryState(
+            prompt_name="test",
+            canary_version=2,
+            production_version=1,
+            started_at=now,
+            expires_at=expires,
+            agent_code="mra",
+        )
+        assert (state.expires_at - state.started_at).total_seconds() == 24 * 3600
+
+
+class TestCanaryKeyFormats:
+    """AC-5: Redis key formats."""
+
+    def test_state_key_format(self):
+        key = CANARY_STATE_KEY.format(name="zorven-wf3-cga-system")
+        assert key == "prompt:canary:zorven-wf3-cga-system"
+
+    def test_metrics_key_format(self):
+        key = CANARY_METRICS_KEY.format(name="zorven-wf3-cga-system", version=5)
+        assert key == "prompt:metrics:zorven-wf3-cga-system:v5"
+
+
+class TestCanaryAllAgents:
+    """AC-4: Covers ALL 15 agents."""
+
+    def test_any_agent_code_accepted(self):
+        now = datetime.now(timezone.utc)
+        for agent in AGENT_PORTS:
+            state = CanaryState(
+                prompt_name=f"zorven-wf1-{agent}-system",
+                canary_version=2,
+                production_version=1,
+                started_at=now,
+                expires_at=now + timedelta(hours=24),
+                agent_code=agent,
+            )
+            assert state.agent_code == agent
+
+    def test_all_15_agents_can_canary(self):
+        assert len(AGENT_PORTS) == 15

--- a/prompt-optimization-svc/tests/test_canary_manager_properties.py
+++ b/prompt-optimization-svc/tests/test_canary_manager_properties.py
@@ -1,0 +1,54 @@
+"""Hypothesis property tests for canary manager (US-033)."""
+
+from datetime import datetime, timedelta, timezone
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from app.logic.canary_manager import (
+    CANARY_DURATION_HOURS,
+    CanaryState,
+    is_canary_request,
+)
+
+
+class TestIsCanaryRequestProperties:
+    @given(st.text(min_size=1, max_size=50))
+    @settings(max_examples=100, deadline=None)
+    def test_deterministic(self, tenant_id):
+        r1 = is_canary_request(tenant_id)
+        r2 = is_canary_request(tenant_id)
+        assert r1 == r2
+
+    @given(st.text(min_size=1, max_size=50))
+    @settings(max_examples=100, deadline=None)
+    def test_returns_bool(self, tenant_id):
+        result = is_canary_request(tenant_id)
+        assert isinstance(result, bool)
+
+    def test_distribution_approximately_10pct(self):
+        total = 5000
+        canary = sum(is_canary_request(f"t-{i}") for i in range(total))
+        pct = canary / total
+        assert 0.05 <= pct <= 0.15, f"Canary rate {pct:.1%} outside [5%, 15%]"
+
+
+class TestCanaryStateProperties:
+    @given(
+        st.text(min_size=1, max_size=30),
+        st.integers(min_value=1, max_value=100),
+        st.integers(min_value=1, max_value=100),
+        st.text(min_size=1, max_size=10),
+    )
+    @settings(max_examples=30, deadline=None)
+    def test_expires_after_started(self, name, cv, pv, agent):
+        now = datetime.now(timezone.utc)
+        state = CanaryState(
+            prompt_name=name,
+            canary_version=cv,
+            production_version=pv,
+            started_at=now,
+            expires_at=now + timedelta(hours=CANARY_DURATION_HOURS),
+            agent_code=agent,
+        )
+        assert state.expires_at > state.started_at


### PR DESCRIPTION
## Summary

Second story in EPIC-9 (Validation, Canary & Promotion). Implements mandatory canary deployment for prompt optimization:

- **Deterministic traffic split**: `is_canary_request()` uses SHA-256 hash of tenant_id for 10% routing (AC-1)
- **Non-configurable**: `CANARY_DURATION_HOURS=24`, `CANARY_PROMOTION_ENABLED=True` hardcoded (AC-2)
- **Auto-rollback**: `check_canary_regression()` triggers ROLLED_BACK + ADMIN alert on >5% regression (AC-3)
- **All 15 agents**: any agent_code accepted for canary deployment (AC-4)
- **Metrics retention**: stored in `prompt:metrics:<name>:v<n>` with 30-day TTL (AC-5)

`CanaryManager` class: `start_canary()`, `get_canary_state()`, `record_canary_metric()`, `check_canary_regression()`, `rollback_canary()`

## Test plan

- [x] 18 unit tests (deterministic routing, constants, state, key formats, all agents)
- [x] 4 Hypothesis property tests (determinism, distribution, expiry)
- [x] 4 integration tests (Redis start/get, metrics, rollback, nonexistent)
- [x] Full suite: 1394 passed, 38 skipped
- [x] Black formatting verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)