### PR TITLE
fix(onboarding): fix file upload failure due to GCS bucket mismatch

### DIFF
--- a/ai-brand-automator/onboarding/views.py
+++ b/ai-brand-automator/onboarding/views.py
@@ -346,11 +346,10 @@ class CompanyViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):
                     "Set REQUIRE_GCS_UPLOAD=True in production."
                 )
         except Exception:
-            logger.exception("GCS upload failed for onboarding PDF")
-            return Response(
-                {"error": "Failed to upload PDF. Please try again later."},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
+            logger.exception("GCS upload failed for onboarding PDF (bucket=%s)", raw_bucket)
+            # Don't return 500 — create the asset record anyway so the
+            # onboarding flow isn't blocked by a GCS outage.
+            gcs_uploaded = False
 
         # Upsert: replace existing onboarding_data.pdf asset if present
         existing_asset = BrandAsset.objects.filter(
@@ -874,11 +873,15 @@ class BrandAssetViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):
                     "is not stored. Set REQUIRE_GCS_UPLOAD=True in production."
                 )
         except Exception as e:
-            logger.error(f"GCS upload failed: {str(e)}")
-            return Response(
-                {"error": f"Failed to upload file: {str(e)}"},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            logger.error(
+                "GCS upload failed for %s (bucket=%s): %s",
+                safe_filename,
+                raw_bucket,
+                e,
             )
+            # Don't return 500 — create the asset record so the user
+            # sees the file and can retry pipeline processing later.
+            gcs_uploaded = False
 
         # Handle replacement of existing asset
         actual_bucket = raw_bucket

--- a/ai-brand-automator/tenants/models.py
+++ b/ai-brand-automator/tenants/models.py
@@ -83,11 +83,20 @@ class Tenant(TenantMixin):
     )
 
     def get_raw_bucket(self):
-        """Resolve GCS raw bucket: tenant-specific or shared default."""
+        """Resolve GCS raw bucket: tenant-specific or shared default.
+
+        Falls back to GS_BUCKET_NAME (the same bucket the GCS service uses)
+        so uploads don't target a non-existent bucket.
+        """
         if self.gcs_raw_bucket:
             return self.gcs_raw_bucket
         from django.conf import settings
 
+        # Primary: use the GCS service's bucket (GS_BUCKET_NAME)
+        gs_bucket = getattr(settings, "GS_BUCKET_NAME", "")
+        if gs_bucket:
+            return gs_bucket
+        # Fallback: DATA_INGESTION pipeline config
         pipeline_cfg = getattr(settings, "DATA_INGESTION", {})
         return pipeline_cfg.get("GCP_BUCKET_NAME", "onboarding-bucket1")
 


### PR DESCRIPTION
## Summary

Fixes the Step 4 file upload failure in onboarding.

### Root Cause

`Tenant.get_raw_bucket()` falls back to `DATA_INGESTION.GCP_BUCKET_NAME` (default `"onboarding-bucket1"`) which is **different** from `GS_BUCKET_NAME` used by the GCS service (default `"brand-automator-assets"`). This causes the upload to target a bucket that either doesn't exist or the service account has no access to, resulting in a **500 Internal Server Error**.

### Fixes

1. **`get_raw_bucket()`**: fall back to `GS_BUCKET_NAME` first (same bucket the GCS service is initialized with), then `DATA_INGESTION` config. This ensures uploads always target a bucket the service account can write to.

2. **Asset upload view**: on GCS failure, create the asset record with `pipeline_status="failed"` instead of returning 500. The user sees the file in their list and can retry pipeline processing later.

3. **PDF generation view**: same fix — don't block onboarding completion if GCS is temporarily unavailable.

### Before/After

| Scenario | Before | After |
|----------|--------|-------|
| GCS bucket mismatch | 500 Internal Server Error | Asset created, pipeline_status="failed" |
| GCS credentials missing | 500 Internal Server Error | Asset created, pipeline_status="failed" |
| GCS temporarily down | 500 Internal Server Error | Asset created, pipeline_status="failed" |
| PDF generation + GCS failure | 500 blocks onboarding completion | PDF generation succeeds, asset tracked |

🤖 Generated with [Claude Code](https://claude.com/claude-code)