### PR TITLE
feat(gepa): support tenant-specific prompt overrides (US-039)

### DIFF
--- a/prompt-optimization-svc/app/api/routes.py
+++ b/prompt-optimization-svc/app/api/routes.py
@@ -691,22 +691,41 @@ async def reject_optimization_run(run_id: str, request: RejectionRequest):
     "/v1/prompts/{name}/tenant-overrides",
     response_model=TenantOverrideResponse,
 )
-async def create_tenant_override_endpoint(name: str, request: TenantOverrideRequest):
+async def create_tenant_override_endpoint(
+    name: str,
+    request: TenantOverrideRequest,
+    x_tenant_id: str = Header(default="", alias="X-Tenant-ID"),
+):
     """Create a tenant-specific prompt override (AC-1: OWNER only)."""
+    from app.cache.prompt_cache import PromptCacheManager
+    from app.core.config import settings
     from app.logic.tenant_override import create_tenant_override
 
-    result = await create_tenant_override(
-        prompt_name=name,
-        tenant_id=request.tenant_id,
-        template=request.template,
-        mlflow_registry=mlflow_registry,
-    )
-    return TenantOverrideResponse(**result)
+    # Verify tenant_id matches the authenticated tenant
+    if x_tenant_id and request.tenant_id != x_tenant_id:
+        return JSONResponse(
+            status_code=403,
+            content={"detail": "tenant_id in body must match X-Tenant-ID header"},
+        )
+
+    cache = PromptCacheManager(redis_url=settings.PROMPT_CACHE_REDIS_URL)
+    await cache.connect()
+    try:
+        result = await create_tenant_override(
+            prompt_name=name,
+            tenant_id=request.tenant_id,
+            template=request.template,
+            mlflow_registry=mlflow_registry,
+            prompt_cache=cache,
+        )
+        return TenantOverrideResponse(**result)
+    finally:
+        await cache.close()
 
 
 @router.get(
     "/v1/prompts/{name}/tenant-overrides/{tenant_id}",
-    response_model=None,
+    response_model=TenantOverrideResponse,
 )
 async def get_tenant_override_endpoint(name: str, tenant_id: str):
     """Get a tenant-specific prompt override."""
@@ -727,7 +746,6 @@ async def get_tenant_override_endpoint(name: str, tenant_id: str):
 
 @router.delete(
     "/v1/prompts/{name}/tenant-overrides/{tenant_id}",
-    response_model=None,
 )
 async def delete_tenant_override_endpoint(name: str, tenant_id: str):
     """Delete a tenant-specific prompt override (AC-1, AC-3)."""

--- a/prompt-optimization-svc/app/api/routes.py
+++ b/prompt-optimization-svc/app/api/routes.py
@@ -26,6 +26,8 @@ from app.api.schemas import (
     ApprovalRequest,
     ApprovalResponse,
     RejectionRequest,
+    TenantOverrideRequest,
+    TenantOverrideResponse,
 )
 from app.logic.lifecycle import (
     InvalidTransitionError,
@@ -680,6 +682,80 @@ async def reject_optimization_run(run_id: str, request: RejectionRequest):
             decision=decision.decision,
             approved_by=decision.approved_by,
             decided_at=decision.decided_at.isoformat(),
+        )
+    finally:
+        await cache.close()
+
+
+@router.post(
+    "/v1/prompts/{name}/tenant-overrides",
+    response_model=TenantOverrideResponse,
+)
+async def create_tenant_override_endpoint(name: str, request: TenantOverrideRequest):
+    """Create a tenant-specific prompt override (AC-1: OWNER only)."""
+    from app.logic.tenant_override import create_tenant_override
+
+    result = await create_tenant_override(
+        prompt_name=name,
+        tenant_id=request.tenant_id,
+        template=request.template,
+        mlflow_registry=mlflow_registry,
+    )
+    return TenantOverrideResponse(**result)
+
+
+@router.get(
+    "/v1/prompts/{name}/tenant-overrides/{tenant_id}",
+    response_model=None,
+)
+async def get_tenant_override_endpoint(name: str, tenant_id: str):
+    """Get a tenant-specific prompt override."""
+    from app.logic.tenant_override import get_tenant_override
+
+    result = await get_tenant_override(
+        prompt_name=name,
+        tenant_id=tenant_id,
+        mlflow_registry=mlflow_registry,
+    )
+    if result is None:
+        return JSONResponse(
+            status_code=404,
+            content={"detail": f"No tenant override for '{name}' tenant '{tenant_id}'"},
+        )
+    return TenantOverrideResponse(**result)
+
+
+@router.delete(
+    "/v1/prompts/{name}/tenant-overrides/{tenant_id}",
+    response_model=None,
+)
+async def delete_tenant_override_endpoint(name: str, tenant_id: str):
+    """Delete a tenant-specific prompt override (AC-1, AC-3)."""
+    from app.cache.prompt_cache import PromptCacheManager
+    from app.core.config import settings
+    from app.logic.tenant_override import delete_tenant_override
+
+    cache = PromptCacheManager(redis_url=settings.PROMPT_CACHE_REDIS_URL)
+    await cache.connect()
+    try:
+        deleted = await delete_tenant_override(
+            prompt_name=name,
+            tenant_id=tenant_id,
+            mlflow_registry=mlflow_registry,
+            prompt_cache=cache,
+        )
+        if not deleted:
+            return JSONResponse(
+                status_code=404,
+                content={
+                    "detail": f"No tenant override for '{name}' tenant '{tenant_id}'"
+                },
+            )
+        return JSONResponse(
+            status_code=200,
+            content={
+                "detail": f"Tenant override deleted for '{name}' tenant '{tenant_id}'"
+            },
         )
     finally:
         await cache.close()

--- a/prompt-optimization-svc/app/api/schemas.py
+++ b/prompt-optimization-svc/app/api/schemas.py
@@ -307,3 +307,23 @@ class ApprovalResponse(BaseModel):
     decision: Literal["approved", "rejected"]
     approved_by: str
     decided_at: str
+
+
+# ── Tenant override schemas ──
+
+
+class TenantOverrideRequest(BaseModel):
+    """Request for POST /v1/prompts/{name}/tenant-overrides."""
+
+    template: str = Field(..., min_length=1, description="Override prompt template")
+    tenant_id: str = Field(..., min_length=1, description="Tenant identifier")
+
+
+class TenantOverrideResponse(BaseModel):
+    """Response for tenant override operations."""
+
+    prompt_name: str
+    tenant_id: str
+    version: int = 0
+    template: str = ""
+    state: str = "TENANT_OVERRIDE"

--- a/prompt-optimization-svc/app/logic/tenant_override.py
+++ b/prompt-optimization-svc/app/logic/tenant_override.py
@@ -1,0 +1,170 @@
+"""Tenant-specific prompt override management (§10.1, §11.1).
+
+Allows tenants to register overrides that take precedence over
+global production prompts. RBAC-restricted to OWNER role.
+"""
+
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+TENANT_CACHE_KEY = "prompt:{name}:tenant:{tenant_id}"
+
+
+async def create_tenant_override(
+    prompt_name: str,
+    tenant_id: str,
+    template: str,
+    mlflow_registry: Any = None,
+    prompt_cache: Any = None,
+    lifecycle_producer: Any = None,
+) -> dict:
+    """Create a tenant-specific prompt override.
+
+    Registers the override in MLflow with TENANT_OVERRIDE state
+    and caches it in Redis for fast resolution.
+
+    Args:
+        prompt_name: Base prompt name (e.g., "zorven-wf3-cga-system").
+        tenant_id: Tenant identifier.
+        template: Override prompt template text.
+        mlflow_registry: MLflow prompt registry client.
+        prompt_cache: Redis prompt cache manager.
+        lifecycle_producer: Kafka lifecycle event producer.
+
+    Returns:
+        Dict with override info (prompt_name, tenant_id, version, state).
+    """
+    version = 0
+
+    # Register in MLflow with TENANT_OVERRIDE state
+    if mlflow_registry is not None:
+        info = mlflow_registry.register_prompt(
+            name=prompt_name,
+            template=template,
+            tags={
+                "state": "TENANT_OVERRIDE",
+                "tenant_id": tenant_id,
+            },
+        )
+        version = info.version
+
+    # Cache in Redis for fast resolution
+    if prompt_cache is not None:
+        try:
+            r = await prompt_cache.connect()
+            key = TENANT_CACHE_KEY.format(name=prompt_name, tenant_id=tenant_id)
+            await r.set(key, template)
+        except Exception as exc:
+            logger.warning("Failed to cache tenant override: %s", exc)
+
+    # Emit Kafka event
+    if lifecycle_producer is not None:
+        lifecycle_producer.send_lifecycle_event_sync(
+            event_type="prompt.tenant_override.created",
+            prompt_name=prompt_name,
+            version=version,
+            from_state="DRAFT",
+            to_state="TENANT_OVERRIDE",
+            tenant_id=tenant_id,
+        )
+
+    logger.info(
+        "Tenant override created: %s tenant=%s v%d",
+        prompt_name,
+        tenant_id,
+        version,
+    )
+    return {
+        "prompt_name": prompt_name,
+        "tenant_id": tenant_id,
+        "version": version,
+        "template": template,
+        "state": "TENANT_OVERRIDE",
+    }
+
+
+async def delete_tenant_override(
+    prompt_name: str,
+    tenant_id: str,
+    mlflow_registry: Any = None,
+    prompt_cache: Any = None,
+    lifecycle_producer: Any = None,
+) -> bool:
+    """Delete a tenant-specific prompt override (AC-3).
+
+    Removes the cache entry and transitions the MLflow version
+    to ARCHIVED.
+
+    Returns:
+        True if override was found and deleted.
+    """
+    found = False
+
+    # Archive the MLflow version
+    if mlflow_registry is not None:
+        override = mlflow_registry.get_prompt_by_state(
+            prompt_name, "TENANT_OVERRIDE", tenant_id=tenant_id
+        )
+        if override is not None:
+            mlflow_registry.set_prompt_state(prompt_name, override.version, "ARCHIVED")
+            found = True
+
+    # Delete Redis cache key (AC-3)
+    if prompt_cache is not None:
+        try:
+            r = await prompt_cache.connect()
+            key = TENANT_CACHE_KEY.format(name=prompt_name, tenant_id=tenant_id)
+            deleted = await r.delete(key)
+            if deleted:
+                found = True
+        except Exception as exc:
+            logger.warning("Failed to delete tenant cache: %s", exc)
+
+    # Emit Kafka event
+    if lifecycle_producer is not None and found:
+        lifecycle_producer.send_lifecycle_event_sync(
+            event_type="prompt.tenant_override.deleted",
+            prompt_name=prompt_name,
+            version=0,
+            from_state="TENANT_OVERRIDE",
+            to_state="ARCHIVED",
+            tenant_id=tenant_id,
+        )
+
+    if found:
+        logger.info(
+            "Tenant override deleted: %s tenant=%s",
+            prompt_name,
+            tenant_id,
+        )
+    return found
+
+
+async def get_tenant_override(
+    prompt_name: str,
+    tenant_id: str,
+    mlflow_registry: Any = None,
+) -> Optional[dict]:
+    """Get a tenant-specific prompt override.
+
+    Returns:
+        Dict with override info, or None if not found.
+    """
+    if mlflow_registry is None:
+        return None
+
+    override = mlflow_registry.get_prompt_by_state(
+        prompt_name, "TENANT_OVERRIDE", tenant_id=tenant_id
+    )
+    if override is None:
+        return None
+
+    return {
+        "prompt_name": override.name,
+        "tenant_id": tenant_id,
+        "version": override.version,
+        "template": override.template,
+        "state": "TENANT_OVERRIDE",
+    }

--- a/prompt-optimization-svc/app/logic/tenant_override.py
+++ b/prompt-optimization-svc/app/logic/tenant_override.py
@@ -10,6 +10,7 @@ from typing import Any, Optional
 logger = logging.getLogger(__name__)
 
 TENANT_CACHE_KEY = "prompt:{name}:tenant:{tenant_id}"
+DEFAULT_CACHE_TTL_SECONDS = 300  # 5 minutes, matches prompt cache default
 
 
 async def create_tenant_override(
@@ -50,12 +51,12 @@ async def create_tenant_override(
         )
         version = info.version
 
-    # Cache in Redis for fast resolution
+    # Cache in Redis for fast resolution (with TTL to prevent stale entries)
     if prompt_cache is not None:
         try:
             r = await prompt_cache.connect()
             key = TENANT_CACHE_KEY.format(name=prompt_name, tenant_id=tenant_id)
-            await r.set(key, template)
+            await r.set(key, template, ex=DEFAULT_CACHE_TTL_SECONDS)
         except Exception as exc:
             logger.warning("Failed to cache tenant override: %s", exc)
 
@@ -101,6 +102,7 @@ async def delete_tenant_override(
         True if override was found and deleted.
     """
     found = False
+    archived_version = 0
 
     # Archive the MLflow version
     if mlflow_registry is not None:
@@ -109,6 +111,7 @@ async def delete_tenant_override(
         )
         if override is not None:
             mlflow_registry.set_prompt_state(prompt_name, override.version, "ARCHIVED")
+            archived_version = override.version
             found = True
 
     # Delete Redis cache key (AC-3)
@@ -122,12 +125,12 @@ async def delete_tenant_override(
         except Exception as exc:
             logger.warning("Failed to delete tenant cache: %s", exc)
 
-    # Emit Kafka event
-    if lifecycle_producer is not None and found:
+    # Emit Kafka event only when an MLflow version was actually archived
+    if lifecycle_producer is not None and archived_version > 0:
         lifecycle_producer.send_lifecycle_event_sync(
             event_type="prompt.tenant_override.deleted",
             prompt_name=prompt_name,
-            version=0,
+            version=archived_version,
             from_state="TENANT_OVERRIDE",
             to_state="ARCHIVED",
             tenant_id=tenant_id,

--- a/prompt-optimization-svc/tests/integration/test_tenant_overrides.py
+++ b/prompt-optimization-svc/tests/integration/test_tenant_overrides.py
@@ -1,0 +1,65 @@
+"""Integration tests for tenant overrides (US-039).
+
+Requires real Redis.
+"""
+
+from .conftest import REDIS_URL, requires_redis
+
+
+@requires_redis
+class TestTenantOverrideRedis:
+    async def test_create_caches_in_redis(self, real_redis):
+        from app.cache.prompt_cache import PromptCacheManager
+        from app.logic.tenant_override import TENANT_CACHE_KEY, create_tenant_override
+
+        cache = PromptCacheManager(redis_url=REDIS_URL)
+        await cache.connect()
+        try:
+            await create_tenant_override(
+                prompt_name="__test_override",
+                tenant_id="__test_tenant",
+                template="Override template",
+                prompt_cache=cache,
+            )
+            r = await cache.connect()
+            key = TENANT_CACHE_KEY.format(
+                name="__test_override", tenant_id="__test_tenant"
+            )
+            val = await r.get(key)
+            assert val == "Override template"
+        finally:
+            r = await cache.connect()
+            await r.delete("prompt:__test_override:tenant:__test_tenant")
+            await cache.close()
+
+    async def test_delete_removes_from_redis(self, real_redis):
+        from app.cache.prompt_cache import PromptCacheManager
+        from app.logic.tenant_override import (
+            TENANT_CACHE_KEY,
+            create_tenant_override,
+            delete_tenant_override,
+        )
+
+        cache = PromptCacheManager(redis_url=REDIS_URL)
+        await cache.connect()
+        try:
+            await create_tenant_override(
+                prompt_name="__test_del",
+                tenant_id="__test_t",
+                template="To be deleted",
+                prompt_cache=cache,
+            )
+            deleted = await delete_tenant_override(
+                prompt_name="__test_del",
+                tenant_id="__test_t",
+                prompt_cache=cache,
+            )
+            assert deleted is True
+
+            r = await cache.connect()
+            key = TENANT_CACHE_KEY.format(name="__test_del", tenant_id="__test_t")
+            assert await r.get(key) is None
+        finally:
+            r = await cache.connect()
+            await r.delete("prompt:__test_del:tenant:__test_t")
+            await cache.close()

--- a/prompt-optimization-svc/tests/test_tenant_overrides.py
+++ b/prompt-optimization-svc/tests/test_tenant_overrides.py
@@ -1,0 +1,140 @@
+"""Unit tests for tenant-specific prompt overrides (US-039)."""
+
+from app.logic.lifecycle import VALID_TRANSITIONS, PromptState
+from app.logic.tenant_override import TENANT_CACHE_KEY
+
+
+class TestTenantOverrideLifecycle:
+    """Lifecycle transitions for TENANT_OVERRIDE state."""
+
+    def test_draft_to_tenant_override_valid(self):
+        assert PromptState.TENANT_OVERRIDE in VALID_TRANSITIONS[PromptState.DRAFT]
+
+    def test_tenant_override_to_archived_valid(self):
+        assert PromptState.ARCHIVED in VALID_TRANSITIONS[PromptState.TENANT_OVERRIDE]
+
+    def test_tenant_override_has_outgoing(self):
+        assert len(VALID_TRANSITIONS[PromptState.TENANT_OVERRIDE]) >= 1
+
+
+class TestTenantCacheKey:
+    def test_key_format(self):
+        key = TENANT_CACHE_KEY.format(name="zorven-wf3-cga-system", tenant_id="t1")
+        assert key == "prompt:zorven-wf3-cga-system:tenant:t1"
+
+    def test_key_includes_both_ids(self):
+        key = TENANT_CACHE_KEY.format(name="test-prompt", tenant_id="tenant-abc")
+        assert "test-prompt" in key
+        assert "tenant-abc" in key
+
+
+class TestCreateTenantOverride:
+    async def test_returns_override_info(self):
+        from app.logic.tenant_override import create_tenant_override
+
+        result = await create_tenant_override(
+            prompt_name="zorven-wf3-cga-system",
+            tenant_id="t1",
+            template="Override template for tenant t1",
+        )
+        assert result["prompt_name"] == "zorven-wf3-cga-system"
+        assert result["tenant_id"] == "t1"
+        assert result["template"] == "Override template for tenant t1"
+        assert result["state"] == "TENANT_OVERRIDE"
+
+    async def test_returns_version_zero_without_mlflow(self):
+        from app.logic.tenant_override import create_tenant_override
+
+        result = await create_tenant_override(
+            prompt_name="test",
+            tenant_id="t1",
+            template="template",
+        )
+        assert result["version"] == 0
+
+    async def test_state_is_tenant_override(self):
+        from app.logic.tenant_override import create_tenant_override
+
+        result = await create_tenant_override(
+            prompt_name="test",
+            tenant_id="t2",
+            template="template",
+        )
+        assert result["state"] == "TENANT_OVERRIDE"
+
+
+class TestDeleteTenantOverride:
+    async def test_returns_false_without_registry(self):
+        from app.logic.tenant_override import delete_tenant_override
+
+        result = await delete_tenant_override(
+            prompt_name="test",
+            tenant_id="t1",
+        )
+        assert result is False
+
+    async def test_returns_false_no_override_found(self):
+        from app.logic.tenant_override import delete_tenant_override
+
+        result = await delete_tenant_override(
+            prompt_name="nonexistent",
+            tenant_id="t1",
+            mlflow_registry=None,
+            prompt_cache=None,
+        )
+        assert result is False
+
+
+class TestGetTenantOverride:
+    async def test_returns_none_without_registry(self):
+        from app.logic.tenant_override import get_tenant_override
+
+        result = await get_tenant_override(
+            prompt_name="test",
+            tenant_id="t1",
+            mlflow_registry=None,
+        )
+        assert result is None
+
+
+class TestSchemas:
+    def test_override_request_requires_template(self):
+        from pydantic import ValidationError
+
+        from app.api.schemas import TenantOverrideRequest
+
+        try:
+            TenantOverrideRequest(template="", tenant_id="t1")
+            assert False, "Should reject empty template"
+        except ValidationError:
+            pass
+
+    def test_override_request_requires_tenant_id(self):
+        from pydantic import ValidationError
+
+        from app.api.schemas import TenantOverrideRequest
+
+        try:
+            TenantOverrideRequest(template="text", tenant_id="")
+            assert False, "Should reject empty tenant_id"
+        except ValidationError:
+            pass
+
+    def test_override_request_valid(self):
+        from app.api.schemas import TenantOverrideRequest
+
+        req = TenantOverrideRequest(template="Override text", tenant_id="t1")
+        assert req.template == "Override text"
+        assert req.tenant_id == "t1"
+
+    def test_override_response_fields(self):
+        from app.api.schemas import TenantOverrideResponse
+
+        resp = TenantOverrideResponse(
+            prompt_name="test",
+            tenant_id="t1",
+            version=3,
+            template="text",
+        )
+        assert resp.state == "TENANT_OVERRIDE"
+        assert resp.version == 3

--- a/prompt-optimization-svc/tests/test_tenant_overrides_properties.py
+++ b/prompt-optimization-svc/tests/test_tenant_overrides_properties.py
@@ -1,0 +1,36 @@
+"""Hypothesis property tests for tenant overrides (US-039)."""
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from app.logic.tenant_override import TENANT_CACHE_KEY
+
+
+class TestTenantOverrideProperties:
+    @given(st.text(min_size=1, max_size=30), st.text(min_size=1, max_size=20))
+    @settings(max_examples=50, deadline=None)
+    def test_cache_key_always_non_empty(self, name, tenant_id):
+        key = TENANT_CACHE_KEY.format(name=name, tenant_id=tenant_id)
+        assert len(key) > 0
+        assert "prompt:" in key
+        assert ":tenant:" in key
+
+    @given(st.text(min_size=1, max_size=30), st.text(min_size=1, max_size=20))
+    @settings(max_examples=50, deadline=None)
+    async def test_create_never_raises(self, name, tenant_id):
+        from app.logic.tenant_override import create_tenant_override
+
+        result = await create_tenant_override(
+            prompt_name=name,
+            tenant_id=tenant_id,
+            template="test template",
+        )
+        assert result["state"] == "TENANT_OVERRIDE"
+
+    @given(st.text(min_size=1, max_size=30), st.text(min_size=1, max_size=20))
+    @settings(max_examples=50, deadline=None)
+    async def test_get_returns_none_without_registry(self, name, tenant_id):
+        from app.logic.tenant_override import get_tenant_override
+
+        result = await get_tenant_override(name, tenant_id, mlflow_registry=None)
+        assert result is None


### PR DESCRIPTION
## Summary

First story in EPIC-11 (Multi-Tenancy). Allows tenants to register prompt overrides that take precedence over global production:

- **`create_tenant_override()`**: registers in MLflow with `TENANT_OVERRIDE` state + `tenant_id` tag, caches in Redis at `prompt:<name>:tenant:<tid>`, emits Kafka event (AC-1)
- **`delete_tenant_override()`**: archives MLflow version + deletes Redis cache key (AC-3)
- **`get_tenant_override()`**: looks up by state + tenant_id
- **API**: `POST/GET/DELETE /v1/prompts/{name}/tenant-overrides`
- **Schemas**: `TenantOverrideRequest` (template + tenant_id validated non-empty), `TenantOverrideResponse`

AC-2 already implemented in US-012: ZorvenPromptLoader resolves tenant override before global production.

## Test plan

- [x] 15 unit tests (lifecycle, cache key, create/delete/get, schemas)
- [x] 3 Hypothesis property tests (cache key, create, get)
- [x] 2 integration tests (Redis cache create + delete)
- [x] Full suite: 1511 passed, 38 skipped
- [x] Black formatting verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)