### PR TITLE
feat(gepa): auto-generate baseline scorers from output schema (US-054)

### DIFF
--- a/prompt-optimization-svc/app/scorers/baseline/__init__.py
+++ b/prompt-optimization-svc/app/scorers/baseline/__init__.py
@@ -1,0 +1,17 @@
+"""Baseline scorers auto-generated from skill output schemas (US-054)."""
+
+from app.scorers.baseline.checks import (
+    make_enum_compliance_scorer,
+    make_field_presence_scorer,
+    make_max_length_scorer,
+    make_schema_completeness_scorer,
+)
+from app.scorers.baseline.factory import BaselineScorerFactory
+
+__all__ = [
+    "BaselineScorerFactory",
+    "make_field_presence_scorer",
+    "make_max_length_scorer",
+    "make_enum_compliance_scorer",
+    "make_schema_completeness_scorer",
+]

--- a/prompt-optimization-svc/app/scorers/baseline/checks.py
+++ b/prompt-optimization-svc/app/scorers/baseline/checks.py
@@ -1,0 +1,190 @@
+"""Individual baseline scorer generators (US-054).
+
+Each function creates a scorer callable that validates a specific aspect
+of agent output against a SkillOutputField constraint. Scorers follow
+the MLflow GEPA protocol: accept (inputs, outputs, expectations) kwargs,
+return Feedback with value 0.0-1.0 and rationale.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Callable, Optional
+
+from mlflow.entities.assessment import Feedback
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_json_output(outputs) -> tuple[Optional[dict], Optional[str]]:
+    """Parse outputs as JSON dict. Returns (parsed, error_rationale)."""
+    if outputs is None:
+        return None, "Output is None."
+    text = str(outputs).strip()
+    if not text:
+        return None, "Output is empty."
+    try:
+        parsed = json.loads(text)
+        if not isinstance(parsed, dict):
+            return None, f"Output is JSON but not a dict (got {type(parsed).__name__})."
+        return parsed, None
+    except json.JSONDecodeError as exc:
+        return None, f"Output is not valid JSON: {exc.msg}."
+
+
+def make_field_presence_scorer(field_name: str, skill_id: str) -> Callable:
+    """Create a scorer that checks if a required field exists in JSON output."""
+    scorer_name = f"baseline_{skill_id}_presence_{field_name}"
+
+    def score(*, inputs, outputs, expectations=None):
+        parsed, error = _parse_json_output(outputs)
+        if parsed is None:
+            return Feedback(name=scorer_name, value=0.0, rationale=error)
+
+        if field_name in parsed:
+            return Feedback(
+                name=scorer_name,
+                value=1.0,
+                rationale=f"Required field '{field_name}' is present.",
+            )
+        return Feedback(
+            name=scorer_name,
+            value=0.0,
+            rationale=f"Required field '{field_name}' is missing from output.",
+        )
+
+    score.__name__ = scorer_name
+    return score
+
+
+def make_max_length_scorer(field_name: str, max_length: int, skill_id: str) -> Callable:
+    """Create a scorer that checks string field length <= max_length.
+
+    Returns 1.0 if within limit. If over, returns a proportional score
+    (max_length / actual_length) clamped to [0.0, 1.0].
+    Returns 1.0 if the field is missing (presence is checked separately).
+    """
+    scorer_name = f"baseline_{skill_id}_maxlen_{field_name}"
+
+    def score(*, inputs, outputs, expectations=None):
+        parsed, error = _parse_json_output(outputs)
+        if parsed is None:
+            return Feedback(name=scorer_name, value=0.0, rationale=error)
+
+        if field_name not in parsed:
+            return Feedback(
+                name=scorer_name,
+                value=1.0,
+                rationale=f"Field '{field_name}' not present — length check skipped.",
+            )
+
+        value = parsed[field_name]
+        if not isinstance(value, str):
+            value = json.dumps(value)
+
+        actual_length = len(value)
+        if actual_length <= max_length:
+            return Feedback(
+                name=scorer_name,
+                value=1.0,
+                rationale=(
+                    f"Field '{field_name}' length {actual_length} "
+                    f"is within limit {max_length}."
+                ),
+            )
+
+        proportional = max_length / actual_length
+        return Feedback(
+            name=scorer_name,
+            value=round(proportional, 4),
+            rationale=(
+                f"Field '{field_name}' length {actual_length} "
+                f"exceeds limit {max_length}."
+            ),
+        )
+
+    score.__name__ = scorer_name
+    return score
+
+
+def make_enum_compliance_scorer(
+    field_name: str, allowed_values: list[str], skill_id: str
+) -> Callable:
+    """Create a scorer that checks field value is in allowed enum_values."""
+    scorer_name = f"baseline_{skill_id}_enum_{field_name}"
+    allowed_set = set(allowed_values)
+
+    def score(*, inputs, outputs, expectations=None):
+        parsed, error = _parse_json_output(outputs)
+        if parsed is None:
+            return Feedback(name=scorer_name, value=0.0, rationale=error)
+
+        if field_name not in parsed:
+            return Feedback(
+                name=scorer_name,
+                value=0.0,
+                rationale=f"Field '{field_name}' is missing from output.",
+            )
+
+        value = str(parsed[field_name])
+        if value in allowed_set:
+            return Feedback(
+                name=scorer_name,
+                value=1.0,
+                rationale=(
+                    f"Field '{field_name}' value '{value}' " f"is in allowed values."
+                ),
+            )
+        return Feedback(
+            name=scorer_name,
+            value=0.0,
+            rationale=(
+                f"Field '{field_name}' value '{value}' "
+                f"is not in allowed values: {sorted(allowed_values)}."
+            ),
+        )
+
+    score.__name__ = scorer_name
+    return score
+
+
+def make_schema_completeness_scorer(
+    required_fields: list[str], skill_id: str
+) -> Callable:
+    """Create a scorer that returns fraction of required fields present."""
+    scorer_name = f"baseline_{skill_id}_schema_completeness"
+
+    def score(*, inputs, outputs, expectations=None):
+        parsed, error = _parse_json_output(outputs)
+        if parsed is None:
+            return Feedback(name=scorer_name, value=0.0, rationale=error)
+
+        if not required_fields:
+            return Feedback(
+                name=scorer_name,
+                value=1.0,
+                rationale="No required fields defined — trivially complete.",
+            )
+
+        present = sum(1 for f in required_fields if f in parsed)
+        total = len(required_fields)
+        value = round(present / total, 4)
+        missing = [f for f in required_fields if f not in parsed]
+
+        if present == total:
+            return Feedback(
+                name=scorer_name,
+                value=1.0,
+                rationale=f"All {total} required fields present.",
+            )
+        return Feedback(
+            name=scorer_name,
+            value=value,
+            rationale=(
+                f"{present}/{total} required fields present. " f"Missing: {missing}."
+            ),
+        )
+
+    score.__name__ = scorer_name
+    return score

--- a/prompt-optimization-svc/app/scorers/baseline/factory.py
+++ b/prompt-optimization-svc/app/scorers/baseline/factory.py
@@ -1,0 +1,78 @@
+"""Baseline Scorer Factory — auto-generates scorers from output schema (US-054).
+
+Creates MLflow GEPA-compatible scorer functions from a SkillDefinition's
+output_schema fields. Each generated scorer validates a specific constraint
+(field presence, max length, enum compliance) and returns Feedback.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from app.registries.skill_definitions import SkillDefinition
+from app.scorers.baseline.checks import (
+    make_enum_compliance_scorer,
+    make_field_presence_scorer,
+    make_max_length_scorer,
+    make_schema_completeness_scorer,
+)
+from app.services.skill_registry_reader import SkillRegistryReader
+
+
+class BaselineScorerFactory:
+    """Generates baseline scorers from skill output schemas."""
+
+    def __init__(self, skill_registry_reader: SkillRegistryReader) -> None:
+        self._reader = skill_registry_reader
+
+    def create_scorers(self, skill: SkillDefinition) -> list[Callable]:
+        """Generate baseline scorers for a skill's output schema.
+
+        Creates up to 3 types of scorers per output field:
+        1. field_presence — required field exists in output
+        2. max_length — string field within max_length constraint
+        3. enum_compliance — field value in allowed enum_values
+        Plus one aggregate scorer:
+        4. schema_completeness — fraction of required fields present
+        """
+        scorers: list[Callable] = []
+        required_fields: list[str] = []
+
+        for field in skill.output_schema:
+            # Field presence for required fields
+            if field.required:
+                required_fields.append(field.field)
+                scorers.append(make_field_presence_scorer(field.field, skill.skill_id))
+
+            # Max length check
+            if field.max_length is not None:
+                scorers.append(
+                    make_max_length_scorer(
+                        field.field, field.max_length, skill.skill_id
+                    )
+                )
+
+            # Enum compliance check
+            if field.enum_values:
+                scorers.append(
+                    make_enum_compliance_scorer(
+                        field.field, field.enum_values, skill.skill_id
+                    )
+                )
+
+        # Always add schema completeness scorer
+        scorers.append(make_schema_completeness_scorer(required_fields, skill.skill_id))
+
+        return scorers
+
+    def create_scorers_for_prompt(
+        self, agent_code: str, prompt_name: str
+    ) -> list[Callable]:
+        """Look up skill for a prompt and generate its baseline scorers.
+
+        Returns empty list if no skill match found.
+        """
+        skill = self._reader.get_skill_for_prompt(agent_code, prompt_name)
+        if skill is None:
+            return []
+        return self.create_scorers(skill)

--- a/prompt-optimization-svc/tests/test_baseline_scorers.py
+++ b/prompt-optimization-svc/tests/test_baseline_scorers.py
@@ -1,0 +1,200 @@
+"""
+US-054 Unit Tests — Baseline Scorers.
+
+All tests use real SkillRegistryReader loading real skills.yaml files.
+No mocks.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.scorers.baseline.checks import (
+    make_enum_compliance_scorer,
+    make_field_presence_scorer,
+    make_max_length_scorer,
+    make_schema_completeness_scorer,
+)
+from app.scorers.baseline.factory import BaselineScorerFactory
+from app.services.skill_registry_reader import (
+    AGENT_SERVICE_DIRS,
+    SkillRegistryReader,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+@pytest.fixture
+def reader():
+    r = SkillRegistryReader(repo_root=REPO_ROOT)
+    yield r
+    r.clear_cache()
+
+
+@pytest.fixture
+def factory(reader):
+    return BaselineScorerFactory(reader)
+
+
+ALL_AGENT_CODES = sorted(AGENT_SERVICE_DIRS.keys())
+
+
+# ---------------------------------------------------------------------------
+# Field presence scorer
+# ---------------------------------------------------------------------------
+
+
+class TestFieldPresenceScorer:
+    def test_returns_1_when_present(self):
+        scorer = make_field_presence_scorer("query", "SKL-MRA-01")
+        result = scorer(inputs={}, outputs=json.dumps({"query": "test"}))
+        assert result.value == 1.0
+
+    def test_returns_0_when_missing(self):
+        scorer = make_field_presence_scorer("query", "SKL-MRA-01")
+        result = scorer(inputs={}, outputs=json.dumps({"other": "value"}))
+        assert result.value == 0.0
+        assert "missing" in result.rationale.lower()
+
+    def test_returns_0_for_invalid_json(self):
+        scorer = make_field_presence_scorer("query", "SKL-MRA-01")
+        result = scorer(inputs={}, outputs="not json")
+        assert result.value == 0.0
+
+    def test_returns_0_for_none_output(self):
+        scorer = make_field_presence_scorer("query", "SKL-MRA-01")
+        result = scorer(inputs={}, outputs=None)
+        assert result.value == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Max length scorer
+# ---------------------------------------------------------------------------
+
+
+class TestMaxLengthScorer:
+    def test_returns_1_when_within_limit(self):
+        scorer = make_max_length_scorer("title", 100, "SKL-CGA-01")
+        result = scorer(inputs={}, outputs=json.dumps({"title": "Short title"}))
+        assert result.value == 1.0
+
+    def test_returns_penalty_when_over(self):
+        scorer = make_max_length_scorer("title", 10, "SKL-CGA-01")
+        result = scorer(
+            inputs={}, outputs=json.dumps({"title": "This is a very long title"})
+        )
+        assert 0.0 < result.value < 1.0
+        assert "exceeds" in result.rationale.lower()
+
+    def test_returns_1_when_field_missing(self):
+        scorer = make_max_length_scorer("title", 100, "SKL-CGA-01")
+        result = scorer(inputs={}, outputs=json.dumps({"other": "value"}))
+        assert result.value == 1.0
+        assert "skipped" in result.rationale.lower()
+
+    def test_returns_0_for_invalid_json(self):
+        scorer = make_max_length_scorer("title", 100, "SKL-CGA-01")
+        result = scorer(inputs={}, outputs="not json")
+        assert result.value == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Enum compliance scorer
+# ---------------------------------------------------------------------------
+
+
+class TestEnumComplianceScorer:
+    def test_returns_1_for_valid_value(self):
+        scorer = make_enum_compliance_scorer(
+            "status", ["active", "paused", "completed"], "SKL-COA-01"
+        )
+        result = scorer(inputs={}, outputs=json.dumps({"status": "active"}))
+        assert result.value == 1.0
+
+    def test_returns_0_for_invalid_value(self):
+        scorer = make_enum_compliance_scorer(
+            "status", ["active", "paused", "completed"], "SKL-COA-01"
+        )
+        result = scorer(inputs={}, outputs=json.dumps({"status": "unknown"}))
+        assert result.value == 0.0
+        assert "not in allowed" in result.rationale.lower()
+
+    def test_returns_0_for_missing_field(self):
+        scorer = make_enum_compliance_scorer(
+            "status", ["active", "paused"], "SKL-COA-01"
+        )
+        result = scorer(inputs={}, outputs=json.dumps({"other": "value"}))
+        assert result.value == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Schema completeness scorer
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaCompletenessScorer:
+    def test_all_present(self):
+        scorer = make_schema_completeness_scorer(
+            ["query", "results", "sources"], "SKL-MRA-01"
+        )
+        output = json.dumps({"query": "q", "results": [], "sources": []})
+        result = scorer(inputs={}, outputs=output)
+        assert result.value == 1.0
+
+    def test_partial(self):
+        scorer = make_schema_completeness_scorer(
+            ["a", "b", "c", "d", "e"], "SKL-MRA-01"
+        )
+        output = json.dumps({"a": 1, "b": 2, "c": 3})
+        result = scorer(inputs={}, outputs=output)
+        assert result.value == pytest.approx(0.6)
+
+    def test_none_present(self):
+        scorer = make_schema_completeness_scorer(["a", "b", "c"], "SKL-MRA-01")
+        output = json.dumps({"x": 1})
+        result = scorer(inputs={}, outputs=output)
+        assert result.value == 0.0
+
+    def test_empty_output(self):
+        scorer = make_schema_completeness_scorer(["a", "b"], "SKL-MRA-01")
+        result = scorer(inputs={}, outputs="not json")
+        assert result.value == 0.0
+
+
+# ---------------------------------------------------------------------------
+# BaselineScorerFactory
+# ---------------------------------------------------------------------------
+
+
+class TestBaselineScorerFactory:
+    def test_create_scorers_returns_list(self, factory, reader):
+        skill = reader.get_skill("mra", "SKL-MRA-01")
+        scorers = factory.create_scorers(skill)
+        assert len(scorers) > 0
+        assert all(callable(s) for s in scorers)
+
+    def test_create_scorers_includes_completeness(self, factory, reader):
+        skill = reader.get_skill("mra", "SKL-MRA-01")
+        scorers = factory.create_scorers(skill)
+        names = [s.__name__ for s in scorers]
+        completeness = [n for n in names if "schema_completeness" in n]
+        assert len(completeness) == 1
+
+    def test_create_scorers_for_prompt_known(self, factory):
+        scorers = factory.create_scorers_for_prompt("mra", "zorven-wf1-mra-synthesis")
+        assert len(scorers) > 0
+
+    def test_create_scorers_for_prompt_unknown_returns_empty(self, factory):
+        scorers = factory.create_scorers_for_prompt("mra", "zorven-wf1-mra-nonexistent")
+        assert scorers == []
+
+    @pytest.mark.parametrize("agent_code", ALL_AGENT_CODES)
+    def test_all_15_agents_first_skill_generates_scorers(
+        self, factory, reader, agent_code
+    ):
+        skills_file = reader.load_skills(agent_code)
+        first_skill = skills_file.skills[0]
+        scorers = factory.create_scorers(first_skill)
+        # At minimum, schema_completeness is always generated
+        assert len(scorers) >= 1

--- a/tests/integration/phase1_contracts/test_baseline_scorers_integration.py
+++ b/tests/integration/phase1_contracts/test_baseline_scorers_integration.py
@@ -1,0 +1,128 @@
+"""
+US-054 Integration Tests — Baseline Scorers Cross-Service Validation.
+
+Exercises BaselineScorerFactory against all 179 real skills across
+15 agent services. No mocks.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT / "prompt-optimization-svc"))
+
+from app.registries.prompt_catalog import PROMPT_CATALOG  # noqa: E402
+from app.scorers.baseline.factory import BaselineScorerFactory  # noqa: E402
+from app.services.skill_registry_reader import (  # noqa: E402
+    AGENT_SERVICE_DIRS,
+    SkillRegistryReader,
+)
+
+
+def _make_factory() -> tuple[BaselineScorerFactory, SkillRegistryReader]:
+    reader = SkillRegistryReader(repo_root=REPO_ROOT)
+    return BaselineScorerFactory(reader), reader
+
+
+class TestBaselineScorersIntegration:
+    """Cross-service integration tests for baseline scorer generation."""
+
+    def test_scorers_for_all_179_skills(self):
+        """Generate scorers for every skill, verify non-empty."""
+        factory, reader = _make_factory()
+        empty_skills = []
+        for agent_code in sorted(AGENT_SERVICE_DIRS.keys()):
+            skills_file = reader.load_skills(agent_code)
+            for skill in skills_file.skills:
+                scorers = factory.create_scorers(skill)
+                if len(scorers) == 0:
+                    empty_skills.append(skill.skill_id)
+        assert empty_skills == [], f"Skills with no scorers: {empty_skills}"
+
+    def test_scorer_names_are_unique_per_skill(self):
+        """No duplicate scorer names within a skill."""
+        factory, reader = _make_factory()
+        duplicates = []
+        for agent_code in sorted(AGENT_SERVICE_DIRS.keys()):
+            skills_file = reader.load_skills(agent_code)
+            for skill in skills_file.skills:
+                scorers = factory.create_scorers(skill)
+                names = [s.__name__ for s in scorers]
+                if len(names) != len(set(names)):
+                    seen = set()
+                    dupes = [n for n in names if n in seen or seen.add(n)]
+                    duplicates.append(f"{skill.skill_id}: {dupes}")
+        assert duplicates == [], f"Duplicate scorer names:\n" + "\n".join(duplicates)
+
+    def test_scorers_return_feedback_for_empty_output(self):
+        """All scorers handle empty string gracefully."""
+        factory, reader = _make_factory()
+        errors = []
+        for agent_code in sorted(AGENT_SERVICE_DIRS.keys()):
+            skills_file = reader.load_skills(agent_code)
+            first_skill = skills_file.skills[0]
+            scorers = factory.create_scorers(first_skill)
+            for scorer in scorers:
+                try:
+                    result = scorer(inputs={}, outputs="")
+                    if result.value is None:
+                        errors.append(f"{scorer.__name__}: returned None value")
+                except Exception as exc:
+                    errors.append(f"{scorer.__name__}: raised {exc}")
+        assert errors == [], f"Scorer errors:\n" + "\n".join(errors)
+
+    def test_scorers_return_feedback_for_valid_json(self):
+        """All scorers handle valid JSON without raising."""
+        factory, reader = _make_factory()
+        valid_output = json.dumps({"test_field": "test_value", "count": 42})
+        errors = []
+        for agent_code in sorted(AGENT_SERVICE_DIRS.keys()):
+            skills_file = reader.load_skills(agent_code)
+            first_skill = skills_file.skills[0]
+            scorers = factory.create_scorers(first_skill)
+            for scorer in scorers:
+                try:
+                    result = scorer(inputs={}, outputs=valid_output)
+                    if result.value is None:
+                        errors.append(f"{scorer.__name__}: returned None value")
+                except Exception as exc:
+                    errors.append(f"{scorer.__name__}: raised {exc}")
+        assert errors == [], f"Scorer errors:\n" + "\n".join(errors)
+
+    def test_scorer_values_in_valid_range(self):
+        """All returned values are in [0.0, 1.0]."""
+        factory, reader = _make_factory()
+        outputs_to_test = [
+            "",
+            "not json",
+            json.dumps({}),
+            json.dumps({"field": "value"}),
+        ]
+        violations = []
+        for agent_code in sorted(AGENT_SERVICE_DIRS.keys()):
+            skills_file = reader.load_skills(agent_code)
+            first_skill = skills_file.skills[0]
+            scorers = factory.create_scorers(first_skill)
+            for scorer in scorers:
+                for output in outputs_to_test:
+                    result = scorer(inputs={}, outputs=output)
+                    if not (0.0 <= result.value <= 1.0):
+                        violations.append(
+                            f"{scorer.__name__}: value={result.value} "
+                            f"for output={output!r}"
+                        )
+        assert violations == [], f"Out-of-range values:\n" + "\n".join(violations)
+
+    def test_prompt_catalog_scorers_resolve(self):
+        """Non-system catalog prompts generate scorers where skills resolve."""
+        factory, _ = _make_factory()
+        resolved_count = 0
+        for entry in PROMPT_CATALOG:
+            if entry.tags.get("prompt_type") == "system":
+                continue
+            agent_code = entry.tags.get("agent_code", "")
+            scorers = factory.create_scorers_for_prompt(agent_code, entry.name)
+            if scorers:
+                resolved_count += 1
+        assert resolved_count > 0

--- a/tests/integration/phase1_contracts/test_baseline_scorers_properties.py
+++ b/tests/integration/phase1_contracts/test_baseline_scorers_properties.py
@@ -1,0 +1,133 @@
+"""
+US-054 Property Tests — Baseline Scorers Hypothesis Tests.
+
+Property-based tests for scorer behavior guarantees. No mocks —
+uses real skills.yaml files.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from hypothesis import given, settings, HealthCheck
+from hypothesis import strategies as st
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT / "prompt-optimization-svc"))
+
+from app.scorers.baseline.checks import (  # noqa: E402
+    make_field_presence_scorer,
+    make_max_length_scorer,
+    make_schema_completeness_scorer,
+)
+from app.scorers.baseline.factory import BaselineScorerFactory  # noqa: E402
+from app.services.skill_registry_reader import (  # noqa: E402
+    AGENT_SERVICE_DIRS,
+    SkillRegistryReader,
+)
+
+# ---------------------------------------------------------------------------
+# Strategies
+# ---------------------------------------------------------------------------
+
+VALID_CODES = sorted(AGENT_SERVICE_DIRS.keys())
+valid_agent_codes = st.sampled_from(VALID_CODES)
+
+# Arbitrary output strings (may or may not be JSON)
+arbitrary_outputs = st.one_of(
+    st.none(),
+    st.text(min_size=0, max_size=200),
+    st.builds(
+        json.dumps,
+        st.dictionaries(
+            keys=st.from_regex(r"[a-z_]{1,20}", fullmatch=True),
+            values=st.one_of(
+                st.text(min_size=0, max_size=50),
+                st.integers(min_value=-100, max_value=100),
+                st.booleans(),
+            ),
+            min_size=0,
+            max_size=5,
+        ),
+    ),
+)
+
+field_names = st.from_regex(r"[a-z_]{1,20}", fullmatch=True)
+max_lengths = st.integers(min_value=1, max_value=10000)
+
+
+# ---------------------------------------------------------------------------
+# Property Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.property
+class TestBaselineScorerProperties:
+    """Hypothesis property tests for baseline scorer behavior."""
+
+    @given(field_name=field_names, output=arbitrary_outputs)
+    @settings(max_examples=50, suppress_health_check=[HealthCheck.too_slow])
+    def test_field_presence_never_raises(self, field_name, output):
+        """Field presence scorer never raises, always returns Feedback."""
+        scorer = make_field_presence_scorer(field_name, "SKL-TST-01")
+        result = scorer(inputs={}, outputs=output)
+        assert 0.0 <= result.value <= 1.0
+        assert isinstance(result.rationale, str)
+
+    @given(
+        field_name=field_names,
+        max_length=max_lengths,
+        output=arbitrary_outputs,
+    )
+    @settings(max_examples=50, suppress_health_check=[HealthCheck.too_slow])
+    def test_max_length_score_always_in_range(self, field_name, max_length, output):
+        """Max length scorer value is always in [0.0, 1.0]."""
+        scorer = make_max_length_scorer(field_name, max_length, "SKL-TST-01")
+        result = scorer(inputs={}, outputs=output)
+        assert 0.0 <= result.value <= 1.0
+
+    @given(
+        data=st.data(),
+    )
+    @settings(max_examples=20, suppress_health_check=[HealthCheck.too_slow])
+    def test_schema_completeness_monotonic(self, data):
+        """More fields present produces higher or equal score."""
+        fields = ["a", "b", "c", "d", "e"]
+        scorer = make_schema_completeness_scorer(fields, "SKL-TST-01")
+
+        subset_size = data.draw(st.integers(min_value=0, max_value=4))
+        superset_size = data.draw(st.integers(min_value=subset_size, max_value=5))
+
+        subset_dict = {fields[i]: "val" for i in range(subset_size)}
+        superset_dict = {fields[i]: "val" for i in range(superset_size)}
+
+        r_sub = scorer(inputs={}, outputs=json.dumps(subset_dict))
+        r_sup = scorer(inputs={}, outputs=json.dumps(superset_dict))
+        assert r_sup.value >= r_sub.value
+
+    @given(agent_code=valid_agent_codes)
+    @settings(max_examples=15, suppress_health_check=[HealthCheck.too_slow])
+    def test_all_scorers_return_feedback_type(self, agent_code):
+        """Every generated scorer returns a Feedback object."""
+        reader = SkillRegistryReader(repo_root=REPO_ROOT)
+        factory = BaselineScorerFactory(reader)
+        skills_file = reader.load_skills(agent_code)
+        skill = skills_file.skills[0]
+        scorers = factory.create_scorers(skill)
+        output = json.dumps({"test": "value"})
+        for scorer in scorers:
+            result = scorer(inputs={}, outputs=output)
+            assert hasattr(result, "value")
+            assert hasattr(result, "rationale")
+            assert hasattr(result, "name")
+
+    @given(output=arbitrary_outputs)
+    @settings(max_examples=30, suppress_health_check=[HealthCheck.too_slow])
+    def test_scorer_deterministic(self, output):
+        """Same input always produces same score."""
+        scorer = make_field_presence_scorer("query", "SKL-MRA-01")
+        r1 = scorer(inputs={}, outputs=output)
+        r2 = scorer(inputs={}, outputs=output)
+        assert r1.value == r2.value
+        assert r1.rationale == r2.rationale


### PR DESCRIPTION
## Summary

- Adds `BaselineScorerFactory` in `app/scorers/baseline/` that auto-generates MLflow GEPA-compatible scorers from `SkillDefinition.output_schema` fields
- Generates 4 scorer types per skill: `field_presence` (required field exists), `max_length` (string within limit), `enum_compliance` (value in allowed set), `schema_completeness` (fraction of required fields present)
- Each scorer returns `Feedback` with value 0.0-1.0 and human-readable rationale, following the existing `@scorer` pattern
- Completes the US-051→054 skill-aware optimization chain: skills.yaml → SkillRegistryReader → schema preamble → baseline scorers

## Test plan

- [x] 34 unit tests — real file I/O, no mocks, covers all 4 scorer types + factory
- [x] 6 integration tests — cross-service validation for all 179 skills, scorer name uniqueness, value range checks
- [x] 5 Hypothesis property tests — monotonicity, determinism, never-raises guarantees
- [x] All 45 tests passing
- [x] Black formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)