### PR TITLE
feat(gepa): emit and dashboard key prompt optimization metrics (US-048)

### DIFF
--- a/prompt-optimization-svc/app/main.py
+++ b/prompt-optimization-svc/app/main.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from prometheus_client import make_asgi_app
 
 from app.api.routes import router
 from app.cache.prompt_cache import PromptCacheManager
@@ -184,3 +185,7 @@ async def validation_exception_handler(
 
 
 app.include_router(router)
+
+# Prometheus metrics endpoint (US-048, AC-1)
+metrics_app = make_asgi_app()
+app.mount("/metrics", metrics_app)

--- a/prompt-optimization-svc/app/metrics.py
+++ b/prompt-optimization-svc/app/metrics.py
@@ -16,7 +16,7 @@ PROMPT_LOAD_LATENCY = Histogram(
 )
 
 PROMPT_CACHE_HIT = Counter(
-    "poi_prompt_cache_hit_total",
+    "poi_prompt_cache_hit",
     "Prompt cache hit/miss count by tier and result",
     ["tier", "result"],
 )
@@ -61,7 +61,7 @@ MLFLOW_HEALTH = Gauge(
 # ── §19.1 Fallback usage ──
 
 PROMPT_FALLBACK_USAGE = Counter(
-    "poi_prompt_fallback_usage_total",
+    "poi_prompt_fallback_usage",
     "Prompt fallback template usage count",
     ["name"],
 )

--- a/prompt-optimization-svc/app/metrics.py
+++ b/prompt-optimization-svc/app/metrics.py
@@ -1,0 +1,104 @@
+"""Prometheus metrics for prompt-optimization-svc (US-048, §19.1).
+
+Central metrics registry — all 8 metrics as module-level singletons,
+alert threshold constants, and convenience record functions.
+"""
+
+from prometheus_client import Counter, Gauge, Histogram
+
+# ── §19.1 Prompt loading ──
+
+PROMPT_LOAD_LATENCY = Histogram(
+    "poi_prompt_load_latency_ms",
+    "Prompt load latency in milliseconds",
+    ["name", "tier", "tenant_id"],
+    buckets=[1, 2, 5, 10, 25, 50, 100, 250, 500, 1000],
+)
+
+PROMPT_CACHE_HIT = Counter(
+    "poi_prompt_cache_hit_total",
+    "Prompt cache hit/miss count by tier and result",
+    ["tier", "result"],
+)
+
+# ── §19.1 Optimization run ──
+
+OPT_RUN_DURATION = Histogram(
+    "poi_optimization_run_duration_seconds",
+    "Optimization run duration in seconds",
+    ["agent_code", "group_name"],
+    buckets=[10, 30, 60, 120, 300, 600, 1800, 3600],
+)
+
+OPT_RUN_COST = Histogram(
+    "poi_optimization_run_cost_usd",
+    "Optimization run cost in USD",
+    ["agent_code"],
+    buckets=[0.5, 1, 2, 5, 10, 15, 20, 25, 50],
+)
+
+# ── §19.1 Quality ──
+
+PROMPT_IMPROVEMENT = Gauge(
+    "poi_prompt_improvement_pct",
+    "Latest prompt improvement percentage",
+    ["agent_code", "prompt_name"],
+)
+
+SCORER_REGRESSION = Gauge(
+    "poi_scorer_regression_pct",
+    "Latest scorer regression percentage",
+    ["agent_code", "prompt_name"],
+)
+
+# ── §19.1 Infrastructure health ──
+
+MLFLOW_HEALTH = Gauge(
+    "poi_mlflow_server_health",
+    "MLflow server health (1=up, 0=down)",
+)
+
+# ── §19.1 Fallback usage ──
+
+PROMPT_FALLBACK_USAGE = Counter(
+    "poi_prompt_fallback_usage_total",
+    "Prompt fallback template usage count",
+    ["name"],
+)
+
+# ── AC-2: Alert threshold constants per §19.1 ──
+
+ALERT_CACHE_HIT_P95_MS = 5.0
+ALERT_COST_PER_AGENT_USD = 25.0
+ALERT_REGRESSION_PCT = 10.0
+
+
+# ── Convenience record functions ──
+
+
+def record_optimization_run(
+    agent_code: str,
+    group_name: str,
+    duration_seconds: float,
+    cost_usd: float,
+) -> None:
+    """Record optimization run duration and cost metrics."""
+    OPT_RUN_DURATION.labels(agent_code=agent_code, group_name=group_name).observe(
+        duration_seconds
+    )
+    OPT_RUN_COST.labels(agent_code=agent_code).observe(cost_usd)
+
+
+def record_prompt_quality(
+    agent_code: str,
+    prompt_name: str,
+    improvement_pct: float,
+    regression_pct: float,
+) -> None:
+    """Record prompt quality improvement and regression gauges."""
+    PROMPT_IMPROVEMENT.labels(agent_code=agent_code, prompt_name=prompt_name).set(
+        improvement_pct
+    )
+    SCORER_REGRESSION.labels(agent_code=agent_code, prompt_name=prompt_name).set(
+        regression_pct
+    )

--- a/prompt-optimization-svc/app/services/health_checker.py
+++ b/prompt-optimization-svc/app/services/health_checker.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import create_async_engine
 
 from app.api.schemas import DependencyStatus, HealthResponse
 from app.core.config import settings
+from app.metrics import MLFLOW_HEALTH
 
 logger = logging.getLogger(__name__)
 
@@ -33,9 +34,11 @@ class HealthChecker:
                 resp = await client.get(f"{settings.MLFLOW_TRACKING_URI}/health")
                 latency = (time.monotonic() - start) * 1000
                 if resp.status_code == 200:
+                    MLFLOW_HEALTH.set(1.0)
                     return DependencyStatus(
                         name="mlflow", status="up", latency_ms=round(latency, 1)
                     )
+                MLFLOW_HEALTH.set(0.0)
                 return DependencyStatus(
                     name="mlflow",
                     status="down",
@@ -44,6 +47,7 @@ class HealthChecker:
                 )
         except Exception as exc:
             latency = (time.monotonic() - start) * 1000
+            MLFLOW_HEALTH.set(0.0)
             return DependencyStatus(
                 name="mlflow",
                 status="down",

--- a/prompt-optimization-svc/app/services/prompt_loader.py
+++ b/prompt-optimization-svc/app/services/prompt_loader.py
@@ -9,10 +9,12 @@ Resolution order:
 import asyncio
 import logging
 import re
+import time
 from typing import Any, Optional
 
 from app.cache.prompt_cache import PromptCacheManager
 from app.cache.tenant_config import DEFAULT_TTL, TenantConfigManager
+from app.metrics import PROMPT_CACHE_HIT, PROMPT_FALLBACK_USAGE, PROMPT_LOAD_LATENCY
 from app.services.mlflow_registry import MLflowPromptRegistry
 
 logger = logging.getLogger(__name__)
@@ -74,6 +76,7 @@ class ZorvenPromptLoader:
                 "All tiers failed for prompt '%s' — using fallback",
                 name,
             )
+            PROMPT_FALLBACK_USAGE.labels(name=name).inc()
             template = fallback_template
 
         return self._format(template, variables)
@@ -85,21 +88,32 @@ class ZorvenPromptLoader:
         ttl: Optional[int],
     ) -> Optional[str]:
         """Resolve prompt template through three tiers."""
+        t0 = time.monotonic()
+        resolved_tier = "tier3_fallback"
+
         # --- Tier 1: Redis cache (AC-1: tenant override first) ---
         if tenant_id:
-            cached = await self.prompt_cache.get_prompt(
-                name, tenant_id=tenant_id
-            )
+            cached = await self.prompt_cache.get_prompt(name, tenant_id=tenant_id)
             if cached is not None:
-                logger.debug(
-                    "Tier 1 HIT (tenant): %s tenant=%s", name, tenant_id
-                )
+                logger.debug("Tier 1 HIT (tenant): %s tenant=%s", name, tenant_id)
+                PROMPT_CACHE_HIT.labels(tier="tier1_tenant", result="hit").inc()
+                elapsed_ms = (time.monotonic() - t0) * 1000
+                PROMPT_LOAD_LATENCY.labels(
+                    name=name, tier="tier1_tenant", tenant_id=tenant_id or ""
+                ).observe(elapsed_ms)
                 return cached
+            PROMPT_CACHE_HIT.labels(tier="tier1_tenant", result="miss").inc()
 
         cached = await self.prompt_cache.get_prompt(name)
         if cached is not None:
             logger.debug("Tier 1 HIT (production): %s", name)
+            PROMPT_CACHE_HIT.labels(tier="tier1_production", result="hit").inc()
+            elapsed_ms = (time.monotonic() - t0) * 1000
+            PROMPT_LOAD_LATENCY.labels(
+                name=name, tier="tier1_production", tenant_id=tenant_id or ""
+            ).observe(elapsed_ms)
             return cached
+        PROMPT_CACHE_HIT.labels(tier="tier1_production", result="miss").inc()
 
         # --- Tier 2: MLflow API (lifecycle-aware) ---
         if self.mlflow_registry is not None:
@@ -109,6 +123,7 @@ class ZorvenPromptLoader:
                 )
                 if template is not None:
                     logger.debug("Tier 2 HIT (MLflow): %s", name)
+                    PROMPT_CACHE_HIT.labels(tier="tier2_mlflow", result="hit").inc()
                     resolved_ttl = await self._resolve_ttl(ttl, tenant_id)
                     await self.prompt_cache.set_prompt(
                         name,
@@ -116,21 +131,28 @@ class ZorvenPromptLoader:
                         ttl=resolved_ttl,
                         tenant_id=resolved_tenant,
                     )
+                    elapsed_ms = (time.monotonic() - t0) * 1000
+                    PROMPT_LOAD_LATENCY.labels(
+                        name=name,
+                        tier="tier2_mlflow",
+                        tenant_id=tenant_id or "",
+                    ).observe(elapsed_ms)
                     return template
                 # AC-3: Missing tenant override silently falls through
                 logger.debug("Tier 2 MISS (MLflow): %s", name)
+                PROMPT_CACHE_HIT.labels(tier="tier2_mlflow", result="miss").inc()
             except Exception as exc:
                 # Only log warnings for actual errors, not "not found"
-                logger.warning(
-                    "Tier 2 ERROR (MLflow) for prompt '%s': %s", name, exc
-                )
+                logger.warning("Tier 2 ERROR (MLflow) for prompt '%s': %s", name, exc)
 
         # --- Tier 3: fallback (handled by caller) ---
+        elapsed_ms = (time.monotonic() - t0) * 1000
+        PROMPT_LOAD_LATENCY.labels(
+            name=name, tier=resolved_tier, tenant_id=tenant_id or ""
+        ).observe(elapsed_ms)
         return None
 
-    async def _resolve_ttl(
-        self, ttl: Optional[int], tenant_id: Optional[str]
-    ) -> int:
+    async def _resolve_ttl(self, ttl: Optional[int], tenant_id: Optional[str]) -> int:
         """Resolve cache TTL: explicit > tenant config > default."""
         if ttl is not None:
             return ttl
@@ -154,9 +176,7 @@ class ZorvenPromptLoader:
         if tenant_id:
             # AC-2: Try tenant-specific named prompt first
             tenant_prompt_name = f"{name}-tenant-{tenant_id}"
-            template = self.mlflow_registry.load_prompt_template(
-                tenant_prompt_name
-            )
+            template = self.mlflow_registry.load_prompt_template(tenant_prompt_name)
             if template is not None:
                 return template, tenant_id
 
@@ -180,9 +200,7 @@ class ZorvenPromptLoader:
         template = self.mlflow_registry.load_prompt_template(name)
         return template, None
 
-    def _format(
-        self, template: str, variables: Optional[dict[str, Any]]
-    ) -> str:
+    def _format(self, template: str, variables: Optional[dict[str, Any]]) -> str:
         """Format a template with variables (AC-4).
 
         Uses single-pass regex substitution to safely replace

--- a/prompt-optimization-svc/deployment/grafana/dashboards/prompt_optimization.json
+++ b/prompt-optimization-svc/deployment/grafana/dashboards/prompt_optimization.json
@@ -1,0 +1,139 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "title": "Prompt Version Timeline",
+      "description": "Prompt load latency over time by prompt name (§19.1 AC-3)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "rate(poi_prompt_load_latency_ms_sum[5m]) / rate(poi_prompt_load_latency_ms_count[5m])",
+          "legendFormat": "{{name}} ({{tier}})",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      }
+    },
+    {
+      "title": "Optimization Cost Tracker",
+      "description": "Cumulative optimization cost per agent (§19.1 AC-3)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "sum by (agent_code) (poi_optimization_run_cost_usd_sum)",
+          "legendFormat": "{{agent_code}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 50
+          }
+        }
+      }
+    },
+    {
+      "title": "Scorer Health Matrix",
+      "description": "Scorer regression percentage by agent (§19.1 AC-3)",
+      "type": "table",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "poi_scorer_regression_pct",
+          "legendFormat": "{{agent_code}} / {{prompt_name}}",
+          "refId": "A",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 5 },
+              { "color": "red", "value": 10 }
+            ]
+          },
+          "custom": {
+            "displayMode": "color-background"
+          }
+        }
+      }
+    },
+    {
+      "title": "Prompt Loading Performance",
+      "description": "Prompt load latency percentiles p50/p95/p99 (§19.1 AC-3)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, rate(poi_prompt_load_latency_ms_bucket[5m]))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, rate(poi_prompt_load_latency_ms_bucket[5m]))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, rate(poi_prompt_load_latency_ms_bucket[5m]))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 5
+          }
+        }
+      }
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["prompt-optimization", "poi"],
+  "templating": {
+    "list": [
+      {
+        "name": "DS_PROMETHEUS",
+        "type": "datasource",
+        "query": "prometheus"
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "title": "Prompt Optimization Service",
+  "uid": "poi-prompt-optimization"
+}

--- a/prompt-optimization-svc/deployment/prometheus/alerts/prompt_optimization.yml
+++ b/prompt-optimization-svc/deployment/prometheus/alerts/prompt_optimization.yml
@@ -1,0 +1,53 @@
+# Prometheus alerting rules for prompt-optimization-svc (US-048, AC-2, §19.1)
+groups:
+  - name: prompt_optimization
+    rules:
+      - alert: HighCacheLatency
+        expr: histogram_quantile(0.95, rate(poi_prompt_load_latency_ms_bucket{tier="tier1_production"}[5m])) > 5
+        for: 5m
+        labels:
+          severity: warning
+          service: prompt-optimization-svc
+        annotations:
+          summary: "Prompt cache p95 latency exceeds 5ms"
+          description: "p95 cache hit latency is {{ $value }}ms (threshold: 5ms)"
+
+      - alert: HighOptimizationCost
+        expr: poi_optimization_run_cost_usd_sum / poi_optimization_run_cost_usd_count > 25
+        for: 1m
+        labels:
+          severity: warning
+          service: prompt-optimization-svc
+        annotations:
+          summary: "Average optimization cost exceeds $25 per agent"
+          description: "Average optimization run cost is ${{ $value }} (threshold: $25)"
+
+      - alert: ScorerRegression
+        expr: poi_scorer_regression_pct > 10
+        for: 1m
+        labels:
+          severity: critical
+          service: prompt-optimization-svc
+        annotations:
+          summary: "Scorer regression exceeds 10%"
+          description: "Scorer regression for {{ $labels.agent_code }}/{{ $labels.prompt_name }} is {{ $value }}%"
+
+      - alert: MLflowDown
+        expr: poi_mlflow_server_health == 0
+        for: 2m
+        labels:
+          severity: critical
+          service: prompt-optimization-svc
+        annotations:
+          summary: "MLflow server is down"
+          description: "MLflow health check has been failing for >2 minutes"
+
+      - alert: HighFallbackUsage
+        expr: rate(poi_prompt_fallback_usage_total[5m]) > 0.1
+        for: 5m
+        labels:
+          severity: warning
+          service: prompt-optimization-svc
+        annotations:
+          summary: "High prompt fallback usage"
+          description: "Fallback template usage rate is {{ $value }}/s for prompt {{ $labels.name }}"

--- a/prompt-optimization-svc/deployment/prometheus/alerts/prompt_optimization.yml
+++ b/prompt-optimization-svc/deployment/prometheus/alerts/prompt_optimization.yml
@@ -13,8 +13,8 @@ groups:
           description: "p95 cache hit latency is {{ $value }}ms (threshold: 5ms)"
 
       - alert: HighOptimizationCost
-        expr: poi_optimization_run_cost_usd_sum / poi_optimization_run_cost_usd_count > 25
-        for: 1m
+        expr: rate(poi_optimization_run_cost_usd_sum[5m]) / rate(poi_optimization_run_cost_usd_count[5m]) > 25
+        for: 5m
         labels:
           severity: warning
           service: prompt-optimization-svc

--- a/prompt-optimization-svc/pyproject.toml
+++ b/prompt-optimization-svc/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "alembic>=1.14.0",
     "celery>=5.4.0",
     "psycopg2-binary>=2.9.0",
+    "prometheus-client>=0.21.0",
 ]
 
 [tool.black]

--- a/prompt-optimization-svc/requirements.txt
+++ b/prompt-optimization-svc/requirements.txt
@@ -12,3 +12,4 @@ asyncpg>=0.30.0
 alembic>=1.14.0
 celery>=5.4.0
 psycopg2-binary>=2.9.0
+prometheus-client>=0.21.0

--- a/prompt-optimization-svc/tests/integration/test_us048_metrics.py
+++ b/prompt-optimization-svc/tests/integration/test_us048_metrics.py
@@ -1,0 +1,185 @@
+"""Integration tests for Prometheus metrics (US-048).
+
+Requires the FastAPI app to be importable and Prometheus client running.
+"""
+
+import pytest
+
+from app.metrics import (
+    MLFLOW_HEALTH,
+    PROMPT_CACHE_HIT,
+    PROMPT_FALLBACK_USAGE,
+    PROMPT_LOAD_LATENCY,
+    record_optimization_run,
+    record_prompt_quality,
+)
+
+
+@pytest.mark.integration
+class TestMetricsEndpointIntegration:
+    def test_metrics_endpoint_returns_prometheus_text_format(self):
+        from fastapi.testclient import TestClient
+
+        from app.main import app
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/metrics")
+        assert resp.status_code == 200
+        # Prometheus text format starts with HELP or TYPE comments
+        assert "# HELP" in resp.text or "# TYPE" in resp.text
+
+    def test_metrics_endpoint_contains_mlflow_health(self):
+        from fastapi.testclient import TestClient
+
+        from app.main import app
+
+        # Set a value first so it appears in output
+        MLFLOW_HEALTH.set(1.0)
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/metrics")
+        assert "poi_mlflow_server_health" in resp.text
+
+    def test_metrics_endpoint_contains_prompt_cache_hit(self):
+        from fastapi.testclient import TestClient
+
+        from app.main import app
+
+        # Ensure at least one sample exists
+        PROMPT_CACHE_HIT.labels(tier="tier1_production", result="hit").inc(0)
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/metrics")
+        assert "poi_prompt_cache_hit_total" in resp.text
+
+    def test_metrics_endpoint_contains_optimization_run_metrics(self):
+        from fastapi.testclient import TestClient
+
+        from app.main import app
+
+        record_optimization_run("test-agent", "test-group", 10.0, 5.0)
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/metrics")
+        assert "poi_optimization_run_duration_seconds" in resp.text
+        assert "poi_optimization_run_cost_usd" in resp.text
+
+    def test_metrics_endpoint_contains_quality_gauges(self):
+        from fastapi.testclient import TestClient
+
+        from app.main import app
+
+        record_prompt_quality("test-agent", "test-prompt", 5.0, 1.0)
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/metrics")
+        assert "poi_prompt_improvement_pct" in resp.text
+        assert "poi_scorer_regression_pct" in resp.text
+
+
+@pytest.mark.integration
+class TestPromptLoaderMetricsIntegration:
+    @pytest.mark.asyncio
+    async def test_fallback_increments_counter(self):
+        """Loading a missing prompt increments the fallback counter."""
+        from app.cache.prompt_cache import PromptCacheManager
+
+        from app.services.prompt_loader import ZorvenPromptLoader
+
+        cache = PromptCacheManager(redis_url="redis://localhost:6379/2")
+        await cache.connect()
+        try:
+            loader = ZorvenPromptLoader(prompt_cache=cache)
+            before = PROMPT_FALLBACK_USAGE.labels(
+                name="nonexistent-prompt-048"
+            )._value.get()
+            await loader.load(
+                "nonexistent-prompt-048",
+                fallback_template="fallback text",
+            )
+            after = PROMPT_FALLBACK_USAGE.labels(
+                name="nonexistent-prompt-048"
+            )._value.get()
+            assert after - before == 1
+        finally:
+            await cache.close()
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_increments_counter(self):
+        """A cache miss on a non-cached prompt increments the miss counter."""
+        from app.cache.prompt_cache import PromptCacheManager
+
+        from app.services.prompt_loader import ZorvenPromptLoader
+
+        cache = PromptCacheManager(redis_url="redis://localhost:6379/2")
+        await cache.connect()
+        try:
+            loader = ZorvenPromptLoader(prompt_cache=cache)
+            before = PROMPT_CACHE_HIT.labels(
+                tier="tier1_production", result="miss"
+            )._value.get()
+            await loader.load(
+                "missing-prompt-048-miss",
+                fallback_template="fb",
+            )
+            after = PROMPT_CACHE_HIT.labels(
+                tier="tier1_production", result="miss"
+            )._value.get()
+            assert after > before
+        finally:
+            await cache.close()
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_increments_counter(self):
+        """Prompt in Redis cache increments the hit counter."""
+        from app.cache.prompt_cache import PromptCacheManager
+
+        from app.services.prompt_loader import ZorvenPromptLoader
+
+        cache = PromptCacheManager(redis_url="redis://localhost:6379/2")
+        await cache.connect()
+        try:
+            # Pre-seed the cache
+            await cache.set_prompt("cached-prompt-048", "Hello {name}", ttl=60)
+            loader = ZorvenPromptLoader(prompt_cache=cache)
+            before = PROMPT_CACHE_HIT.labels(
+                tier="tier1_production", result="hit"
+            )._value.get()
+            result = await loader.load(
+                "cached-prompt-048",
+                variables={"name": "World"},
+            )
+            after = PROMPT_CACHE_HIT.labels(
+                tier="tier1_production", result="hit"
+            )._value.get()
+            assert after > before
+            assert result == "Hello World"
+            # Clean up
+            await cache.invalidate_prompt("cached-prompt-048")
+        finally:
+            await cache.close()
+
+    @pytest.mark.asyncio
+    async def test_latency_histogram_observed(self):
+        """Prompt load observes the latency histogram."""
+        from app.cache.prompt_cache import PromptCacheManager
+
+        from app.services.prompt_loader import ZorvenPromptLoader
+
+        cache = PromptCacheManager(redis_url="redis://localhost:6379/2")
+        await cache.connect()
+        try:
+            loader = ZorvenPromptLoader(prompt_cache=cache)
+            before = PROMPT_LOAD_LATENCY.labels(
+                name="latency-test-048",
+                tier="tier3_fallback",
+                tenant_id="",
+            )._sum.get()
+            await loader.load(
+                "latency-test-048",
+                fallback_template="fb",
+            )
+            after = PROMPT_LOAD_LATENCY.labels(
+                name="latency-test-048",
+                tier="tier3_fallback",
+                tenant_id="",
+            )._sum.get()
+            assert after > before
+        finally:
+            await cache.close()

--- a/prompt-optimization-svc/tests/test_us048_metrics.py
+++ b/prompt-optimization-svc/tests/test_us048_metrics.py
@@ -1,0 +1,289 @@
+"""Unit tests for Prometheus metrics instrumentation (US-048).
+
+Tests metric definitions, alert thresholds, record helpers,
+prompt loader instrumentation, health checker instrumentation,
+and the /metrics endpoint.
+"""
+
+from prometheus_client import Counter, Gauge, Histogram
+
+from app.metrics import (
+    ALERT_CACHE_HIT_P95_MS,
+    ALERT_COST_PER_AGENT_USD,
+    ALERT_REGRESSION_PCT,
+    MLFLOW_HEALTH,
+    OPT_RUN_COST,
+    OPT_RUN_DURATION,
+    PROMPT_CACHE_HIT,
+    PROMPT_FALLBACK_USAGE,
+    PROMPT_IMPROVEMENT,
+    PROMPT_LOAD_LATENCY,
+    SCORER_REGRESSION,
+    record_optimization_run,
+    record_prompt_quality,
+)
+
+
+# ── Metric definitions ──
+
+
+class TestMetricDefinitions:
+    def test_prompt_load_latency_type(self):
+        assert isinstance(PROMPT_LOAD_LATENCY, Histogram)
+
+    def test_prompt_load_latency_name(self):
+        assert PROMPT_LOAD_LATENCY._name == "poi_prompt_load_latency_ms"
+
+    def test_prompt_load_latency_labels(self):
+        assert PROMPT_LOAD_LATENCY._labelnames == ("name", "tier", "tenant_id")
+
+    def test_prompt_cache_hit_type(self):
+        assert isinstance(PROMPT_CACHE_HIT, Counter)
+
+    def test_prompt_cache_hit_name(self):
+        assert PROMPT_CACHE_HIT._name == "poi_prompt_cache_hit"
+
+    def test_prompt_cache_hit_labels(self):
+        assert PROMPT_CACHE_HIT._labelnames == ("tier", "result")
+
+    def test_opt_run_duration_type(self):
+        assert isinstance(OPT_RUN_DURATION, Histogram)
+
+    def test_opt_run_duration_name(self):
+        assert OPT_RUN_DURATION._name == "poi_optimization_run_duration_seconds"
+
+    def test_opt_run_duration_labels(self):
+        assert OPT_RUN_DURATION._labelnames == ("agent_code", "group_name")
+
+    def test_opt_run_cost_type(self):
+        assert isinstance(OPT_RUN_COST, Histogram)
+
+    def test_opt_run_cost_name(self):
+        assert OPT_RUN_COST._name == "poi_optimization_run_cost_usd"
+
+    def test_opt_run_cost_labels(self):
+        assert OPT_RUN_COST._labelnames == ("agent_code",)
+
+    def test_prompt_improvement_type(self):
+        assert isinstance(PROMPT_IMPROVEMENT, Gauge)
+
+    def test_prompt_improvement_name(self):
+        assert PROMPT_IMPROVEMENT._name == "poi_prompt_improvement_pct"
+
+    def test_prompt_improvement_labels(self):
+        assert PROMPT_IMPROVEMENT._labelnames == ("agent_code", "prompt_name")
+
+    def test_scorer_regression_type(self):
+        assert isinstance(SCORER_REGRESSION, Gauge)
+
+    def test_scorer_regression_name(self):
+        assert SCORER_REGRESSION._name == "poi_scorer_regression_pct"
+
+    def test_scorer_regression_labels(self):
+        assert SCORER_REGRESSION._labelnames == ("agent_code", "prompt_name")
+
+    def test_mlflow_health_type(self):
+        assert isinstance(MLFLOW_HEALTH, Gauge)
+
+    def test_mlflow_health_name(self):
+        assert MLFLOW_HEALTH._name == "poi_mlflow_server_health"
+
+    def test_mlflow_health_no_labels(self):
+        assert MLFLOW_HEALTH._labelnames == ()
+
+    def test_prompt_fallback_usage_type(self):
+        assert isinstance(PROMPT_FALLBACK_USAGE, Counter)
+
+    def test_prompt_fallback_usage_name(self):
+        assert PROMPT_FALLBACK_USAGE._name == "poi_prompt_fallback_usage"
+
+    def test_prompt_fallback_usage_labels(self):
+        assert PROMPT_FALLBACK_USAGE._labelnames == ("name",)
+
+    def test_prompt_load_latency_buckets(self):
+        expected_count = 11  # 10 explicit + Inf
+        assert len(PROMPT_LOAD_LATENCY._upper_bounds) == expected_count
+
+    def test_opt_run_duration_buckets(self):
+        expected_count = 9  # 8 explicit + Inf
+        assert len(OPT_RUN_DURATION._upper_bounds) == expected_count
+
+    def test_opt_run_cost_buckets(self):
+        expected_count = 10  # 9 explicit + Inf
+        assert len(OPT_RUN_COST._upper_bounds) == expected_count
+
+
+# ── Alert thresholds ──
+
+
+class TestAlertThresholds:
+    def test_cache_hit_p95_ms(self):
+        assert ALERT_CACHE_HIT_P95_MS == 5.0
+
+    def test_cost_per_agent_usd(self):
+        assert ALERT_COST_PER_AGENT_USD == 25.0
+
+    def test_regression_pct(self):
+        assert ALERT_REGRESSION_PCT == 10.0
+
+
+# ── Record optimization run ──
+
+
+class TestRecordOptimizationRun:
+    def test_records_duration(self):
+        before = OPT_RUN_DURATION.labels(
+            agent_code="CAA", group_name="wf3-creative-pipeline"
+        )._sum.get()
+        record_optimization_run("CAA", "wf3-creative-pipeline", 120.5, 10.0)
+        after = OPT_RUN_DURATION.labels(
+            agent_code="CAA", group_name="wf3-creative-pipeline"
+        )._sum.get()
+        assert after - before == 120.5
+
+    def test_records_cost(self):
+        before = OPT_RUN_COST.labels(agent_code="CGA")._sum.get()
+        record_optimization_run("CGA", "wf3-creative-pipeline", 60.0, 15.5)
+        after = OPT_RUN_COST.labels(agent_code="CGA")._sum.get()
+        assert after - before == 15.5
+
+    def test_labels_applied_correctly(self):
+        record_optimization_run("COA", "wf3-optimization-loop", 30.0, 5.0)
+        val = OPT_RUN_DURATION.labels(
+            agent_code="COA", group_name="wf3-optimization-loop"
+        )._sum.get()
+        assert val >= 30.0
+
+    def test_multiple_calls_accumulate(self):
+        before = OPT_RUN_COST.labels(agent_code="ILA")._sum.get()
+        record_optimization_run("ILA", "wf3-optimization-loop", 10.0, 2.0)
+        record_optimization_run("ILA", "wf3-optimization-loop", 20.0, 3.0)
+        after = OPT_RUN_COST.labels(agent_code="ILA")._sum.get()
+        assert after - before == 5.0
+
+
+# ── Record prompt quality ──
+
+
+class TestRecordPromptQuality:
+    def test_sets_improvement(self):
+        record_prompt_quality("CAA", "caa-system-prompt", 12.5, 0.0)
+        val = PROMPT_IMPROVEMENT.labels(
+            agent_code="CAA", prompt_name="caa-system-prompt"
+        )._value.get()
+        assert val == 12.5
+
+    def test_sets_regression(self):
+        record_prompt_quality("CGA", "cga-system-prompt", 5.0, 3.2)
+        val = SCORER_REGRESSION.labels(
+            agent_code="CGA", prompt_name="cga-system-prompt"
+        )._value.get()
+        assert val == 3.2
+
+    def test_gauge_updates_on_subsequent_calls(self):
+        record_prompt_quality("ADPUB", "adpub-system-prompt", 10.0, 1.0)
+        record_prompt_quality("ADPUB", "adpub-system-prompt", 15.0, 2.0)
+        val = PROMPT_IMPROVEMENT.labels(
+            agent_code="ADPUB", prompt_name="adpub-system-prompt"
+        )._value.get()
+        assert val == 15.0
+
+    def test_labels_applied_correctly(self):
+        record_prompt_quality("BPA", "bpa-system-prompt", 7.0, 0.5)
+        # Gauge should be accessible with the exact labels
+        val = SCORER_REGRESSION.labels(
+            agent_code="BPA", prompt_name="bpa-system-prompt"
+        )._value.get()
+        assert val == 0.5
+
+
+# ── MLflow health metric ──
+
+
+class TestMLflowHealthMetric:
+    def test_set_up(self):
+        MLFLOW_HEALTH.set(1.0)
+        assert MLFLOW_HEALTH._value.get() == 1.0
+
+    def test_set_down(self):
+        MLFLOW_HEALTH.set(0.0)
+        assert MLFLOW_HEALTH._value.get() == 0.0
+
+    def test_toggles(self):
+        MLFLOW_HEALTH.set(1.0)
+        assert MLFLOW_HEALTH._value.get() == 1.0
+        MLFLOW_HEALTH.set(0.0)
+        assert MLFLOW_HEALTH._value.get() == 0.0
+        MLFLOW_HEALTH.set(1.0)
+        assert MLFLOW_HEALTH._value.get() == 1.0
+
+
+# ── Prompt loader instrumentation ──
+
+
+class TestPromptLoaderInstrumentation:
+    def test_cache_hit_counter_import(self):
+        """PROMPT_CACHE_HIT is importable and used in prompt_loader."""
+        from app.services.prompt_loader import PROMPT_CACHE_HIT as imported
+
+        assert imported is PROMPT_CACHE_HIT
+
+    def test_fallback_counter_import(self):
+        """PROMPT_FALLBACK_USAGE is importable and used in prompt_loader."""
+        from app.services.prompt_loader import PROMPT_FALLBACK_USAGE as imported
+
+        assert imported is PROMPT_FALLBACK_USAGE
+
+    def test_load_latency_import(self):
+        """PROMPT_LOAD_LATENCY is importable and used in prompt_loader."""
+        from app.services.prompt_loader import PROMPT_LOAD_LATENCY as imported
+
+        assert imported is PROMPT_LOAD_LATENCY
+
+    def test_tier1_tenant_label_exists(self):
+        """Verify tier1_tenant label is used in counter."""
+        PROMPT_CACHE_HIT.labels(tier="tier1_tenant", result="hit").inc(0)
+        # No error means the label combination is valid
+
+    def test_tier1_production_label_exists(self):
+        """Verify tier1_production label is used in counter."""
+        PROMPT_CACHE_HIT.labels(tier="tier1_production", result="hit").inc(0)
+
+    def test_tier2_mlflow_label_exists(self):
+        """Verify tier2_mlflow label is used in counter."""
+        PROMPT_CACHE_HIT.labels(tier="tier2_mlflow", result="hit").inc(0)
+
+
+# ── Health checker instrumentation ──
+
+
+class TestHealthCheckerInstrumentation:
+    def test_mlflow_health_import(self):
+        """MLFLOW_HEALTH is importable in health_checker."""
+        from app.services.health_checker import MLFLOW_HEALTH as imported
+
+        assert imported is MLFLOW_HEALTH
+
+
+# ── /metrics endpoint ──
+
+
+class TestMetricsEndpoint:
+    def test_metrics_endpoint_returns_200(self):
+        from fastapi.testclient import TestClient
+
+        from app.main import app
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/metrics")
+        assert resp.status_code == 200
+
+    def test_metrics_response_contains_poi_prefix(self):
+        from fastapi.testclient import TestClient
+
+        from app.main import app
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/metrics")
+        body = resp.text
+        assert "poi_" in body

--- a/prompt-optimization-svc/tests/test_us048_properties.py
+++ b/prompt-optimization-svc/tests/test_us048_properties.py
@@ -1,0 +1,82 @@
+"""Hypothesis property-based tests for Prometheus metrics (US-048)."""
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from app.metrics import (
+    MLFLOW_HEALTH,
+    OPT_RUN_COST,
+    OPT_RUN_DURATION,
+    PROMPT_CACHE_HIT,
+    PROMPT_FALLBACK_USAGE,
+    PROMPT_IMPROVEMENT,
+    PROMPT_LOAD_LATENCY,
+    SCORER_REGRESSION,
+    record_optimization_run,
+    record_prompt_quality,
+)
+
+ALL_METRICS = [
+    PROMPT_LOAD_LATENCY,
+    PROMPT_CACHE_HIT,
+    OPT_RUN_DURATION,
+    OPT_RUN_COST,
+    PROMPT_IMPROVEMENT,
+    SCORER_REGRESSION,
+    MLFLOW_HEALTH,
+    PROMPT_FALLBACK_USAGE,
+]
+
+
+class TestMetricNamePrefix:
+    @pytest.mark.parametrize("metric", ALL_METRICS)
+    def test_all_metric_names_prefixed_poi(self, metric):
+        assert metric._name.startswith("poi_")
+
+
+class TestHistogramBucketsSorted:
+    @pytest.mark.parametrize(
+        "metric",
+        [PROMPT_LOAD_LATENCY, OPT_RUN_DURATION, OPT_RUN_COST],
+    )
+    def test_histogram_buckets_sorted_ascending(self, metric):
+        bounds = list(metric._upper_bounds)
+        assert bounds == sorted(bounds)
+        assert bounds[-1] == float("inf")
+
+
+class TestRecordFunctionsAcceptFloats:
+    @settings(max_examples=50)
+    @given(
+        duration=st.floats(min_value=0, max_value=1e6),
+        cost=st.floats(min_value=0, max_value=1e6),
+    )
+    def test_record_optimization_run_accepts_positive_floats(self, duration, cost):
+        record_optimization_run("test-agent", "test-group", duration, cost)
+
+
+class TestGaugeSetGetRoundtrip:
+    @settings(max_examples=50)
+    @given(value=st.floats(min_value=-100, max_value=100))
+    def test_prompt_improvement_set_get_roundtrip(self, value):
+        PROMPT_IMPROVEMENT.labels(
+            agent_code="roundtrip-agent", prompt_name="roundtrip-prompt"
+        ).set(value)
+        actual = PROMPT_IMPROVEMENT.labels(
+            agent_code="roundtrip-agent", prompt_name="roundtrip-prompt"
+        )._value.get()
+        assert actual == value
+
+
+class TestCounterOnlyIncrements:
+    @settings(max_examples=50)
+    @given(n=st.integers(min_value=1, max_value=100))
+    def test_cache_hit_counter_never_decreases(self, n):
+        label_set = PROMPT_CACHE_HIT.labels(tier="property_test", result="hit")
+        before = label_set._value.get()
+        for _ in range(n):
+            label_set.inc()
+        after = label_set._value.get()
+        assert after >= before
+        assert after - before == n


### PR DESCRIPTION
## Summary
- Add `prometheus-client` dependency and create `app/metrics.py` with 8 Prometheus metrics (histograms, counters, gauges) per §19.1
- Instrument prompt loader (`_resolve()` and `load()`) with cache hit/miss counters, load latency histogram, and fallback usage counter
- Instrument health checker with MLflow server health gauge (1=up, 0=down)
- Expose `/metrics` endpoint via `prometheus_client.make_asgi_app()` mount (AC-1)
- Define alert threshold constants: p95 cache hit ≤5ms, cost ≤$25/agent, regression >10% (AC-2)
- Add Grafana dashboard JSON with 4 panels: Prompt Version Timeline, Optimization Cost Tracker, Scorer Health Matrix, Prompt Loading Performance (AC-3)
- Add Prometheus alerting rules (5 alerts) for cache latency, optimization cost, scorer regression, MLflow health, and fallback usage

## Metrics Exported
| Metric | Type | Labels |
|--------|------|--------|
| `poi_prompt_load_latency_ms` | Histogram | `name`, `tier`, `tenant_id` |
| `poi_prompt_cache_hit_total` | Counter | `tier`, `result` |
| `poi_optimization_run_duration_seconds` | Histogram | `agent_code`, `group_name` |
| `poi_optimization_run_cost_usd` | Histogram | `agent_code` |
| `poi_prompt_improvement_pct` | Gauge | `agent_code`, `prompt_name` |
| `poi_scorer_regression_pct` | Gauge | `agent_code`, `prompt_name` |
| `poi_mlflow_server_health` | Gauge | — |
| `poi_prompt_fallback_usage_total` | Counter | `name` |

## Test plan
- [x] 50 unit tests (`tests/test_us048_metrics.py`) — metric definitions, alert thresholds, record helpers, instrumentation, /metrics endpoint
- [x] 14 property tests (`tests/test_us048_properties.py`) — name prefix, bucket ordering, float acceptance, gauge roundtrip, counter monotonicity
- [x] 9 integration tests (`tests/integration/test_us048_metrics.py`) — /metrics endpoint format, prompt loader metric increments with real Redis
- [x] Full non-integration suite passes (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)