### PR TITLE
feat(gepa): implement prompt loading circuit breaker and auto-rollback (US-050)

### DIFF
--- a/prompt-optimization-svc/app/core/config.py
+++ b/prompt-optimization-svc/app/core/config.py
@@ -65,6 +65,14 @@ class Settings(BaseSettings):
     # Length sanity (OPT-06)
     LENGTH_MULTIPLIER_LIMIT: float = 3.0
 
+    # Circuit breaker (§17.2)
+    CIRCUIT_BREAKER_FAILURE_THRESHOLD_SECONDS: int = 300  # 5 min
+    CIRCUIT_BREAKER_HALF_OPEN_INTERVAL_SECONDS: int = 60  # probe every 60s
+
+    # Auto-rollback (§17.2)
+    AUTO_ROLLBACK_REGRESSION_THRESHOLD: float = 0.15  # 15%
+    AUTO_ROLLBACK_WINDOW_HOURS: int = 48
+
     # Logging
     LOG_LEVEL: str = "INFO"
 

--- a/prompt-optimization-svc/app/logic/circuit_breaker.py
+++ b/prompt-optimization-svc/app/logic/circuit_breaker.py
@@ -1,0 +1,121 @@
+"""MLflow circuit breaker (§17.2 Production Safety Net, US-050).
+
+Three-state circuit breaker for MLflow prompt loading:
+    CLOSED    — normal operation, all requests go to MLflow
+    OPEN      — MLflow down ≥5 min, skip tier 2 entirely
+    HALF_OPEN — periodic probe (every 60s) to check recovery
+
+In-memory, per-process state. No Redis dependency to avoid circular
+dependencies (the breaker protects the MLflow path, and Redis itself
+may be down per AC-2).
+"""
+
+import enum
+import logging
+import time
+from dataclasses import dataclass
+
+from app.metrics import CIRCUIT_BREAKER_STATE
+
+logger = logging.getLogger(__name__)
+
+# Gauge values for Prometheus
+_STATE_GAUGE = {
+    "CLOSED": 0.0,
+    "OPEN": 1.0,
+    "HALF_OPEN": 2.0,
+}
+
+
+class CircuitState(str, enum.Enum):
+    """Circuit breaker states."""
+
+    CLOSED = "CLOSED"
+    OPEN = "OPEN"
+    HALF_OPEN = "HALF_OPEN"
+
+
+@dataclass
+class CircuitBreakerConfig:
+    """Configuration for the MLflow circuit breaker."""
+
+    failure_threshold_seconds: int = 300  # 5 min
+    half_open_interval_seconds: int = 60  # probe every 60s
+
+
+class MLflowCircuitBreaker:
+    """In-memory, per-process circuit breaker for MLflow availability.
+
+    Tracks consecutive failures using monotonic time. After
+    ``failure_threshold_seconds`` of uninterrupted failures the circuit
+    opens, skipping MLflow calls until a half-open probe succeeds.
+    """
+
+    def __init__(self, config: CircuitBreakerConfig | None = None) -> None:
+        self._config = config or CircuitBreakerConfig()
+        self._state = CircuitState.CLOSED
+        self._first_failure_at: float | None = None
+        self._last_probe_at: float = 0.0
+        self._consecutive_failures: int = 0
+        CIRCUIT_BREAKER_STATE.set(_STATE_GAUGE[self._state.value])
+
+    @property
+    def state(self) -> CircuitState:
+        """Current circuit breaker state."""
+        return self._state
+
+    @property
+    def consecutive_failures(self) -> int:
+        """Number of consecutive failures since last success."""
+        return self._consecutive_failures
+
+    def _set_state(self, new_state: CircuitState) -> None:
+        """Transition to a new state and update the Prometheus gauge."""
+        if self._state != new_state:
+            logger.info(
+                "Circuit breaker: %s → %s (failures=%d)",
+                self._state.value,
+                new_state.value,
+                self._consecutive_failures,
+            )
+            self._state = new_state
+            CIRCUIT_BREAKER_STATE.set(_STATE_GAUGE[new_state.value])
+
+    def should_allow_request(self) -> bool:
+        """Check if a request to MLflow should be attempted.
+
+        Returns:
+            True for CLOSED (always), True once per probe interval
+            for OPEN/HALF_OPEN, False otherwise.
+        """
+        if self._state == CircuitState.CLOSED:
+            return True
+
+        now = time.monotonic()
+        elapsed_since_probe = now - self._last_probe_at
+        if elapsed_since_probe >= self._config.half_open_interval_seconds:
+            self._set_state(CircuitState.HALF_OPEN)
+            self._last_probe_at = now
+            return True
+
+        return False
+
+    def record_success(self) -> None:
+        """Record a successful MLflow call. Resets to CLOSED."""
+        self._consecutive_failures = 0
+        self._first_failure_at = None
+        self._set_state(CircuitState.CLOSED)
+
+    def record_failure(self) -> None:
+        """Record a failed MLflow call. May transition to OPEN."""
+        now = time.monotonic()
+        self._consecutive_failures += 1
+
+        if self._first_failure_at is None:
+            self._first_failure_at = now
+
+        elapsed = now - self._first_failure_at
+        if elapsed >= self._config.failure_threshold_seconds:
+            if self._state != CircuitState.OPEN:
+                self._last_probe_at = now
+            self._set_state(CircuitState.OPEN)

--- a/prompt-optimization-svc/app/metrics.py
+++ b/prompt-optimization-svc/app/metrics.py
@@ -66,6 +66,21 @@ PROMPT_FALLBACK_USAGE = Counter(
     ["name"],
 )
 
+# ── §17.2 Circuit breaker ──
+
+CIRCUIT_BREAKER_STATE = Gauge(
+    "poi_circuit_breaker_state",
+    "MLflow circuit breaker state (0=CLOSED, 1=OPEN, 2=HALF_OPEN)",
+)
+
+# ── §17.2 Auto-rollback ──
+
+AUTO_ROLLBACK_TOTAL = Counter(
+    "poi_auto_rollback",
+    "Auto-rollback events triggered by health check",
+    ["prompt_name"],
+)
+
 # ── AC-2: Alert threshold constants per §19.1 ──
 
 ALERT_CACHE_HIT_P95_MS = 5.0

--- a/prompt-optimization-svc/app/services/mlflow_registry.py
+++ b/prompt-optimization-svc/app/services/mlflow_registry.py
@@ -106,8 +106,21 @@ class MLflowPromptRegistry:
             return None
 
     def set_prompt_state(self, name: str, version: int, state: str) -> None:
-        """Update the state tag on a prompt version."""
+        """Update the state tag on a prompt version.
+
+        When promoting to PRODUCTION, also writes a ``promoted_at``
+        ISO-8601 timestamp tag for auto-rollback window tracking (§17.2).
+        """
         self.client.set_prompt_version_tag(name, version, "state", state)
+        if state == "PRODUCTION":
+            from datetime import datetime, timezone
+
+            self.client.set_prompt_version_tag(
+                name,
+                version,
+                "promoted_at",
+                datetime.now(timezone.utc).isoformat(),
+            )
         logger.info("State updated: %s v%d → %s", name, version, state)
 
     def get_prompt_by_state(

--- a/prompt-optimization-svc/app/services/prompt_loader.py
+++ b/prompt-optimization-svc/app/services/prompt_loader.py
@@ -159,7 +159,11 @@ class ZorvenPromptLoader:
                             tenant_id=tenant_id or "",
                         ).observe(elapsed_ms)
                         return template
-                    # AC-3: Missing tenant override silently falls through
+                    # MLflow returned None — either prompt not found or
+                    # MLflow is down (registry swallows exceptions).
+                    # Record as failure so the circuit breaker can detect
+                    # sustained MLflow unavailability.
+                    self.circuit_breaker.record_failure()
                     logger.debug("Tier 2 MISS (MLflow): %s", name)
                     PROMPT_CACHE_HIT.labels(tier="tier2_mlflow", result="miss").inc()
                 except Exception as exc:

--- a/prompt-optimization-svc/app/services/prompt_loader.py
+++ b/prompt-optimization-svc/app/services/prompt_loader.py
@@ -14,6 +14,8 @@ from typing import Any, Optional
 
 from app.cache.prompt_cache import PromptCacheManager
 from app.cache.tenant_config import DEFAULT_TTL, TenantConfigManager
+from app.core.config import settings
+from app.logic.circuit_breaker import CircuitBreakerConfig, MLflowCircuitBreaker
 from app.metrics import PROMPT_CACHE_HIT, PROMPT_FALLBACK_USAGE, PROMPT_LOAD_LATENCY
 from app.services.mlflow_registry import MLflowPromptRegistry
 
@@ -24,6 +26,14 @@ _MLFLOW_VAR_PATTERN = re.compile(r"\{\{(\w[\w.]*)\}\}")
 
 # Single-pass placeholder pattern for safe substitution
 _PLACEHOLDER_PATTERN = re.compile(r"\{([\w.]+)\}")
+
+# Module-level singleton — shared across all loader instances in this process
+_default_circuit_breaker = MLflowCircuitBreaker(
+    CircuitBreakerConfig(
+        failure_threshold_seconds=settings.CIRCUIT_BREAKER_FAILURE_THRESHOLD_SECONDS,
+        half_open_interval_seconds=settings.CIRCUIT_BREAKER_HALF_OPEN_INTERVAL_SECONDS,
+    )
+)
 
 
 def _convert_mlflow_template(template: str) -> str:
@@ -43,10 +53,14 @@ class ZorvenPromptLoader:
         prompt_cache: PromptCacheManager,
         mlflow_registry: Optional[MLflowPromptRegistry] = None,
         tenant_config: Optional[TenantConfigManager] = None,
+        circuit_breaker: Optional[MLflowCircuitBreaker] = None,
     ) -> None:
         self.prompt_cache = prompt_cache
         self.mlflow_registry = mlflow_registry
         self.tenant_config = tenant_config
+        self.circuit_breaker = (
+            circuit_breaker if circuit_breaker is not None else _default_circuit_breaker
+        )
 
     async def load(
         self,
@@ -115,35 +129,44 @@ class ZorvenPromptLoader:
             return cached
         PROMPT_CACHE_HIT.labels(tier="tier1_production", result="miss").inc()
 
-        # --- Tier 2: MLflow API (lifecycle-aware) ---
+        # --- Tier 2: MLflow API (lifecycle-aware, circuit-breaker protected) ---
         if self.mlflow_registry is not None:
-            try:
-                template, resolved_tenant = await asyncio.to_thread(
-                    self._mlflow_resolve, name, tenant_id
-                )
-                if template is not None:
-                    logger.debug("Tier 2 HIT (MLflow): %s", name)
-                    PROMPT_CACHE_HIT.labels(tier="tier2_mlflow", result="hit").inc()
-                    resolved_ttl = await self._resolve_ttl(ttl, tenant_id)
-                    await self.prompt_cache.set_prompt(
-                        name,
-                        template,
-                        ttl=resolved_ttl,
-                        tenant_id=resolved_tenant,
+            if not self.circuit_breaker.should_allow_request():
+                logger.debug("Circuit breaker OPEN — skipping MLflow for %s", name)
+                PROMPT_CACHE_HIT.labels(
+                    tier="tier2_mlflow", result="circuit_open"
+                ).inc()
+            else:
+                try:
+                    template, resolved_tenant = await asyncio.to_thread(
+                        self._mlflow_resolve, name, tenant_id
                     )
-                    elapsed_ms = (time.monotonic() - t0) * 1000
-                    PROMPT_LOAD_LATENCY.labels(
-                        name=name,
-                        tier="tier2_mlflow",
-                        tenant_id=tenant_id or "",
-                    ).observe(elapsed_ms)
-                    return template
-                # AC-3: Missing tenant override silently falls through
-                logger.debug("Tier 2 MISS (MLflow): %s", name)
-                PROMPT_CACHE_HIT.labels(tier="tier2_mlflow", result="miss").inc()
-            except Exception as exc:
-                # Only log warnings for actual errors, not "not found"
-                logger.warning("Tier 2 ERROR (MLflow) for prompt '%s': %s", name, exc)
+                    if template is not None:
+                        self.circuit_breaker.record_success()
+                        logger.debug("Tier 2 HIT (MLflow): %s", name)
+                        PROMPT_CACHE_HIT.labels(tier="tier2_mlflow", result="hit").inc()
+                        resolved_ttl = await self._resolve_ttl(ttl, tenant_id)
+                        await self.prompt_cache.set_prompt(
+                            name,
+                            template,
+                            ttl=resolved_ttl,
+                            tenant_id=resolved_tenant,
+                        )
+                        elapsed_ms = (time.monotonic() - t0) * 1000
+                        PROMPT_LOAD_LATENCY.labels(
+                            name=name,
+                            tier="tier2_mlflow",
+                            tenant_id=tenant_id or "",
+                        ).observe(elapsed_ms)
+                        return template
+                    # AC-3: Missing tenant override silently falls through
+                    logger.debug("Tier 2 MISS (MLflow): %s", name)
+                    PROMPT_CACHE_HIT.labels(tier="tier2_mlflow", result="miss").inc()
+                except Exception as exc:
+                    self.circuit_breaker.record_failure()
+                    logger.warning(
+                        "Tier 2 ERROR (MLflow) for prompt '%s': %s", name, exc
+                    )
 
         # --- Tier 3: fallback (handled by caller) ---
         elapsed_ms = (time.monotonic() - t0) * 1000

--- a/prompt-optimization-svc/app/tasks/prompt_health_check.py
+++ b/prompt-optimization-svc/app/tasks/prompt_health_check.py
@@ -1,9 +1,13 @@
-"""Celery task: daily prompt health check (§14.1).
+"""Celery task: daily prompt health check (§14.1, §17.2).
 
 Scheduled via Beat: Daily 10:00 UTC (06:00 ET) per §14.1.
 
 AC-3: Verifies all PRODUCTION prompts are loadable from MLflow
 and triggers re-optimization on >10% scorer regression.
+
+§17.2 Auto-rollback (US-050): When regression >15% is detected within
+48 hours of promotion, automatically rolls back to the previous
+ARCHIVED version and alerts ADMIN.
 
 Regression detection checks two sources for score data:
 1. MLflow prompt version tag 'score_after' (set by optimization pipeline
@@ -16,9 +20,11 @@ primarily validates prompt loadability and cacheability.
 
 import asyncio
 import logging
+from datetime import datetime, timedelta, timezone
 
 from app.celery_app import celery_app
 from app.core.config import settings
+from app.metrics import AUTO_ROLLBACK_TOTAL
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +46,55 @@ def _get_reopt_task_name(prompt_name: str) -> str | None:
         if prompt_name.startswith(prefix):
             return task_name
     return None
+
+
+def _is_within_rollback_window(
+    promoted_at_str: str | None,
+    window_hours: int,
+) -> bool:
+    """Check if a prompt was promoted within the rollback window.
+
+    Args:
+        promoted_at_str: ISO-8601 timestamp of promotion (from MLflow tag).
+        window_hours: Maximum hours since promotion for auto-rollback.
+
+    Returns:
+        True if promotion is within the window. False if None or invalid.
+    """
+    if promoted_at_str is None:
+        return False
+    try:
+        promoted_at = datetime.fromisoformat(promoted_at_str)
+        cutoff = datetime.now(timezone.utc) - timedelta(hours=window_hours)
+        return promoted_at >= cutoff
+    except (ValueError, TypeError):
+        return False
+
+
+def _find_previous_archived_version(
+    registry,
+    prompt_name: str,
+    current_version: int,
+) -> int | None:
+    """Find the highest ARCHIVED version below current_version.
+
+    Used to determine the rollback target for auto-rollback.
+    """
+    try:
+        versions = registry.client.search_prompt_versions(prompt_name)
+        archived = []
+        for pv in versions:
+            tags = pv.tags or {}
+            if tags.get("state") == "ARCHIVED" and int(pv.version) < current_version:
+                archived.append(int(pv.version))
+        return max(archived) if archived else None
+    except Exception as exc:
+        logger.error(
+            "Failed to find previous archived version for %s: %s",
+            prompt_name,
+            exc,
+        )
+        return None
 
 
 def _check_regression(score_after: float | None, threshold: float) -> bool:
@@ -105,23 +160,27 @@ def _get_latest_run_score(prompt_name: str) -> float | None:
     name="app.tasks.prompt_health_check.prompt_health_check",
 )
 def prompt_health_check(self):
-    """Verify all PRODUCTION prompts are loadable and performing (AC-3).
+    """Verify all PRODUCTION prompts are loadable and performing (AC-3, §17.2).
 
     1. Lists all registered prompts from MLflow
     2. Checks each PRODUCTION prompt is loadable
     3. Checks score_after tag or OptimizationRun metrics for regression
-    4. Triggers re-optimization if >10% regression detected
+    4. Auto-rollback if >15% regression within 48h of promotion (US-050)
+    5. Triggers re-optimization if >10% regression detected
     """
     from app.services.mlflow_registry import MLflowPromptRegistry
 
     registry = MLflowPromptRegistry(tracking_uri=settings.MLFLOW_TRACKING_URI)
 
     threshold = settings.HEALTH_CHECK_REGRESSION_THRESHOLD
+    auto_rollback_threshold = settings.AUTO_ROLLBACK_REGRESSION_THRESHOLD
+    rollback_window_hours = settings.AUTO_ROLLBACK_WINDOW_HOURS
     result = {
         "checked": 0,
         "healthy": 0,
         "degraded": 0,
         "reopt_triggered": 0,
+        "rollback_triggered": 0,
         "not_loadable": 0,
         "details": [],
     }
@@ -189,9 +248,61 @@ def prompt_health_check(self):
             )
             result["degraded"] += 1
             result["details"].append(
-                f"{name} v{prod_info.version}: " f"regression score={score_after:.3f}"
+                f"{name} v{prod_info.version}: regression score={score_after:.3f}"
             )
 
+            # §17.2 Auto-rollback: >15% regression within 48h of promotion
+            promoted_at_str = prod_info.tags.get("promoted_at")
+            if _check_regression(
+                score_after, auto_rollback_threshold
+            ) and _is_within_rollback_window(promoted_at_str, rollback_window_hours):
+                prev_version = _find_previous_archived_version(
+                    registry, name, prod_info.version
+                )
+                if prev_version is not None:
+                    try:
+                        from app.cache.prompt_cache import PromptCacheManager
+                        from app.logic.rollback_manager import rollback_to_version
+
+                        async def _do_rollback():
+                            cache_mgr = PromptCacheManager(
+                                redis_url=settings.PROMPT_CACHE_REDIS_URL
+                            )
+                            await cache_mgr.connect()
+                            try:
+                                return await rollback_to_version(
+                                    prompt_name=name,
+                                    target_version=prev_version,
+                                    mlflow_registry=registry,
+                                    prompt_cache=cache_mgr,
+                                )
+                            finally:
+                                await cache_mgr.close()
+
+                        rb_result = asyncio.run(_do_rollback())
+                        if rb_result.success:
+                            logger.error(
+                                "ADMIN ALERT: Auto-rollback triggered for "
+                                "%s v%d → v%d (regression %.1f%% within "
+                                "%dh of promotion)",
+                                name,
+                                prod_info.version,
+                                prev_version,
+                                (1.0 - score_after) * 100,
+                                rollback_window_hours,
+                            )
+                            AUTO_ROLLBACK_TOTAL.labels(prompt_name=name).inc()
+                            result["rollback_triggered"] += 1
+                        else:
+                            logger.error(
+                                "ADMIN ALERT: Auto-rollback FAILED for " "%s: %s",
+                                name,
+                                rb_result.error,
+                            )
+                    except Exception as exc:
+                        logger.error("Auto-rollback exception for %s: %s", name, exc)
+
+            # Always trigger re-optimization for any regression >10%
             task_name = _get_reopt_task_name(name)
             if task_name and task_name not in triggered_tasks:
                 try:
@@ -214,11 +325,12 @@ def prompt_health_check(self):
 
     logger.info(
         "Health check complete: checked=%d, healthy=%d, degraded=%d, "
-        "reopt_triggered=%d",
+        "reopt_triggered=%d, rollback_triggered=%d",
         result["checked"],
         result["healthy"],
         result["degraded"],
         result["reopt_triggered"],
+        result["rollback_triggered"],
     )
 
     # Limit details for Celery result backend

--- a/prompt-optimization-svc/tests/integration/test_us050_circuit_breaker.py
+++ b/prompt-optimization-svc/tests/integration/test_us050_circuit_breaker.py
@@ -1,0 +1,126 @@
+"""Integration tests for circuit breaker and auto-rollback (US-050).
+
+Tests prompt loader with circuit breaker using real Redis, and
+rollback window validation with real datetime.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tests.integration.conftest import REDIS_URL, requires_redis
+
+from app.cache.prompt_cache import PromptCacheManager
+from app.logic.circuit_breaker import (
+    CircuitBreakerConfig,
+    CircuitState,
+    MLflowCircuitBreaker,
+)
+from app.services.prompt_loader import ZorvenPromptLoader
+from app.tasks.prompt_health_check import _is_within_rollback_window
+
+
+@pytest.mark.integration
+@requires_redis
+class TestLoaderCircuitBreakerWithRedis:
+    """Prompt loader with circuit breaker and real Redis cache."""
+
+    @pytest.fixture
+    async def cache(self):
+        mgr = PromptCacheManager(redis_url=REDIS_URL)
+        await mgr.connect()
+        yield mgr
+        # Cleanup test keys
+        r = await mgr.connect()
+        async for key in r.scan_iter(match="prompt:__test-cb*"):
+            await r.delete(key)
+        await mgr.close()
+
+    async def test_circuit_open_returns_cached_prompt(self, cache):
+        """AC-1: When circuit is OPEN, loader returns Redis-cached prompt."""
+        # Pre-populate cache
+        await cache.set_prompt("__test-cb-cached", "cached template", ttl=60)
+
+        # Create circuit in OPEN state
+        cb = MLflowCircuitBreaker(CircuitBreakerConfig(failure_threshold_seconds=0))
+        cb.record_failure()  # Opens immediately
+        assert cb.state == CircuitState.OPEN
+
+        loader = ZorvenPromptLoader(
+            prompt_cache=cache,
+            mlflow_registry=None,
+            circuit_breaker=cb,
+        )
+        result = await loader.load("__test-cb-cached", fallback_template="fallback")
+        assert result == "cached template"
+
+    async def test_circuit_open_no_cache_returns_fallback(self, cache):
+        """AC-2: When circuit OPEN and no cache, fallback is engaged."""
+        cb = MLflowCircuitBreaker(CircuitBreakerConfig(failure_threshold_seconds=0))
+        cb.record_failure()
+        assert cb.state == CircuitState.OPEN
+
+        loader = ZorvenPromptLoader(
+            prompt_cache=cache,
+            mlflow_registry=None,
+            circuit_breaker=cb,
+        )
+        result = await loader.load(
+            "__test-cb-no-cache", fallback_template="hardcoded fallback"
+        )
+        assert result == "hardcoded fallback"
+
+    async def test_circuit_closed_allows_mlflow_attempt(self, cache):
+        """CLOSED circuit allows MLflow tier (even if MLflow is None here)."""
+        cb = MLflowCircuitBreaker()
+        assert cb.state == CircuitState.CLOSED
+
+        loader = ZorvenPromptLoader(
+            prompt_cache=cache,
+            mlflow_registry=None,  # No MLflow → falls to fallback
+            circuit_breaker=cb,
+        )
+        result = await loader.load("__test-cb-closed", fallback_template="fallback")
+        # With no MLflow registry, falls to fallback
+        assert result == "fallback"
+        # Circuit should still be CLOSED (no failure recorded since
+        # mlflow_registry is None — the tier 2 block is skipped entirely)
+        assert cb.state == CircuitState.CLOSED
+
+    async def test_half_open_recovery_on_success(self, cache):
+        """HALF_OPEN → CLOSED when MLflow probe succeeds."""
+        cb = MLflowCircuitBreaker(
+            CircuitBreakerConfig(
+                failure_threshold_seconds=0, half_open_interval_seconds=0
+            )
+        )
+        cb.record_failure()  # OPEN
+        cb.should_allow_request()  # HALF_OPEN
+        assert cb.state == CircuitState.HALF_OPEN
+
+        # Simulate success
+        cb.record_success()
+        assert cb.state == CircuitState.CLOSED
+
+        # Now loader should work normally with cached data
+        await cache.set_prompt("__test-cb-recovery", "recovered", ttl=60)
+        loader = ZorvenPromptLoader(
+            prompt_cache=cache,
+            mlflow_registry=None,
+            circuit_breaker=cb,
+        )
+        result = await loader.load("__test-cb-recovery")
+        assert result == "recovered"
+
+
+@pytest.mark.integration
+class TestRollbackWindowRealTime:
+    """Rollback window validation with real datetime."""
+
+    def test_recent_promotion_within_window(self):
+        promoted = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        assert _is_within_rollback_window(promoted, 48) is True
+
+    def test_old_promotion_outside_window(self):
+        promoted = (datetime.now(timezone.utc) - timedelta(days=5)).isoformat()
+        assert _is_within_rollback_window(promoted, 48) is False

--- a/prompt-optimization-svc/tests/test_us050_circuit_breaker.py
+++ b/prompt-optimization-svc/tests/test_us050_circuit_breaker.py
@@ -1,0 +1,256 @@
+"""Unit tests for prompt loading circuit breaker and auto-rollback (US-050).
+
+Tests the MLflowCircuitBreaker state machine, rollback window helper,
+auto-rollback regression detection, and config constants. NO mocks.
+"""
+
+import time
+from datetime import datetime, timedelta, timezone
+
+from app.core.config import settings
+from app.logic.circuit_breaker import (
+    CircuitBreakerConfig,
+    CircuitState,
+    MLflowCircuitBreaker,
+)
+from app.tasks.prompt_health_check import (
+    _check_regression,
+    _is_within_rollback_window,
+)
+
+
+# ── CircuitBreakerConfig ──
+
+
+class TestCircuitBreakerConfig:
+    def test_default_values(self):
+        config = CircuitBreakerConfig()
+        assert config.failure_threshold_seconds == 300
+        assert config.half_open_interval_seconds == 60
+
+    def test_custom_values(self):
+        config = CircuitBreakerConfig(
+            failure_threshold_seconds=10, half_open_interval_seconds=5
+        )
+        assert config.failure_threshold_seconds == 10
+        assert config.half_open_interval_seconds == 5
+
+
+# ── CircuitBreaker state machine ──
+
+
+class TestCircuitBreakerState:
+    def test_initial_state_is_closed(self):
+        cb = MLflowCircuitBreaker()
+        assert cb.state == CircuitState.CLOSED
+
+    def test_single_failure_stays_closed(self):
+        cb = MLflowCircuitBreaker(CircuitBreakerConfig(failure_threshold_seconds=300))
+        cb.record_failure()
+        assert cb.state == CircuitState.CLOSED
+
+    def test_success_resets_failure_tracking(self):
+        cb = MLflowCircuitBreaker(CircuitBreakerConfig(failure_threshold_seconds=300))
+        cb.record_failure()
+        cb.record_failure()
+        assert cb.consecutive_failures == 2
+        cb.record_success()
+        assert cb.consecutive_failures == 0
+        assert cb.state == CircuitState.CLOSED
+
+    def test_failures_within_threshold_stays_closed(self):
+        """Failures within the threshold window do not open the circuit."""
+        cb = MLflowCircuitBreaker(CircuitBreakerConfig(failure_threshold_seconds=300))
+        for _ in range(100):
+            cb.record_failure()
+        # Still within threshold (< 300s elapsed since first failure)
+        assert cb.state == CircuitState.CLOSED
+
+    def test_failures_exceeding_threshold_opens(self):
+        """After failure_threshold_seconds of failures, circuit opens."""
+        # Use a tiny threshold so time.monotonic() crosses it immediately
+        cb = MLflowCircuitBreaker(CircuitBreakerConfig(failure_threshold_seconds=0))
+        cb.record_failure()
+        assert cb.state == CircuitState.OPEN
+
+    def test_open_blocks_requests(self):
+        cb = MLflowCircuitBreaker(
+            CircuitBreakerConfig(
+                failure_threshold_seconds=0, half_open_interval_seconds=9999
+            )
+        )
+        cb.record_failure()  # Opens immediately (threshold=0)
+        assert cb.state == CircuitState.OPEN
+        assert cb.should_allow_request() is False
+
+    def test_half_open_allows_one_probe(self):
+        """After probe interval elapses, one request is allowed."""
+        cb = MLflowCircuitBreaker(
+            CircuitBreakerConfig(
+                failure_threshold_seconds=0, half_open_interval_seconds=0
+            )
+        )
+        cb.record_failure()  # Opens immediately
+        assert cb.state == CircuitState.OPEN
+        # Probe interval is 0, so should_allow_request transitions to HALF_OPEN
+        assert cb.should_allow_request() is True
+        assert cb.state == CircuitState.HALF_OPEN
+
+    def test_half_open_success_closes(self):
+        cb = MLflowCircuitBreaker(
+            CircuitBreakerConfig(
+                failure_threshold_seconds=0, half_open_interval_seconds=0
+            )
+        )
+        cb.record_failure()
+        cb.should_allow_request()  # Transition to HALF_OPEN
+        assert cb.state == CircuitState.HALF_OPEN
+        cb.record_success()
+        assert cb.state == CircuitState.CLOSED
+
+    def test_half_open_failure_reopens(self):
+        cb = MLflowCircuitBreaker(
+            CircuitBreakerConfig(
+                failure_threshold_seconds=0, half_open_interval_seconds=0
+            )
+        )
+        cb.record_failure()
+        cb.should_allow_request()  # HALF_OPEN
+        cb.record_failure()  # Should reopen (threshold=0, elapsed >= 0)
+        assert cb.state == CircuitState.OPEN
+
+    def test_consecutive_successes_keep_closed(self):
+        cb = MLflowCircuitBreaker()
+        cb.record_success()
+        cb.record_success()
+        cb.record_success()
+        assert cb.state == CircuitState.CLOSED
+        assert cb.consecutive_failures == 0
+
+    def test_success_from_open_closes(self):
+        cb = MLflowCircuitBreaker(CircuitBreakerConfig(failure_threshold_seconds=0))
+        cb.record_failure()
+        assert cb.state == CircuitState.OPEN
+        cb.record_success()
+        assert cb.state == CircuitState.CLOSED
+
+    def test_probe_interval_respected(self):
+        """No probe allowed before interval elapses."""
+        cb = MLflowCircuitBreaker(
+            CircuitBreakerConfig(
+                failure_threshold_seconds=0, half_open_interval_seconds=9999
+            )
+        )
+        cb.record_failure()  # Opens
+        # First call updates _last_probe_at, but interval hasn't elapsed
+        assert cb.should_allow_request() is False
+        assert cb.state == CircuitState.OPEN
+
+
+# ── Edge cases ──
+
+
+class TestCircuitBreakerEdgeCases:
+    def test_immediate_success_after_first_failure(self):
+        cb = MLflowCircuitBreaker(CircuitBreakerConfig(failure_threshold_seconds=300))
+        cb.record_failure()
+        assert cb.consecutive_failures == 1
+        cb.record_success()
+        assert cb.consecutive_failures == 0
+        assert cb.state == CircuitState.CLOSED
+
+    def test_state_property_reflects_internal(self):
+        cb = MLflowCircuitBreaker(CircuitBreakerConfig(failure_threshold_seconds=0))
+        assert cb.state == CircuitState.CLOSED
+        cb.record_failure()
+        assert cb.state == CircuitState.OPEN
+
+    def test_consecutive_failures_accuracy(self):
+        cb = MLflowCircuitBreaker()
+        for i in range(1, 6):
+            cb.record_failure()
+            assert cb.consecutive_failures == i
+        cb.record_success()
+        assert cb.consecutive_failures == 0
+
+    def test_closed_always_allows_requests(self):
+        cb = MLflowCircuitBreaker()
+        for _ in range(10):
+            assert cb.should_allow_request() is True
+        assert cb.state == CircuitState.CLOSED
+
+
+# ── Rollback window ──
+
+
+class TestRollbackWindow:
+    def test_recent_promotion_within_window(self):
+        promoted = (datetime.now(timezone.utc) - timedelta(hours=24)).isoformat()
+        assert _is_within_rollback_window(promoted, 48) is True
+
+    def test_old_promotion_outside_window(self):
+        promoted = (datetime.now(timezone.utc) - timedelta(hours=72)).isoformat()
+        assert _is_within_rollback_window(promoted, 48) is False
+
+    def test_none_returns_false(self):
+        assert _is_within_rollback_window(None, 48) is False
+
+    def test_invalid_iso_returns_false(self):
+        assert _is_within_rollback_window("not-a-date", 48) is False
+
+    def test_exactly_at_boundary(self):
+        """Promotion exactly at cutoff is within window (>=)."""
+        promoted = (datetime.now(timezone.utc) - timedelta(hours=48)).isoformat()
+        # Due to time passing between creation and check, this may be just outside
+        # So test with a tiny margin inside
+        promoted_inside = (
+            datetime.now(timezone.utc) - timedelta(hours=47, minutes=59)
+        ).isoformat()
+        assert _is_within_rollback_window(promoted_inside, 48) is True
+
+    def test_just_promoted(self):
+        promoted = datetime.now(timezone.utc).isoformat()
+        assert _is_within_rollback_window(promoted, 48) is True
+
+
+# ── Auto-rollback regression ──
+
+
+class TestAutoRollbackRegression:
+    def test_16pct_regression_detected(self):
+        """Score 0.84 means 16% regression (> 15% threshold)."""
+        assert _check_regression(0.84, 0.15) is True
+
+    def test_14pct_regression_not_detected(self):
+        """Score 0.87 means 13% regression (< 15% threshold)."""
+        assert _check_regression(0.87, 0.15) is False
+
+    def test_exact_boundary_not_regression(self):
+        """Score exactly 0.85 means exactly 15% regression — not strictly less."""
+        assert _check_regression(0.85, 0.15) is False
+
+    def test_none_score_not_regression(self):
+        assert _check_regression(None, 0.15) is False
+
+    def test_zero_score_is_regression(self):
+        assert _check_regression(0.0, 0.15) is True
+
+    def test_perfect_score_no_regression(self):
+        assert _check_regression(1.0, 0.15) is False
+
+
+# ── Config settings defaults ──
+
+
+class TestConfigDefaults:
+    def test_circuit_breaker_failure_threshold(self):
+        assert settings.CIRCUIT_BREAKER_FAILURE_THRESHOLD_SECONDS == 300
+
+    def test_circuit_breaker_half_open_interval(self):
+        assert settings.CIRCUIT_BREAKER_HALF_OPEN_INTERVAL_SECONDS == 60
+
+    def test_auto_rollback_regression_threshold(self):
+        assert settings.AUTO_ROLLBACK_REGRESSION_THRESHOLD == 0.15
+
+    def test_auto_rollback_window_hours(self):
+        assert settings.AUTO_ROLLBACK_WINDOW_HOURS == 48

--- a/prompt-optimization-svc/tests/test_us050_circuit_breaker.py
+++ b/prompt-optimization-svc/tests/test_us050_circuit_breaker.py
@@ -4,7 +4,6 @@ Tests the MLflowCircuitBreaker state machine, rollback window helper,
 auto-rollback regression detection, and config constants. NO mocks.
 """
 
-import time
 from datetime import datetime, timedelta, timezone
 
 from app.core.config import settings

--- a/prompt-optimization-svc/tests/test_us050_circuit_breaker_properties.py
+++ b/prompt-optimization-svc/tests/test_us050_circuit_breaker_properties.py
@@ -1,0 +1,84 @@
+"""Hypothesis property-based tests for circuit breaker and auto-rollback (US-050)."""
+
+from datetime import datetime, timedelta, timezone
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from app.logic.circuit_breaker import (
+    CircuitBreakerConfig,
+    CircuitState,
+    MLflowCircuitBreaker,
+)
+from app.tasks.prompt_health_check import _is_within_rollback_window
+
+
+class TestCircuitBreakerProperties:
+    @settings(max_examples=50, deadline=None)
+    @given(threshold=st.integers(min_value=1, max_value=3600))
+    def test_circuit_never_opens_before_threshold(self, threshold):
+        """The circuit must stay CLOSED if failures haven't persisted
+        for failure_threshold_seconds."""
+        cb = MLflowCircuitBreaker(
+            CircuitBreakerConfig(failure_threshold_seconds=threshold)
+        )
+        # Record failures — but since time.monotonic() advances minimally,
+        # the threshold (≥1s) should not be exceeded
+        for _ in range(10):
+            cb.record_failure()
+        assert cb.state == CircuitState.CLOSED
+
+    @settings(max_examples=50, deadline=None)
+    @given(
+        n_failures=st.integers(min_value=0, max_value=20),
+    )
+    def test_record_success_always_closes(self, n_failures):
+        """Any sequence ending in record_success() yields CLOSED state."""
+        cb = MLflowCircuitBreaker(CircuitBreakerConfig(failure_threshold_seconds=0))
+        for _ in range(n_failures):
+            cb.record_failure()
+        cb.record_success()
+        assert cb.state == CircuitState.CLOSED
+        assert cb.consecutive_failures == 0
+
+    @settings(max_examples=50, deadline=None)
+    @given(n=st.integers(min_value=1, max_value=50))
+    def test_consecutive_failures_monotonic(self, n):
+        """consecutive_failures increases with each failure, resets on success."""
+        cb = MLflowCircuitBreaker(CircuitBreakerConfig(failure_threshold_seconds=9999))
+        for i in range(1, n + 1):
+            cb.record_failure()
+            assert cb.consecutive_failures == i
+        cb.record_success()
+        assert cb.consecutive_failures == 0
+
+
+class TestRollbackWindowProperties:
+    @settings(max_examples=50, deadline=None)
+    @given(hours_ago=st.integers(min_value=0, max_value=47))
+    def test_within_window_returns_true(self, hours_ago):
+        """Promotions within the window always return True."""
+        promoted = (datetime.now(timezone.utc) - timedelta(hours=hours_ago)).isoformat()
+        assert _is_within_rollback_window(promoted, 48) is True
+
+    @settings(max_examples=50, deadline=None)
+    @given(hours_ago=st.integers(min_value=49, max_value=1000))
+    def test_outside_window_returns_false(self, hours_ago):
+        """Promotions outside the window always return False."""
+        promoted = (datetime.now(timezone.utc) - timedelta(hours=hours_ago)).isoformat()
+        assert _is_within_rollback_window(promoted, 48) is False
+
+
+class TestCircuitBreakerConfigProperties:
+    @settings(max_examples=30, deadline=None)
+    @given(
+        threshold=st.integers(min_value=1, max_value=10000),
+        interval=st.integers(min_value=1, max_value=10000),
+    )
+    def test_any_positive_config_is_valid(self, threshold, interval):
+        config = CircuitBreakerConfig(
+            failure_threshold_seconds=threshold,
+            half_open_interval_seconds=interval,
+        )
+        assert config.failure_threshold_seconds > 0
+        assert config.half_open_interval_seconds > 0

--- a/prompt-optimization-svc/tests/test_us050_circuit_breaker_properties.py
+++ b/prompt-optimization-svc/tests/test_us050_circuit_breaker_properties.py
@@ -15,15 +15,16 @@ from app.tasks.prompt_health_check import _is_within_rollback_window
 
 class TestCircuitBreakerProperties:
     @settings(max_examples=50, deadline=None)
-    @given(threshold=st.integers(min_value=1, max_value=3600))
+    @given(threshold=st.integers(min_value=10, max_value=3600))
     def test_circuit_never_opens_before_threshold(self, threshold):
         """The circuit must stay CLOSED if failures haven't persisted
-        for failure_threshold_seconds."""
+        for failure_threshold_seconds. Uses min_value=10 to avoid
+        flakiness on slow CI where the loop itself could exceed 1s."""
         cb = MLflowCircuitBreaker(
             CircuitBreakerConfig(failure_threshold_seconds=threshold)
         )
-        # Record failures — but since time.monotonic() advances minimally,
-        # the threshold (≥1s) should not be exceeded
+        # Record failures — time.monotonic() advances minimally,
+        # so the threshold (≥10s) will not be exceeded by 10 iterations
         for _ in range(10):
             cb.record_failure()
         assert cb.state == CircuitState.CLOSED


### PR DESCRIPTION
## Summary

- **Circuit breaker** (`app/logic/circuit_breaker.py`): Three-state (CLOSED/OPEN/HALF_OPEN) in-memory circuit breaker for MLflow prompt loading. After 5 minutes of continuous MLflow failures, skips tier 2 entirely — agents fall to Redis cache (AC-1) or hardcoded fallback (AC-2). Half-open probes every 60s to detect recovery.
- **Auto-rollback** (`app/tasks/prompt_health_check.py`): When daily health check detects >15% scorer regression within 48 hours of promotion, automatically rolls back to previous ARCHIVED version and logs ADMIN alert (AC-3). Existing >10% re-optimization path preserved for all regressions.
- **Promotion timestamp** (`app/services/mlflow_registry.py`): Writes `promoted_at` ISO-8601 tag on every PRODUCTION promotion for rollback window tracking.
- **Config**: 4 new settings — `CIRCUIT_BREAKER_FAILURE_THRESHOLD_SECONDS` (300), `CIRCUIT_BREAKER_HALF_OPEN_INTERVAL_SECONDS` (60), `AUTO_ROLLBACK_REGRESSION_THRESHOLD` (0.15), `AUTO_ROLLBACK_WINDOW_HOURS` (48)
- **Metrics**: `poi_circuit_breaker_state` gauge, `poi_auto_rollback` counter

## Test plan

- [x] 34 unit tests (circuit breaker state machine, rollback window, regression detection, config defaults)
- [x] 6 Hypothesis property tests (timing invariants, recovery invariants, window boundary properties)
- [x] 6 integration tests (loader + circuit breaker with real Redis, rollback window with real datetime)
- [x] Full regression suite: 2077 passed, 15 pre-existing failures (unrelated)
- [ ] Verify circuit breaker with real MLflow down scenario
- [ ] Verify auto-rollback triggers on staged regression in staging environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)