### PR TITLE
fix(onboarding): fix Zorven brand onboarding data upload failures

### DIFF
--- a/ai-brand-automator/onboarding/models.py
+++ b/ai-brand-automator/onboarding/models.py
@@ -117,7 +117,8 @@ class Company(models.Model):
         verbose_name_plural = "Companies"
 
     def __str__(self):
-        return f"{self.name} ({self.tenant.name})"
+        tenant_name = self.tenant.name if self.tenant else "no-tenant"
+        return f"{self.name} ({tenant_name})"
 
     @property
     def formatted_address(self):

--- a/ai-brand-automator/onboarding/views.py
+++ b/ai-brand-automator/onboarding/views.py
@@ -91,8 +91,16 @@ class CompanyViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):
 
         # Check if tenant already has a company (OneToOneField constraint)
         if Company.objects.filter(tenant=tenant).exists():
-            raise ValueError(
-                f"Tenant {tenant.name} already has a company. Cannot create another."
+            from rest_framework.exceptions import ValidationError
+
+            raise ValidationError(
+                {
+                    "error": "duplicate_company",
+                    "message": (
+                        f"Tenant {tenant.name} already has a company. "
+                        "Use PATCH to update instead of POST to create."
+                    ),
+                }
             )
 
         # Save company with tenant


### PR DESCRIPTION
## Summary

Fixes two bugs causing onboarding data upload failures for the Zorven brand:

### Bug 1: `Company.__str__` crashes on None tenant
The `Company` model declares `tenant = OneToOneField(null=True)` but `__str__` unconditionally accesses `self.tenant.name`, causing `AttributeError` when the Company is logged, serialized, or displayed in admin without a tenant context.

**Fix**: Safely handle None tenant with fallback string `"no-tenant"`.

### Bug 2: `perform_create` raises unhandled `ValueError`
When a tenant already has a company and the frontend sends POST again (browser refresh, stale `localStorage` company_id), the code raises `ValueError` which DRF converts to a **500 Internal Server Error** instead of a meaningful client error.

**Fix**: Raise `ValidationError` with structured error response including `"duplicate_company"` error code and guidance to use PATCH.

## Root cause analysis

The onboarding wizard flow:
1. Step 1 (CompanyForm): POST to create or PATCH to update company
2. Steps 2-3: PATCH to update additional fields
3. Step 5 (Review): POST to `generate_onboarding_pdf`

The failure occurs when:
- Frontend has a stale `company_id` in localStorage and tries POST instead of PATCH
- Or when `Company.__str__` is called during error logging/serialization with a null tenant

## Test plan

- [x] Verified `Company.__str__` handles None tenant
- [x] Verified duplicate company creation returns 400 instead of 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)