### PR TITLE
feat(gepa): auto-generate schema preamble and inject as protected zone (US-053)

### DIFF
--- a/prompt-optimization-svc/app/services/schema_preamble.py
+++ b/prompt-optimization-svc/app/services/schema_preamble.py
@@ -1,0 +1,115 @@
+"""Schema Preamble Generator — auto-generate and inject protected schema zones (US-053).
+
+Generates a structured text preamble from a SkillDefinition's input/output
+schemas, marks it with delimiters so GEPA optimization cannot modify it,
+and provides utilities to inject, extract, and strip preambles from prompts.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+from app.registries.skill_definitions import SkillDefinition
+from app.services.skill_registry_reader import SkillRegistryReader
+
+# Protected zone delimiters
+PREAMBLE_START = "<!-- SCHEMA_PREAMBLE_START -->"
+PREAMBLE_END = "<!-- SCHEMA_PREAMBLE_END -->"
+
+# Regex to match the full preamble block (including markers)
+_PREAMBLE_PATTERN = re.compile(
+    re.escape(PREAMBLE_START) + r".*?" + re.escape(PREAMBLE_END),
+    re.DOTALL,
+)
+
+
+class SchemaPreambleGenerator:
+    """Generates and manages schema preambles for prompt protection."""
+
+    def __init__(self, skill_registry_reader: SkillRegistryReader) -> None:
+        self._reader = skill_registry_reader
+
+    def generate(self, skill: SkillDefinition) -> str:
+        """Generate a schema preamble from a SkillDefinition.
+
+        Returns a structured block with input/output schema tables,
+        wrapped in PREAMBLE_START/END markers.
+        """
+        lines = [
+            PREAMBLE_START,
+            "[SCHEMA CONSTRAINT — DO NOT MODIFY]",
+            f"Skill: {skill.skill_id} ({skill.name})",
+            "",
+            "## Expected Input",
+            "| Field | Type | Required |",
+            "|-------|------|----------|",
+        ]
+
+        for field in skill.input_schema:
+            field_name = field.get("field", "unknown")
+            field_type = field.get("type", "unknown")
+            required = "yes" if field.get("required", True) else "no"
+            lines.append(f"| {field_name} | {field_type} | {required} |")
+
+        lines.append("")
+        lines.append("## Required Output")
+        lines.append("| Field | Type | Max Length |")
+        lines.append("|-------|------|-----------|")
+
+        for field in skill.output_schema:
+            max_len = str(field.max_length) if field.max_length else "—"
+            lines.append(f"| {field.field} | {field.type} | {max_len} |")
+
+        lines.append("")
+        idempotent_str = "yes" if skill.idempotent else "no"
+        lines.append(f"Timeout: {skill.timeout_ms}ms | Idempotent: {idempotent_str}")
+        lines.append(PREAMBLE_END)
+
+        return "\n".join(lines)
+
+    def generate_for_prompt(self, agent_code: str, prompt_name: str) -> Optional[str]:
+        """Look up the skill for a prompt and generate its preamble.
+
+        Returns None if no skill match found.
+        """
+        skill = self._reader.get_skill_for_prompt(agent_code, prompt_name)
+        if skill is None:
+            return None
+        return self.generate(skill)
+
+    def inject(self, prompt_template: str, preamble: str) -> str:
+        """Prepend the preamble to a prompt template.
+
+        If a preamble already exists in the template, it is replaced.
+        """
+        stripped = self.strip(prompt_template)
+        return preamble + "\n\n" + stripped
+
+    def strip(self, prompt_text: str) -> str:
+        """Remove the preamble section from prompt text."""
+        result = _PREAMBLE_PATTERN.sub("", prompt_text)
+        # Clean up leading/trailing whitespace left by removal
+        return result.strip()
+
+    def extract(self, prompt_text: str) -> Optional[str]:
+        """Extract the preamble section from prompt text, or None."""
+        match = _PREAMBLE_PATTERN.search(prompt_text)
+        if match:
+            return match.group(0)
+        return None
+
+    def is_protected(self, prompt_text: str) -> bool:
+        """Check if prompt text contains a schema preamble."""
+        return PREAMBLE_START in prompt_text and PREAMBLE_END in prompt_text
+
+    def has_changed(self, prompt_text: str, skill: SkillDefinition) -> bool:
+        """Check if the embedded preamble differs from current skill schema.
+
+        Returns True if the preamble is missing or outdated.
+        """
+        existing = self.extract(prompt_text)
+        if existing is None:
+            return True
+        current = self.generate(skill)
+        return existing != current

--- a/prompt-optimization-svc/app/services/schema_preamble.py
+++ b/prompt-optimization-svc/app/services/schema_preamble.py
@@ -82,14 +82,19 @@ class SchemaPreambleGenerator:
         """Prepend the preamble to a prompt template.
 
         If a preamble already exists in the template, it is replaced.
+        The content portion is stripped to ensure idempotent injection.
         """
-        stripped = self.strip(prompt_template)
-        return preamble + "\n\n" + stripped
+        if self.is_protected(prompt_template):
+            content = _PREAMBLE_PATTERN.sub("", prompt_template).strip()
+        else:
+            content = prompt_template.strip()
+        return preamble + "\n\n" + content
 
     def strip(self, prompt_text: str) -> str:
         """Remove the preamble section from prompt text."""
+        if not self.is_protected(prompt_text):
+            return prompt_text
         result = _PREAMBLE_PATTERN.sub("", prompt_text)
-        # Clean up leading/trailing whitespace left by removal
         return result.strip()
 
     def extract(self, prompt_text: str) -> Optional[str]:
@@ -100,8 +105,8 @@ class SchemaPreambleGenerator:
         return None
 
     def is_protected(self, prompt_text: str) -> bool:
-        """Check if prompt text contains a schema preamble."""
-        return PREAMBLE_START in prompt_text and PREAMBLE_END in prompt_text
+        """Check if prompt text contains a valid schema preamble block."""
+        return self.extract(prompt_text) is not None
 
     def has_changed(self, prompt_text: str, skill: SkillDefinition) -> bool:
         """Check if the embedded preamble differs from current skill schema.

--- a/prompt-optimization-svc/tests/test_schema_preamble.py
+++ b/prompt-optimization-svc/tests/test_schema_preamble.py
@@ -1,0 +1,175 @@
+"""
+US-053 Unit Tests — SchemaPreambleGenerator.
+
+All tests use real SkillRegistryReader loading real skills.yaml files.
+No mocks.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from app.registries.skill_definitions import SkillDefinition
+from app.services.schema_preamble import (
+    PREAMBLE_END,
+    PREAMBLE_START,
+    SchemaPreambleGenerator,
+)
+from app.services.skill_registry_reader import (
+    AGENT_SERVICE_DIRS,
+    SkillRegistryReader,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+@pytest.fixture
+def reader():
+    r = SkillRegistryReader(repo_root=REPO_ROOT)
+    yield r
+    r.clear_cache()
+
+
+@pytest.fixture
+def generator(reader):
+    return SchemaPreambleGenerator(reader)
+
+
+@pytest.fixture
+def mra_skill(reader):
+    """First skill from MRA agent."""
+    return reader.get_skill("mra", "SKL-MRA-01")
+
+
+ALL_AGENT_CODES = sorted(AGENT_SERVICE_DIRS.keys())
+
+
+class TestGenerate:
+    def test_generate_produces_preamble_with_markers(self, generator, mra_skill):
+        preamble = generator.generate(mra_skill)
+        assert PREAMBLE_START in preamble
+        assert PREAMBLE_END in preamble
+        assert preamble.startswith(PREAMBLE_START)
+        assert preamble.endswith(PREAMBLE_END)
+
+    def test_generate_includes_input_schema_fields(self, generator, mra_skill):
+        preamble = generator.generate(mra_skill)
+        assert "input_prompt" in preamble
+        assert "string" in preamble
+
+    def test_generate_includes_output_schema_fields(self, generator, mra_skill):
+        preamble = generator.generate(mra_skill)
+        for field in mra_skill.output_schema:
+            assert field.field in preamble
+
+    def test_generate_includes_skill_metadata(self, generator, mra_skill):
+        preamble = generator.generate(mra_skill)
+        assert "SKL-MRA-01" in preamble
+        assert "web_market_search" in preamble
+        assert "30000ms" in preamble
+        assert "Idempotent: yes" in preamble
+
+    @pytest.mark.parametrize("agent_code", ALL_AGENT_CODES)
+    def test_generate_all_15_agents_first_skill(self, generator, reader, agent_code):
+        """Generate preamble for first skill of every agent without error."""
+        skills_file = reader.load_skills(agent_code)
+        first_skill = skills_file.skills[0]
+        preamble = generator.generate(first_skill)
+        assert PREAMBLE_START in preamble
+        assert PREAMBLE_END in preamble
+        assert first_skill.skill_id in preamble
+
+
+class TestGenerateForPrompt:
+    def test_generate_for_prompt_known_skill(self, generator):
+        result = generator.generate_for_prompt("mra", "zorven-wf1-mra-synthesis")
+        assert result is not None
+        assert PREAMBLE_START in result
+
+    def test_generate_for_prompt_unknown_returns_none(self, generator):
+        result = generator.generate_for_prompt("mra", "zorven-wf1-mra-nonexistent")
+        assert result is None
+
+    def test_generate_for_prompt_system_prompt_returns_none(self, generator):
+        """System prompts typically don't map to a specific skill."""
+        result = generator.generate_for_prompt("mra", "zorven-wf1-mra-system")
+        # 'system' may or may not match — assert it doesn't raise
+        assert result is None or PREAMBLE_START in result
+
+
+class TestInject:
+    def test_inject_prepends_preamble(self, generator, mra_skill):
+        preamble = generator.generate(mra_skill)
+        prompt = "You are a market research analyst."
+        result = generator.inject(prompt, preamble)
+        assert result.startswith(PREAMBLE_START)
+        assert "You are a market research analyst." in result
+
+    def test_inject_replaces_existing_preamble(self, generator, mra_skill):
+        preamble = generator.generate(mra_skill)
+        prompt = "You are a market research analyst."
+        # Inject once
+        first = generator.inject(prompt, preamble)
+        # Inject again — should not duplicate
+        second = generator.inject(first, preamble)
+        assert second.count(PREAMBLE_START) == 1
+        assert second.count(PREAMBLE_END) == 1
+
+
+class TestStrip:
+    def test_strip_removes_preamble(self, generator, mra_skill):
+        preamble = generator.generate(mra_skill)
+        prompt = "You are a market research analyst."
+        injected = generator.inject(prompt, preamble)
+        stripped = generator.strip(injected)
+        assert PREAMBLE_START not in stripped
+        assert PREAMBLE_END not in stripped
+        assert "You are a market research analyst." in stripped
+
+    def test_strip_no_preamble_returns_unchanged(self, generator):
+        prompt = "You are a market research analyst."
+        assert generator.strip(prompt) == prompt
+
+
+class TestExtract:
+    def test_extract_returns_preamble_content(self, generator, mra_skill):
+        preamble = generator.generate(mra_skill)
+        prompt = "You are a market research analyst."
+        injected = generator.inject(prompt, preamble)
+        extracted = generator.extract(injected)
+        assert extracted == preamble
+
+    def test_extract_no_preamble_returns_none(self, generator):
+        assert generator.extract("Just a plain prompt.") is None
+
+
+class TestIsProtected:
+    def test_is_protected_true_when_preamble_present(self, generator, mra_skill):
+        preamble = generator.generate(mra_skill)
+        prompt = "You are a market research analyst."
+        injected = generator.inject(prompt, preamble)
+        assert generator.is_protected(injected) is True
+
+    def test_is_protected_false_when_no_preamble(self, generator):
+        assert generator.is_protected("Plain prompt text.") is False
+
+
+class TestHasChanged:
+    def test_has_changed_detects_missing_preamble(self, generator, mra_skill):
+        """Prompt without preamble → has_changed is True."""
+        assert generator.has_changed("Plain prompt.", mra_skill) is True
+
+    def test_has_changed_false_when_current(self, generator, mra_skill):
+        """Prompt with current preamble → has_changed is False."""
+        preamble = generator.generate(mra_skill)
+        injected = generator.inject("Some prompt.", preamble)
+        assert generator.has_changed(injected, mra_skill) is False
+
+    def test_has_changed_detects_schema_drift(self, generator, reader):
+        """If skill schema differs from embedded preamble → True."""
+        skill = reader.get_skill("mra", "SKL-MRA-01")
+        preamble = generator.generate(skill)
+        injected = generator.inject("Some prompt.", preamble)
+        # Simulate drift by checking against a different skill
+        other_skill = reader.get_skill("mra", "SKL-MRA-02")
+        assert generator.has_changed(injected, other_skill) is True

--- a/tests/integration/phase1_contracts/test_schema_preamble_integration.py
+++ b/tests/integration/phase1_contracts/test_schema_preamble_integration.py
@@ -1,0 +1,107 @@
+"""
+US-053 Integration Tests — Schema Preamble Cross-Service Validation.
+
+Exercises SchemaPreambleGenerator against all real skills.yaml files
+and the prompt catalog. No mocks.
+"""
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT / "prompt-optimization-svc"))
+
+from app.registries.prompt_catalog import PROMPT_CATALOG  # noqa: E402
+from app.services.schema_preamble import (  # noqa: E402
+    PREAMBLE_END,
+    PREAMBLE_START,
+    SchemaPreambleGenerator,
+)
+from app.services.skill_registry_reader import (  # noqa: E402
+    AGENT_SERVICE_DIRS,
+    SkillRegistryReader,
+)
+
+
+def _make_generator() -> SchemaPreambleGenerator:
+    reader = SkillRegistryReader(repo_root=REPO_ROOT)
+    return SchemaPreambleGenerator(reader)
+
+
+class TestSchemaPreambleIntegration:
+    """Cross-service integration tests for schema preamble generation."""
+
+    def test_generate_preamble_for_all_catalog_prompts(self):
+        """Generate preambles for non-system prompts where skills resolve."""
+        gen = _make_generator()
+        generated_count = 0
+        for entry in PROMPT_CATALOG:
+            if entry.tags.get("prompt_type") == "system":
+                continue
+            agent_code = entry.tags.get("agent_code", "")
+            result = gen.generate_for_prompt(agent_code, entry.name)
+            if result is not None:
+                generated_count += 1
+                assert PREAMBLE_START in result
+                assert PREAMBLE_END in result
+        # At least some prompts should resolve
+        assert generated_count > 0
+
+    def test_preamble_roundtrip_inject_extract(self):
+        """inject then extract → get same preamble back."""
+        gen = _make_generator()
+        preamble = gen.generate_for_prompt("mra", "zorven-wf1-mra-synthesis")
+        assert preamble is not None
+        prompt = "Synthesize the following market research findings."
+        injected = gen.inject(prompt, preamble)
+        extracted = gen.extract(injected)
+        assert extracted == preamble
+
+    def test_preamble_roundtrip_inject_strip(self):
+        """inject then strip → get original prompt back."""
+        gen = _make_generator()
+        preamble = gen.generate_for_prompt("mra", "zorven-wf1-mra-synthesis")
+        assert preamble is not None
+        prompt = "Synthesize the following market research findings."
+        injected = gen.inject(prompt, preamble)
+        stripped = gen.strip(injected)
+        assert stripped == prompt
+
+    def test_all_generated_preambles_contain_markers(self):
+        """Every generated preamble has START/END markers."""
+        gen = _make_generator()
+        reader = SkillRegistryReader(repo_root=REPO_ROOT)
+        for agent_code in sorted(AGENT_SERVICE_DIRS.keys()):
+            skills_file = reader.load_skills(agent_code)
+            for skill in skills_file.skills:
+                preamble = gen.generate(skill)
+                assert (
+                    PREAMBLE_START in preamble
+                ), f"Missing START marker for {skill.skill_id}"
+                assert (
+                    PREAMBLE_END in preamble
+                ), f"Missing END marker for {skill.skill_id}"
+
+    def test_preamble_content_matches_skill_schema(self):
+        """Field names from skills.yaml appear in the generated preamble."""
+        gen = _make_generator()
+        reader = SkillRegistryReader(repo_root=REPO_ROOT)
+        skill = reader.get_skill("mra", "SKL-MRA-01")
+        assert skill is not None
+        preamble = gen.generate(skill)
+        # Check input fields
+        for field in skill.input_schema:
+            assert field["field"] in preamble
+        # Check output fields
+        for field in skill.output_schema:
+            assert field.field in preamble
+
+    def test_inject_does_not_modify_template_variables(self):
+        """{{context.brand_name}} placeholders survive injection."""
+        gen = _make_generator()
+        preamble = gen.generate_for_prompt("mra", "zorven-wf1-mra-synthesis")
+        assert preamble is not None
+        template = "Analyze market for {{context.brand_name}} in {{context.industry}}."
+        injected = gen.inject(template, preamble)
+        assert "{{context.brand_name}}" in injected
+        assert "{{context.industry}}" in injected

--- a/tests/integration/phase1_contracts/test_schema_preamble_properties.py
+++ b/tests/integration/phase1_contracts/test_schema_preamble_properties.py
@@ -1,0 +1,124 @@
+"""
+US-053 Property Tests — Schema Preamble Hypothesis Tests.
+
+Property-based tests for preamble inject/strip/extract idempotency
+and roundtrip guarantees. No mocks — uses real skills.yaml files.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+from hypothesis import given, settings, HealthCheck
+from hypothesis import strategies as st
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT / "prompt-optimization-svc"))
+
+from app.services.schema_preamble import (  # noqa: E402
+    PREAMBLE_END,
+    PREAMBLE_START,
+    SchemaPreambleGenerator,
+)
+from app.services.skill_registry_reader import (  # noqa: E402
+    AGENT_SERVICE_DIRS,
+    SkillRegistryReader,
+)
+
+# ---------------------------------------------------------------------------
+# Strategies
+# ---------------------------------------------------------------------------
+
+VALID_CODES = sorted(AGENT_SERVICE_DIRS.keys())
+
+# Prompt templates that don't contain preamble markers
+arbitrary_prompts = st.text(
+    min_size=1,
+    max_size=200,
+    alphabet=st.characters(
+        whitelist_categories=("L", "N", "P", "Z"),
+        whitelist_characters=" \n\t.,!?{}()",
+    ),
+).filter(lambda t: PREAMBLE_START not in t and PREAMBLE_END not in t)
+
+valid_agent_codes = st.sampled_from(VALID_CODES)
+
+
+def _make_generator() -> tuple[SchemaPreambleGenerator, SkillRegistryReader]:
+    reader = SkillRegistryReader(repo_root=REPO_ROOT)
+    return SchemaPreambleGenerator(reader), reader
+
+
+# ---------------------------------------------------------------------------
+# Property Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.property
+class TestSchemaPreambleProperties:
+    """Hypothesis property tests for schema preamble operations."""
+
+    @given(prompt_text=arbitrary_prompts, agent_code=valid_agent_codes)
+    @settings(max_examples=30, suppress_health_check=[HealthCheck.too_slow])
+    def test_inject_then_strip_is_identity(self, prompt_text, agent_code):
+        """For any prompt text, strip(inject(text, preamble)) == text."""
+        gen, reader = _make_generator()
+        skills_file = reader.load_skills(agent_code)
+        skill = skills_file.skills[0]
+        preamble = gen.generate(skill)
+        injected = gen.inject(prompt_text, preamble)
+        stripped = gen.strip(injected)
+        assert stripped == prompt_text.strip()
+
+    @given(prompt_text=arbitrary_prompts, agent_code=valid_agent_codes)
+    @settings(max_examples=30, suppress_health_check=[HealthCheck.too_slow])
+    def test_inject_always_produces_protected_text(self, prompt_text, agent_code):
+        """After inject, is_protected() is always True."""
+        gen, reader = _make_generator()
+        skills_file = reader.load_skills(agent_code)
+        skill = skills_file.skills[0]
+        preamble = gen.generate(skill)
+        injected = gen.inject(prompt_text, preamble)
+        assert gen.is_protected(injected)
+
+    @given(prompt_text=arbitrary_prompts)
+    @settings(max_examples=30)
+    def test_strip_always_produces_unprotected_text(self, prompt_text):
+        """After strip, is_protected() is always False."""
+        gen, _ = _make_generator()
+        stripped = gen.strip(prompt_text)
+        assert not gen.is_protected(stripped)
+
+    @given(prompt_text=arbitrary_prompts, agent_code=valid_agent_codes)
+    @settings(max_examples=30, suppress_health_check=[HealthCheck.too_slow])
+    def test_extract_after_inject_returns_preamble(self, prompt_text, agent_code):
+        """inject then extract → gets the preamble back."""
+        gen, reader = _make_generator()
+        skills_file = reader.load_skills(agent_code)
+        skill = skills_file.skills[0]
+        preamble = gen.generate(skill)
+        injected = gen.inject(prompt_text, preamble)
+        extracted = gen.extract(injected)
+        assert extracted == preamble
+
+    @given(agent_code=valid_agent_codes)
+    @settings(max_examples=15, suppress_health_check=[HealthCheck.too_slow])
+    def test_generate_never_raises_for_valid_skill(self, agent_code):
+        """Generating from any real skill never raises."""
+        gen, reader = _make_generator()
+        skills_file = reader.load_skills(agent_code)
+        for skill in skills_file.skills:
+            preamble = gen.generate(skill)
+            assert PREAMBLE_START in preamble
+
+    @given(prompt_text=arbitrary_prompts, agent_code=valid_agent_codes)
+    @settings(max_examples=30, suppress_health_check=[HealthCheck.too_slow])
+    def test_double_inject_same_as_single(self, prompt_text, agent_code):
+        """Injecting twice produces same result as once (idempotent)."""
+        gen, reader = _make_generator()
+        skills_file = reader.load_skills(agent_code)
+        skill = skills_file.skills[0]
+        preamble = gen.generate(skill)
+        first = gen.inject(prompt_text, preamble)
+        second = gen.inject(first, preamble)
+        assert first == second


### PR DESCRIPTION
## Summary

- Adds `SchemaPreambleGenerator` in `prompt-optimization-svc/app/services/schema_preamble.py` that generates structured schema preambles from SkillDefinition input/output schemas
- Preambles wrapped in `<!-- SCHEMA_PREAMBLE_START/END -->` markers to prevent GEPA optimization from modifying schema constraints
- Provides `inject()`, `strip()`, `extract()`, `is_protected()`, and `has_changed()` utilities for preamble lifecycle management
- Builds on US-052 SkillRegistryReader for skill-to-prompt resolution

## Test plan

- [x] 33 unit tests — real file I/O, no mocks, covers generate/inject/strip/extract/is_protected/has_changed
- [x] 6 integration tests — cross-service preamble generation for all 179 skills, roundtrip validation
- [x] 6 Hypothesis property tests — inject/strip idempotency, double-inject stability
- [x] All 45 tests passing
- [x] Black formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)