### PR TITLE
feat(gepa): implement OPT-12 schema preamble protection guardrail (US-057)

### DIFF
--- a/prompt-optimization-svc/app/logic/gepa_guardrails.py
+++ b/prompt-optimization-svc/app/logic/gepa_guardrails.py
@@ -1,11 +1,16 @@
-"""GEPA mutation guardrails (OPT-11).
+"""GEPA mutation guardrails (OPT-11, OPT-12).
 
 Validates GEPA candidate templates against the original to ensure
-placeholder invariance and template-context separation.
+placeholder invariance (OPT-11) and schema preamble protection (OPT-12).
 """
 
 import logging
 
+from app.logic.guardrails import GuardrailResult
+from app.logic.preamble_validator import (
+    PreambleProtectionResult,
+    validate_preamble_protection,
+)
 from app.logic.placeholder_validator import (
     PlaceholderInvarianceResult,
     validate_placeholder_invariance,
@@ -46,3 +51,62 @@ def check_gepa_mutation(
         )
 
     return result.valid, result
+
+
+def check_preamble_protection(
+    original_template: str,
+    candidate_template: str,
+    tenant_id: str | None = None,
+    prompt_id: str | None = None,
+    optimization_run_id: str | None = None,
+) -> GuardrailResult:
+    """OPT-12: Validate schema preamble hasn't been weakened by GEPA.
+
+    Wraps validate_preamble_protection() into a GuardrailResult.
+    Logs detailed violation info for AUDIT trail (AC-2).
+
+    Args:
+        original_template: The original prompt template (pre-mutation).
+        candidate_template: The GEPA-generated candidate template.
+        tenant_id: Tenant identifier for audit logging.
+        prompt_id: Prompt identifier for audit logging.
+        optimization_run_id: Optimization run ID for audit logging.
+
+    Returns:
+        GuardrailResult with passed=False if preamble protection violated.
+    """
+    result = validate_preamble_protection(original_template, candidate_template)
+
+    if not result.valid:
+        logger.error(
+            "OPT-12: Schema preamble protection VIOLATION — %s | "
+            "tenant_id=%s prompt_id=%s optimization_run_id=%s",
+            "; ".join(result.violation_reasons),
+            tenant_id,
+            prompt_id,
+            optimization_run_id,
+        )
+        return GuardrailResult(
+            passed=False,
+            guardrail_id="OPT-12",
+            message=f"Schema preamble weakened: {'; '.join(result.violation_reasons)}",
+            details={
+                "preamble_present": result.preamble_present,
+                "preamble_at_top": result.preamble_at_top,
+                "fields_removed": result.fields_removed,
+                "fields_added": result.fields_added,
+                "max_length_weakened": result.max_length_weakened,
+                "required_relaxed": result.required_relaxed,
+                "violation_reasons": result.violation_reasons,
+                "tenant_id": tenant_id,
+                "prompt_id": prompt_id,
+                "optimization_run_id": optimization_run_id,
+            },
+        )
+
+    return GuardrailResult(
+        passed=True,
+        guardrail_id="OPT-12",
+        message="Schema preamble protection OK",
+        details={"preamble_present": result.preamble_present},
+    )

--- a/prompt-optimization-svc/app/logic/gepa_guardrails.py
+++ b/prompt-optimization-svc/app/logic/gepa_guardrails.py
@@ -7,10 +7,7 @@ placeholder invariance (OPT-11) and schema preamble protection (OPT-12).
 import logging
 
 from app.logic.guardrails import GuardrailResult
-from app.logic.preamble_validator import (
-    PreambleProtectionResult,
-    validate_preamble_protection,
-)
+from app.logic.preamble_validator import validate_preamble_protection
 from app.logic.placeholder_validator import (
     PlaceholderInvarianceResult,
     validate_placeholder_invariance,

--- a/prompt-optimization-svc/app/logic/guardrails.py
+++ b/prompt-optimization-svc/app/logic/guardrails.py
@@ -323,11 +323,15 @@ def run_candidate_guardrails(
     tenant_id: Optional[str] = None,
     reflection_context: Optional[str] = None,
     all_tenant_ids: Optional[list[str]] = None,
+    prompt_id: Optional[str] = None,
+    optimization_run_id: Optional[str] = None,
 ) -> GuardrailChainResult:
-    """Run OPT-02, OPT-06, OPT-09, OPT-10 on a candidate.
+    """Run OPT-02, OPT-06, OPT-09, OPT-10, OPT-12 on a candidate.
 
     Short-circuits on first failure.
     """
+    from app.logic.gepa_guardrails import check_preamble_protection
+
     results: list[GuardrailResult] = []
 
     # OPT-02: Cost cap
@@ -352,5 +356,19 @@ def run_candidate_guardrails(
     if tenant_id and reflection_context is not None:
         r = check_tenant_isolation(reflection_context, tenant_id, all_tenant_ids)
         results.append(r)
+        if not r.passed:
+            return _build_chain_result(results)
+
+    # OPT-12: Schema preamble protection
+    r = check_preamble_protection(
+        base_text,
+        candidate_text,
+        tenant_id=tenant_id,
+        prompt_id=prompt_id,
+        optimization_run_id=optimization_run_id,
+    )
+    results.append(r)
+    if not r.passed:
+        return _build_chain_result(results)
 
     return _build_chain_result(results)

--- a/prompt-optimization-svc/app/logic/preamble_validator.py
+++ b/prompt-optimization-svc/app/logic/preamble_validator.py
@@ -1,0 +1,259 @@
+"""OPT-12 Preamble Protection Validator (US-057).
+
+Validates that GEPA mutations have not weakened or removed the schema
+preamble from prompt templates. Detects missing markers, positional
+drift, field removals, max_length increases, and required→optional flips.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from app.services.schema_preamble import PREAMBLE_END, PREAMBLE_START, _PREAMBLE_PATTERN
+
+# Regex to match a markdown table data row: | val | val | val |
+_TABLE_ROW_RE = re.compile(r"^\|\s*(.+?)\s*\|\s*(.+?)\s*\|\s*(.+?)\s*\|$")
+
+
+@dataclass
+class PreambleProtectionResult:
+    """Result of preamble protection validation."""
+
+    valid: bool = True
+    preamble_present: bool = True
+    preamble_at_top: bool = True
+    fields_removed: list[str] = field(default_factory=list)
+    fields_added: list[str] = field(default_factory=list)
+    max_length_weakened: list[dict] = field(default_factory=list)
+    required_relaxed: list[dict] = field(default_factory=list)
+    violation_reasons: list[str] = field(default_factory=list)
+
+
+def _parse_output_table(preamble_text: str) -> list[dict[str, Any]]:
+    """Parse '## Required Output' markdown table from preamble text.
+
+    Returns list of dicts with keys: field, type, max_length.
+    max_length is int or None (when cell contains dash).
+    """
+    fields: list[dict[str, Any]] = []
+    in_section = False
+
+    for line in preamble_text.splitlines():
+        stripped = line.strip()
+
+        if stripped.startswith("## Required Output"):
+            in_section = True
+            continue
+
+        if in_section and (
+            stripped.startswith("##") or stripped.startswith("Timeout:")
+        ):
+            break
+
+        if not in_section:
+            continue
+
+        # Skip header and separator rows
+        if stripped.startswith("|---") or (
+            "Field" in stripped and "Max Length" in stripped
+        ):
+            continue
+
+        match = _TABLE_ROW_RE.match(stripped)
+        if match:
+            field_name = match.group(1).strip()
+            field_type = match.group(2).strip()
+            max_len_str = match.group(3).strip()
+
+            if max_len_str in ("\u2014", "-", "None", "\u2013"):
+                max_length = None
+            else:
+                try:
+                    max_length = int(max_len_str)
+                except ValueError:
+                    max_length = None
+
+            fields.append(
+                {
+                    "field": field_name,
+                    "type": field_type,
+                    "max_length": max_length,
+                }
+            )
+
+    return fields
+
+
+def _parse_input_table(preamble_text: str) -> list[dict[str, Any]]:
+    """Parse '## Expected Input' markdown table from preamble text.
+
+    Returns list of dicts with keys: field, type, required.
+    required is bool (parsed from 'yes'/'no').
+    """
+    fields: list[dict[str, Any]] = []
+    in_section = False
+
+    for line in preamble_text.splitlines():
+        stripped = line.strip()
+
+        if stripped.startswith("## Expected Input"):
+            in_section = True
+            continue
+
+        if in_section and stripped.startswith("##"):
+            break
+
+        if not in_section:
+            continue
+
+        # Skip header and separator rows
+        if stripped.startswith("|---") or (
+            "Field" in stripped and "Required" in stripped
+        ):
+            continue
+
+        match = _TABLE_ROW_RE.match(stripped)
+        if match:
+            field_name = match.group(1).strip()
+            field_type = match.group(2).strip()
+            required_str = match.group(3).strip().lower()
+
+            fields.append(
+                {
+                    "field": field_name,
+                    "type": field_type,
+                    "required": required_str in ("yes", "true"),
+                }
+            )
+
+    return fields
+
+
+def validate_preamble_protection(
+    original_template: str,
+    mutated_template: str,
+) -> PreambleProtectionResult:
+    """Validate GEPA mutation hasn't weakened the schema preamble.
+
+    Checks:
+    1. Preamble markers present in mutated template
+    2. Preamble at top (first non-whitespace content)
+    3. All output fields preserved (no removals)
+    4. max_length not increased (or changed from value to None)
+    5. Required fields not changed to optional
+
+    If original has no preamble, returns valid=True (nothing to protect).
+    """
+    result = PreambleProtectionResult()
+
+    # Extract preamble from original
+    orig_match = _PREAMBLE_PATTERN.search(original_template)
+    if orig_match is None:
+        # No preamble in original — nothing to protect
+        return result
+
+    original_preamble = orig_match.group(0)
+
+    # Check 1: Preamble markers present in mutated
+    has_start = PREAMBLE_START in mutated_template
+    has_end = PREAMBLE_END in mutated_template
+
+    if not has_start or not has_end:
+        result.preamble_present = False
+        result.valid = False
+        result.violation_reasons.append("Preamble markers missing from candidate")
+        return result
+
+    # Check 2: Preamble at top of template
+    if not mutated_template.lstrip().startswith(PREAMBLE_START):
+        result.preamble_at_top = False
+        result.valid = False
+        result.violation_reasons.append("Preamble not at top of template")
+        # Continue checking content even if position is wrong
+
+    # Extract mutated preamble for content comparison
+    mutated_match = _PREAMBLE_PATTERN.search(mutated_template)
+    if mutated_match is None:
+        result.preamble_present = False
+        result.valid = False
+        result.violation_reasons.append("Preamble markers missing from candidate")
+        return result
+
+    mutated_preamble = mutated_match.group(0)
+
+    # Check 3: Output field preservation
+    orig_output = _parse_output_table(original_preamble)
+    mutated_output = _parse_output_table(mutated_preamble)
+
+    orig_output_map = {f["field"]: f for f in orig_output}
+    mutated_output_map = {f["field"]: f for f in mutated_output}
+
+    for field_name in orig_output_map:
+        if field_name not in mutated_output_map:
+            result.fields_removed.append(field_name)
+            result.violation_reasons.append(f"Output field '{field_name}' removed")
+
+    for field_name in mutated_output_map:
+        if field_name not in orig_output_map:
+            result.fields_added.append(field_name)
+
+    # Check 4: max_length not weakened
+    for field_name, orig_field in orig_output_map.items():
+        if field_name not in mutated_output_map:
+            continue
+        mutated_field = mutated_output_map[field_name]
+        orig_ml = orig_field["max_length"]
+        mutated_ml = mutated_field["max_length"]
+
+        if orig_ml is not None:
+            if mutated_ml is None:
+                # Value → None is weakening
+                result.max_length_weakened.append(
+                    {
+                        "field": field_name,
+                        "original": orig_ml,
+                        "mutated": None,
+                    }
+                )
+                result.violation_reasons.append(
+                    f"max_length for '{field_name}' weakened: {orig_ml} \u2192 None"
+                )
+            elif mutated_ml > orig_ml:
+                # Increased is weakening
+                result.max_length_weakened.append(
+                    {
+                        "field": field_name,
+                        "original": orig_ml,
+                        "mutated": mutated_ml,
+                    }
+                )
+                result.violation_reasons.append(
+                    f"max_length for '{field_name}' weakened: {orig_ml} \u2192 {mutated_ml}"
+                )
+
+    # Check 5: Required fields not relaxed
+    orig_input = _parse_input_table(original_preamble)
+    mutated_input = _parse_input_table(mutated_preamble)
+
+    orig_input_map = {f["field"]: f for f in orig_input}
+    mutated_input_map = {f["field"]: f for f in mutated_input}
+
+    for field_name, orig_field in orig_input_map.items():
+        if field_name not in mutated_input_map:
+            continue
+        if orig_field["required"] and not mutated_input_map[field_name]["required"]:
+            result.required_relaxed.append(
+                {
+                    "field": field_name,
+                    "original": True,
+                    "mutated": False,
+                }
+            )
+            result.violation_reasons.append(
+                f"Field '{field_name}' changed from required to optional"
+            )
+
+    result.valid = len(result.violation_reasons) == 0
+    return result

--- a/prompt-optimization-svc/app/logic/preamble_validator.py
+++ b/prompt-optimization-svc/app/logic/preamble_validator.py
@@ -242,6 +242,18 @@ def validate_preamble_protection(
 
     for field_name, orig_field in orig_input_map.items():
         if field_name not in mutated_input_map:
+            # Required input field removed entirely — weakening
+            if orig_field["required"]:
+                result.required_relaxed.append(
+                    {
+                        "field": field_name,
+                        "original": True,
+                        "mutated": None,
+                    }
+                )
+                result.violation_reasons.append(
+                    f"Required input field '{field_name}' removed from preamble"
+                )
             continue
         if orig_field["required"] and not mutated_input_map[field_name]["required"]:
             result.required_relaxed.append(

--- a/prompt-optimization-svc/tests/test_preamble_validator.py
+++ b/prompt-optimization-svc/tests/test_preamble_validator.py
@@ -1,0 +1,461 @@
+"""
+US-057 Unit Tests — OPT-12 Schema Preamble Protection Guardrail.
+
+All tests use real SkillRegistryReader loading real skills.yaml files.
+No mocks.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from app.logic.gepa_guardrails import check_preamble_protection
+from app.logic.guardrails import GuardrailResult, run_candidate_guardrails
+from app.logic.preamble_validator import (
+    PreambleProtectionResult,
+    _parse_input_table,
+    _parse_output_table,
+    validate_preamble_protection,
+)
+from app.services.schema_preamble import (
+    PREAMBLE_END,
+    PREAMBLE_START,
+    SchemaPreambleGenerator,
+)
+from app.services.skill_registry_reader import (
+    AGENT_SERVICE_DIRS,
+    SkillRegistryReader,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+@pytest.fixture
+def reader():
+    r = SkillRegistryReader(repo_root=REPO_ROOT)
+    yield r
+    r.clear_cache()
+
+
+@pytest.fixture
+def generator(reader):
+    return SchemaPreambleGenerator(reader)
+
+
+@pytest.fixture
+def mra_skill(reader):
+    skills_file = reader.load_skills("mra")
+    return skills_file.skills[0]
+
+
+@pytest.fixture
+def cga_skill_with_max_length(reader):
+    """Find a CGA skill that has output fields with max_length."""
+    skills_file = reader.load_skills("cga")
+    for skill in skills_file.skills:
+        for f in skill.output_schema:
+            if f.max_length is not None:
+                return skill
+    return None
+
+
+@pytest.fixture
+def preamble_template(generator, mra_skill):
+    """A real template with preamble injected."""
+    preamble = generator.generate(mra_skill)
+    return generator.inject("You are a market research analyst.", preamble)
+
+
+@pytest.fixture
+def cga_preamble_template(generator, cga_skill_with_max_length):
+    """A real CGA template with preamble containing max_length fields."""
+    if cga_skill_with_max_length is None:
+        return None
+    preamble = generator.generate(cga_skill_with_max_length)
+    return generator.inject("You are a creative generation agent.", preamble)
+
+
+ALL_AGENT_CODES = sorted(AGENT_SERVICE_DIRS.keys())
+
+
+# ---------------------------------------------------------------------------
+# PreambleProtectionResult
+# ---------------------------------------------------------------------------
+
+
+class TestPreambleProtectionResult:
+    def test_dataclass_default_values(self):
+        result = PreambleProtectionResult()
+        assert result.valid is True
+        assert result.preamble_present is True
+        assert result.preamble_at_top is True
+        assert result.fields_removed == []
+        assert result.fields_added == []
+        assert result.max_length_weakened == []
+        assert result.required_relaxed == []
+        assert result.violation_reasons == []
+
+    def test_invalid_when_violations_present(self):
+        result = PreambleProtectionResult(
+            valid=False,
+            violation_reasons=["Preamble markers missing from candidate"],
+        )
+        assert result.valid is False
+        assert len(result.violation_reasons) == 1
+
+
+# ---------------------------------------------------------------------------
+# _parse_output_table
+# ---------------------------------------------------------------------------
+
+
+class TestParseOutputTable:
+    def test_parse_output_table_real_preamble(self, generator, mra_skill):
+        preamble = generator.generate(mra_skill)
+        fields = _parse_output_table(preamble)
+        assert len(fields) > 0
+        assert all("field" in f and "type" in f and "max_length" in f for f in fields)
+
+    def test_parse_output_table_includes_max_length(self, generator, mra_skill):
+        preamble = generator.generate(mra_skill)
+        fields = _parse_output_table(preamble)
+        # At least verify the field names match the skill output_schema
+        preamble_field_names = [f["field"] for f in fields]
+        schema_field_names = [f.field for f in mra_skill.output_schema]
+        assert preamble_field_names == schema_field_names
+
+    def test_parse_output_table_dash_as_none(self):
+        preamble = (
+            "## Required Output\n"
+            "| Field | Type | Max Length |\n"
+            "|-------|------|------------|\n"
+            "| notes | string | \u2014 |\n"
+        )
+        fields = _parse_output_table(preamble)
+        assert len(fields) == 1
+        assert fields[0]["max_length"] is None
+
+
+# ---------------------------------------------------------------------------
+# _parse_input_table
+# ---------------------------------------------------------------------------
+
+
+class TestParseInputTable:
+    def test_parse_input_table_real_preamble(self, generator, mra_skill):
+        preamble = generator.generate(mra_skill)
+        fields = _parse_input_table(preamble)
+        assert len(fields) > 0
+        assert all("field" in f and "type" in f and "required" in f for f in fields)
+
+    def test_parse_input_table_required_flags(self):
+        preamble = (
+            "## Expected Input\n"
+            "| Field | Type | Required |\n"
+            "|-------|------|----------|\n"
+            "| query | string | yes |\n"
+            "| notes | string | no |\n"
+        )
+        fields = _parse_input_table(preamble)
+        assert len(fields) == 2
+        assert fields[0]["required"] is True
+        assert fields[1]["required"] is False
+
+
+# ---------------------------------------------------------------------------
+# validate_preamble_protection
+# ---------------------------------------------------------------------------
+
+
+class TestValidatePreambleProtection:
+    def test_identical_templates_valid(self, preamble_template):
+        result = validate_preamble_protection(preamble_template, preamble_template)
+        assert result.valid is True
+        assert result.violation_reasons == []
+
+    def test_preamble_removed_entirely(self, preamble_template, generator):
+        mutated = generator.strip(preamble_template)
+        result = validate_preamble_protection(preamble_template, mutated)
+        assert result.valid is False
+        assert result.preamble_present is False
+
+    def test_start_marker_removed(self, preamble_template):
+        mutated = preamble_template.replace(PREAMBLE_START, "")
+        result = validate_preamble_protection(preamble_template, mutated)
+        assert result.valid is False
+        assert result.preamble_present is False
+
+    def test_end_marker_removed(self, preamble_template):
+        mutated = preamble_template.replace(PREAMBLE_END, "")
+        result = validate_preamble_protection(preamble_template, mutated)
+        assert result.valid is False
+        assert result.preamble_present is False
+
+    def test_preamble_moved_to_middle(self, preamble_template, generator):
+        preamble = generator.extract(preamble_template)
+        content = generator.strip(preamble_template)
+        mutated = content + "\n\n" + preamble
+        result = validate_preamble_protection(preamble_template, mutated)
+        assert result.valid is False
+        assert result.preamble_at_top is False
+
+    def test_preamble_moved_to_end(self, preamble_template, generator):
+        preamble = generator.extract(preamble_template)
+        mutated = "Some intro text.\n\nMore content.\n\n" + preamble
+        result = validate_preamble_protection(preamble_template, mutated)
+        assert result.valid is False
+        assert result.preamble_at_top is False
+
+    def test_output_field_removed(self, preamble_template, mra_skill):
+        # Remove first output field row from the preamble
+        first_output = mra_skill.output_schema[0]
+        # Find the row in the template and remove it
+        lines = preamble_template.splitlines()
+        mutated_lines = [
+            line
+            for line in lines
+            if not (
+                line.strip().startswith(f"| {first_output.field} ")
+                and "Required Output" not in line
+            )
+        ]
+        mutated = "\n".join(mutated_lines)
+        result = validate_preamble_protection(preamble_template, mutated)
+        assert result.valid is False
+        assert first_output.field in result.fields_removed
+
+    def test_output_field_added_is_ok(self, preamble_template):
+        # Add a new field row to the output table
+        new_row = "| new_field | string | 100 |"
+        mutated = preamble_template.replace(
+            PREAMBLE_END,
+            new_row + "\n" + PREAMBLE_END,
+        )
+        # Move the row to be inside the output table section
+        # Simpler: insert before the Timeout line
+        lines = preamble_template.splitlines()
+        mutated_lines = []
+        for line in lines:
+            if line.strip().startswith("Timeout:"):
+                mutated_lines.append(new_row)
+            mutated_lines.append(line)
+        mutated = "\n".join(mutated_lines)
+        result = validate_preamble_protection(preamble_template, mutated)
+        assert result.valid is True
+        assert "new_field" in result.fields_added
+
+    def test_max_length_increased_is_weakening(
+        self, cga_preamble_template, cga_skill_with_max_length
+    ):
+        if cga_preamble_template is None:
+            pytest.skip("No CGA skill with max_length found")
+        template = cga_preamble_template
+        skill = cga_skill_with_max_length
+        for field in skill.output_schema:
+            if field.max_length is not None:
+                original_val = str(field.max_length)
+                weakened_val = str(field.max_length + 500)
+                old_row = f"| {field.field} | {field.type} | {original_val} |"
+                new_row = f"| {field.field} | {field.type} | {weakened_val} |"
+                if old_row in template:
+                    mutated = template.replace(old_row, new_row, 1)
+                    result = validate_preamble_protection(template, mutated)
+                    assert result.valid is False
+                    assert len(result.max_length_weakened) >= 1
+                    assert result.max_length_weakened[0]["field"] == field.field
+                    return
+        pytest.skip("No matching output row found in CGA preamble")
+
+    def test_max_length_decreased_is_ok(
+        self, cga_preamble_template, cga_skill_with_max_length
+    ):
+        if cga_preamble_template is None:
+            pytest.skip("No CGA skill with max_length found")
+        template = cga_preamble_template
+        skill = cga_skill_with_max_length
+        for field in skill.output_schema:
+            if field.max_length is not None and field.max_length > 10:
+                original_val = str(field.max_length)
+                strengthened_val = str(field.max_length - 5)
+                old_row = f"| {field.field} | {field.type} | {original_val} |"
+                new_row = f"| {field.field} | {field.type} | {strengthened_val} |"
+                if old_row in template:
+                    mutated = template.replace(old_row, new_row, 1)
+                    result = validate_preamble_protection(template, mutated)
+                    assert result.valid is True
+                    assert result.max_length_weakened == []
+                    return
+        pytest.skip("No matching output row found in CGA preamble")
+
+    def test_max_length_to_dash_is_weakening(
+        self, cga_preamble_template, cga_skill_with_max_length
+    ):
+        if cga_preamble_template is None:
+            pytest.skip("No CGA skill with max_length found")
+        template = cga_preamble_template
+        skill = cga_skill_with_max_length
+        for field in skill.output_schema:
+            if field.max_length is not None:
+                original_val = str(field.max_length)
+                old_row = f"| {field.field} | {field.type} | {original_val} |"
+                new_row = f"| {field.field} | {field.type} | \u2014 |"
+                if old_row in template:
+                    mutated = template.replace(old_row, new_row, 1)
+                    result = validate_preamble_protection(template, mutated)
+                    assert result.valid is False
+                    assert len(result.max_length_weakened) >= 1
+                    return
+        pytest.skip("No matching output row found in CGA preamble")
+
+    def test_required_made_optional(self, preamble_template, mra_skill):
+        # Find a required input field and make it optional
+        for inp in mra_skill.input_schema:
+            if inp.get("required", True):
+                field_name = inp.get("field", inp.get("name", "unknown"))
+                old_row = f"| {field_name} | {inp.get('type', 'string')} | yes |"
+                new_row = f"| {field_name} | {inp.get('type', 'string')} | no |"
+                if old_row in preamble_template:
+                    mutated = preamble_template.replace(old_row, new_row, 1)
+                    result = validate_preamble_protection(preamble_template, mutated)
+                    assert result.valid is False
+                    assert len(result.required_relaxed) >= 1
+                    assert result.required_relaxed[0]["field"] == field_name
+                    return
+        pytest.skip("No required input fields found in MRA skill")
+
+    def test_optional_made_required_is_ok(self, preamble_template, mra_skill):
+        # Find an optional input field and make it required (strengthening)
+        for inp in mra_skill.input_schema:
+            if not inp.get("required", True):
+                field_name = inp.get("field", inp.get("name", "unknown"))
+                old_row = f"| {field_name} | {inp.get('type', 'string')} | no |"
+                new_row = f"| {field_name} | {inp.get('type', 'string')} | yes |"
+                if old_row in preamble_template:
+                    mutated = preamble_template.replace(old_row, new_row, 1)
+                    result = validate_preamble_protection(preamble_template, mutated)
+                    assert result.valid is True
+                    assert result.required_relaxed == []
+                    return
+        pytest.skip("No optional input fields found in MRA skill")
+
+    def test_no_preamble_in_original_passes(self):
+        original = "You are a helpful assistant."
+        mutated = "You are a very helpful assistant."
+        result = validate_preamble_protection(original, mutated)
+        assert result.valid is True
+
+    def test_whitespace_before_preamble_ok(self, preamble_template):
+        mutated = "\n  \n" + preamble_template
+        result = validate_preamble_protection(preamble_template, mutated)
+        assert result.valid is True
+        assert result.preamble_at_top is True
+
+    def test_multiple_violations_collected(self, preamble_template, mra_skill):
+        # Remove a field AND change required → optional simultaneously
+        lines = preamble_template.splitlines()
+        first_output = mra_skill.output_schema[0]
+        # Remove first output field row
+        mutated_lines = [
+            line
+            for line in lines
+            if not line.strip().startswith(f"| {first_output.field} ")
+        ]
+        mutated = "\n".join(mutated_lines)
+        # Also flip a required input field if possible
+        for inp in mra_skill.input_schema:
+            if inp.get("required", True):
+                field_name = inp.get("field", inp.get("name", "unknown"))
+                old_row = f"| {field_name} | {inp.get('type', 'string')} | yes |"
+                new_row = f"| {field_name} | {inp.get('type', 'string')} | no |"
+                if old_row in mutated:
+                    mutated = mutated.replace(old_row, new_row, 1)
+                    break
+        result = validate_preamble_protection(preamble_template, mutated)
+        assert result.valid is False
+        assert len(result.violation_reasons) >= 1
+
+
+# ---------------------------------------------------------------------------
+# check_preamble_protection
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPreambleProtection:
+    def test_returns_guardrail_result(self, preamble_template):
+        result = check_preamble_protection(preamble_template, preamble_template)
+        assert isinstance(result, GuardrailResult)
+
+    def test_passed_true_for_valid(self, preamble_template):
+        result = check_preamble_protection(preamble_template, preamble_template)
+        assert result.passed is True
+        assert result.guardrail_id == "OPT-12"
+
+    def test_passed_false_for_removed(self, preamble_template, generator):
+        mutated = generator.strip(preamble_template)
+        result = check_preamble_protection(preamble_template, mutated)
+        assert result.passed is False
+        assert result.guardrail_id == "OPT-12"
+
+    def test_details_include_audit_fields(self, preamble_template, generator):
+        mutated = generator.strip(preamble_template)
+        result = check_preamble_protection(
+            preamble_template,
+            mutated,
+            tenant_id="tenant-123",
+            prompt_id="prompt-456",
+            optimization_run_id="run-789",
+        )
+        assert result.details["tenant_id"] == "tenant-123"
+        assert result.details["prompt_id"] == "prompt-456"
+        assert result.details["optimization_run_id"] == "run-789"
+
+    def test_guardrail_id_is_opt12(self, preamble_template):
+        result = check_preamble_protection(preamble_template, preamble_template)
+        assert result.guardrail_id == "OPT-12"
+
+
+# ---------------------------------------------------------------------------
+# run_candidate_guardrails with OPT-12
+# ---------------------------------------------------------------------------
+
+
+class TestRunCandidateGuardrailsOPT12:
+    def test_opt12_in_chain_all_pass(self, preamble_template):
+        chain = run_candidate_guardrails(
+            candidate_text=preamble_template,
+            base_text=preamble_template,
+            current_cost_usd=0.0,
+        )
+        assert chain.all_passed is True
+        guardrail_ids = [r.guardrail_id for r in chain.results]
+        assert "OPT-12" in guardrail_ids
+
+    def test_opt12_rejects_in_chain(self, preamble_template, generator):
+        mutated = generator.strip(preamble_template)
+        chain = run_candidate_guardrails(
+            candidate_text=mutated,
+            base_text=preamble_template,
+            current_cost_usd=0.0,
+        )
+        assert chain.all_passed is False
+        assert chain.first_failure.guardrail_id == "OPT-12"
+
+
+# ---------------------------------------------------------------------------
+# All 15 agents
+# ---------------------------------------------------------------------------
+
+
+class TestAllAgents:
+    @pytest.mark.parametrize("agent_code", ALL_AGENT_CODES)
+    def test_all_15_agents_self_invariant(self, reader, agent_code):
+        """Generate preamble per agent, validate self → valid=True."""
+        gen = SchemaPreambleGenerator(reader)
+        skills_file = reader.load_skills(agent_code)
+        skill = skills_file.skills[0]
+        if not skill.output_schema:
+            pytest.skip(f"No output_schema for {agent_code} first skill")
+        preamble = gen.generate(skill)
+        template = gen.inject("You are an agent.", preamble)
+        result = validate_preamble_protection(template, template)
+        assert result.valid is True, f"Self-invariance failed for {agent_code}"

--- a/prompt-optimization-svc/tests/test_preamble_validator.py
+++ b/prompt-optimization-svc/tests/test_preamble_validator.py
@@ -307,6 +307,22 @@ class TestValidatePreambleProtection:
                     return
         pytest.skip("No matching output row found in CGA preamble")
 
+    def test_required_input_field_removed(self, preamble_template, mra_skill):
+        # Remove a required input field row entirely
+        for inp in mra_skill.input_schema:
+            if inp.get("required", True):
+                field_name = inp.get("field", inp.get("name", "unknown"))
+                row = f"| {field_name} | {inp.get('type', 'string')} | yes |"
+                if row in preamble_template:
+                    mutated = preamble_template.replace(row + "\n", "", 1)
+                    result = validate_preamble_protection(preamble_template, mutated)
+                    assert result.valid is False
+                    assert len(result.required_relaxed) >= 1
+                    assert result.required_relaxed[0]["field"] == field_name
+                    assert result.required_relaxed[0]["mutated"] is None
+                    return
+        pytest.skip("No required input fields found in MRA skill")
+
     def test_required_made_optional(self, preamble_template, mra_skill):
         # Find a required input field and make it optional
         for inp in mra_skill.input_schema:

--- a/tests/integration/phase1_contracts/test_preamble_protection_integration.py
+++ b/tests/integration/phase1_contracts/test_preamble_protection_integration.py
@@ -1,0 +1,177 @@
+"""
+US-057 Integration Tests — OPT-12 Schema Preamble Protection Cross-Service.
+
+Exercises preamble protection across all 15 agent services.
+No mocks.
+"""
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT / "prompt-optimization-svc"))
+
+from app.logic.guardrails import run_candidate_guardrails  # noqa: E402
+from app.logic.preamble_validator import validate_preamble_protection  # noqa: E402
+from app.services.schema_preamble import SchemaPreambleGenerator  # noqa: E402
+from app.services.skill_registry_reader import (  # noqa: E402
+    AGENT_SERVICE_DIRS,
+    SkillRegistryReader,
+)
+
+
+def _make_reader_and_gen() -> tuple[SkillRegistryReader, SchemaPreambleGenerator]:
+    reader = SkillRegistryReader(repo_root=REPO_ROOT)
+    return reader, SchemaPreambleGenerator(reader)
+
+
+ALL_AGENT_CODES = sorted(AGENT_SERVICE_DIRS.keys())
+
+
+class TestPreambleProtectionIntegration:
+    """Cross-service integration tests for OPT-12 preamble protection."""
+
+    def test_all_15_agents_preamble_roundtrip(self):
+        """Generate + inject + validate self → valid=True for all agents."""
+        reader, gen = _make_reader_and_gen()
+        tested = 0
+        for agent_code in ALL_AGENT_CODES:
+            skills_file = reader.load_skills(agent_code)
+            for skill in skills_file.skills:
+                if not skill.output_schema:
+                    continue
+                preamble = gen.generate(skill)
+                template = gen.inject("You are an agent.", preamble)
+                result = validate_preamble_protection(template, template)
+                assert (
+                    result.valid is True
+                ), f"Self-invariance failed for {skill.skill_id}"
+                tested += 1
+                break  # One per agent
+        assert tested >= 10  # At least 10 of 15 agents have output_schema
+
+    def test_preamble_removal_detected_all_agents(self):
+        """Strip preamble → valid=False for all agents."""
+        reader, gen = _make_reader_and_gen()
+        for agent_code in ALL_AGENT_CODES:
+            skills_file = reader.load_skills(agent_code)
+            for skill in skills_file.skills:
+                if not skill.output_schema:
+                    continue
+                preamble = gen.generate(skill)
+                template = gen.inject("You are an agent.", preamble)
+                mutated = gen.strip(template)
+                result = validate_preamble_protection(template, mutated)
+                assert (
+                    result.valid is False
+                ), f"Preamble removal not detected for {skill.skill_id}"
+                assert result.preamble_present is False
+                break
+
+    def test_field_removal_detected_across_agents(self):
+        """Remove one output field row → valid=False for agents with ≥2 fields."""
+        reader, gen = _make_reader_and_gen()
+        tested = 0
+        for agent_code in ALL_AGENT_CODES:
+            skills_file = reader.load_skills(agent_code)
+            for skill in skills_file.skills:
+                if len(skill.output_schema) < 2:
+                    continue
+                preamble = gen.generate(skill)
+                template = gen.inject("You are an agent.", preamble)
+                first_field = skill.output_schema[0]
+                # Remove the first output field's row
+                lines = template.splitlines()
+                mutated_lines = [
+                    line
+                    for line in lines
+                    if not line.strip().startswith(f"| {first_field.field} ")
+                ]
+                mutated = "\n".join(mutated_lines)
+                result = validate_preamble_protection(template, mutated)
+                assert (
+                    result.valid is False
+                ), f"Field removal not detected for {skill.skill_id}"
+                assert first_field.field in result.fields_removed
+                tested += 1
+                break
+        assert tested >= 5
+
+    def test_max_length_weakening_detected_across_agents(self):
+        """Increase max_length → valid=False for agents with max_length fields."""
+        reader, gen = _make_reader_and_gen()
+        tested = 0
+        for agent_code in ALL_AGENT_CODES:
+            skills_file = reader.load_skills(agent_code)
+            for skill in skills_file.skills:
+                preamble = gen.generate(skill)
+                template = gen.inject("You are an agent.", preamble)
+                for field in skill.output_schema:
+                    if field.max_length is None:
+                        continue
+                    old_val = str(field.max_length)
+                    new_val = str(field.max_length + 1000)
+                    old_row = f"| {field.field} | {field.type} | {old_val} |"
+                    new_row = f"| {field.field} | {field.type} | {new_val} |"
+                    if old_row in template:
+                        mutated = template.replace(old_row, new_row, 1)
+                        result = validate_preamble_protection(template, mutated)
+                        assert result.valid is False, (
+                            f"max_length weakening not detected for "
+                            f"{skill.skill_id}.{field.field}"
+                        )
+                        tested += 1
+                        break
+                if tested > 0:
+                    break
+        # Only CGA has max_length, so at least 1
+        assert tested >= 1
+
+    def test_required_relaxation_detected_across_agents(self):
+        """Flip required yes→no → valid=False for agents with required input fields."""
+        reader, gen = _make_reader_and_gen()
+        tested = 0
+        for agent_code in ALL_AGENT_CODES:
+            skills_file = reader.load_skills(agent_code)
+            for skill in skills_file.skills:
+                if not skill.output_schema:
+                    continue
+                preamble = gen.generate(skill)
+                template = gen.inject("You are an agent.", preamble)
+                for inp in skill.input_schema:
+                    if not inp.get("required", True):
+                        continue
+                    field_name = inp.get("field", inp.get("name", "unknown"))
+                    field_type = inp.get("type", "string")
+                    old_row = f"| {field_name} | {field_type} | yes |"
+                    new_row = f"| {field_name} | {field_type} | no |"
+                    if old_row in template:
+                        mutated = template.replace(old_row, new_row, 1)
+                        result = validate_preamble_protection(template, mutated)
+                        assert result.valid is False, (
+                            f"Required relaxation not detected for "
+                            f"{skill.skill_id}.{field_name}"
+                        )
+                        tested += 1
+                        break
+                if tested > 0:
+                    break
+            if tested > 0:
+                break
+        assert tested >= 1
+
+    def test_guardrail_chain_includes_opt12(self):
+        """run_candidate_guardrails includes OPT-12 in results."""
+        reader, gen = _make_reader_and_gen()
+        skills_file = reader.load_skills("mra")
+        skill = skills_file.skills[0]
+        preamble = gen.generate(skill)
+        template = gen.inject("You are a market research analyst.", preamble)
+        chain = run_candidate_guardrails(
+            candidate_text=template,
+            base_text=template,
+            current_cost_usd=0.0,
+        )
+        guardrail_ids = [r.guardrail_id for r in chain.results]
+        assert "OPT-12" in guardrail_ids
+        assert chain.all_passed is True

--- a/tests/integration/phase1_contracts/test_preamble_protection_properties.py
+++ b/tests/integration/phase1_contracts/test_preamble_protection_properties.py
@@ -1,0 +1,106 @@
+"""
+US-057 Property Tests — OPT-12 Preamble Protection Hypothesis Tests.
+
+Property-based tests for schema preamble protection guarantees.
+No mocks — uses real skills.yaml files.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+from hypothesis import given, settings, HealthCheck
+from hypothesis import strategies as st
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT / "prompt-optimization-svc"))
+
+from app.logic.preamble_validator import validate_preamble_protection  # noqa: E402
+from app.services.schema_preamble import (  # noqa: E402
+    PREAMBLE_START,
+    PREAMBLE_END,
+    SchemaPreambleGenerator,
+)
+from app.services.skill_registry_reader import (  # noqa: E402
+    AGENT_SERVICE_DIRS,
+    SkillRegistryReader,
+)
+
+VALID_CODES = sorted(AGENT_SERVICE_DIRS.keys())
+valid_agent_codes = st.sampled_from(VALID_CODES)
+
+
+def _get_preamble_template(agent_code: str) -> str | None:
+    """Build a real preamble template for an agent. Returns None if no output_schema."""
+    reader = SkillRegistryReader(repo_root=REPO_ROOT)
+    gen = SchemaPreambleGenerator(reader)
+    skills_file = reader.load_skills(agent_code)
+    for skill in skills_file.skills:
+        if skill.output_schema:
+            preamble = gen.generate(skill)
+            return gen.inject("You are an agent.", preamble)
+    return None
+
+
+@pytest.mark.property
+class TestPreambleProtectionProperties:
+    """Hypothesis property tests for OPT-12 preamble protection."""
+
+    @given(agent_code=valid_agent_codes)
+    @settings(max_examples=15, suppress_health_check=[HealthCheck.too_slow])
+    def test_self_invariant_always_valid(self, agent_code):
+        """Any agent's preamble template validated against itself is always valid."""
+        template = _get_preamble_template(agent_code)
+        if template is None:
+            return  # Skip agents without output_schema
+        result = validate_preamble_protection(template, template)
+        assert result.valid is True
+
+    @given(
+        original=st.text(min_size=1, max_size=200),
+        mutated=st.text(min_size=1, max_size=200),
+    )
+    @settings(max_examples=30, suppress_health_check=[HealthCheck.too_slow])
+    def test_no_preamble_original_always_valid(self, original, mutated):
+        """If original has no preamble markers, result is always valid."""
+        # Ensure no markers in original
+        original = original.replace(PREAMBLE_START, "").replace(PREAMBLE_END, "")
+        result = validate_preamble_protection(original, mutated)
+        assert result.valid is True
+
+    @given(agent_code=valid_agent_codes)
+    @settings(max_examples=15, suppress_health_check=[HealthCheck.too_slow])
+    def test_removing_start_marker_always_invalid(self, agent_code):
+        """Removing PREAMBLE_START from any agent's template always yields invalid."""
+        template = _get_preamble_template(agent_code)
+        if template is None:
+            return
+        mutated = template.replace(PREAMBLE_START, "")
+        result = validate_preamble_protection(template, mutated)
+        assert result.valid is False
+        assert result.preamble_present is False
+
+    @given(agent_code=valid_agent_codes)
+    @settings(max_examples=15, suppress_health_check=[HealthCheck.too_slow])
+    def test_removing_end_marker_always_invalid(self, agent_code):
+        """Removing PREAMBLE_END from any agent's template always yields invalid."""
+        template = _get_preamble_template(agent_code)
+        if template is None:
+            return
+        mutated = template.replace(PREAMBLE_END, "")
+        result = validate_preamble_protection(template, mutated)
+        assert result.valid is False
+        assert result.preamble_present is False
+
+    @given(agent_code=valid_agent_codes, extra=st.text(max_size=200))
+    @settings(max_examples=15, suppress_health_check=[HealthCheck.too_slow])
+    def test_appending_text_stays_valid(self, agent_code, extra):
+        """Appending arbitrary text after the template keeps preamble at top."""
+        template = _get_preamble_template(agent_code)
+        if template is None:
+            return
+        # Ensure extra doesn't contain preamble markers
+        extra = extra.replace(PREAMBLE_START, "").replace(PREAMBLE_END, "")
+        mutated = template + "\n" + extra
+        result = validate_preamble_protection(template, mutated)
+        assert result.valid is True


### PR DESCRIPTION
## Summary
- Implement OPT-12 guardrail that validates GEPA mutations haven't weakened or removed schema preambles from prompt templates
- Core validator checks: marker presence, top-of-template position, output field preservation, max_length not increased, required fields not relaxed
- Integrated into `run_candidate_guardrails()` chain after OPT-10 with detailed audit logging (tenant_id, prompt_id, optimization_run_id)
- 45 unit tests, 6 integration tests, 5 Hypothesis property tests — all using real skills.yaml files, no mocks

## Files Changed
| File | Action | Purpose |
|------|--------|---------|
| `app/logic/preamble_validator.py` | New | `PreambleProtectionResult`, `_parse_output_table`, `_parse_input_table`, `validate_preamble_protection` |
| `app/logic/gepa_guardrails.py` | Modified | Added `check_preamble_protection()` wrapper with audit logging |
| `app/logic/guardrails.py` | Modified | Added OPT-12 to candidate guardrail chain after OPT-10 |
| `tests/test_preamble_validator.py` | New | 45 unit tests (40 pass, 5 skip for agents without output_schema) |
| `tests/.../test_preamble_protection_integration.py` | New | 6 cross-service integration tests |
| `tests/.../test_preamble_protection_properties.py` | New | 5 Hypothesis property tests |

## Test plan
- [x] Unit tests: `pytest tests/test_preamble_validator.py -v` (40 passed, 5 skipped)
- [x] Integration tests: `pytest tests/integration/phase1_contracts/test_preamble_protection_integration.py -v --noconftest` (6 passed)
- [x] Property tests: `pytest tests/integration/phase1_contracts/test_preamble_protection_properties.py -v --noconftest` (5 passed)
- [x] Regression: existing guardrail tests pass (98 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)