### PR TITLE
test(gepa): build integration test suite using testcontainers (US-059)

### DIFF
--- a/prompt-optimization-svc/pyproject.toml
+++ b/prompt-optimization-svc/pyproject.toml
@@ -31,7 +31,16 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 markers = [
     "integration: integration tests requiring Redis (deselect with '-m not integration')",
+    "property: property-based tests using Hypothesis",
 ]
+
+[tool.coverage.run]
+source = ["app"]
+omit = ["alembic/*"]
+
+[tool.coverage.report]
+fail_under = 60
+show_missing = true
 
 [tool.mypy]
 python_version = "3.12"

--- a/prompt-optimization-svc/requirements-dev.txt
+++ b/prompt-optimization-svc/requirements-dev.txt
@@ -2,6 +2,9 @@
 pytest>=8.0.0
 pytest-asyncio>=0.24.0
 pytest-httpx>=0.30.0
+pytest-cov>=5.0.0
 black>=24.0.0
 mypy>=1.11.0
 respx>=0.21.0
+testcontainers>=4.0.0
+hypothesis>=6.100.0

--- a/prompt-optimization-svc/tests/conftest.py
+++ b/prompt-optimization-svc/tests/conftest.py
@@ -12,6 +12,24 @@ import pytest
 import redis.asyncio as aioredis
 from httpx import ASGITransport, AsyncClient
 
+
+def pytest_configure(config):
+    """Load testcontainer fixtures only when integration tests may run.
+
+    When the user runs ``pytest -m "not integration"``, Docker containers
+    are not needed so we skip loading the testcontainer plugin.
+    """
+    markexpr = getattr(config.option, "markexpr", "") or ""
+    if "not integration" in markexpr:
+        return
+    try:
+        config.pluginmanager.import_plugin("conftest_testcontainers")
+    except Exception:
+        # testcontainers not installed or Docker unavailable — integration
+        # tests will fail at fixture resolution time with a clear message.
+        pass
+
+
 REDIS_URL = os.environ.get(
     "POI_PROMPT_CACHE_REDIS_URL",
     os.environ.get("POI_REDIS_URL", "redis://localhost:6379/2"),

--- a/prompt-optimization-svc/tests/conftest.py
+++ b/prompt-optimization-svc/tests/conftest.py
@@ -16,41 +16,15 @@ REDIS_URL = os.environ.get(
     "POI_PROMPT_CACHE_REDIS_URL",
     os.environ.get("POI_REDIS_URL", "redis://localhost:6379/2"),
 )
-MLFLOW_URI = os.environ.get(
-    "POI_MLFLOW_TRACKING_URI", "http://localhost:5000"
-)
+MLFLOW_URI = os.environ.get("POI_MLFLOW_TRACKING_URI", "http://localhost:5000")
 ANTHROPIC_API_KEY = os.environ.get("POI_ANTHROPIC_API_KEY", "")
 
 
-def _redis_available() -> bool:
-    import redis as sync_redis
-    try:
-        r = sync_redis.from_url(REDIS_URL)
-        r.ping()
-        r.close()
-        return True
-    except Exception:
-        return False
+# No-op markers — testcontainers always provides real Redis and MLflow.
+# Kept as aliases so existing test imports continue to work.
+requires_redis = pytest.mark.integration
+requires_mlflow = pytest.mark.integration
 
-
-def _mlflow_available() -> bool:
-    try:
-        import httpx
-        resp = httpx.get(f"{MLFLOW_URI}/health", timeout=5)
-        return resp.status_code == 200
-    except Exception:
-        return False
-
-
-REDIS_AVAILABLE = _redis_available()
-MLFLOW_AVAILABLE = _mlflow_available()
-
-requires_redis = pytest.mark.skipif(
-    not REDIS_AVAILABLE, reason=f"Redis not available at {REDIS_URL}"
-)
-requires_mlflow = pytest.mark.skipif(
-    not MLFLOW_AVAILABLE, reason=f"MLflow not available at {MLFLOW_URI}"
-)
 requires_anthropic = pytest.mark.skipif(
     not ANTHROPIC_API_KEY, reason="POI_ANTHROPIC_API_KEY not set"
 )
@@ -62,9 +36,12 @@ async def real_redis():
     r = aioredis.from_url(REDIS_URL, decode_responses=True)
     yield r
     # Targeted cleanup — only test-prefixed keys
-    for pattern in ("prompt:__test*", "tenant:__test*",
-                    "prompt:optimization:lock:__test*",
-                    "prompt:optimization:progress:__test*"):
+    for pattern in (
+        "prompt:__test*",
+        "tenant:__test*",
+        "prompt:optimization:lock:__test*",
+        "prompt:optimization:progress:__test*",
+    ):
         async for key in r.scan_iter(match=pattern):
             await r.delete(key)
     await r.aclose()
@@ -76,7 +53,5 @@ async def api_client():
     from app.main import app
 
     transport = ASGITransport(app=app, raise_app_exceptions=False)
-    async with AsyncClient(
-        transport=transport, base_url="http://test"
-    ) as client:
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
         yield client

--- a/prompt-optimization-svc/tests/conftest_testcontainers.py
+++ b/prompt-optimization-svc/tests/conftest_testcontainers.py
@@ -1,0 +1,205 @@
+"""Testcontainer fixtures for integration tests (US-059).
+
+Session-scoped fixtures that start Redis, PostgreSQL, Kafka, and MLflow
+containers once per pytest session. All integration tests use these
+real services — no skip markers needed.
+
+Environment variables POI_* are set before any app imports so that
+module-level singletons (database.py engine) bind to container URLs.
+"""
+
+import os
+import socket
+import subprocess
+import time
+
+import pytest
+
+
+def _find_free_port() -> int:
+    """Find a free TCP port on localhost."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def _wait_for_url(url: str, timeout: int = 30) -> None:
+    """Wait for an HTTP endpoint to respond with 200."""
+    import httpx
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            resp = httpx.get(url, timeout=3)
+            if resp.status_code == 200:
+                return
+        except Exception:
+            pass
+        time.sleep(0.5)
+    raise TimeoutError(f"Timed out waiting for {url}")
+
+
+# ── Redis Container ──
+
+
+@pytest.fixture(scope="session")
+def redis_container():
+    """Start a Redis 7 container with 27 databases."""
+    from testcontainers.redis import RedisContainer
+
+    with RedisContainer("redis:7-alpine").with_command(
+        "redis-server --databases 27"
+    ) as redis:
+        yield redis
+
+
+@pytest.fixture(scope="session")
+def tc_redis_url(redis_container):
+    """Redis URL for prompt cache (DB 2)."""
+    host = redis_container.get_container_host_ip()
+    port = redis_container.get_exposed_port(6379)
+    return f"redis://{host}:{port}/2"
+
+
+@pytest.fixture(scope="session")
+def tc_redis_general_url(redis_container):
+    """Redis URL for general cache / Celery broker (DB 26)."""
+    host = redis_container.get_container_host_ip()
+    port = redis_container.get_exposed_port(6379)
+    return f"redis://{host}:{port}/26"
+
+
+# ── PostgreSQL Container ──
+
+
+@pytest.fixture(scope="session")
+def postgres_container():
+    """Start a PostgreSQL 15 container (mlflow user/db)."""
+    from testcontainers.postgres import PostgresContainer
+
+    with PostgresContainer(
+        "postgres:15-alpine",
+        username="mlflow",
+        password="mlflow",
+        dbname="mlflow",
+    ) as pg:
+        yield pg
+
+
+@pytest.fixture(scope="session")
+def tc_postgres_url(postgres_container):
+    """PostgreSQL connection URL."""
+    return postgres_container.get_connection_url()
+
+
+# ── Kafka Container ──
+
+
+@pytest.fixture(scope="session")
+def kafka_container():
+    """Start a Kafka container (includes built-in KRaft)."""
+    from testcontainers.kafka import KafkaContainer
+
+    with KafkaContainer("confluentinc/cp-kafka:7.6.0") as kafka:
+        yield kafka
+
+
+@pytest.fixture(scope="session")
+def tc_kafka_bootstrap(kafka_container):
+    """Kafka bootstrap server address."""
+    return kafka_container.get_bootstrap_server()
+
+
+# ── MLflow Server (subprocess) ──
+
+
+@pytest.fixture(scope="session")
+def tc_mlflow_uri(tc_postgres_url):
+    """Start MLflow tracking server backed by testcontainer PostgreSQL."""
+    port = _find_free_port()
+    proc = subprocess.Popen(
+        [
+            "mlflow",
+            "server",
+            "--backend-store-uri",
+            tc_postgres_url,
+            "--host",
+            "0.0.0.0",
+            "--port",
+            str(port),
+            "--default-artifact-root",
+            "/tmp/mlflow-test-artifacts",
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    uri = f"http://localhost:{port}"
+    try:
+        _wait_for_url(f"{uri}/health", timeout=30)
+    except TimeoutError:
+        proc.terminate()
+        raise
+    yield uri
+    proc.terminate()
+    proc.wait(timeout=10)
+
+
+# ── Alembic Migrations ──
+
+
+@pytest.fixture(scope="session")
+def tc_db_migrated(tc_postgres_url):
+    """Run Alembic migrations against testcontainer PostgreSQL."""
+    svc_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    env = os.environ.copy()
+    env["POI_DATABASE_URL"] = tc_postgres_url
+    result = subprocess.run(
+        ["alembic", "upgrade", "head"],
+        cwd=svc_dir,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Alembic migration failed: {result.stderr}")
+    return True
+
+
+# ── Environment Override ──
+
+
+@pytest.fixture(scope="session", autouse=True)
+def tc_override_env(
+    tc_redis_url,
+    tc_redis_general_url,
+    tc_postgres_url,
+    tc_kafka_bootstrap,
+    tc_mlflow_uri,
+    tc_db_migrated,
+):
+    """Set POI_* env vars to point at testcontainer-managed services.
+
+    This fixture is autouse + session-scoped, so it runs before any
+    app imports and lasts for the entire test session.
+    """
+    originals = {}
+    overrides = {
+        "POI_PROMPT_CACHE_REDIS_URL": tc_redis_url,
+        "POI_REDIS_URL": tc_redis_general_url,
+        "POI_DATABASE_URL": tc_postgres_url,
+        "POI_KAFKA_BOOTSTRAP_SERVERS": tc_kafka_bootstrap,
+        "POI_MLFLOW_TRACKING_URI": tc_mlflow_uri,
+        "POI_CELERY_BROKER_URL": tc_redis_general_url,
+    }
+    for key, val in overrides.items():
+        originals[key] = os.environ.get(key)
+        os.environ[key] = val
+
+    yield
+
+    for key, orig in originals.items():
+        if orig is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = orig

--- a/prompt-optimization-svc/tests/integration/conftest.py
+++ b/prompt-optimization-svc/tests/integration/conftest.py
@@ -1,11 +1,10 @@
-"""Integration test fixtures — require real Redis and MLflow.
+"""Integration test fixtures — backed by testcontainers (US-059).
+
+Containers are managed by session-scoped fixtures in
+tests/conftest_testcontainers.py. This conftest reads connection
+URLs from environment variables set by those fixtures.
 
 Run with: pytest tests/integration/ -v -m integration
-Skip with: pytest tests/ -m "not integration"
-
-Environment variables:
-    POI_REDIS_URL: Redis URL (default redis://localhost:6379/2)
-    POI_MLFLOW_TRACKING_URI: MLflow URI (default http://localhost:5000)
 """
 
 import os
@@ -14,51 +13,23 @@ import pytest
 import redis.asyncio as aioredis
 from mlflow.tracking import MlflowClient
 
-REDIS_URL = os.environ.get("POI_REDIS_URL", "redis://localhost:6379/2")
-MLFLOW_URI = os.environ.get(
-    "POI_MLFLOW_TRACKING_URI", "http://localhost:5000"
+REDIS_URL = os.environ.get(
+    "POI_PROMPT_CACHE_REDIS_URL",
+    os.environ.get("POI_REDIS_URL", "redis://localhost:6379/2"),
 )
+MLFLOW_URI = os.environ.get("POI_MLFLOW_TRACKING_URI", "http://localhost:5000")
 
-
-def _redis_available() -> bool:
-    """Check if Redis is reachable."""
-    import redis as sync_redis
-
-    try:
-        r = sync_redis.from_url(REDIS_URL)
-        r.ping()
-        r.close()
-        return True
-    except Exception:
-        return False
-
-
-def _mlflow_available() -> bool:
-    """Check if MLflow tracking server is reachable."""
-    try:
-        import httpx
-
-        resp = httpx.get(f"{MLFLOW_URI}/health", timeout=5)
-        return resp.status_code == 200
-    except Exception:
-        return False
-
-
-requires_redis = pytest.mark.skipif(
-    not _redis_available(),
-    reason=f"Redis not available at {REDIS_URL}",
-)
-
-requires_mlflow = pytest.mark.skipif(
-    not _mlflow_available(),
-    reason=f"MLflow not available at {MLFLOW_URI}",
-)
+# No-op markers — testcontainers always provides real Redis and MLflow.
+# Kept as aliases so existing test imports continue to work.
+requires_redis = pytest.mark.integration
+requires_mlflow = pytest.mark.integration
 
 
 @pytest.fixture
 async def real_redis():
-    """Real async Redis connection (DB 2 — prompt cache)."""
-    r = aioredis.from_url(REDIS_URL, decode_responses=True)
+    """Real async Redis connection (prompt cache DB)."""
+    url = os.environ.get("POI_PROMPT_CACHE_REDIS_URL", REDIS_URL)
+    r = aioredis.from_url(url, decode_responses=True)
     yield r
     await r.aclose()
 
@@ -66,4 +37,5 @@ async def real_redis():
 @pytest.fixture
 def real_mlflow_client():
     """Real MLflow tracking client."""
-    return MlflowClient(MLFLOW_URI)
+    uri = os.environ.get("POI_MLFLOW_TRACKING_URI", MLFLOW_URI)
+    return MlflowClient(uri)

--- a/prompt-optimization-svc/tests/integration/test_celery_beat_schedules.py
+++ b/prompt-optimization-svc/tests/integration/test_celery_beat_schedules.py
@@ -6,50 +6,11 @@ schedule behavior with real Redis tenant config.
 Run with: pytest tests/integration/test_celery_beat_schedules.py -v -m integration
 """
 
-import os
-
 import pytest
 
-
-def _redis_available() -> bool:
-    """Check if Redis is reachable."""
-    redis_url = os.environ.get("POI_PROMPT_CACHE_REDIS_URL", "")
-    if not redis_url:
-        return False
-    try:
-        import redis
-
-        r = redis.from_url(redis_url)
-        r.ping()
-        r.close()
-        return True
-    except Exception:
-        return False
-
-
-def _mlflow_available() -> bool:
-    """Check if MLflow is reachable."""
-    mlflow_uri = os.environ.get("POI_MLFLOW_TRACKING_URI", "")
-    if not mlflow_uri:
-        return False
-    try:
-        import httpx
-
-        resp = httpx.get(f"{mlflow_uri}/health", timeout=5)
-        return resp.status_code == 200
-    except Exception:
-        return False
-
-
-requires_redis = pytest.mark.skipif(
-    not _redis_available(),
-    reason="Redis not available (set POI_PROMPT_CACHE_REDIS_URL)",
-)
-
-requires_mlflow = pytest.mark.skipif(
-    not _mlflow_available(),
-    reason="MLflow not available (set POI_MLFLOW_TRACKING_URI)",
-)
+# No-op markers — testcontainers always provides real services (US-059).
+requires_redis = pytest.mark.integration
+requires_mlflow = pytest.mark.integration
 
 
 @pytest.mark.integration

--- a/prompt-optimization-svc/tests/integration/test_celery_beat_tc.py
+++ b/prompt-optimization-svc/tests/integration/test_celery_beat_tc.py
@@ -1,0 +1,82 @@
+"""Integration tests for Celery Beat schedule via testcontainers (US-059).
+
+Tests Celery app connectivity, beat schedule entries, task module
+imports, and task routing against a real Redis container.
+"""
+
+import importlib
+import os
+
+import pytest
+from celery import Celery
+
+
+@pytest.mark.integration
+class TestCeleryBeatTC:
+    """Celery Beat schedule validation via testcontainers."""
+
+    @pytest.fixture
+    def celery_test_app(self):
+        """Create a Celery app connected to testcontainer Redis."""
+        broker_url = os.environ.get(
+            "POI_CELERY_BROKER_URL",
+            os.environ.get("POI_REDIS_URL", "redis://localhost:6379/26"),
+        )
+        from app.celery_app import celery_app
+
+        celery_app.conf.broker_url = broker_url
+        celery_app.conf.result_backend = broker_url
+        return celery_app
+
+    def test_celery_app_connects_to_redis_broker(self, celery_test_app):
+        """Celery app can connect to testcontainer Redis broker."""
+        conn = celery_test_app.connection()
+        try:
+            conn.ensure_connection(max_retries=3, timeout=5)
+            assert conn.connected is True
+        finally:
+            conn.close()
+
+    def test_beat_schedule_has_required_entries(self, celery_test_app):
+        """Verify all 6 scheduled tasks are present in beat_schedule."""
+        schedule = celery_test_app.conf.beat_schedule
+        required_keys = [
+            "mine-golden-examples-weekly",
+            "optimize-wf1-pipeline-monthly",
+            "optimize-wf2-pipeline-monthly",
+            "optimize-wf3-creative-pipeline",
+            "optimize-wf3-optimization-loop",
+            "prompt-health-check-daily",
+        ]
+        for key in required_keys:
+            assert key in schedule, f"Missing beat schedule entry: {key}"
+            assert "task" in schedule[key], f"No task in schedule entry: {key}"
+            assert "schedule" in schedule[key], f"No schedule in entry: {key}"
+
+    def test_all_task_modules_importable(self, celery_test_app):
+        """Each module in celery_app.conf.include is importable."""
+        include = celery_test_app.conf.include
+        assert (
+            len(include) >= 5
+        ), f"Expected at least 5 task modules, got {len(include)}"
+
+        for module_path in include:
+            mod = importlib.import_module(module_path)
+            assert mod is not None, f"Failed to import {module_path}"
+
+    def test_task_routing_keys_valid(self, celery_test_app):
+        """All beat schedule tasks reference valid task paths."""
+        schedule = celery_test_app.conf.beat_schedule
+        for entry_name, entry in schedule.items():
+            task_path = entry["task"]
+            parts = task_path.rsplit(".", 1)
+            assert len(parts) == 2, (
+                f"Task path '{task_path}' in '{entry_name}' "
+                "should be 'module.function'"
+            )
+            module_path, func_name = parts
+            mod = importlib.import_module(module_path)
+            assert hasattr(mod, func_name), (
+                f"Module '{module_path}' has no function '{func_name}' "
+                f"(referenced by '{entry_name}')"
+            )

--- a/prompt-optimization-svc/tests/integration/test_kafka_lifecycle_tc.py
+++ b/prompt-optimization-svc/tests/integration/test_kafka_lifecycle_tc.py
@@ -1,0 +1,162 @@
+"""Integration tests for Kafka publish/consume via testcontainers (US-059).
+
+Tests LifecycleProducer and AuditProducer against a real Kafka container.
+"""
+
+import json
+import os
+
+import pytest
+
+from app.kafka.producer import AuditProducer, LifecycleProducer
+from app.kafka.schemas import PROMPT_PROMOTED
+
+
+@pytest.mark.integration
+class TestKafkaLifecycleTC:
+    """Kafka publish/consume via testcontainers."""
+
+    @pytest.fixture
+    async def lifecycle_producer(self):
+        bootstrap = os.environ.get("POI_KAFKA_BOOTSTRAP_SERVERS", "")
+        producer = LifecycleProducer(bootstrap)
+        await producer.start()
+        yield producer
+        await producer.stop()
+
+    @pytest.fixture
+    async def audit_producer(self):
+        bootstrap = os.environ.get("POI_KAFKA_BOOTSTRAP_SERVERS", "")
+        producer = AuditProducer(bootstrap)
+        await producer.start()
+        yield producer
+        await producer.stop()
+
+    @pytest.fixture
+    async def lifecycle_consumer(self):
+        from aiokafka import AIOKafkaConsumer
+
+        bootstrap = os.environ.get("POI_KAFKA_BOOTSTRAP_SERVERS", "")
+        consumer = AIOKafkaConsumer(
+            LifecycleProducer.TOPIC,
+            bootstrap_servers=bootstrap,
+            auto_offset_reset="earliest",
+            value_deserializer=lambda v: json.loads(v.decode("utf-8")),
+            consumer_timeout_ms=10000,
+            group_id="tc-test-lifecycle",
+        )
+        await consumer.start()
+        yield consumer
+        await consumer.stop()
+
+    @pytest.fixture
+    async def audit_consumer(self):
+        from aiokafka import AIOKafkaConsumer
+
+        bootstrap = os.environ.get("POI_KAFKA_BOOTSTRAP_SERVERS", "")
+        consumer = AIOKafkaConsumer(
+            AuditProducer.TOPIC,
+            bootstrap_servers=bootstrap,
+            auto_offset_reset="earliest",
+            value_deserializer=lambda v: json.loads(v.decode("utf-8")),
+            consumer_timeout_ms=10000,
+            group_id="tc-test-audit",
+        )
+        await consumer.start()
+        yield consumer
+        await consumer.stop()
+
+    async def test_lifecycle_producer_connects(self, lifecycle_producer):
+        """LifecycleProducer connects to real Kafka."""
+        assert lifecycle_producer.is_connected is True
+
+    async def test_audit_producer_connects(self, audit_producer):
+        """AuditProducer connects to real Kafka."""
+        assert audit_producer.is_connected is True
+
+    async def test_publish_and_consume_lifecycle_event(
+        self, lifecycle_producer, lifecycle_consumer
+    ):
+        """Send PROMPT_PROMOTED event, consume it, verify fields."""
+        lifecycle_producer.send_lifecycle_event_sync(
+            event_type=PROMPT_PROMOTED,
+            prompt_name="__tc-kafka-test",
+            version=1,
+            from_state="CANARY",
+            to_state="PRODUCTION",
+            agent_code="mra",
+            correlation_id="tc-corr-001",
+        )
+
+        found = False
+        async for msg in lifecycle_consumer:
+            if msg.value.get("prompt_name") == "__tc-kafka-test":
+                assert msg.value["event_type"] == PROMPT_PROMOTED
+                assert msg.value["version"] == 1
+                assert msg.value["from_state"] == "CANARY"
+                assert msg.value["to_state"] == "PRODUCTION"
+                found = True
+                break
+
+        assert found, "Lifecycle event not consumed from Kafka"
+
+    async def test_audit_producer_publish_and_consume(
+        self, audit_producer, audit_consumer
+    ):
+        """Send audit event, consume and verify."""
+        await audit_producer.send_audit(
+            job_id="tc-job-001",
+            tenant_id="tc-tenant",
+            action="TEST_ACTION",
+            details={"key": "value"},
+        )
+
+        found = False
+        async for msg in audit_consumer:
+            if msg.value.get("job_id") == "tc-job-001":
+                assert msg.value["tenant_id"] == "tc-tenant"
+                assert msg.value["action"] == "TEST_ACTION"
+                found = True
+                break
+
+        assert found, "Audit event not consumed from Kafka"
+
+    async def test_correlation_id_as_message_key(
+        self, lifecycle_producer, lifecycle_consumer
+    ):
+        """Verify Kafka message key equals the correlation_id."""
+        lifecycle_producer.send_lifecycle_event_sync(
+            event_type=PROMPT_PROMOTED,
+            prompt_name="__tc-kafka-key-test",
+            version=2,
+            from_state="DRAFT",
+            to_state="CANARY",
+            correlation_id="tc-key-check-001",
+        )
+
+        async for msg in lifecycle_consumer:
+            if msg.value.get("prompt_name") == "__tc-kafka-key-test":
+                assert msg.key is not None
+                assert msg.key.decode("utf-8") == "tc-key-check-001"
+                break
+
+    async def test_schema_version_header(self, lifecycle_producer, lifecycle_consumer):
+        """Verify schema_version header is '1.0' on consumed message."""
+        lifecycle_producer.send_lifecycle_event_sync(
+            event_type=PROMPT_PROMOTED,
+            prompt_name="__tc-kafka-header-test",
+            version=3,
+            from_state="DRAFT",
+            to_state="PRODUCTION",
+            correlation_id="tc-header-check-001",
+        )
+
+        async for msg in lifecycle_consumer:
+            if msg.value.get("prompt_name") == "__tc-kafka-header-test":
+                headers = dict(msg.headers) if msg.headers else {}
+                assert b"schema_version" in headers or "schema_version" in headers
+                sv = headers.get("schema_version", headers.get(b"schema_version", b""))
+                if isinstance(sv, bytes):
+                    sv = sv.decode("utf-8")
+                assert sv == "1.0"
+                break

--- a/prompt-optimization-svc/tests/integration/test_kafka_properties_tc.py
+++ b/prompt-optimization-svc/tests/integration/test_kafka_properties_tc.py
@@ -1,0 +1,117 @@
+"""Hypothesis property tests for Kafka via testcontainers (US-059).
+
+Property-based tests that verify Kafka message invariants hold for
+arbitrary inputs against a real Kafka container.
+"""
+
+import json
+import os
+
+import pytest
+from hypothesis import given, settings as h_settings, HealthCheck
+from hypothesis import strategies as st
+
+from app.kafka.producer import LifecycleProducer
+from app.kafka.schemas import PROMPT_PROMOTED
+
+
+@pytest.mark.integration
+@pytest.mark.property
+class TestKafkaPropertiesTC:
+    """Hypothesis property tests against real Kafka."""
+
+    @pytest.fixture
+    async def lifecycle_producer(self):
+        bootstrap = os.environ.get("POI_KAFKA_BOOTSTRAP_SERVERS", "")
+        producer = LifecycleProducer(bootstrap)
+        await producer.start()
+        yield producer
+        await producer.stop()
+
+    @pytest.fixture
+    async def lifecycle_consumer(self):
+        from aiokafka import AIOKafkaConsumer
+
+        bootstrap = os.environ.get("POI_KAFKA_BOOTSTRAP_SERVERS", "")
+        consumer = AIOKafkaConsumer(
+            LifecycleProducer.TOPIC,
+            bootstrap_servers=bootstrap,
+            auto_offset_reset="earliest",
+            value_deserializer=lambda v: json.loads(v.decode("utf-8")),
+            consumer_timeout_ms=10000,
+            group_id="tc-prop-lifecycle",
+        )
+        await consumer.start()
+        yield consumer
+        await consumer.stop()
+
+    @given(
+        prompt_name=st.text(
+            alphabet=st.characters(
+                whitelist_categories=("L", "N"),
+                whitelist_characters="-_",
+            ),
+            min_size=1,
+            max_size=50,
+        ),
+        version=st.integers(min_value=1, max_value=9999),
+    )
+    @h_settings(
+        max_examples=5,
+        deadline=30000,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    async def test_lifecycle_event_roundtrips_through_kafka(
+        self, lifecycle_producer, lifecycle_consumer, prompt_name, version
+    ):
+        """Random event fields serialize/deserialize correctly through Kafka."""
+        tagged_name = f"__tc_prop_{prompt_name}"
+        lifecycle_producer.send_lifecycle_event_sync(
+            event_type=PROMPT_PROMOTED,
+            prompt_name=tagged_name,
+            version=version,
+            from_state="DRAFT",
+            to_state="PRODUCTION",
+            correlation_id=f"prop-rt-{version}",
+        )
+
+        async for msg in lifecycle_consumer:
+            if msg.value.get("prompt_name") == tagged_name:
+                assert msg.value["version"] == version
+                assert msg.value["event_type"] == PROMPT_PROMOTED
+                break
+
+    @given(
+        correlation_id=st.text(
+            alphabet=st.characters(
+                whitelist_categories=("L", "N"),
+                whitelist_characters="-_",
+            ),
+            min_size=1,
+            max_size=50,
+        ),
+    )
+    @h_settings(
+        max_examples=5,
+        deadline=30000,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    async def test_correlation_id_preserved_as_key(
+        self, lifecycle_producer, lifecycle_consumer, correlation_id
+    ):
+        """Random correlation IDs appear as Kafka message key."""
+        tagged_name = f"__tc_prop_key_{correlation_id[:20]}"
+        lifecycle_producer.send_lifecycle_event_sync(
+            event_type=PROMPT_PROMOTED,
+            prompt_name=tagged_name,
+            version=1,
+            from_state="DRAFT",
+            to_state="CANARY",
+            correlation_id=correlation_id,
+        )
+
+        async for msg in lifecycle_consumer:
+            if msg.value.get("prompt_name") == tagged_name:
+                assert msg.key is not None
+                assert msg.key.decode("utf-8") == correlation_id
+                break

--- a/prompt-optimization-svc/tests/integration/test_mlflow_roundtrip_tc.py
+++ b/prompt-optimization-svc/tests/integration/test_mlflow_roundtrip_tc.py
@@ -1,0 +1,79 @@
+"""Integration tests for MLflow round-trip via testcontainers (US-059).
+
+Tests prompt registration, versioning, state management, and template
+loading against a real MLflow tracking server backed by testcontainer
+PostgreSQL.
+"""
+
+import os
+
+import pytest
+
+from app.services.mlflow_registry import MLflowPromptRegistry
+
+TEST_PREFIX = "__tc_mlflow_"
+
+
+@pytest.mark.integration
+class TestMLflowRoundtripTC:
+    """MLflow prompt registry round-trip via testcontainers."""
+
+    @pytest.fixture
+    def registry(self):
+        uri = os.environ.get("POI_MLFLOW_TRACKING_URI", "http://localhost:5000")
+        return MLflowPromptRegistry(uri)
+
+    def test_register_get_roundtrip(self, registry):
+        """Register a prompt, retrieve it, verify template matches."""
+        name = f"{TEST_PREFIX}roundtrip"
+        info = registry.register_prompt(
+            name=name,
+            template="You are a helpful assistant for {{context.brand_name}}.",
+            tags={"state": "DRAFT", "agent_code": "mra"},
+        )
+        assert info.name == name
+        assert info.version >= 1
+
+        retrieved = registry.get_prompt(name)
+        assert retrieved is not None
+        assert "helpful assistant" in retrieved.template
+
+    def test_versioning_increments(self, registry):
+        """Register same name twice — version increments."""
+        name = f"{TEST_PREFIX}versioning"
+        v1 = registry.register_prompt(name=name, template="Version 1")
+        v2 = registry.register_prompt(name=name, template="Version 2")
+        assert v2.version > v1.version
+
+    def test_promote_sets_production_tag(self, registry):
+        """Register, set state to PRODUCTION, verify promoted_at tag."""
+        name = f"{TEST_PREFIX}promote"
+        info = registry.register_prompt(
+            name=name, template="Promote me", tags={"state": "DRAFT"}
+        )
+        registry.set_prompt_state(name, info.version, "PRODUCTION")
+
+        promoted = registry.get_prompt_by_state(name, "PRODUCTION")
+        assert promoted is not None
+        assert promoted.tags.get("state") == "PRODUCTION"
+        assert "promoted_at" in promoted.tags
+
+    def test_load_prompt_template_resolves(self, registry):
+        """Load template text by name."""
+        name = f"{TEST_PREFIX}load"
+        registry.register_prompt(name=name, template="Load me: {{context.x}}")
+        template = registry.load_prompt_template(name)
+        assert template is not None
+        assert "Load me" in template
+
+    def test_list_prompts_includes_registered(self, registry):
+        """Listing includes newly registered prompt."""
+        name = f"{TEST_PREFIX}list"
+        registry.register_prompt(name=name, template="List me")
+        names = registry.list_prompts()
+        assert name in names
+
+    def test_nonexistent_prompt_returns_none(self, registry):
+        """Unknown prompt name returns None."""
+        info = registry.get_prompt(f"{TEST_PREFIX}nonexistent-xyz-999")
+        assert info is None

--- a/prompt-optimization-svc/tests/integration/test_postgres_persistence_tc.py
+++ b/prompt-optimization-svc/tests/integration/test_postgres_persistence_tc.py
@@ -1,0 +1,223 @@
+"""Integration tests for PostgreSQL persistence via testcontainers (US-059).
+
+Tests golden dataset, optimization run, schema snapshot, and tenant config
+persistence against a real PostgreSQL container. Uses a test-specific
+engine/session to avoid the module-level singleton in database.py.
+"""
+
+import os
+import subprocess
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from app.models.base import Base
+from app.models.golden_dataset import GoldenDataset
+from app.models.optimization_run import OptimizationRun
+from app.models.schema_snapshot import SchemaSnapshot
+from app.models.tenant_config import TenantConfig
+
+TEST_PREFIX = "__tc_pg_"
+
+
+@pytest.mark.integration
+class TestPostgresPersistenceTC:
+    """PostgreSQL persistence via testcontainers."""
+
+    @pytest.fixture
+    async def session(self):
+        """Create a test-specific async engine and session."""
+        sync_url = os.environ.get(
+            "POI_DATABASE_URL", "postgresql://mlflow:mlflow@localhost:5432/mlflow"
+        )
+        async_url = sync_url.replace("postgresql://", "postgresql+asyncpg://", 1)
+        if "postgresql+psycopg2://" in async_url:
+            async_url = async_url.replace(
+                "postgresql+psycopg2://", "postgresql+asyncpg://", 1
+            )
+
+        engine = create_async_engine(async_url, pool_pre_ping=True, echo=False)
+        factory = async_sessionmaker(
+            engine, class_=AsyncSession, expire_on_commit=False
+        )
+
+        async with factory() as session:
+            yield session
+
+        # Cleanup test data
+        async with factory() as cleanup:
+            await cleanup.execute(
+                text(
+                    "DELETE FROM prompt_optimization.golden_datasets "
+                    "WHERE prompt_name LIKE :prefix"
+                ),
+                {"prefix": f"{TEST_PREFIX}%"},
+            )
+            await cleanup.execute(
+                text(
+                    "DELETE FROM prompt_optimization.optimization_runs "
+                    "WHERE prompt_name LIKE :prefix"
+                ),
+                {"prefix": f"{TEST_PREFIX}%"},
+            )
+            await cleanup.execute(
+                text(
+                    "DELETE FROM prompt_optimization.schema_snapshots "
+                    "WHERE prompt_name LIKE :prefix"
+                ),
+                {"prefix": f"{TEST_PREFIX}%"},
+            )
+            await cleanup.execute(
+                text(
+                    "DELETE FROM prompt_optimization.tenant_configs "
+                    "WHERE tenant_id LIKE :prefix"
+                ),
+                {"prefix": f"{TEST_PREFIX}%"},
+            )
+            await cleanup.commit()
+
+        await engine.dispose()
+
+    async def test_golden_dataset_insert_and_query(self, session):
+        """Insert GoldenDataset row, query back, verify fields."""
+        row = GoldenDataset(
+            prompt_name=f"{TEST_PREFIX}gd-roundtrip",
+            agent_code="mra",
+            tenant_id=None,
+            input_context={"context": {"brand_name": "TestBrand"}},
+            expected_output="A comprehensive market research analysis.",
+            source="manual",
+            quality_score=0.95,
+            active=True,
+            metadata_extra={"industry": "tech"},
+        )
+        session.add(row)
+        await session.commit()
+        await session.refresh(row)
+
+        assert row.id is not None
+        assert row.prompt_name == f"{TEST_PREFIX}gd-roundtrip"
+        assert row.agent_code == "mra"
+        assert row.input_context["context"]["brand_name"] == "TestBrand"
+        assert row.quality_score == 0.95
+        assert row.active is True
+        assert row.created_at is not None
+
+    async def test_golden_dataset_tenant_isolation(self, session):
+        """Tenant A rows not visible when filtering by tenant B."""
+        row_a = GoldenDataset(
+            prompt_name=f"{TEST_PREFIX}gd-iso",
+            agent_code="cga",
+            tenant_id="tenant-a",
+            input_context={"key": "value-a"},
+            source="manual",
+            active=True,
+        )
+        row_b = GoldenDataset(
+            prompt_name=f"{TEST_PREFIX}gd-iso",
+            agent_code="cga",
+            tenant_id="tenant-b",
+            input_context={"key": "value-b"},
+            source="manual",
+            active=True,
+        )
+        session.add_all([row_a, row_b])
+        await session.commit()
+
+        result = await session.execute(
+            text(
+                "SELECT tenant_id FROM prompt_optimization.golden_datasets "
+                "WHERE prompt_name = :name AND tenant_id = :tid"
+            ),
+            {"name": f"{TEST_PREFIX}gd-iso", "tid": "tenant-a"},
+        )
+        rows = result.fetchall()
+        assert len(rows) == 1
+        assert rows[0][0] == "tenant-a"
+
+    async def test_optimization_run_state_transitions(self, session):
+        """QUEUED → RUNNING → COMPLETED persists correctly."""
+        run_id = str(uuid.uuid4())
+        run = OptimizationRun(
+            id=run_id,
+            prompt_name=f"{TEST_PREFIX}run-states",
+            agent_code="bpa",
+            group_name="wf2-positioning",
+            state="QUEUED",
+        )
+        session.add(run)
+        await session.commit()
+
+        # Transition to RUNNING
+        run.state = "RUNNING"
+        run.mlflow_run_id = "mlflow-run-123"
+        await session.commit()
+        await session.refresh(run)
+        assert run.state == "RUNNING"
+        assert run.mlflow_run_id == "mlflow-run-123"
+
+        # Transition to COMPLETED
+        run.state = "COMPLETED"
+        await session.commit()
+        await session.refresh(run)
+        assert run.state == "COMPLETED"
+
+    async def test_schema_snapshot_roundtrip(self, session):
+        """Insert SchemaSnapshot, verify schema_json round-trips."""
+        schema_data = [
+            {"name": "summary", "type": "string", "required": True, "max_length": 500},
+            {"name": "score", "type": "number", "required": False},
+        ]
+        snap = SchemaSnapshot(
+            prompt_name=f"{TEST_PREFIX}snap-rt",
+            agent_code="mra",
+            schema_json=schema_data,
+            optimization_run_id=str(uuid.uuid4()),
+        )
+        session.add(snap)
+        await session.commit()
+        await session.refresh(snap)
+
+        assert snap.id is not None
+        assert snap.schema_json == schema_data
+        assert len(snap.schema_json) == 2
+        assert snap.schema_json[0]["name"] == "summary"
+        assert snap.schema_json[1]["required"] is False
+
+    async def test_tenant_config_persistence(self, session):
+        """Insert TenantConfig row, query back, verify schedule."""
+        config = TenantConfig(
+            tenant_id=f"{TEST_PREFIX}cfg-persist",
+            wf3_optimization_schedule="weekly",
+        )
+        session.add(config)
+        await session.commit()
+        await session.refresh(config)
+
+        assert config.id is not None
+        assert config.tenant_id == f"{TEST_PREFIX}cfg-persist"
+        assert config.wf3_optimization_schedule == "weekly"
+        assert config.created_at is not None
+
+    async def test_alembic_migrations_at_head(self):
+        """Verify alembic current shows head revision."""
+        svc_dir = os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        )
+        env = os.environ.copy()
+        result = subprocess.run(
+            ["alembic", "current"],
+            cwd=svc_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        assert result.returncode == 0
+        assert "head" in result.stdout.lower() or "(head)" in result.stdout

--- a/prompt-optimization-svc/tests/integration/test_redis_cache_lifecycle_tc.py
+++ b/prompt-optimization-svc/tests/integration/test_redis_cache_lifecycle_tc.py
@@ -1,0 +1,108 @@
+"""Integration tests for Redis cache lifecycle via testcontainers (US-059).
+
+Tests prompt cache set/get/invalidate, tenant isolation, optimization
+locks, and tenant config against a real Redis container.
+"""
+
+import asyncio
+import os
+
+import pytest
+
+from app.cache.prompt_cache import PromptCacheManager
+from app.cache.tenant_config import TenantConfigManager
+
+TEST_PREFIX = "__tc_redis_"
+
+
+@pytest.mark.integration
+class TestRedisCacheLifecycleTC:
+    """Redis cache lifecycle via testcontainers."""
+
+    @pytest.fixture
+    async def cache(self):
+        url = os.environ.get("POI_PROMPT_CACHE_REDIS_URL", "redis://localhost:6379/2")
+        mgr = PromptCacheManager(redis_url=url)
+        await mgr.connect()
+        yield mgr
+        r = await mgr.connect()
+        async for key in r.scan_iter(match=f"prompt:{TEST_PREFIX}*"):
+            await r.delete(key)
+        async for key in r.scan_iter(match=f"prompt:optimization:lock:{TEST_PREFIX}*"):
+            await r.delete(key)
+        async for key in r.scan_iter(match=f"tenant:{TEST_PREFIX}*"):
+            await r.delete(key)
+        await mgr.close()
+
+    async def test_set_get_invalidate_cycle(self, cache):
+        """Full lifecycle: set → get (hit) → invalidate → get (miss)."""
+        key = f"{TEST_PREFIX}lifecycle"
+        await cache.set_prompt(key, "cached template", ttl=30)
+        assert await cache.get_prompt(key) == "cached template"
+        await cache.invalidate_prompt(key)
+        assert await cache.get_prompt(key) is None
+
+    async def test_ttl_expiry(self, cache):
+        """Set with 1s TTL, wait, verify expired."""
+        key = f"{TEST_PREFIX}ttl-expiry"
+        await cache.set_prompt(key, "short lived", ttl=1)
+        assert await cache.get_prompt(key) == "short lived"
+        await asyncio.sleep(2)
+        assert await cache.get_prompt(key) is None
+
+    async def test_tenant_isolation_no_cross_read(self, cache):
+        """Tenant A can't read tenant B's cached prompt."""
+        key = f"{TEST_PREFIX}isolation"
+        await cache.set_prompt(key, "Tenant A data", ttl=30, tenant_id="t-a")
+        result = await cache.get_prompt(key, tenant_id="t-b")
+        assert result is None
+
+    async def test_invalidate_deletes_all_variants(self, cache):
+        """Invalidate removes production + tenant keys."""
+        key = f"{TEST_PREFIX}inv-all"
+        await cache.set_prompt(key, "prod", ttl=30)
+        await cache.set_prompt(key, "tenant-1", ttl=30, tenant_id="t-1")
+        deleted = await cache.invalidate_prompt(key)
+        assert deleted >= 2
+        assert await cache.get_prompt(key) is None
+        assert await cache.get_prompt(key, tenant_id="t-1") is None
+
+    async def test_optimization_lock_lifecycle(self, cache):
+        """Acquire → verify held → release → verify released."""
+        group = f"{TEST_PREFIX}lock-lc"
+        acquired = await cache.acquire_optimization_lock(group, "worker-1", ttl=30)
+        assert acquired is True
+        info = await cache.get_optimization_lock_info(group)
+        assert info["owner"] == "worker-1"
+        released = await cache.release_optimization_lock(group, "worker-1")
+        assert released is True
+
+    async def test_optimization_lock_owner_safety(self, cache):
+        """Wrong owner cannot release the lock."""
+        group = f"{TEST_PREFIX}lock-owner"
+        await cache.acquire_optimization_lock(group, "worker-1", ttl=30)
+        released = await cache.release_optimization_lock(group, "worker-2")
+        assert released is False
+        await cache.release_optimization_lock(group, "worker-1")
+
+    async def test_optimization_lock_prevents_double_acquire(self, cache):
+        """Second acquire by different owner fails."""
+        group = f"{TEST_PREFIX}lock-double"
+        await cache.acquire_optimization_lock(group, "worker-1", ttl=30)
+        second = await cache.acquire_optimization_lock(group, "worker-2", ttl=30)
+        assert second is False
+        await cache.release_optimization_lock(group, "worker-1")
+
+    async def test_tenant_config_set_and_get_ttl(self, cache):
+        """Set tenant TTL, retrieve matches."""
+        config = TenantConfigManager(cache)
+        await config.set_prompt_cache_ttl(f"{TEST_PREFIX}tenant-ttl", 600)
+        ttl = await config.get_prompt_cache_ttl(f"{TEST_PREFIX}tenant-ttl")
+        assert ttl == 600
+
+    async def test_tenant_config_clamp_enforced(self, cache):
+        """TTL below 10 clamped to 10."""
+        config = TenantConfigManager(cache)
+        await config.set_prompt_cache_ttl(f"{TEST_PREFIX}tenant-clamp", 5)
+        ttl = await config.get_prompt_cache_ttl(f"{TEST_PREFIX}tenant-clamp")
+        assert ttl == 10

--- a/prompt-optimization-svc/tests/integration/test_redis_properties_tc.py
+++ b/prompt-optimization-svc/tests/integration/test_redis_properties_tc.py
@@ -1,0 +1,121 @@
+"""Hypothesis property tests for Redis cache via testcontainers (US-059).
+
+Property-based tests that verify cache invariants hold for arbitrary
+inputs against a real Redis container.
+"""
+
+import os
+
+import pytest
+from hypothesis import given, settings as h_settings, HealthCheck
+from hypothesis import strategies as st
+
+from app.cache.prompt_cache import PromptCacheManager
+
+TEST_PREFIX = "__tc_prop_"
+
+
+@pytest.mark.integration
+@pytest.mark.property
+class TestRedisPropertiesTC:
+    """Hypothesis property tests against real Redis."""
+
+    @pytest.fixture
+    async def cache(self):
+        url = os.environ.get("POI_PROMPT_CACHE_REDIS_URL", "redis://localhost:6379/2")
+        mgr = PromptCacheManager(redis_url=url)
+        await mgr.connect()
+        yield mgr
+        # Cleanup test keys
+        r = await mgr.connect()
+        async for key in r.scan_iter(match=f"prompt:{TEST_PREFIX}*"):
+            await r.delete(key)
+        async for key in r.scan_iter(match=f"prompt:optimization:lock:{TEST_PREFIX}*"):
+            await r.delete(key)
+        await mgr.close()
+
+    @given(
+        name_suffix=st.text(
+            alphabet=st.characters(
+                whitelist_categories=("L", "N"),
+                whitelist_characters="-_",
+            ),
+            min_size=1,
+            max_size=50,
+        ),
+        template=st.text(min_size=1, max_size=200),
+    )
+    @h_settings(
+        max_examples=15,
+        deadline=10000,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    async def test_any_prompt_name_roundtrips(self, cache, name_suffix, template):
+        """Any valid prompt name set/get round-trips correctly."""
+        key = f"{TEST_PREFIX}{name_suffix}"
+        await cache.set_prompt(key, template, ttl=30)
+        result = await cache.get_prompt(key)
+        assert result == template
+        await cache.invalidate_prompt(key)
+
+    @given(
+        tenant_a=st.text(
+            alphabet=st.characters(whitelist_categories=("L", "N")),
+            min_size=1,
+            max_size=20,
+        ),
+        tenant_b=st.text(
+            alphabet=st.characters(whitelist_categories=("L", "N")),
+            min_size=1,
+            max_size=20,
+        ),
+    )
+    @h_settings(
+        max_examples=15,
+        deadline=10000,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    async def test_any_tenant_id_isolates_cache(self, cache, tenant_a, tenant_b):
+        """Any two different tenant IDs never cross-read cached prompts."""
+        from hypothesis import assume
+
+        assume(tenant_a != tenant_b)
+
+        key = f"{TEST_PREFIX}iso-prop"
+        await cache.set_prompt(key, "tenant-a-data", ttl=30, tenant_id=tenant_a)
+        result = await cache.get_prompt(key, tenant_id=tenant_b)
+        assert result is None
+        await cache.invalidate_prompt(key)
+
+    @given(
+        owner_a=st.text(
+            alphabet=st.characters(whitelist_categories=("L", "N")),
+            min_size=1,
+            max_size=20,
+        ),
+        owner_b=st.text(
+            alphabet=st.characters(whitelist_categories=("L", "N")),
+            min_size=1,
+            max_size=20,
+        ),
+    )
+    @h_settings(
+        max_examples=15,
+        deadline=10000,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    async def test_lock_acquire_rejects_second_owner(self, cache, owner_a, owner_b):
+        """Any two different owners — second acquire always fails."""
+        from hypothesis import assume
+
+        assume(owner_a != owner_b)
+
+        group = f"{TEST_PREFIX}lock-prop"
+        # Ensure clean state
+        await cache.release_optimization_lock(group, owner_a)
+
+        acquired = await cache.acquire_optimization_lock(group, owner_a, ttl=30)
+        assert acquired is True
+        second = await cache.acquire_optimization_lock(group, owner_b, ttl=30)
+        assert second is False
+        await cache.release_optimization_lock(group, owner_a)

--- a/tests/integration/phase1_contracts/test_testcontainers_integration.py
+++ b/tests/integration/phase1_contracts/test_testcontainers_integration.py
@@ -1,0 +1,109 @@
+"""Cross-service integration tests for testcontainer infrastructure (US-059).
+
+Validates that testcontainer-managed services (Redis, PostgreSQL, Kafka,
+MLflow) are healthy and that POI_* environment variables point to them.
+"""
+
+import os
+
+import pytest
+
+
+@pytest.mark.integration
+class TestTestcontainersInfrastructure:
+    """Validate testcontainer infrastructure is healthy."""
+
+    def test_redis_container_responds_to_ping(self):
+        """Redis container is reachable and responds to PING."""
+        import redis
+
+        url = os.environ.get("POI_PROMPT_CACHE_REDIS_URL", "redis://localhost:6379/2")
+        r = redis.from_url(url)
+        assert r.ping() is True
+        r.close()
+
+    def test_postgres_container_accepts_connections(self):
+        """PostgreSQL container accepts connections and runs queries."""
+        from sqlalchemy import create_engine, text
+
+        url = os.environ.get(
+            "POI_DATABASE_URL",
+            "postgresql://mlflow:mlflow@localhost:5432/mlflow",
+        )
+        engine = create_engine(url)
+        with engine.connect() as conn:
+            result = conn.execute(text("SELECT 1"))
+            assert result.scalar() == 1
+        engine.dispose()
+
+    def test_kafka_container_accepts_connections(self):
+        """Kafka container bootstrap server is reachable."""
+        from kafka import KafkaProducer
+
+        bootstrap = os.environ.get("POI_KAFKA_BOOTSTRAP_SERVERS", "")
+        if not bootstrap:
+            pytest.skip("POI_KAFKA_BOOTSTRAP_SERVERS not set")
+
+        producer = KafkaProducer(
+            bootstrap_servers=bootstrap,
+            request_timeout_ms=5000,
+        )
+        assert producer.bootstrap_connected()
+        producer.close()
+
+    def test_mlflow_server_health_endpoint(self):
+        """MLflow /health endpoint returns 200."""
+        import httpx
+
+        uri = os.environ.get("POI_MLFLOW_TRACKING_URI", "http://localhost:5000")
+        resp = httpx.get(f"{uri}/health", timeout=5)
+        assert resp.status_code == 200
+
+    def test_all_containers_use_expected_images(self):
+        """Verify expected service versions are running by querying them."""
+        import httpx
+        import redis
+
+        # Redis 7 check — INFO server contains redis_version:7.*
+        redis_url = os.environ.get(
+            "POI_PROMPT_CACHE_REDIS_URL", "redis://localhost:6379/2"
+        )
+        r = redis.from_url(redis_url)
+        info = r.info("server")
+        assert info["redis_version"].startswith(
+            "7"
+        ), f"Expected Redis 7.x, got {info['redis_version']}"
+        r.close()
+
+        # PostgreSQL 15 check — via server_version
+        from sqlalchemy import create_engine, text
+
+        pg_url = os.environ.get(
+            "POI_DATABASE_URL",
+            "postgresql://mlflow:mlflow@localhost:5432/mlflow",
+        )
+        engine = create_engine(pg_url)
+        with engine.connect() as conn:
+            result = conn.execute(text("SHOW server_version"))
+            version = result.scalar()
+            assert version.startswith("15"), f"Expected PostgreSQL 15.x, got {version}"
+        engine.dispose()
+
+        # MLflow version check — /health or /version returns successfully
+        mlflow_uri = os.environ.get("POI_MLFLOW_TRACKING_URI", "http://localhost:5000")
+        resp = httpx.get(f"{mlflow_uri}/health", timeout=5)
+        assert resp.status_code == 200
+
+    def test_env_vars_point_to_containers(self):
+        """POI_* env vars are set and non-empty."""
+        required_vars = [
+            "POI_PROMPT_CACHE_REDIS_URL",
+            "POI_REDIS_URL",
+            "POI_DATABASE_URL",
+            "POI_KAFKA_BOOTSTRAP_SERVERS",
+            "POI_MLFLOW_TRACKING_URI",
+        ]
+        for var in required_vars:
+            value = os.environ.get(var)
+            assert value, f"{var} is not set or empty"
+            assert len(value) > 5, f"{var} value too short: {value}"

--- a/tests/integration/phase1_contracts/test_testcontainers_integration.py
+++ b/tests/integration/phase1_contracts/test_testcontainers_integration.py
@@ -4,6 +4,7 @@ Validates that testcontainer-managed services (Redis, PostgreSQL, Kafka,
 MLflow) are healthy and that POI_* environment variables point to them.
 """
 
+import asyncio
 import os
 
 import pytest
@@ -17,7 +18,8 @@ class TestTestcontainersInfrastructure:
         """Redis container is reachable and responds to PING."""
         import redis
 
-        url = os.environ.get("POI_PROMPT_CACHE_REDIS_URL", "redis://localhost:6379/2")
+        url = os.environ.get("POI_PROMPT_CACHE_REDIS_URL", "")
+        assert url, "POI_PROMPT_CACHE_REDIS_URL must be set by testcontainers"
         r = redis.from_url(url)
         assert r.ping() is True
         r.close()
@@ -26,10 +28,8 @@ class TestTestcontainersInfrastructure:
         """PostgreSQL container accepts connections and runs queries."""
         from sqlalchemy import create_engine, text
 
-        url = os.environ.get(
-            "POI_DATABASE_URL",
-            "postgresql://mlflow:mlflow@localhost:5432/mlflow",
-        )
+        url = os.environ.get("POI_DATABASE_URL", "")
+        assert url, "POI_DATABASE_URL must be set by testcontainers"
         engine = create_engine(url)
         with engine.connect() as conn:
             result = conn.execute(text("SELECT 1"))
@@ -38,24 +38,27 @@ class TestTestcontainersInfrastructure:
 
     def test_kafka_container_accepts_connections(self):
         """Kafka container bootstrap server is reachable."""
-        from kafka import KafkaProducer
+        from aiokafka import AIOKafkaProducer
 
         bootstrap = os.environ.get("POI_KAFKA_BOOTSTRAP_SERVERS", "")
-        if not bootstrap:
-            pytest.skip("POI_KAFKA_BOOTSTRAP_SERVERS not set")
+        assert bootstrap, "POI_KAFKA_BOOTSTRAP_SERVERS must be set by testcontainers"
 
-        producer = KafkaProducer(
-            bootstrap_servers=bootstrap,
-            request_timeout_ms=5000,
-        )
-        assert producer.bootstrap_connected()
-        producer.close()
+        async def _check():
+            producer = AIOKafkaProducer(bootstrap_servers=bootstrap)
+            await producer.start()
+            connected = producer.client._connected
+            await producer.stop()
+            return connected
+
+        result = asyncio.get_event_loop().run_until_complete(_check())
+        assert result is True
 
     def test_mlflow_server_health_endpoint(self):
         """MLflow /health endpoint returns 200."""
         import httpx
 
-        uri = os.environ.get("POI_MLFLOW_TRACKING_URI", "http://localhost:5000")
+        uri = os.environ.get("POI_MLFLOW_TRACKING_URI", "")
+        assert uri, "POI_MLFLOW_TRACKING_URI must be set by testcontainers"
         resp = httpx.get(f"{uri}/health", timeout=5)
         assert resp.status_code == 200
 
@@ -65,9 +68,8 @@ class TestTestcontainersInfrastructure:
         import redis
 
         # Redis 7 check — INFO server contains redis_version:7.*
-        redis_url = os.environ.get(
-            "POI_PROMPT_CACHE_REDIS_URL", "redis://localhost:6379/2"
-        )
+        redis_url = os.environ.get("POI_PROMPT_CACHE_REDIS_URL", "")
+        assert redis_url, "POI_PROMPT_CACHE_REDIS_URL must be set by testcontainers"
         r = redis.from_url(redis_url)
         info = r.info("server")
         assert info["redis_version"].startswith(
@@ -78,10 +80,8 @@ class TestTestcontainersInfrastructure:
         # PostgreSQL 15 check — via server_version
         from sqlalchemy import create_engine, text
 
-        pg_url = os.environ.get(
-            "POI_DATABASE_URL",
-            "postgresql://mlflow:mlflow@localhost:5432/mlflow",
-        )
+        pg_url = os.environ.get("POI_DATABASE_URL", "")
+        assert pg_url, "POI_DATABASE_URL must be set by testcontainers"
         engine = create_engine(pg_url)
         with engine.connect() as conn:
             result = conn.execute(text("SHOW server_version"))
@@ -89,8 +89,9 @@ class TestTestcontainersInfrastructure:
             assert version.startswith("15"), f"Expected PostgreSQL 15.x, got {version}"
         engine.dispose()
 
-        # MLflow version check — /health or /version returns successfully
-        mlflow_uri = os.environ.get("POI_MLFLOW_TRACKING_URI", "http://localhost:5000")
+        # MLflow version check — /health returns successfully
+        mlflow_uri = os.environ.get("POI_MLFLOW_TRACKING_URI", "")
+        assert mlflow_uri, "POI_MLFLOW_TRACKING_URI must be set by testcontainers"
         resp = httpx.get(f"{mlflow_uri}/health", timeout=5)
         assert resp.status_code == 200
 


### PR DESCRIPTION
## Summary

- Replace skip-if-unavailable integration test pattern with **testcontainers-managed** Redis 7, PostgreSQL 15, Kafka 7.6, and MLflow containers — tests never skip, they either pass or fail
- Add **42 new tests** across 8 test files: MLflow round-trip (6), Redis cache lifecycle (9), Kafka publish/consume (6), PostgreSQL persistence (6), Celery Beat schedule (4), Hypothesis property tests for Redis (3) and Kafka (2), cross-service infrastructure validation (6)
- Replace `@requires_redis`/`@requires_mlflow` skip markers with no-op `pytest.mark.integration` aliases so existing test imports continue to work
- Add `testcontainers>=4.0.0`, `hypothesis>=6.100.0`, `pytest-cov>=5.0.0` to dev dependencies
- Add coverage config (≥60% gate) and `property` marker to pyproject.toml

## New Files

| File | Tests | Description |
|------|-------|-------------|
| `tests/conftest_testcontainers.py` | — | Session-scoped fixtures: Redis, PostgreSQL, Kafka containers + MLflow subprocess + Alembic migrations + env override |
| `tests/integration/test_mlflow_roundtrip_tc.py` | 6 | Register, version, promote, load, list, nonexistent prompt |
| `tests/integration/test_redis_cache_lifecycle_tc.py` | 9 | Set/get/invalidate, TTL expiry, tenant isolation, locks, tenant config |
| `tests/integration/test_kafka_lifecycle_tc.py` | 6 | Producer connect, publish/consume lifecycle + audit events, correlation key, schema header |
| `tests/integration/test_postgres_persistence_tc.py` | 6 | GoldenDataset, OptimizationRun state transitions, SchemaSnapshot, TenantConfig, Alembic head |
| `tests/integration/test_celery_beat_tc.py` | 4 | Broker connect, schedule entries, module imports, task routing |
| `tests/integration/test_redis_properties_tc.py` | 3 | Hypothesis: prompt name roundtrip, tenant isolation, lock owner safety |
| `tests/integration/test_kafka_properties_tc.py` | 2 | Hypothesis: event roundtrip, correlation ID as key |
| `tests/integration/phase1_contracts/test_testcontainers_integration.py` | 6 | Redis ping, PostgreSQL query, Kafka connect, MLflow health, version checks, env vars |

## Modified Files

| File | Change |
|------|--------|
| `requirements-dev.txt` | Add testcontainers, hypothesis, pytest-cov |
| `pyproject.toml` | Add property marker + coverage config |
| `tests/conftest.py` | Remove availability probes, replace skip markers with no-op aliases |
| `tests/integration/conftest.py` | Add no-op marker aliases for backward compatibility |
| `tests/integration/test_celery_beat_schedules.py` | Replace local skip markers with no-op aliases |

## Test plan

- [ ] `pytest tests/ -m "not integration" -v` — 2279 passed (14 pre-existing synthetic_context_gen failures unrelated)
- [ ] `pytest tests/integration/ -v -m integration` — all testcontainer tests pass with Docker running
- [ ] `pytest tests/ --cov=app --cov-report=term-missing` — coverage ≥ 60%
- [ ] No existing tests broken by skip marker migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)