### PR TITLE
fix(onboarding): return clear error when GCS credentials are missing

### DIFF
--- a/ai-brand-automator/files/services.py
+++ b/ai-brand-automator/files/services.py
@@ -80,18 +80,29 @@ class GCSService:
         self.credentials_path = settings.GS_CREDENTIALS_PATH
 
         # Initialize GCS client
+        self._init_error = None
         try:
             credentials = self._resolve_credentials()
             self.client = storage.Client(
                 credentials=credentials, project=self.project_id
             )
         except Exception as e:
-            # Fallback: create a mock client for development
+            self._init_error = str(e)
+            # Use print() because logging may not be configured yet
+            # at module import time
+            print(
+                f"[GCS] WARNING: Initialization failed: {e}. "
+                f"File uploads will not work."
+            )
             logger.warning("GCS initialization failed: %s. Using mock service.", e)
             self.client = None
 
         if self.client:
             self.bucket = self.client.bucket(self.bucket_name)
+            print(
+                f"[GCS] OK: project={self.project_id} "
+                f"bucket={self.bucket_name}"
+            )
             logger.info(
                 "GCS service initialized: project=%s bucket=%s",
                 self.project_id,
@@ -99,12 +110,18 @@ class GCSService:
             )
         else:
             self.bucket = None
+            print(
+                f"[GCS] ERROR: GCS not available. "
+                f"bucket={self.bucket_name} project={self.project_id} "
+                f"error={self._init_error}"
+            )
             logger.error(
                 "GCS service NOT available — file uploads will fail. "
-                "Set GCS_CREDENTIALS_JSON env var with the service account "
-                "JSON to enable file storage. (bucket=%s, project=%s)",
+                "Set GCS_CREDENTIALS_JSON env var. (bucket=%s, project=%s, "
+                "error=%s)",
                 self.bucket_name,
                 self.project_id,
+                self._init_error,
             )
 
     def get_bucket(self, bucket_name=None):
@@ -128,28 +145,29 @@ class GCSService:
         # 1. Inline JSON from environment variable (Railway / Heroku / CI)
         creds_json = os.environ.get("GCS_CREDENTIALS_JSON", "").strip()
         if creds_json:
-            logger.info("Loading GCS credentials from GCS_CREDENTIALS_JSON env var")
+            print(f"[GCS] Loading credentials from GCS_CREDENTIALS_JSON ({len(creds_json)} chars)")
             try:
                 info = json.loads(creds_json)
-                return service_account.Credentials.from_service_account_info(
+                creds = service_account.Credentials.from_service_account_info(
                     info, scopes=GCS_SCOPES
                 )
+                print(f"[GCS] Credentials loaded: {info.get('client_email', '?')}")
+                return creds
             except (json.JSONDecodeError, ValueError) as e:
+                print(f"[GCS] Invalid GCS_CREDENTIALS_JSON: {e}")
                 logger.warning(
-                    "Invalid GCS_CREDENTIALS_JSON env var; falling back to "
-                    "file/ADC credentials: %s",
-                    e,
+                    "Invalid GCS_CREDENTIALS_JSON env var; falling back: %s", e
                 )
 
         # 2. Service account key file on disk (local development)
         if self.credentials_path and os.path.exists(self.credentials_path):
-            logger.info("Loading GCS credentials from file: %s", self.credentials_path)
+            print(f"[GCS] Loading credentials from file: {self.credentials_path}")
             return service_account.Credentials.from_service_account_file(
                 self.credentials_path, scopes=GCS_SCOPES
             )
 
         # 3. Fall back to Application Default Credentials (with explicit scopes)
-        logger.info("No explicit GCS credentials found, using ADC")
+        print("[GCS] No explicit credentials found, trying ADC")
         credentials, project = google.auth.default(scopes=GCS_SCOPES)
         return credentials
 

--- a/ai-brand-automator/files/services.py
+++ b/ai-brand-automator/files/services.py
@@ -92,8 +92,20 @@ class GCSService:
 
         if self.client:
             self.bucket = self.client.bucket(self.bucket_name)
+            logger.info(
+                "GCS service initialized: project=%s bucket=%s",
+                self.project_id,
+                self.bucket_name,
+            )
         else:
             self.bucket = None
+            logger.error(
+                "GCS service NOT available — file uploads will fail. "
+                "Set GCS_CREDENTIALS_JSON env var with the service account "
+                "JSON to enable file storage. (bucket=%s, project=%s)",
+                self.bucket_name,
+                self.project_id,
+            )
 
     def get_bucket(self, bucket_name=None):
         """Return a GCS bucket object.

--- a/ai-brand-automator/onboarding/views.py
+++ b/ai-brand-automator/onboarding/views.py
@@ -334,22 +334,20 @@ class CompanyViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):
                 )
                 gcs_uploaded = True
             else:
-                require_gcs = getattr(settings, "REQUIRE_GCS_UPLOAD", False)
-                if require_gcs:
-                    logger.error("GCS is required but not configured")
-                    return Response(
-                        {"error": "File storage is not configured"},
-                        status=status.HTTP_503_SERVICE_UNAVAILABLE,
+                if not settings.DEBUG:
+                    logger.error(
+                        "GCS_CREDENTIALS_JSON not configured — cannot store "
+                        "onboarding PDF. Set the env var on Railway."
                     )
-                logger.warning(
-                    "GCS not configured — onboarding PDF not stored. "
-                    "Set REQUIRE_GCS_UPLOAD=True in production."
-                )
+                else:
+                    logger.warning(
+                        "GCS not configured (DEBUG mode) — onboarding PDF "
+                        "not stored."
+                    )
         except Exception:
-            logger.exception("GCS upload failed for onboarding PDF (bucket=%s)", raw_bucket)
-            # Don't return 500 — create the asset record anyway so the
-            # onboarding flow isn't blocked by a GCS outage.
-            gcs_uploaded = False
+            logger.exception(
+                "GCS upload failed for onboarding PDF (bucket=%s)", raw_bucket
+            )
 
         # Upsert: replace existing onboarding_data.pdf asset if present
         existing_asset = BrandAsset.objects.filter(
@@ -863,17 +861,26 @@ class BrandAssetViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):
                 )
                 gcs_uploaded = True
             else:
-                # GCS not configured - check if we should fail or allow for dev/testing
-                require_gcs = getattr(settings, "REQUIRE_GCS_UPLOAD", False)
-                if require_gcs:
-                    logger.error("GCS is required but not configured")
+                # GCS client is None — credentials not configured
+                if not settings.DEBUG:
+                    # Production: fail clearly so the operator fixes env vars
+                    logger.error(
+                        "GCS_CREDENTIALS_JSON not configured — cannot upload "
+                        "files. Set the GCS_CREDENTIALS_JSON environment "
+                        "variable with the service account JSON."
+                    )
                     return Response(
-                        {"error": "File storage is not configured"},
+                        {
+                            "error": (
+                                "File storage is not configured. Please contact "
+                                "your administrator to set up GCS credentials."
+                            )
+                        },
                         status=status.HTTP_503_SERVICE_UNAVAILABLE,
                     )
                 logger.warning(
-                    "GCS not configured, asset record will be created but file "
-                    "is not stored. Set REQUIRE_GCS_UPLOAD=True in production."
+                    "GCS not configured (DEBUG mode), asset record will be "
+                    "created but file is not stored."
                 )
         except Exception as e:
             logger.error(
@@ -882,9 +889,15 @@ class BrandAssetViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):
                 raw_bucket,
                 e,
             )
-            # Don't return 500 — create the asset record so the user
-            # sees the file and can retry pipeline processing later.
-            gcs_uploaded = False
+            return Response(
+                {
+                    "error": (
+                        f"Failed to upload file to storage: {e}. "
+                        "Please try again or contact your administrator."
+                    )
+                },
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
 
         # Handle replacement of existing asset
         actual_bucket = raw_bucket

--- a/ai-brand-automator/onboarding/views.py
+++ b/ai-brand-automator/onboarding/views.py
@@ -344,9 +344,13 @@ class CompanyViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):
                         "GCS not configured (DEBUG mode) — onboarding PDF "
                         "not stored."
                     )
-        except Exception:
+        except Exception as e:
             logger.exception(
                 "GCS upload failed for onboarding PDF (bucket=%s)", raw_bucket
+            )
+            return Response(
+                {"error": f"Failed to store onboarding PDF: {e}"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
         # Upsert: replace existing onboarding_data.pdf asset if present
@@ -883,11 +887,10 @@ class BrandAssetViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):
                     "created but file is not stored."
                 )
         except Exception as e:
-            logger.error(
-                "GCS upload failed for %s (bucket=%s): %s",
+            logger.exception(
+                "GCS upload failed for %s (bucket=%s)",
                 safe_filename,
                 raw_bucket,
-                e,
             )
             return Response(
                 {


### PR DESCRIPTION
## Summary

The previous fixes (PRs 401-403) addressed code bugs but missed the actual root cause: **GCS_CREDENTIALS_JSON is not set on Railway**, so `gcs_service.client` is `None` and ALL file uploads silently fail.

PR 402 made this worse by changing the 500 error to silently create asset records with `pipeline_status="failed"` — users see files in their list but they never process.

### What's actually broken

```
GCS_CREDENTIALS_JSON not set on Railway
→ gcs_service._resolve_credentials() fails
→ self.client = None
→ get_bucket() returns None
→ upload silently creates "failed" asset record
→ user sees file but it never indexes/curates
```

### Fixes

1. **Upload view**: in production (`DEBUG=False`), return **503** with clear error: *"File storage is not configured. Please contact your administrator to set up GCS credentials."* In dev (`DEBUG=True`), allow degraded mode.

2. **Upload exception**: return **500** with the actual GCS error instead of silently creating a broken record.

3. **GCS service startup**: log `ERROR` with the specific env var that needs to be set when client init fails.

4. **PDF generation**: log `ERROR` in production when GCS not configured.

### Action required on Railway

Set the `GCS_CREDENTIALS_JSON` environment variable on the Django backend service with the GCP service account JSON:

```bash
railway variables set GCS_CREDENTIALS_JSON='{"type":"service_account","project_id":"...","private_key":"...","client_email":"..."}'
```

Then redeploy the service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)