### PR TITLE
fix: add startup timeouts to prompt loader and cache invalidator

### DIFF
--- a/ad-publishing-agent-svc/app/prompts/invalidator.py
+++ b/ad-publishing-agent-svc/app/prompts/invalidator.py
@@ -50,8 +50,9 @@ class PromptCacheInvalidator:
                 self.TOPIC,
                 self.GROUP_ID,
             )
-        except (Exception, asyncio.TimeoutError) as exc:
+        except Exception as exc:
             logger.warning("PromptCacheInvalidator failed: %s — no-op mode", exc)
+            self._consumer = None
 
     async def stop(self) -> None:
         """Stop the consumer and background task."""
@@ -65,7 +66,7 @@ class PromptCacheInvalidator:
         if self._consumer is not None:
             try:
                 await self._consumer.stop()
-            except (Exception, asyncio.TimeoutError) as exc:
+            except Exception as exc:
                 logger.warning("Error stopping PromptCacheInvalidator: %s", exc)
             self._consumer = None
 
@@ -76,7 +77,7 @@ class PromptCacheInvalidator:
                 await self.handle_event(msg.value)
         except asyncio.CancelledError:
             pass
-        except (Exception, asyncio.TimeoutError) as exc:
+        except Exception as exc:
             logger.error("PromptCacheInvalidator consume error: %s", exc)
 
     async def handle_event(self, event: dict) -> None:
@@ -100,5 +101,5 @@ class PromptCacheInvalidator:
                                 len(keys),
                                 prompt_name,
                             )
-                except (Exception, asyncio.TimeoutError) as exc:
+                except Exception as exc:
                     logger.warning("Cache invalidation failed: %s", exc)

--- a/ad-publishing-agent-svc/app/prompts/invalidator.py
+++ b/ad-publishing-agent-svc/app/prompts/invalidator.py
@@ -43,14 +43,14 @@ class PromptCacheInvalidator:
                 auto_offset_reset="latest",
                 value_deserializer=lambda v: json.loads(v.decode("utf-8")),
             )
-            await self._consumer.start()
+            await asyncio.wait_for(self._consumer.start(), timeout=10.0)
             self._task = asyncio.create_task(self._consume_loop())
             logger.info(
                 "PromptCacheInvalidator started (topic=%s, group=%s)",
                 self.TOPIC,
                 self.GROUP_ID,
             )
-        except Exception as exc:
+        except (Exception, asyncio.TimeoutError) as exc:
             logger.warning("PromptCacheInvalidator failed: %s — no-op mode", exc)
 
     async def stop(self) -> None:
@@ -65,7 +65,7 @@ class PromptCacheInvalidator:
         if self._consumer is not None:
             try:
                 await self._consumer.stop()
-            except Exception as exc:
+            except (Exception, asyncio.TimeoutError) as exc:
                 logger.warning("Error stopping PromptCacheInvalidator: %s", exc)
             self._consumer = None
 
@@ -76,7 +76,7 @@ class PromptCacheInvalidator:
                 await self.handle_event(msg.value)
         except asyncio.CancelledError:
             pass
-        except Exception as exc:
+        except (Exception, asyncio.TimeoutError) as exc:
             logger.error("PromptCacheInvalidator consume error: %s", exc)
 
     async def handle_event(self, event: dict) -> None:
@@ -91,9 +91,7 @@ class PromptCacheInvalidator:
                     r = self.prompt_loader._redis
                     if r:
                         keys = []
-                        async for key in r.scan_iter(
-                            match=f"prompt:{prompt_name}:*"
-                        ):
+                        async for key in r.scan_iter(match=f"prompt:{prompt_name}:*"):
                             keys.append(key)
                         if keys:
                             await r.delete(*keys)
@@ -102,5 +100,5 @@ class PromptCacheInvalidator:
                                 len(keys),
                                 prompt_name,
                             )
-                except Exception as exc:
+                except (Exception, asyncio.TimeoutError) as exc:
                     logger.warning("Cache invalidation failed: %s", exc)

--- a/ad-publishing-agent-svc/app/prompts/loader.py
+++ b/ad-publishing-agent-svc/app/prompts/loader.py
@@ -36,10 +36,12 @@ class AgentPromptClient:
         redis_url: str = "redis://localhost:6379/2",
         mlflow_uri: str = "http://mlflow-server:5000",
         default_ttl: int = 300,
+        critical_agent: bool = False,
     ) -> None:
         self.redis_url = redis_url
         self.mlflow_uri = mlflow_uri
         self.default_ttl = default_ttl
+        self.critical_agent = critical_agent
         self._redis: Optional[aioredis.Redis] = None
         self._http: Optional[httpx.AsyncClient] = None
 
@@ -123,7 +125,16 @@ class AgentPromptClient:
         # Tier 3: Fallback
         if template is None:
             if fallback:
-                logger.debug("Using fallback for prompt '%s'", name)
+                if self.critical_agent:
+                    logger.warning(
+                        "CRITICAL AGENT FALLBACK: prompt '%s' (tenant=%s) "
+                        "— MLflow and Redis both unreachable, using "
+                        "hardcoded fallback. This agent handles ad spend.",
+                        name,
+                        tenant_id,
+                    )
+                else:
+                    logger.debug("Using fallback for prompt '%s'", name)
             template = fallback
 
         return self._format(template, variables)

--- a/ad-publishing-agent-svc/app/prompts/loader.py
+++ b/ad-publishing-agent-svc/app/prompts/loader.py
@@ -7,7 +7,7 @@ and MLflow tracking server independently of the prompt-optimization-svc.
 Usage in an agent service:
     loader = AgentPromptClient(redis_url="redis://redis:6379/2", mlflow_uri="http://mlflow-server:5000")
     await loader.start()
-    prompt = await loader.load("zorven-wf1-mra-system", tenant_id="t-1", fallback="You are...")
+    prompt = await loader.load("zorven-<wf>-<agent>-system", tenant_id="t-1", fallback="You are...")
     await loader.stop()
 """
 
@@ -129,7 +129,7 @@ class AgentPromptClient:
                     logger.warning(
                         "CRITICAL AGENT FALLBACK: prompt '%s' (tenant=%s) "
                         "— MLflow and Redis both unreachable, using "
-                        "hardcoded fallback. This agent handles ad spend.",
+                        "hardcoded fallback.",
                         name,
                         tenant_id,
                     )

--- a/ad-publishing-agent-svc/app/prompts/loader.py
+++ b/ad-publishing-agent-svc/app/prompts/loader.py
@@ -11,6 +11,7 @@ Usage in an agent service:
     await loader.stop()
 """
 
+import asyncio
 import logging
 import re
 from typing import Any, Optional
@@ -35,12 +36,10 @@ class AgentPromptClient:
         redis_url: str = "redis://localhost:6379/2",
         mlflow_uri: str = "http://mlflow-server:5000",
         default_ttl: int = 300,
-        critical_agent: bool = False,
     ) -> None:
         self.redis_url = redis_url
         self.mlflow_uri = mlflow_uri
         self.default_ttl = default_ttl
-        self.critical_agent = critical_agent
         self._redis: Optional[aioredis.Redis] = None
         self._http: Optional[httpx.AsyncClient] = None
 
@@ -48,9 +47,11 @@ class AgentPromptClient:
         """Initialize Redis and HTTP connections."""
         try:
             self._redis = aioredis.from_url(
-                self.redis_url, decode_responses=True
+                self.redis_url,
+                decode_responses=True,
+                socket_connect_timeout=5,
             )
-            await self._redis.ping()
+            await asyncio.wait_for(self._redis.ping(), timeout=5.0)
             logger.info("Prompt cache connected: %s", self.redis_url)
         except Exception as exc:
             logger.warning("Prompt cache unavailable: %s", exc)
@@ -58,9 +59,7 @@ class AgentPromptClient:
 
         if self.mlflow_uri:
             try:
-                self._http = httpx.AsyncClient(
-                    base_url=self.mlflow_uri, timeout=5.0
-                )
+                self._http = httpx.AsyncClient(base_url=self.mlflow_uri, timeout=5.0)
                 resp = await self._http.get("/health")
                 if resp.status_code == 200:
                     logger.info("MLflow connected: %s", self.mlflow_uri)
@@ -74,7 +73,9 @@ class AgentPromptClient:
                     await self._http.aclose()
                 self._http = None
         else:
-            logger.info("MLflow URI not configured — prompt loader in fallback-only mode")
+            logger.info(
+                "MLflow URI not configured — prompt loader in fallback-only mode"
+            )
 
         logger.info("Prompt loader initialized")
 
@@ -122,25 +123,14 @@ class AgentPromptClient:
         # Tier 3: Fallback
         if template is None:
             if fallback:
-                if self.critical_agent:
-                    logger.warning(
-                        "CRITICAL AGENT FALLBACK: prompt '%s' (tenant=%s) "
-                        "— MLflow and Redis both unreachable, using "
-                        "hardcoded fallback. This agent handles ad spend.",
-                        name,
-                        tenant_id,
-                    )
-                else:
-                    logger.debug("Using fallback for prompt '%s'", name)
+                logger.debug("Using fallback for prompt '%s'", name)
             template = fallback
 
         return self._format(template, variables)
 
     # --- Tier 1: Redis cache ---
 
-    async def _cache_get(
-        self, name: str, tenant_id: Optional[str]
-    ) -> Optional[str]:
+    async def _cache_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._redis is None:
             return None
         try:
@@ -174,17 +164,13 @@ class AgentPromptClient:
 
     # --- Tier 2: MLflow REST API ---
 
-    async def _mlflow_get(
-        self, name: str, tenant_id: Optional[str]
-    ) -> Optional[str]:
+    async def _mlflow_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._http is None:
             return None
         try:
             # Try tenant-specific named prompt first
             if tenant_id:
-                template = await self._fetch_prompt(
-                    f"{name}-tenant-{tenant_id}"
-                )
+                template = await self._fetch_prompt(f"{name}-tenant-{tenant_id}")
                 if template is not None:
                     return template
 
@@ -235,9 +221,7 @@ class AgentPromptClient:
                     )
                     if ver_resp.status_code == 200:
                         ver_data = ver_resp.json()
-                        return ver_data.get("prompt_version", {}).get(
-                            "template"
-                        )
+                        return ver_data.get("prompt_version", {}).get("template")
             return None
         except Exception:
             return None
@@ -245,9 +229,7 @@ class AgentPromptClient:
     # --- Template formatting ---
 
     @staticmethod
-    def _format(
-        template: str, variables: Optional[dict[str, Any]]
-    ) -> str:
+    def _format(template: str, variables: Optional[dict[str, Any]]) -> str:
         if not template or not variables:
             return template
 

--- a/audience-persona-agent-svc/app/prompts/invalidator.py
+++ b/audience-persona-agent-svc/app/prompts/invalidator.py
@@ -50,8 +50,9 @@ class PromptCacheInvalidator:
                 self.TOPIC,
                 self.GROUP_ID,
             )
-        except (Exception, asyncio.TimeoutError) as exc:
+        except Exception as exc:
             logger.warning("PromptCacheInvalidator failed: %s — no-op mode", exc)
+            self._consumer = None
 
     async def stop(self) -> None:
         """Stop the consumer and background task."""
@@ -65,7 +66,7 @@ class PromptCacheInvalidator:
         if self._consumer is not None:
             try:
                 await self._consumer.stop()
-            except (Exception, asyncio.TimeoutError) as exc:
+            except Exception as exc:
                 logger.warning("Error stopping PromptCacheInvalidator: %s", exc)
             self._consumer = None
 
@@ -76,7 +77,7 @@ class PromptCacheInvalidator:
                 await self.handle_event(msg.value)
         except asyncio.CancelledError:
             pass
-        except (Exception, asyncio.TimeoutError) as exc:
+        except Exception as exc:
             logger.error("PromptCacheInvalidator consume error: %s", exc)
 
     async def handle_event(self, event: dict) -> None:
@@ -107,5 +108,5 @@ class PromptCacheInvalidator:
                                 deleted,
                                 prompt_name,
                             )
-                except (Exception, asyncio.TimeoutError) as exc:
+                except Exception as exc:
                     logger.warning("Cache invalidation failed: %s", exc)

--- a/audience-persona-agent-svc/app/prompts/invalidator.py
+++ b/audience-persona-agent-svc/app/prompts/invalidator.py
@@ -43,14 +43,14 @@ class PromptCacheInvalidator:
                 auto_offset_reset="latest",
                 value_deserializer=lambda v: json.loads(v.decode("utf-8")),
             )
-            await self._consumer.start()
+            await asyncio.wait_for(self._consumer.start(), timeout=10.0)
             self._task = asyncio.create_task(self._consume_loop())
             logger.info(
                 "PromptCacheInvalidator started (topic=%s, group=%s)",
                 self.TOPIC,
                 self.GROUP_ID,
             )
-        except Exception as exc:
+        except (Exception, asyncio.TimeoutError) as exc:
             logger.warning("PromptCacheInvalidator failed: %s — no-op mode", exc)
 
     async def stop(self) -> None:
@@ -65,7 +65,7 @@ class PromptCacheInvalidator:
         if self._consumer is not None:
             try:
                 await self._consumer.stop()
-            except Exception as exc:
+            except (Exception, asyncio.TimeoutError) as exc:
                 logger.warning("Error stopping PromptCacheInvalidator: %s", exc)
             self._consumer = None
 
@@ -76,7 +76,7 @@ class PromptCacheInvalidator:
                 await self.handle_event(msg.value)
         except asyncio.CancelledError:
             pass
-        except Exception as exc:
+        except (Exception, asyncio.TimeoutError) as exc:
             logger.error("PromptCacheInvalidator consume error: %s", exc)
 
     async def handle_event(self, event: dict) -> None:
@@ -92,9 +92,7 @@ class PromptCacheInvalidator:
                     if r:
                         deleted = 0
                         batch = []
-                        async for key in r.scan_iter(
-                            match=f"prompt:{prompt_name}:*"
-                        ):
+                        async for key in r.scan_iter(match=f"prompt:{prompt_name}:*"):
                             batch.append(key)
                             if len(batch) >= 100:
                                 await r.delete(*batch)
@@ -109,5 +107,5 @@ class PromptCacheInvalidator:
                                 deleted,
                                 prompt_name,
                             )
-                except Exception as exc:
+                except (Exception, asyncio.TimeoutError) as exc:
                     logger.warning("Cache invalidation failed: %s", exc)

--- a/audience-persona-agent-svc/app/prompts/loader.py
+++ b/audience-persona-agent-svc/app/prompts/loader.py
@@ -11,6 +11,7 @@ Usage in an agent service:
     await loader.stop()
 """
 
+import asyncio
 import logging
 import re
 from typing import Any, Optional
@@ -46,9 +47,11 @@ class AgentPromptClient:
         """Initialize Redis and HTTP connections."""
         try:
             self._redis = aioredis.from_url(
-                self.redis_url, decode_responses=True
+                self.redis_url,
+                decode_responses=True,
+                socket_connect_timeout=5,
             )
-            await self._redis.ping()
+            await asyncio.wait_for(self._redis.ping(), timeout=5.0)
             logger.info("Prompt cache connected: %s", self.redis_url)
         except Exception as exc:
             logger.warning("Prompt cache unavailable: %s", exc)
@@ -56,9 +59,7 @@ class AgentPromptClient:
 
         if self.mlflow_uri:
             try:
-                self._http = httpx.AsyncClient(
-                    base_url=self.mlflow_uri, timeout=5.0
-                )
+                self._http = httpx.AsyncClient(base_url=self.mlflow_uri, timeout=5.0)
                 resp = await self._http.get("/health")
                 if resp.status_code == 200:
                     logger.info("MLflow connected: %s", self.mlflow_uri)
@@ -72,7 +73,9 @@ class AgentPromptClient:
                     await self._http.aclose()
                 self._http = None
         else:
-            logger.info("MLflow URI not configured — prompt loader in fallback-only mode")
+            logger.info(
+                "MLflow URI not configured — prompt loader in fallback-only mode"
+            )
 
         logger.info("Prompt loader initialized")
 
@@ -127,9 +130,7 @@ class AgentPromptClient:
 
     # --- Tier 1: Redis cache ---
 
-    async def _cache_get(
-        self, name: str, tenant_id: Optional[str]
-    ) -> Optional[str]:
+    async def _cache_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._redis is None:
             return None
         try:
@@ -163,17 +164,13 @@ class AgentPromptClient:
 
     # --- Tier 2: MLflow REST API ---
 
-    async def _mlflow_get(
-        self, name: str, tenant_id: Optional[str]
-    ) -> Optional[str]:
+    async def _mlflow_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._http is None:
             return None
         try:
             # Try tenant-specific named prompt first
             if tenant_id:
-                template = await self._fetch_prompt(
-                    f"{name}-tenant-{tenant_id}"
-                )
+                template = await self._fetch_prompt(f"{name}-tenant-{tenant_id}")
                 if template is not None:
                     return template
 
@@ -224,9 +221,7 @@ class AgentPromptClient:
                     )
                     if ver_resp.status_code == 200:
                         ver_data = ver_resp.json()
-                        return ver_data.get("prompt_version", {}).get(
-                            "template"
-                        )
+                        return ver_data.get("prompt_version", {}).get("template")
             return None
         except Exception:
             return None
@@ -234,9 +229,7 @@ class AgentPromptClient:
     # --- Template formatting ---
 
     @staticmethod
-    def _format(
-        template: str, variables: Optional[dict[str, Any]]
-    ) -> str:
+    def _format(template: str, variables: Optional[dict[str, Any]]) -> str:
         if not template or not variables:
             return template
 

--- a/audience-persona-agent-svc/app/prompts/loader.py
+++ b/audience-persona-agent-svc/app/prompts/loader.py
@@ -36,10 +36,12 @@ class AgentPromptClient:
         redis_url: str = "redis://localhost:6379/2",
         mlflow_uri: str = "http://mlflow-server:5000",
         default_ttl: int = 300,
+        critical_agent: bool = False,
     ) -> None:
         self.redis_url = redis_url
         self.mlflow_uri = mlflow_uri
         self.default_ttl = default_ttl
+        self.critical_agent = critical_agent
         self._redis: Optional[aioredis.Redis] = None
         self._http: Optional[httpx.AsyncClient] = None
 
@@ -123,7 +125,16 @@ class AgentPromptClient:
         # Tier 3: Fallback
         if template is None:
             if fallback:
-                logger.debug("Using fallback for prompt '%s'", name)
+                if self.critical_agent:
+                    logger.warning(
+                        "CRITICAL AGENT FALLBACK: prompt '%s' (tenant=%s) "
+                        "— MLflow and Redis both unreachable, using "
+                        "hardcoded fallback. This agent handles ad spend.",
+                        name,
+                        tenant_id,
+                    )
+                else:
+                    logger.debug("Using fallback for prompt '%s'", name)
             template = fallback
 
         return self._format(template, variables)

--- a/audience-persona-agent-svc/app/prompts/loader.py
+++ b/audience-persona-agent-svc/app/prompts/loader.py
@@ -7,7 +7,7 @@ and MLflow tracking server independently of the prompt-optimization-svc.
 Usage in an agent service:
     loader = AgentPromptClient(redis_url="redis://redis:6379/2", mlflow_uri="http://mlflow-server:5000")
     await loader.start()
-    prompt = await loader.load("zorven-wf1-mra-system", tenant_id="t-1", fallback="You are...")
+    prompt = await loader.load("zorven-<wf>-<agent>-system", tenant_id="t-1", fallback="You are...")
     await loader.stop()
 """
 
@@ -129,7 +129,7 @@ class AgentPromptClient:
                     logger.warning(
                         "CRITICAL AGENT FALLBACK: prompt '%s' (tenant=%s) "
                         "— MLflow and Redis both unreachable, using "
-                        "hardcoded fallback. This agent handles ad spend.",
+                        "hardcoded fallback.",
                         name,
                         tenant_id,
                     )

--- a/brand-architecture-agent-svc/app/prompts/invalidator.py
+++ b/brand-architecture-agent-svc/app/prompts/invalidator.py
@@ -50,8 +50,9 @@ class PromptCacheInvalidator:
                 self.TOPIC,
                 self.GROUP_ID,
             )
-        except (Exception, asyncio.TimeoutError) as exc:
+        except Exception as exc:
             logger.warning("PromptCacheInvalidator failed: %s — no-op mode", exc)
+            self._consumer = None
 
     async def stop(self) -> None:
         """Stop the consumer and background task."""
@@ -65,7 +66,7 @@ class PromptCacheInvalidator:
         if self._consumer is not None:
             try:
                 await self._consumer.stop()
-            except (Exception, asyncio.TimeoutError) as exc:
+            except Exception as exc:
                 logger.warning("Error stopping PromptCacheInvalidator: %s", exc)
             self._consumer = None
 
@@ -76,7 +77,7 @@ class PromptCacheInvalidator:
                 await self.handle_event(msg.value)
         except asyncio.CancelledError:
             pass
-        except (Exception, asyncio.TimeoutError) as exc:
+        except Exception as exc:
             logger.error("PromptCacheInvalidator consume error: %s", exc)
 
     async def handle_event(self, event: dict) -> None:
@@ -107,5 +108,5 @@ class PromptCacheInvalidator:
                                 deleted,
                                 prompt_name,
                             )
-                except (Exception, asyncio.TimeoutError) as exc:
+                except Exception as exc:
                     logger.warning("Cache invalidation failed: %s", exc)

--- a/brand-architecture-agent-svc/app/prompts/invalidator.py
+++ b/brand-architecture-agent-svc/app/prompts/invalidator.py
@@ -43,14 +43,14 @@ class PromptCacheInvalidator:
                 auto_offset_reset="latest",
                 value_deserializer=lambda v: json.loads(v.decode("utf-8")),
             )
-            await self._consumer.start()
+            await asyncio.wait_for(self._consumer.start(), timeout=10.0)
             self._task = asyncio.create_task(self._consume_loop())
             logger.info(
                 "PromptCacheInvalidator started (topic=%s, group=%s)",
                 self.TOPIC,
                 self.GROUP_ID,
             )
-        except Exception as exc:
+        except (Exception, asyncio.TimeoutError) as exc:
             logger.warning("PromptCacheInvalidator failed: %s — no-op mode", exc)
 
     async def stop(self) -> None:
@@ -65,7 +65,7 @@ class PromptCacheInvalidator:
         if self._consumer is not None:
             try:
                 await self._consumer.stop()
-            except Exception as exc:
+            except (Exception, asyncio.TimeoutError) as exc:
                 logger.warning("Error stopping PromptCacheInvalidator: %s", exc)
             self._consumer = None
 
@@ -76,7 +76,7 @@ class PromptCacheInvalidator:
                 await self.handle_event(msg.value)
         except asyncio.CancelledError:
             pass
-        except Exception as exc:
+        except (Exception, asyncio.TimeoutError) as exc:
             logger.error("PromptCacheInvalidator consume error: %s", exc)
 
     async def handle_event(self, event: dict) -> None:
@@ -92,9 +92,7 @@ class PromptCacheInvalidator:
                     if r:
                         deleted = 0
                         batch = []
-                        async for key in r.scan_iter(
-                            match=f"prompt:{prompt_name}:*"
-                        ):
+                        async for key in r.scan_iter(match=f"prompt:{prompt_name}:*"):
                             batch.append(key)
                             if len(batch) >= 100:
                                 await r.delete(*batch)
@@ -109,5 +107,5 @@ class PromptCacheInvalidator:
                                 deleted,
                                 prompt_name,
                             )
-                except Exception as exc:
+                except (Exception, asyncio.TimeoutError) as exc:
                     logger.warning("Cache invalidation failed: %s", exc)

--- a/brand-architecture-agent-svc/app/prompts/loader.py
+++ b/brand-architecture-agent-svc/app/prompts/loader.py
@@ -36,10 +36,12 @@ class AgentPromptClient:
         redis_url: str = "redis://localhost:6379/2",
         mlflow_uri: str = "http://mlflow-server:5000",
         default_ttl: int = 300,
+        critical_agent: bool = False,
     ) -> None:
         self.redis_url = redis_url
         self.mlflow_uri = mlflow_uri
         self.default_ttl = default_ttl
+        self.critical_agent = critical_agent
         self._redis: Optional[aioredis.Redis] = None
         self._http: Optional[httpx.AsyncClient] = None
 
@@ -123,7 +125,16 @@ class AgentPromptClient:
         # Tier 3: Fallback
         if template is None:
             if fallback:
-                logger.debug("Using fallback for prompt '%s'", name)
+                if self.critical_agent:
+                    logger.warning(
+                        "CRITICAL AGENT FALLBACK: prompt '%s' (tenant=%s) "
+                        "— MLflow and Redis both unreachable, using "
+                        "hardcoded fallback. This agent handles ad spend.",
+                        name,
+                        tenant_id,
+                    )
+                else:
+                    logger.debug("Using fallback for prompt '%s'", name)
             template = fallback
 
         return self._format(template, variables)

--- a/brand-architecture-agent-svc/app/prompts/loader.py
+++ b/brand-architecture-agent-svc/app/prompts/loader.py
@@ -7,7 +7,7 @@ and MLflow tracking server independently of the prompt-optimization-svc.
 Usage in an agent service:
     loader = AgentPromptClient(redis_url="redis://redis:6379/2", mlflow_uri="http://mlflow-server:5000")
     await loader.start()
-    prompt = await loader.load("zorven-wf1-mra-system", tenant_id="t-1", fallback="You are...")
+    prompt = await loader.load("zorven-<wf>-<agent>-system", tenant_id="t-1", fallback="You are...")
     await loader.stop()
 """
 
@@ -129,7 +129,7 @@ class AgentPromptClient:
                     logger.warning(
                         "CRITICAL AGENT FALLBACK: prompt '%s' (tenant=%s) "
                         "— MLflow and Redis both unreachable, using "
-                        "hardcoded fallback. This agent handles ad spend.",
+                        "hardcoded fallback.",
                         name,
                         tenant_id,
                     )

--- a/brand-architecture-agent-svc/app/prompts/loader.py
+++ b/brand-architecture-agent-svc/app/prompts/loader.py
@@ -7,10 +7,11 @@ and MLflow tracking server independently of the prompt-optimization-svc.
 Usage in an agent service:
     loader = AgentPromptClient(redis_url="redis://redis:6379/2", mlflow_uri="http://mlflow-server:5000")
     await loader.start()
-    prompt = await loader.load("zorven-wf2-<agent>-system", tenant_id="t-1", fallback="You are...")
+    prompt = await loader.load("zorven-wf1-mra-system", tenant_id="t-1", fallback="You are...")
     await loader.stop()
 """
 
+import asyncio
 import logging
 import re
 from typing import Any, Optional
@@ -46,9 +47,11 @@ class AgentPromptClient:
         """Initialize Redis and HTTP connections."""
         try:
             self._redis = aioredis.from_url(
-                self.redis_url, decode_responses=True
+                self.redis_url,
+                decode_responses=True,
+                socket_connect_timeout=5,
             )
-            await self._redis.ping()
+            await asyncio.wait_for(self._redis.ping(), timeout=5.0)
             logger.info("Prompt cache connected: %s", self.redis_url)
         except Exception as exc:
             logger.warning("Prompt cache unavailable: %s", exc)
@@ -56,9 +59,7 @@ class AgentPromptClient:
 
         if self.mlflow_uri:
             try:
-                self._http = httpx.AsyncClient(
-                    base_url=self.mlflow_uri, timeout=5.0
-                )
+                self._http = httpx.AsyncClient(base_url=self.mlflow_uri, timeout=5.0)
                 resp = await self._http.get("/health")
                 if resp.status_code == 200:
                     logger.info("MLflow connected: %s", self.mlflow_uri)
@@ -72,7 +73,9 @@ class AgentPromptClient:
                     await self._http.aclose()
                 self._http = None
         else:
-            logger.info("MLflow URI not configured — prompt loader in fallback-only mode")
+            logger.info(
+                "MLflow URI not configured — prompt loader in fallback-only mode"
+            )
 
         logger.info("Prompt loader initialized")
 
@@ -127,9 +130,7 @@ class AgentPromptClient:
 
     # --- Tier 1: Redis cache ---
 
-    async def _cache_get(
-        self, name: str, tenant_id: Optional[str]
-    ) -> Optional[str]:
+    async def _cache_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._redis is None:
             return None
         try:
@@ -163,17 +164,13 @@ class AgentPromptClient:
 
     # --- Tier 2: MLflow REST API ---
 
-    async def _mlflow_get(
-        self, name: str, tenant_id: Optional[str]
-    ) -> Optional[str]:
+    async def _mlflow_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._http is None:
             return None
         try:
             # Try tenant-specific named prompt first
             if tenant_id:
-                template = await self._fetch_prompt(
-                    f"{name}-tenant-{tenant_id}"
-                )
+                template = await self._fetch_prompt(f"{name}-tenant-{tenant_id}")
                 if template is not None:
                     return template
 
@@ -224,9 +221,7 @@ class AgentPromptClient:
                     )
                     if ver_resp.status_code == 200:
                         ver_data = ver_resp.json()
-                        return ver_data.get("prompt_version", {}).get(
-                            "template"
-                        )
+                        return ver_data.get("prompt_version", {}).get("template")
             return None
         except Exception:
             return None
@@ -234,9 +229,7 @@ class AgentPromptClient:
     # --- Template formatting ---
 
     @staticmethod
-    def _format(
-        template: str, variables: Optional[dict[str, Any]]
-    ) -> str:
+    def _format(template: str, variables: Optional[dict[str, Any]]) -> str:
         if not template or not variables:
             return template
 

--- a/brand-naming-agent-svc/app/prompts/invalidator.py
+++ b/brand-naming-agent-svc/app/prompts/invalidator.py
@@ -50,8 +50,9 @@ class PromptCacheInvalidator:
                 self.TOPIC,
                 self.GROUP_ID,
             )
-        except (Exception, asyncio.TimeoutError) as exc:
+        except Exception as exc:
             logger.warning("PromptCacheInvalidator failed: %s — no-op mode", exc)
+            self._consumer = None
 
     async def stop(self) -> None:
         """Stop the consumer and background task."""
@@ -65,7 +66,7 @@ class PromptCacheInvalidator:
         if self._consumer is not None:
             try:
                 await self._consumer.stop()
-            except (Exception, asyncio.TimeoutError) as exc:
+            except Exception as exc:
                 logger.warning("Error stopping PromptCacheInvalidator: %s", exc)
             self._consumer = None
 
@@ -76,7 +77,7 @@ class PromptCacheInvalidator:
                 await self.handle_event(msg.value)
         except asyncio.CancelledError:
             pass
-        except (Exception, asyncio.TimeoutError) as exc:
+        except Exception as exc:
             logger.error("PromptCacheInvalidator consume error: %s", exc)
 
     async def handle_event(self, event: dict) -> None:
@@ -107,5 +108,5 @@ class PromptCacheInvalidator:
                                 deleted,
                                 prompt_name,
                             )
-                except (Exception, asyncio.TimeoutError) as exc:
+                except Exception as exc:
                     logger.warning("Cache invalidation failed: %s", exc)

--- a/brand-naming-agent-svc/app/prompts/invalidator.py
+++ b/brand-naming-agent-svc/app/prompts/invalidator.py
@@ -43,14 +43,14 @@ class PromptCacheInvalidator:
                 auto_offset_reset="latest",
                 value_deserializer=lambda v: json.loads(v.decode("utf-8")),
             )
-            await self._consumer.start()
+            await asyncio.wait_for(self._consumer.start(), timeout=10.0)
             self._task = asyncio.create_task(self._consume_loop())
             logger.info(
                 "PromptCacheInvalidator started (topic=%s, group=%s)",
                 self.TOPIC,
                 self.GROUP_ID,
             )
-        except Exception as exc:
+        except (Exception, asyncio.TimeoutError) as exc:
             logger.warning("PromptCacheInvalidator failed: %s — no-op mode", exc)
 
     async def stop(self) -> None:
@@ -65,7 +65,7 @@ class PromptCacheInvalidator:
         if self._consumer is not None:
             try:
                 await self._consumer.stop()
-            except Exception as exc:
+            except (Exception, asyncio.TimeoutError) as exc:
                 logger.warning("Error stopping PromptCacheInvalidator: %s", exc)
             self._consumer = None
 
@@ -76,7 +76,7 @@ class PromptCacheInvalidator:
                 await self.handle_event(msg.value)
         except asyncio.CancelledError:
             pass
-        except Exception as exc:
+        except (Exception, asyncio.TimeoutError) as exc:
             logger.error("PromptCacheInvalidator consume error: %s", exc)
 
     async def handle_event(self, event: dict) -> None:
@@ -92,9 +92,7 @@ class PromptCacheInvalidator:
                     if r:
                         deleted = 0
                         batch = []
-                        async for key in r.scan_iter(
-                            match=f"prompt:{prompt_name}:*"
-                        ):
+                        async for key in r.scan_iter(match=f"prompt:{prompt_name}:*"):
                             batch.append(key)
                             if len(batch) >= 100:
                                 await r.delete(*batch)
@@ -109,5 +107,5 @@ class PromptCacheInvalidator:
                                 deleted,
                                 prompt_name,
                             )
-                except Exception as exc:
+                except (Exception, asyncio.TimeoutError) as exc:
                     logger.warning("Cache invalidation failed: %s", exc)

--- a/brand-naming-agent-svc/app/prompts/loader.py
+++ b/brand-naming-agent-svc/app/prompts/loader.py
@@ -36,10 +36,12 @@ class AgentPromptClient:
         redis_url: str = "redis://localhost:6379/2",
         mlflow_uri: str = "http://mlflow-server:5000",
         default_ttl: int = 300,
+        critical_agent: bool = False,
     ) -> None:
         self.redis_url = redis_url
         self.mlflow_uri = mlflow_uri
         self.default_ttl = default_ttl
+        self.critical_agent = critical_agent
         self._redis: Optional[aioredis.Redis] = None
         self._http: Optional[httpx.AsyncClient] = None
 
@@ -123,7 +125,16 @@ class AgentPromptClient:
         # Tier 3: Fallback
         if template is None:
             if fallback:
-                logger.debug("Using fallback for prompt '%s'", name)
+                if self.critical_agent:
+                    logger.warning(
+                        "CRITICAL AGENT FALLBACK: prompt '%s' (tenant=%s) "
+                        "— MLflow and Redis both unreachable, using "
+                        "hardcoded fallback. This agent handles ad spend.",
+                        name,
+                        tenant_id,
+                    )
+                else:
+                    logger.debug("Using fallback for prompt '%s'", name)
             template = fallback
 
         return self._format(template, variables)

--- a/brand-naming-agent-svc/app/prompts/loader.py
+++ b/brand-naming-agent-svc/app/prompts/loader.py
@@ -7,7 +7,7 @@ and MLflow tracking server independently of the prompt-optimization-svc.
 Usage in an agent service:
     loader = AgentPromptClient(redis_url="redis://redis:6379/2", mlflow_uri="http://mlflow-server:5000")
     await loader.start()
-    prompt = await loader.load("zorven-wf1-mra-system", tenant_id="t-1", fallback="You are...")
+    prompt = await loader.load("zorven-<wf>-<agent>-system", tenant_id="t-1", fallback="You are...")
     await loader.stop()
 """
 
@@ -129,7 +129,7 @@ class AgentPromptClient:
                     logger.warning(
                         "CRITICAL AGENT FALLBACK: prompt '%s' (tenant=%s) "
                         "— MLflow and Redis both unreachable, using "
-                        "hardcoded fallback. This agent handles ad spend.",
+                        "hardcoded fallback.",
                         name,
                         tenant_id,
                     )

--- a/brand-naming-agent-svc/app/prompts/loader.py
+++ b/brand-naming-agent-svc/app/prompts/loader.py
@@ -7,10 +7,11 @@ and MLflow tracking server independently of the prompt-optimization-svc.
 Usage in an agent service:
     loader = AgentPromptClient(redis_url="redis://redis:6379/2", mlflow_uri="http://mlflow-server:5000")
     await loader.start()
-    prompt = await loader.load("zorven-wf2-<agent>-system", tenant_id="t-1", fallback="You are...")
+    prompt = await loader.load("zorven-wf1-mra-system", tenant_id="t-1", fallback="You are...")
     await loader.stop()
 """
 
+import asyncio
 import logging
 import re
 from typing import Any, Optional
@@ -46,9 +47,11 @@ class AgentPromptClient:
         """Initialize Redis and HTTP connections."""
         try:
             self._redis = aioredis.from_url(
-                self.redis_url, decode_responses=True
+                self.redis_url,
+                decode_responses=True,
+                socket_connect_timeout=5,
             )
-            await self._redis.ping()
+            await asyncio.wait_for(self._redis.ping(), timeout=5.0)
             logger.info("Prompt cache connected: %s", self.redis_url)
         except Exception as exc:
             logger.warning("Prompt cache unavailable: %s", exc)
@@ -56,9 +59,7 @@ class AgentPromptClient:
 
         if self.mlflow_uri:
             try:
-                self._http = httpx.AsyncClient(
-                    base_url=self.mlflow_uri, timeout=5.0
-                )
+                self._http = httpx.AsyncClient(base_url=self.mlflow_uri, timeout=5.0)
                 resp = await self._http.get("/health")
                 if resp.status_code == 200:
                     logger.info("MLflow connected: %s", self.mlflow_uri)
@@ -72,7 +73,9 @@ class AgentPromptClient:
                     await self._http.aclose()
                 self._http = None
         else:
-            logger.info("MLflow URI not configured — prompt loader in fallback-only mode")
+            logger.info(
+                "MLflow URI not configured — prompt loader in fallback-only mode"
+            )
 
         logger.info("Prompt loader initialized")
 
@@ -127,9 +130,7 @@ class AgentPromptClient:
 
     # --- Tier 1: Redis cache ---
 
-    async def _cache_get(
-        self, name: str, tenant_id: Optional[str]
-    ) -> Optional[str]:
+    async def _cache_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._redis is None:
             return None
         try:
@@ -163,17 +164,13 @@ class AgentPromptClient:
 
     # --- Tier 2: MLflow REST API ---
 
-    async def _mlflow_get(
-        self, name: str, tenant_id: Optional[str]
-    ) -> Optional[str]:
+    async def _mlflow_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._http is None:
             return None
         try:
             # Try tenant-specific named prompt first
             if tenant_id:
-                template = await self._fetch_prompt(
-                    f"{name}-tenant-{tenant_id}"
-                )
+                template = await self._fetch_prompt(f"{name}-tenant-{tenant_id}")
                 if template is not None:
                     return template
 
@@ -224,9 +221,7 @@ class AgentPromptClient:
                     )
                     if ver_resp.status_code == 200:
                         ver_data = ver_resp.json()
-                        return ver_data.get("prompt_version", {}).get(
-                            "template"
-                        )
+                        return ver_data.get("prompt_version", {}).get("template")
             return None
         except Exception:
             return None
@@ -234,9 +229,7 @@ class AgentPromptClient:
     # --- Template formatting ---
 
     @staticmethod
-    def _format(
-        template: str, variables: Optional[dict[str, Any]]
-    ) -> str:
+    def _format(template: str, variables: Optional[dict[str, Any]]) -> str:
         if not template or not variables:
             return template
 

--- a/brand-personality-agent-svc/app/prompts/invalidator.py
+++ b/brand-personality-agent-svc/app/prompts/invalidator.py
@@ -50,8 +50,9 @@ class PromptCacheInvalidator:
                 self.TOPIC,
                 self.GROUP_ID,
             )
-        except (Exception, asyncio.TimeoutError) as exc:
+        except Exception as exc:
             logger.warning("PromptCacheInvalidator failed: %s — no-op mode", exc)
+            self._consumer = None
 
     async def stop(self) -> None:
         """Stop the consumer and background task."""
@@ -65,7 +66,7 @@ class PromptCacheInvalidator:
         if self._consumer is not None:
             try:
                 await self._consumer.stop()
-            except (Exception, asyncio.TimeoutError) as exc:
+            except Exception as exc:
                 logger.warning("Error stopping PromptCacheInvalidator: %s", exc)
             self._consumer = None
 
@@ -76,7 +77,7 @@ class PromptCacheInvalidator:
                 await self.handle_event(msg.value)
         except asyncio.CancelledError:
             pass
-        except (Exception, asyncio.TimeoutError) as exc:
+        except Exception as exc:
             logger.error("PromptCacheInvalidator consume error: %s", exc)
 
     async def handle_event(self, event: dict) -> None:
@@ -107,5 +108,5 @@ class PromptCacheInvalidator:
                                 deleted,
                                 prompt_name,
                             )
-                except (Exception, asyncio.TimeoutError) as exc:
+                except Exception as exc:
                     logger.warning("Cache invalidation failed: %s", exc)

--- a/brand-personality-agent-svc/app/prompts/invalidator.py
+++ b/brand-personality-agent-svc/app/prompts/invalidator.py
@@ -43,14 +43,14 @@ class PromptCacheInvalidator:
                 auto_offset_reset="latest",
                 value_deserializer=lambda v: json.loads(v.decode("utf-8")),
             )
-            await self._consumer.start()
+            await asyncio.wait_for(self._consumer.start(), timeout=10.0)
             self._task = asyncio.create_task(self._consume_loop())
             logger.info(
                 "PromptCacheInvalidator started (topic=%s, group=%s)",
                 self.TOPIC,
                 self.GROUP_ID,
             )
-        except Exception as exc:
+        except (Exception, asyncio.TimeoutError) as exc:
             logger.warning("PromptCacheInvalidator failed: %s — no-op mode", exc)
 
     async def stop(self) -> None:
@@ -65,7 +65,7 @@ class PromptCacheInvalidator:
         if self._consumer is not None:
             try:
                 await self._consumer.stop()
-            except Exception as exc:
+            except (Exception, asyncio.TimeoutError) as exc:
                 logger.warning("Error stopping PromptCacheInvalidator: %s", exc)
             self._consumer = None
 
@@ -76,7 +76,7 @@ class PromptCacheInvalidator:
                 await self.handle_event(msg.value)
         except asyncio.CancelledError:
             pass
-        except Exception as exc:
+        except (Exception, asyncio.TimeoutError) as exc:
             logger.error("PromptCacheInvalidator consume error: %s", exc)
 
     async def handle_event(self, event: dict) -> None:
@@ -92,9 +92,7 @@ class PromptCacheInvalidator:
                     if r:
                         deleted = 0
                         batch = []
-                        async for key in r.scan_iter(
-                            match=f"prompt:{prompt_name}:*"
-                        ):
+                        async for key in r.scan_iter(match=f"prompt:{prompt_name}:*"):
                             batch.append(key)
                             if len(batch) >= 100:
                                 await r.delete(*batch)
@@ -109,5 +107,5 @@ class PromptCacheInvalidator:
                                 deleted,
                                 prompt_name,
                             )
-                except Exception as exc:
+                except (Exception, asyncio.TimeoutError) as exc:
                     logger.warning("Cache invalidation failed: %s", exc)

--- a/brand-personality-agent-svc/app/prompts/loader.py
+++ b/brand-personality-agent-svc/app/prompts/loader.py
@@ -36,10 +36,12 @@ class AgentPromptClient:
         redis_url: str = "redis://localhost:6379/2",
         mlflow_uri: str = "http://mlflow-server:5000",
         default_ttl: int = 300,
+        critical_agent: bool = False,
     ) -> None:
         self.redis_url = redis_url
         self.mlflow_uri = mlflow_uri
         self.default_ttl = default_ttl
+        self.critical_agent = critical_agent
         self._redis: Optional[aioredis.Redis] = None
         self._http: Optional[httpx.AsyncClient] = None
 
@@ -123,7 +125,16 @@ class AgentPromptClient:
         # Tier 3: Fallback
         if template is None:
             if fallback:
-                logger.debug("Using fallback for prompt '%s'", name)
+                if self.critical_agent:
+                    logger.warning(
+                        "CRITICAL AGENT FALLBACK: prompt '%s' (tenant=%s) "
+                        "— MLflow and Redis both unreachable, using "
+                        "hardcoded fallback. This agent handles ad spend.",
+                        name,
+                        tenant_id,
+                    )
+                else:
+                    logger.debug("Using fallback for prompt '%s'", name)
             template = fallback
 
         return self._format(template, variables)

--- a/brand-personality-agent-svc/app/prompts/loader.py
+++ b/brand-personality-agent-svc/app/prompts/loader.py
@@ -7,7 +7,7 @@ and MLflow tracking server independently of the prompt-optimization-svc.
 Usage in an agent service:
     loader = AgentPromptClient(redis_url="redis://redis:6379/2", mlflow_uri="http://mlflow-server:5000")
     await loader.start()
-    prompt = await loader.load("zorven-wf1-mra-system", tenant_id="t-1", fallback="You are...")
+    prompt = await loader.load("zorven-<wf>-<agent>-system", tenant_id="t-1", fallback="You are...")
     await loader.stop()
 """
 
@@ -129,7 +129,7 @@ class AgentPromptClient:
                     logger.warning(
                         "CRITICAL AGENT FALLBACK: prompt '%s' (tenant=%s) "
                         "— MLflow and Redis both unreachable, using "
-                        "hardcoded fallback. This agent handles ad spend.",
+                        "hardcoded fallback.",
                         name,
                         tenant_id,
                     )

--- a/brand-personality-agent-svc/app/prompts/loader.py
+++ b/brand-personality-agent-svc/app/prompts/loader.py
@@ -7,10 +7,11 @@ and MLflow tracking server independently of the prompt-optimization-svc.
 Usage in an agent service:
     loader = AgentPromptClient(redis_url="redis://redis:6379/2", mlflow_uri="http://mlflow-server:5000")
     await loader.start()
-    prompt = await loader.load("zorven-wf2-<agent>-system", tenant_id="t-1", fallback="You are...")
+    prompt = await loader.load("zorven-wf1-mra-system", tenant_id="t-1", fallback="You are...")
     await loader.stop()
 """
 
+import asyncio
 import logging
 import re
 from typing import Any, Optional
@@ -46,9 +47,11 @@ class AgentPromptClient:
         """Initialize Redis and HTTP connections."""
         try:
             self._redis = aioredis.from_url(
-                self.redis_url, decode_responses=True
+                self.redis_url,
+                decode_responses=True,
+                socket_connect_timeout=5,
             )
-            await self._redis.ping()
+            await asyncio.wait_for(self._redis.ping(), timeout=5.0)
             logger.info("Prompt cache connected: %s", self.redis_url)
         except Exception as exc:
             logger.warning("Prompt cache unavailable: %s", exc)
@@ -56,9 +59,7 @@ class AgentPromptClient:
 
         if self.mlflow_uri:
             try:
-                self._http = httpx.AsyncClient(
-                    base_url=self.mlflow_uri, timeout=5.0
-                )
+                self._http = httpx.AsyncClient(base_url=self.mlflow_uri, timeout=5.0)
                 resp = await self._http.get("/health")
                 if resp.status_code == 200:
                     logger.info("MLflow connected: %s", self.mlflow_uri)
@@ -72,7 +73,9 @@ class AgentPromptClient:
                     await self._http.aclose()
                 self._http = None
         else:
-            logger.info("MLflow URI not configured — prompt loader in fallback-only mode")
+            logger.info(
+                "MLflow URI not configured — prompt loader in fallback-only mode"
+            )
 
         logger.info("Prompt loader initialized")
 
@@ -127,9 +130,7 @@ class AgentPromptClient:
 
     # --- Tier 1: Redis cache ---
 
-    async def _cache_get(
-        self, name: str, tenant_id: Optional[str]
-    ) -> Optional[str]:
+    async def _cache_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._redis is None:
             return None
         try:
@@ -163,17 +164,13 @@ class AgentPromptClient:
 
     # --- Tier 2: MLflow REST API ---
 
-    async def _mlflow_get(
-        self, name: str, tenant_id: Optional[str]
-    ) -> Optional[str]:
+    async def _mlflow_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._http is None:
             return None
         try:
             # Try tenant-specific named prompt first
             if tenant_id:
-                template = await self._fetch_prompt(
-                    f"{name}-tenant-{tenant_id}"
-                )
+                template = await self._fetch_prompt(f"{name}-tenant-{tenant_id}")
                 if template is not None:
                     return template
 
@@ -224,9 +221,7 @@ class AgentPromptClient:
                     )
                     if ver_resp.status_code == 200:
                         ver_data = ver_resp.json()
-                        return ver_data.get("prompt_version", {}).get(
-                            "template"
-                        )
+                        return ver_data.get("prompt_version", {}).get("template")
             return None
         except Exception:
             return None
@@ -234,9 +229,7 @@ class AgentPromptClient:
     # --- Template formatting ---
 
     @staticmethod
-    def _format(
-        template: str, variables: Optional[dict[str, Any]]
-    ) -> str:
+    def _format(template: str, variables: Optional[dict[str, Any]]) -> str:
         if not template or not variables:
             return template
 

--- a/brand-positioning-agent-svc/app/prompts/invalidator.py
+++ b/brand-positioning-agent-svc/app/prompts/invalidator.py
@@ -50,8 +50,9 @@ class PromptCacheInvalidator:
                 self.TOPIC,
                 self.GROUP_ID,
             )
-        except (Exception, asyncio.TimeoutError) as exc:
+        except Exception as exc:
             logger.warning("PromptCacheInvalidator failed: %s — no-op mode", exc)
+            self._consumer = None
 
     async def stop(self) -> None:
         """Stop the consumer and background task."""
@@ -65,7 +66,7 @@ class PromptCacheInvalidator:
         if self._consumer is not None:
             try:
                 await self._consumer.stop()
-            except (Exception, asyncio.TimeoutError) as exc:
+            except Exception as exc:
                 logger.warning("Error stopping PromptCacheInvalidator: %s", exc)
             self._consumer = None
 
@@ -76,7 +77,7 @@ class PromptCacheInvalidator:
                 await self.handle_event(msg.value)
         except asyncio.CancelledError:
             pass
-        except (Exception, asyncio.TimeoutError) as exc:
+        except Exception as exc:
             logger.error("PromptCacheInvalidator consume error: %s", exc)
 
     async def handle_event(self, event: dict) -> None:
@@ -107,5 +108,5 @@ class PromptCacheInvalidator:
                                 deleted,
                                 prompt_name,
                             )
-                except (Exception, asyncio.TimeoutError) as exc:
+                except Exception as exc:
                     logger.warning("Cache invalidation failed: %s", exc)

--- a/brand-positioning-agent-svc/app/prompts/invalidator.py
+++ b/brand-positioning-agent-svc/app/prompts/invalidator.py
@@ -43,14 +43,14 @@ class PromptCacheInvalidator:
                 auto_offset_reset="latest",
                 value_deserializer=lambda v: json.loads(v.decode("utf-8")),
             )
-            await self._consumer.start()
+            await asyncio.wait_for(self._consumer.start(), timeout=10.0)
             self._task = asyncio.create_task(self._consume_loop())
             logger.info(
                 "PromptCacheInvalidator started (topic=%s, group=%s)",
                 self.TOPIC,
                 self.GROUP_ID,
             )
-        except Exception as exc:
+        except (Exception, asyncio.TimeoutError) as exc:
             logger.warning("PromptCacheInvalidator failed: %s — no-op mode", exc)
 
     async def stop(self) -> None:
@@ -65,7 +65,7 @@ class PromptCacheInvalidator:
         if self._consumer is not None:
             try:
                 await self._consumer.stop()
-            except Exception as exc:
+            except (Exception, asyncio.TimeoutError) as exc:
                 logger.warning("Error stopping PromptCacheInvalidator: %s", exc)
             self._consumer = None
 
@@ -76,7 +76,7 @@ class PromptCacheInvalidator:
                 await self.handle_event(msg.value)
         except asyncio.CancelledError:
             pass
-        except Exception as exc:
+        except (Exception, asyncio.TimeoutError) as exc:
             logger.error("PromptCacheInvalidator consume error: %s", exc)
 
     async def handle_event(self, event: dict) -> None:
@@ -92,9 +92,7 @@ class PromptCacheInvalidator:
                     if r:
                         deleted = 0
                         batch = []
-                        async for key in r.scan_iter(
-                            match=f"prompt:{prompt_name}:*"
-                        ):
+                        async for key in r.scan_iter(match=f"prompt:{prompt_name}:*"):
                             batch.append(key)
                             if len(batch) >= 100:
                                 await r.delete(*batch)
@@ -109,5 +107,5 @@ class PromptCacheInvalidator:
                                 deleted,
                                 prompt_name,
                             )
-                except Exception as exc:
+                except (Exception, asyncio.TimeoutError) as exc:
                     logger.warning("Cache invalidation failed: %s", exc)

--- a/brand-positioning-agent-svc/app/prompts/loader.py
+++ b/brand-positioning-agent-svc/app/prompts/loader.py
@@ -36,10 +36,12 @@ class AgentPromptClient:
         redis_url: str = "redis://localhost:6379/2",
         mlflow_uri: str = "http://mlflow-server:5000",
         default_ttl: int = 300,
+        critical_agent: bool = False,
     ) -> None:
         self.redis_url = redis_url
         self.mlflow_uri = mlflow_uri
         self.default_ttl = default_ttl
+        self.critical_agent = critical_agent
         self._redis: Optional[aioredis.Redis] = None
         self._http: Optional[httpx.AsyncClient] = None
 
@@ -123,7 +125,16 @@ class AgentPromptClient:
         # Tier 3: Fallback
         if template is None:
             if fallback:
-                logger.debug("Using fallback for prompt '%s'", name)
+                if self.critical_agent:
+                    logger.warning(
+                        "CRITICAL AGENT FALLBACK: prompt '%s' (tenant=%s) "
+                        "— MLflow and Redis both unreachable, using "
+                        "hardcoded fallback. This agent handles ad spend.",
+                        name,
+                        tenant_id,
+                    )
+                else:
+                    logger.debug("Using fallback for prompt '%s'", name)
             template = fallback
 
         return self._format(template, variables)

--- a/brand-positioning-agent-svc/app/prompts/loader.py
+++ b/brand-positioning-agent-svc/app/prompts/loader.py
@@ -7,7 +7,7 @@ and MLflow tracking server independently of the prompt-optimization-svc.
 Usage in an agent service:
     loader = AgentPromptClient(redis_url="redis://redis:6379/2", mlflow_uri="http://mlflow-server:5000")
     await loader.start()
-    prompt = await loader.load("zorven-wf1-mra-system", tenant_id="t-1", fallback="You are...")
+    prompt = await loader.load("zorven-<wf>-<agent>-system", tenant_id="t-1", fallback="You are...")
     await loader.stop()
 """
 
@@ -129,7 +129,7 @@ class AgentPromptClient:
                     logger.warning(
                         "CRITICAL AGENT FALLBACK: prompt '%s' (tenant=%s) "
                         "— MLflow and Redis both unreachable, using "
-                        "hardcoded fallback. This agent handles ad spend.",
+                        "hardcoded fallback.",
                         name,
                         tenant_id,
                     )

--- a/brand-positioning-agent-svc/app/prompts/loader.py
+++ b/brand-positioning-agent-svc/app/prompts/loader.py
@@ -7,10 +7,11 @@ and MLflow tracking server independently of the prompt-optimization-svc.
 Usage in an agent service:
     loader = AgentPromptClient(redis_url="redis://redis:6379/2", mlflow_uri="http://mlflow-server:5000")
     await loader.start()
-    prompt = await loader.load("zorven-wf2-<agent>-system", tenant_id="t-1", fallback="You are...")
+    prompt = await loader.load("zorven-wf1-mra-system", tenant_id="t-1", fallback="You are...")
     await loader.stop()
 """
 
+import asyncio
 import logging
 import re
 from typing import Any, Optional
@@ -46,9 +47,11 @@ class AgentPromptClient:
         """Initialize Redis and HTTP connections."""
         try:
             self._redis = aioredis.from_url(
-                self.redis_url, decode_responses=True
+                self.redis_url,
+                decode_responses=True,
+                socket_connect_timeout=5,
             )
-            await self._redis.ping()
+            await asyncio.wait_for(self._redis.ping(), timeout=5.0)
             logger.info("Prompt cache connected: %s", self.redis_url)
         except Exception as exc:
             logger.warning("Prompt cache unavailable: %s", exc)
@@ -56,9 +59,7 @@ class AgentPromptClient:
 
         if self.mlflow_uri:
             try:
-                self._http = httpx.AsyncClient(
-                    base_url=self.mlflow_uri, timeout=5.0
-                )
+                self._http = httpx.AsyncClient(base_url=self.mlflow_uri, timeout=5.0)
                 resp = await self._http.get("/health")
                 if resp.status_code == 200:
                     logger.info("MLflow connected: %s", self.mlflow_uri)
@@ -72,7 +73,9 @@ class AgentPromptClient:
                     await self._http.aclose()
                 self._http = None
         else:
-            logger.info("MLflow URI not configured — prompt loader in fallback-only mode")
+            logger.info(
+                "MLflow URI not configured — prompt loader in fallback-only mode"
+            )
 
         logger.info("Prompt loader initialized")
 
@@ -127,9 +130,7 @@ class AgentPromptClient:
 
     # --- Tier 1: Redis cache ---
 
-    async def _cache_get(
-        self, name: str, tenant_id: Optional[str]
-    ) -> Optional[str]:
+    async def _cache_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._redis is None:
             return None
         try:
@@ -163,17 +164,13 @@ class AgentPromptClient:
 
     # --- Tier 2: MLflow REST API ---
 
-    async def _mlflow_get(
-        self, name: str, tenant_id: Optional[str]
-    ) -> Optional[str]:
+    async def _mlflow_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._http is None:
             return None
         try:
             # Try tenant-specific named prompt first
             if tenant_id:
-                template = await self._fetch_prompt(
-                    f"{name}-tenant-{tenant_id}"
-                )
+                template = await self._fetch_prompt(f"{name}-tenant-{tenant_id}")
                 if template is not None:
                     return template
 
@@ -224,9 +221,7 @@ class AgentPromptClient:
                     )
                     if ver_resp.status_code == 200:
                         ver_data = ver_resp.json()
-                        return ver_data.get("prompt_version", {}).get(
-                            "template"
-                        )
+                        return ver_data.get("prompt_version", {}).get("template")
             return None
         except Exception:
             return None
@@ -234,9 +229,7 @@ class AgentPromptClient:
     # --- Template formatting ---
 
     @staticmethod
-    def _format(
-        template: str, variables: Optional[dict[str, Any]]
-    ) -> str:
+    def _format(template: str, variables: Optional[dict[str, Any]]) -> str:
         if not template or not variables:
             return template
 

--- a/brand-story-agent-svc/app/prompts/invalidator.py
+++ b/brand-story-agent-svc/app/prompts/invalidator.py
@@ -50,8 +50,9 @@ class PromptCacheInvalidator:
                 self.TOPIC,
                 self.GROUP_ID,
             )
-        except (Exception, asyncio.TimeoutError) as exc:
+        except Exception as exc:
             logger.warning("PromptCacheInvalidator failed: %s — no-op mode", exc)
+            self._consumer = None
 
     async def stop(self) -> None:
         """Stop the consumer and background task."""
@@ -65,7 +66,7 @@ class PromptCacheInvalidator:
         if self._consumer is not None:
             try:
                 await self._consumer.stop()
-            except (Exception, asyncio.TimeoutError) as exc:
+            except Exception as exc:
                 logger.warning("Error stopping PromptCacheInvalidator: %s", exc)
             self._consumer = None
 
@@ -76,7 +77,7 @@ class PromptCacheInvalidator:
                 await self.handle_event(msg.value)
         except asyncio.CancelledError:
             pass
-        except (Exception, asyncio.TimeoutError) as exc:
+        except Exception as exc:
             logger.error("PromptCacheInvalidator consume error: %s", exc)
 
     async def handle_event(self, event: dict) -> None:
@@ -107,5 +108,5 @@ class PromptCacheInvalidator:
                                 deleted,
                                 prompt_name,
                             )
-                except (Exception, asyncio.TimeoutError) as exc:
+                except Exception as exc:
                     logger.warning("Cache invalidation failed: %s", exc)

--- a/brand-story-agent-svc/app/prompts/invalidator.py
+++ b/brand-story-agent-svc/app/prompts/invalidator.py
@@ -43,14 +43,14 @@ class PromptCacheInvalidator:
                 auto_offset_reset="latest",
                 value_deserializer=lambda v: json.loads(v.decode("utf-8")),
             )
-            await self._consumer.start()
+            await asyncio.wait_for(self._consumer.start(), timeout=10.0)
             self._task = asyncio.create_task(self._consume_loop())
             logger.info(
                 "PromptCacheInvalidator started (topic=%s, group=%s)",
                 self.TOPIC,
                 self.GROUP_ID,
             )
-        except Exception as exc:
+        except (Exception, asyncio.TimeoutError) as exc:
             logger.warning("PromptCacheInvalidator failed: %s — no-op mode", exc)
 
     async def stop(self) -> None:
@@ -65,7 +65,7 @@ class PromptCacheInvalidator:
         if self._consumer is not None:
             try:
                 await self._consumer.stop()
-            except Exception as exc:
+            except (Exception, asyncio.TimeoutError) as exc:
                 logger.warning("Error stopping PromptCacheInvalidator: %s", exc)
             self._consumer = None
 
@@ -76,7 +76,7 @@ class PromptCacheInvalidator:
                 await self.handle_event(msg.value)
         except asyncio.CancelledError:
             pass
-        except Exception as exc:
+        except (Exception, asyncio.TimeoutError) as exc:
             logger.error("PromptCacheInvalidator consume error: %s", exc)
 
     async def handle_event(self, event: dict) -> None:
@@ -92,9 +92,7 @@ class PromptCacheInvalidator:
                     if r:
                         deleted = 0
                         batch = []
-                        async for key in r.scan_iter(
-                            match=f"prompt:{prompt_name}:*"
-                        ):
+                        async for key in r.scan_iter(match=f"prompt:{prompt_name}:*"):
                             batch.append(key)
                             if len(batch) >= 100:
                                 await r.delete(*batch)
@@ -109,5 +107,5 @@ class PromptCacheInvalidator:
                                 deleted,
                                 prompt_name,
                             )
-                except Exception as exc:
+                except (Exception, asyncio.TimeoutError) as exc:
                     logger.warning("Cache invalidation failed: %s", exc)

--- a/brand-story-agent-svc/app/prompts/loader.py
+++ b/brand-story-agent-svc/app/prompts/loader.py
@@ -36,10 +36,12 @@ class AgentPromptClient:
         redis_url: str = "redis://localhost:6379/2",
         mlflow_uri: str = "http://mlflow-server:5000",
         default_ttl: int = 300,
+        critical_agent: bool = False,
     ) -> None:
         self.redis_url = redis_url
         self.mlflow_uri = mlflow_uri
         self.default_ttl = default_ttl
+        self.critical_agent = critical_agent
         self._redis: Optional[aioredis.Redis] = None
         self._http: Optional[httpx.AsyncClient] = None
 
@@ -123,7 +125,16 @@ class AgentPromptClient:
         # Tier 3: Fallback
         if template is None:
             if fallback:
-                logger.debug("Using fallback for prompt '%s'", name)
+                if self.critical_agent:
+                    logger.warning(
+                        "CRITICAL AGENT FALLBACK: prompt '%s' (tenant=%s) "
+                        "— MLflow and Redis both unreachable, using "
+                        "hardcoded fallback. This agent handles ad spend.",
+                        name,
+                        tenant_id,
+                    )
+                else:
+                    logger.debug("Using fallback for prompt '%s'", name)
             template = fallback
 
         return self._format(template, variables)

--- a/brand-story-agent-svc/app/prompts/loader.py
+++ b/brand-story-agent-svc/app/prompts/loader.py
@@ -7,7 +7,7 @@ and MLflow tracking server independently of the prompt-optimization-svc.
 Usage in an agent service:
     loader = AgentPromptClient(redis_url="redis://redis:6379/2", mlflow_uri="http://mlflow-server:5000")
     await loader.start()
-    prompt = await loader.load("zorven-wf1-mra-system", tenant_id="t-1", fallback="You are...")
+    prompt = await loader.load("zorven-<wf>-<agent>-system", tenant_id="t-1", fallback="You are...")
     await loader.stop()
 """
 
@@ -129,7 +129,7 @@ class AgentPromptClient:
                     logger.warning(
                         "CRITICAL AGENT FALLBACK: prompt '%s' (tenant=%s) "
                         "— MLflow and Redis both unreachable, using "
-                        "hardcoded fallback. This agent handles ad spend.",
+                        "hardcoded fallback.",
                         name,
                         tenant_id,
                     )

--- a/brand-story-agent-svc/app/prompts/loader.py
+++ b/brand-story-agent-svc/app/prompts/loader.py
@@ -7,10 +7,11 @@ and MLflow tracking server independently of the prompt-optimization-svc.
 Usage in an agent service:
     loader = AgentPromptClient(redis_url="redis://redis:6379/2", mlflow_uri="http://mlflow-server:5000")
     await loader.start()
-    prompt = await loader.load("zorven-wf2-<agent>-system", tenant_id="t-1", fallback="You are...")
+    prompt = await loader.load("zorven-wf1-mra-system", tenant_id="t-1", fallback="You are...")
     await loader.stop()
 """
 
+import asyncio
 import logging
 import re
 from typing import Any, Optional
@@ -46,9 +47,11 @@ class AgentPromptClient:
         """Initialize Redis and HTTP connections."""
         try:
             self._redis = aioredis.from_url(
-                self.redis_url, decode_responses=True
+                self.redis_url,
+                decode_responses=True,
+                socket_connect_timeout=5,
             )
-            await self._redis.ping()
+            await asyncio.wait_for(self._redis.ping(), timeout=5.0)
             logger.info("Prompt cache connected: %s", self.redis_url)
         except Exception as exc:
             logger.warning("Prompt cache unavailable: %s", exc)
@@ -56,9 +59,7 @@ class AgentPromptClient:
 
         if self.mlflow_uri:
             try:
-                self._http = httpx.AsyncClient(
-                    base_url=self.mlflow_uri, timeout=5.0
-                )
+                self._http = httpx.AsyncClient(base_url=self.mlflow_uri, timeout=5.0)
                 resp = await self._http.get("/health")
                 if resp.status_code == 200:
                     logger.info("MLflow connected: %s", self.mlflow_uri)
@@ -72,7 +73,9 @@ class AgentPromptClient:
                     await self._http.aclose()
                 self._http = None
         else:
-            logger.info("MLflow URI not configured — prompt loader in fallback-only mode")
+            logger.info(
+                "MLflow URI not configured — prompt loader in fallback-only mode"
+            )
 
         logger.info("Prompt loader initialized")
 
@@ -127,9 +130,7 @@ class AgentPromptClient:
 
     # --- Tier 1: Redis cache ---
 
-    async def _cache_get(
-        self, name: str, tenant_id: Optional[str]
-    ) -> Optional[str]:
+    async def _cache_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._redis is None:
             return None
         try:
@@ -163,17 +164,13 @@ class AgentPromptClient:
 
     # --- Tier 2: MLflow REST API ---
 
-    async def _mlflow_get(
-        self, name: str, tenant_id: Optional[str]
-    ) -> Optional[str]:
+    async def _mlflow_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._http is None:
             return None
         try:
             # Try tenant-specific named prompt first
             if tenant_id:
-                template = await self._fetch_prompt(
-                    f"{name}-tenant-{tenant_id}"
-                )
+                template = await self._fetch_prompt(f"{name}-tenant-{tenant_id}")
                 if template is not None:
                     return template
 
@@ -224,9 +221,7 @@ class AgentPromptClient:
                     )
                     if ver_resp.status_code == 200:
                         ver_data = ver_resp.json()
-                        return ver_data.get("prompt_version", {}).get(
-                            "template"
-                        )
+                        return ver_data.get("prompt_version", {}).get("template")
             return None
         except Exception:
             return None
@@ -234,9 +229,7 @@ class AgentPromptClient:
     # --- Template formatting ---
 
     @staticmethod
-    def _format(
-        template: str, variables: Optional[dict[str, Any]]
-    ) -> str:
+    def _format(template: str, variables: Optional[dict[str, Any]]) -> str:
         if not template or not variables:
             return template
 

--- a/campaign-architecture-agent-svc/app/prompts/invalidator.py
+++ b/campaign-architecture-agent-svc/app/prompts/invalidator.py
@@ -50,8 +50,9 @@ class PromptCacheInvalidator:
                 self.TOPIC,
                 self.GROUP_ID,
             )
-        except (Exception, asyncio.TimeoutError) as exc:
+        except Exception as exc:
             logger.warning("PromptCacheInvalidator failed: %s — no-op mode", exc)
+            self._consumer = None
 
     async def stop(self) -> None:
         """Stop the consumer and background task."""
@@ -65,7 +66,7 @@ class PromptCacheInvalidator:
         if self._consumer is not None:
             try:
                 await self._consumer.stop()
-            except (Exception, asyncio.TimeoutError) as exc:
+            except Exception as exc:
                 logger.warning("Error stopping PromptCacheInvalidator: %s", exc)
             self._consumer = None
 
@@ -76,7 +77,7 @@ class PromptCacheInvalidator:
                 await self.handle_event(msg.value)
         except asyncio.CancelledError:
             pass
-        except (Exception, asyncio.TimeoutError) as exc:
+        except Exception as exc:
             logger.error("PromptCacheInvalidator consume error: %s", exc)
 
     async def handle_event(self, event: dict) -> None:
@@ -100,5 +101,5 @@ class PromptCacheInvalidator:
                                 len(keys),
                                 prompt_name,
                             )
-                except (Exception, asyncio.TimeoutError) as exc:
+                except Exception as exc:
                     logger.warning("Cache invalidation failed: %s", exc)

--- a/campaign-architecture-agent-svc/app/prompts/invalidator.py
+++ b/campaign-architecture-agent-svc/app/prompts/invalidator.py
@@ -43,14 +43,14 @@ class PromptCacheInvalidator:
                 auto_offset_reset="latest",
                 value_deserializer=lambda v: json.loads(v.decode("utf-8")),
             )
-            await self._consumer.start()
+            await asyncio.wait_for(self._consumer.start(), timeout=10.0)
             self._task = asyncio.create_task(self._consume_loop())
             logger.info(
                 "PromptCacheInvalidator started (topic=%s, group=%s)",
                 self.TOPIC,
                 self.GROUP_ID,
             )
-        except Exception as exc:
+        except (Exception, asyncio.TimeoutError) as exc:
             logger.warning("PromptCacheInvalidator failed: %s — no-op mode", exc)
 
     async def stop(self) -> None:
@@ -65,7 +65,7 @@ class PromptCacheInvalidator:
         if self._consumer is not None:
             try:
                 await self._consumer.stop()
-            except Exception as exc:
+            except (Exception, asyncio.TimeoutError) as exc:
                 logger.warning("Error stopping PromptCacheInvalidator: %s", exc)
             self._consumer = None
 
@@ -76,7 +76,7 @@ class PromptCacheInvalidator:
                 await self.handle_event(msg.value)
         except asyncio.CancelledError:
             pass
-        except Exception as exc:
+        except (Exception, asyncio.TimeoutError) as exc:
             logger.error("PromptCacheInvalidator consume error: %s", exc)
 
     async def handle_event(self, event: dict) -> None:
@@ -91,9 +91,7 @@ class PromptCacheInvalidator:
                     r = self.prompt_loader._redis
                     if r:
                         keys = []
-                        async for key in r.scan_iter(
-                            match=f"prompt:{prompt_name}:*"
-                        ):
+                        async for key in r.scan_iter(match=f"prompt:{prompt_name}:*"):
                             keys.append(key)
                         if keys:
                             await r.delete(*keys)
@@ -102,5 +100,5 @@ class PromptCacheInvalidator:
                                 len(keys),
                                 prompt_name,
                             )
-                except Exception as exc:
+                except (Exception, asyncio.TimeoutError) as exc:
                     logger.warning("Cache invalidation failed: %s", exc)

--- a/campaign-architecture-agent-svc/app/prompts/loader.py
+++ b/campaign-architecture-agent-svc/app/prompts/loader.py
@@ -36,10 +36,12 @@ class AgentPromptClient:
         redis_url: str = "redis://localhost:6379/2",
         mlflow_uri: str = "http://mlflow-server:5000",
         default_ttl: int = 300,
+        critical_agent: bool = False,
     ) -> None:
         self.redis_url = redis_url
         self.mlflow_uri = mlflow_uri
         self.default_ttl = default_ttl
+        self.critical_agent = critical_agent
         self._redis: Optional[aioredis.Redis] = None
         self._http: Optional[httpx.AsyncClient] = None
 
@@ -123,7 +125,16 @@ class AgentPromptClient:
         # Tier 3: Fallback
         if template is None:
             if fallback:
-                logger.debug("Using fallback for prompt '%s'", name)
+                if self.critical_agent:
+                    logger.warning(
+                        "CRITICAL AGENT FALLBACK: prompt '%s' (tenant=%s) "
+                        "— MLflow and Redis both unreachable, using "
+                        "hardcoded fallback. This agent handles ad spend.",
+                        name,
+                        tenant_id,
+                    )
+                else:
+                    logger.debug("Using fallback for prompt '%s'", name)
             template = fallback
 
         return self._format(template, variables)

--- a/campaign-architecture-agent-svc/app/prompts/loader.py
+++ b/campaign-architecture-agent-svc/app/prompts/loader.py
@@ -7,7 +7,7 @@ and MLflow tracking server independently of the prompt-optimization-svc.
 Usage in an agent service:
     loader = AgentPromptClient(redis_url="redis://redis:6379/2", mlflow_uri="http://mlflow-server:5000")
     await loader.start()
-    prompt = await loader.load("zorven-wf1-mra-system", tenant_id="t-1", fallback="You are...")
+    prompt = await loader.load("zorven-<wf>-<agent>-system", tenant_id="t-1", fallback="You are...")
     await loader.stop()
 """
 
@@ -129,7 +129,7 @@ class AgentPromptClient:
                     logger.warning(
                         "CRITICAL AGENT FALLBACK: prompt '%s' (tenant=%s) "
                         "— MLflow and Redis both unreachable, using "
-                        "hardcoded fallback. This agent handles ad spend.",
+                        "hardcoded fallback.",
                         name,
                         tenant_id,
                     )

--- a/campaign-architecture-agent-svc/app/prompts/loader.py
+++ b/campaign-architecture-agent-svc/app/prompts/loader.py
@@ -11,6 +11,7 @@ Usage in an agent service:
     await loader.stop()
 """
 
+import asyncio
 import logging
 import re
 from typing import Any, Optional
@@ -35,12 +36,10 @@ class AgentPromptClient:
         redis_url: str = "redis://localhost:6379/2",
         mlflow_uri: str = "http://mlflow-server:5000",
         default_ttl: int = 300,
-        critical_agent: bool = False,
     ) -> None:
         self.redis_url = redis_url
         self.mlflow_uri = mlflow_uri
         self.default_ttl = default_ttl
-        self.critical_agent = critical_agent
         self._redis: Optional[aioredis.Redis] = None
         self._http: Optional[httpx.AsyncClient] = None
 
@@ -48,9 +47,11 @@ class AgentPromptClient:
         """Initialize Redis and HTTP connections."""
         try:
             self._redis = aioredis.from_url(
-                self.redis_url, decode_responses=True
+                self.redis_url,
+                decode_responses=True,
+                socket_connect_timeout=5,
             )
-            await self._redis.ping()
+            await asyncio.wait_for(self._redis.ping(), timeout=5.0)
             logger.info("Prompt cache connected: %s", self.redis_url)
         except Exception as exc:
             logger.warning("Prompt cache unavailable: %s", exc)
@@ -58,9 +59,7 @@ class AgentPromptClient:
 
         if self.mlflow_uri:
             try:
-                self._http = httpx.AsyncClient(
-                    base_url=self.mlflow_uri, timeout=5.0
-                )
+                self._http = httpx.AsyncClient(base_url=self.mlflow_uri, timeout=5.0)
                 resp = await self._http.get("/health")
                 if resp.status_code == 200:
                     logger.info("MLflow connected: %s", self.mlflow_uri)
@@ -74,7 +73,9 @@ class AgentPromptClient:
                     await self._http.aclose()
                 self._http = None
         else:
-            logger.info("MLflow URI not configured — prompt loader in fallback-only mode")
+            logger.info(
+                "MLflow URI not configured — prompt loader in fallback-only mode"
+            )
 
         logger.info("Prompt loader initialized")
 
@@ -122,25 +123,14 @@ class AgentPromptClient:
         # Tier 3: Fallback
         if template is None:
             if fallback:
-                if self.critical_agent:
-                    logger.warning(
-                        "CRITICAL AGENT FALLBACK: prompt '%s' (tenant=%s) "
-                        "— MLflow and Redis both unreachable, using "
-                        "hardcoded fallback. This agent handles ad spend.",
-                        name,
-                        tenant_id,
-                    )
-                else:
-                    logger.debug("Using fallback for prompt '%s'", name)
+                logger.debug("Using fallback for prompt '%s'", name)
             template = fallback
 
         return self._format(template, variables)
 
     # --- Tier 1: Redis cache ---
 
-    async def _cache_get(
-        self, name: str, tenant_id: Optional[str]
-    ) -> Optional[str]:
+    async def _cache_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._redis is None:
             return None
         try:
@@ -174,17 +164,13 @@ class AgentPromptClient:
 
     # --- Tier 2: MLflow REST API ---
 
-    async def _mlflow_get(
-        self, name: str, tenant_id: Optional[str]
-    ) -> Optional[str]:
+    async def _mlflow_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._http is None:
             return None
         try:
             # Try tenant-specific named prompt first
             if tenant_id:
-                template = await self._fetch_prompt(
-                    f"{name}-tenant-{tenant_id}"
-                )
+                template = await self._fetch_prompt(f"{name}-tenant-{tenant_id}")
                 if template is not None:
                     return template
 
@@ -235,9 +221,7 @@ class AgentPromptClient:
                     )
                     if ver_resp.status_code == 200:
                         ver_data = ver_resp.json()
-                        return ver_data.get("prompt_version", {}).get(
-                            "template"
-                        )
+                        return ver_data.get("prompt_version", {}).get("template")
             return None
         except Exception:
             return None
@@ -245,9 +229,7 @@ class AgentPromptClient:
     # --- Template formatting ---
 
     @staticmethod
-    def _format(
-        template: str, variables: Optional[dict[str, Any]]
-    ) -> str:
+    def _format(template: str, variables: Optional[dict[str, Any]]) -> str:
         if not template or not variables:
             return template
 

--- a/campaign-optimization-agent-svc/app/prompts/invalidator.py
+++ b/campaign-optimization-agent-svc/app/prompts/invalidator.py
@@ -50,8 +50,9 @@ class PromptCacheInvalidator:
                 self.TOPIC,
                 self.GROUP_ID,
             )
-        except (Exception, asyncio.TimeoutError) as exc:
+        except Exception as exc:
             logger.warning("PromptCacheInvalidator failed: %s — no-op mode", exc)
+            self._consumer = None
 
     async def stop(self) -> None:
         """Stop the consumer and background task."""
@@ -65,7 +66,7 @@ class PromptCacheInvalidator:
         if self._consumer is not None:
             try:
                 await self._consumer.stop()
-            except (Exception, asyncio.TimeoutError) as exc:
+            except Exception as exc:
                 logger.warning("Error stopping PromptCacheInvalidator: %s", exc)
             self._consumer = None
 
@@ -76,7 +77,7 @@ class PromptCacheInvalidator:
                 await self.handle_event(msg.value)
         except asyncio.CancelledError:
             pass
-        except (Exception, asyncio.TimeoutError) as exc:
+        except Exception as exc:
             logger.error("PromptCacheInvalidator consume error: %s", exc)
 
     async def handle_event(self, event: dict) -> None:
@@ -100,5 +101,5 @@ class PromptCacheInvalidator:
                                 len(keys),
                                 prompt_name,
                             )
-                except (Exception, asyncio.TimeoutError) as exc:
+                except Exception as exc:
                     logger.warning("Cache invalidation failed: %s", exc)

--- a/campaign-optimization-agent-svc/app/prompts/invalidator.py
+++ b/campaign-optimization-agent-svc/app/prompts/invalidator.py
@@ -43,14 +43,14 @@ class PromptCacheInvalidator:
                 auto_offset_reset="latest",
                 value_deserializer=lambda v: json.loads(v.decode("utf-8")),
             )
-            await self._consumer.start()
+            await asyncio.wait_for(self._consumer.start(), timeout=10.0)
             self._task = asyncio.create_task(self._consume_loop())
             logger.info(
                 "PromptCacheInvalidator started (topic=%s, group=%s)",
                 self.TOPIC,
                 self.GROUP_ID,
             )
-        except Exception as exc:
+        except (Exception, asyncio.TimeoutError) as exc:
             logger.warning("PromptCacheInvalidator failed: %s — no-op mode", exc)
 
     async def stop(self) -> None:
@@ -65,7 +65,7 @@ class PromptCacheInvalidator:
         if self._consumer is not None:
             try:
                 await self._consumer.stop()
-            except Exception as exc:
+            except (Exception, asyncio.TimeoutError) as exc:
                 logger.warning("Error stopping PromptCacheInvalidator: %s", exc)
             self._consumer = None
 
@@ -76,7 +76,7 @@ class PromptCacheInvalidator:
                 await self.handle_event(msg.value)
         except asyncio.CancelledError:
             pass
-        except Exception as exc:
+        except (Exception, asyncio.TimeoutError) as exc:
             logger.error("PromptCacheInvalidator consume error: %s", exc)
 
     async def handle_event(self, event: dict) -> None:
@@ -91,9 +91,7 @@ class PromptCacheInvalidator:
                     r = self.prompt_loader._redis
                     if r:
                         keys = []
-                        async for key in r.scan_iter(
-                            match=f"prompt:{prompt_name}:*"
-                        ):
+                        async for key in r.scan_iter(match=f"prompt:{prompt_name}:*"):
                             keys.append(key)
                         if keys:
                             await r.delete(*keys)
@@ -102,5 +100,5 @@ class PromptCacheInvalidator:
                                 len(keys),
                                 prompt_name,
                             )
-                except Exception as exc:
+                except (Exception, asyncio.TimeoutError) as exc:
                     logger.warning("Cache invalidation failed: %s", exc)

--- a/campaign-optimization-agent-svc/app/prompts/loader.py
+++ b/campaign-optimization-agent-svc/app/prompts/loader.py
@@ -36,10 +36,12 @@ class AgentPromptClient:
         redis_url: str = "redis://localhost:6379/2",
         mlflow_uri: str = "http://mlflow-server:5000",
         default_ttl: int = 300,
+        critical_agent: bool = False,
     ) -> None:
         self.redis_url = redis_url
         self.mlflow_uri = mlflow_uri
         self.default_ttl = default_ttl
+        self.critical_agent = critical_agent
         self._redis: Optional[aioredis.Redis] = None
         self._http: Optional[httpx.AsyncClient] = None
 
@@ -123,7 +125,16 @@ class AgentPromptClient:
         # Tier 3: Fallback
         if template is None:
             if fallback:
-                logger.debug("Using fallback for prompt '%s'", name)
+                if self.critical_agent:
+                    logger.warning(
+                        "CRITICAL AGENT FALLBACK: prompt '%s' (tenant=%s) "
+                        "— MLflow and Redis both unreachable, using "
+                        "hardcoded fallback. This agent handles ad spend.",
+                        name,
+                        tenant_id,
+                    )
+                else:
+                    logger.debug("Using fallback for prompt '%s'", name)
             template = fallback
 
         return self._format(template, variables)

--- a/campaign-optimization-agent-svc/app/prompts/loader.py
+++ b/campaign-optimization-agent-svc/app/prompts/loader.py
@@ -7,7 +7,7 @@ and MLflow tracking server independently of the prompt-optimization-svc.
 Usage in an agent service:
     loader = AgentPromptClient(redis_url="redis://redis:6379/2", mlflow_uri="http://mlflow-server:5000")
     await loader.start()
-    prompt = await loader.load("zorven-wf1-mra-system", tenant_id="t-1", fallback="You are...")
+    prompt = await loader.load("zorven-<wf>-<agent>-system", tenant_id="t-1", fallback="You are...")
     await loader.stop()
 """
 
@@ -129,7 +129,7 @@ class AgentPromptClient:
                     logger.warning(
                         "CRITICAL AGENT FALLBACK: prompt '%s' (tenant=%s) "
                         "— MLflow and Redis both unreachable, using "
-                        "hardcoded fallback. This agent handles ad spend.",
+                        "hardcoded fallback.",
                         name,
                         tenant_id,
                     )

--- a/campaign-optimization-agent-svc/app/prompts/loader.py
+++ b/campaign-optimization-agent-svc/app/prompts/loader.py
@@ -11,6 +11,7 @@ Usage in an agent service:
     await loader.stop()
 """
 
+import asyncio
 import logging
 import re
 from typing import Any, Optional
@@ -35,12 +36,10 @@ class AgentPromptClient:
         redis_url: str = "redis://localhost:6379/2",
         mlflow_uri: str = "http://mlflow-server:5000",
         default_ttl: int = 300,
-        critical_agent: bool = False,
     ) -> None:
         self.redis_url = redis_url
         self.mlflow_uri = mlflow_uri
         self.default_ttl = default_ttl
-        self.critical_agent = critical_agent
         self._redis: Optional[aioredis.Redis] = None
         self._http: Optional[httpx.AsyncClient] = None
 
@@ -48,9 +47,11 @@ class AgentPromptClient:
         """Initialize Redis and HTTP connections."""
         try:
             self._redis = aioredis.from_url(
-                self.redis_url, decode_responses=True
+                self.redis_url,
+                decode_responses=True,
+                socket_connect_timeout=5,
             )
-            await self._redis.ping()
+            await asyncio.wait_for(self._redis.ping(), timeout=5.0)
             logger.info("Prompt cache connected: %s", self.redis_url)
         except Exception as exc:
             logger.warning("Prompt cache unavailable: %s", exc)
@@ -58,9 +59,7 @@ class AgentPromptClient:
 
         if self.mlflow_uri:
             try:
-                self._http = httpx.AsyncClient(
-                    base_url=self.mlflow_uri, timeout=5.0
-                )
+                self._http = httpx.AsyncClient(base_url=self.mlflow_uri, timeout=5.0)
                 resp = await self._http.get("/health")
                 if resp.status_code == 200:
                     logger.info("MLflow connected: %s", self.mlflow_uri)
@@ -74,7 +73,9 @@ class AgentPromptClient:
                     await self._http.aclose()
                 self._http = None
         else:
-            logger.info("MLflow URI not configured — prompt loader in fallback-only mode")
+            logger.info(
+                "MLflow URI not configured — prompt loader in fallback-only mode"
+            )
 
         logger.info("Prompt loader initialized")
 
@@ -122,25 +123,14 @@ class AgentPromptClient:
         # Tier 3: Fallback
         if template is None:
             if fallback:
-                if self.critical_agent:
-                    logger.warning(
-                        "CRITICAL AGENT FALLBACK: prompt '%s' (tenant=%s) "
-                        "— MLflow and Redis both unreachable, using "
-                        "hardcoded fallback. This agent handles ad spend.",
-                        name,
-                        tenant_id,
-                    )
-                else:
-                    logger.debug("Using fallback for prompt '%s'", name)
+                logger.debug("Using fallback for prompt '%s'", name)
             template = fallback
 
         return self._format(template, variables)
 
     # --- Tier 1: Redis cache ---
 
-    async def _cache_get(
-        self, name: str, tenant_id: Optional[str]
-    ) -> Optional[str]:
+    async def _cache_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._redis is None:
             return None
         try:
@@ -174,17 +164,13 @@ class AgentPromptClient:
 
     # --- Tier 2: MLflow REST API ---
 
-    async def _mlflow_get(
-        self, name: str, tenant_id: Optional[str]
-    ) -> Optional[str]:
+    async def _mlflow_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._http is None:
             return None
         try:
             # Try tenant-specific named prompt first
             if tenant_id:
-                template = await self._fetch_prompt(
-                    f"{name}-tenant-{tenant_id}"
-                )
+                template = await self._fetch_prompt(f"{name}-tenant-{tenant_id}")
                 if template is not None:
                     return template
 
@@ -235,9 +221,7 @@ class AgentPromptClient:
                     )
                     if ver_resp.status_code == 200:
                         ver_data = ver_resp.json()
-                        return ver_data.get("prompt_version", {}).get(
-                            "template"
-                        )
+                        return ver_data.get("prompt_version", {}).get("template")
             return None
         except Exception:
             return None
@@ -245,9 +229,7 @@ class AgentPromptClient:
     # --- Template formatting ---
 
     @staticmethod
-    def _format(
-        template: str, variables: Optional[dict[str, Any]]
-    ) -> str:
+    def _format(template: str, variables: Optional[dict[str, Any]]) -> str:
         if not template or not variables:
             return template
 

--- a/competitor-intel-agent-svc/app/prompts/invalidator.py
+++ b/competitor-intel-agent-svc/app/prompts/invalidator.py
@@ -50,8 +50,9 @@ class PromptCacheInvalidator:
                 self.TOPIC,
                 self.GROUP_ID,
             )
-        except (Exception, asyncio.TimeoutError) as exc:
+        except Exception as exc:
             logger.warning("PromptCacheInvalidator failed: %s — no-op mode", exc)
+            self._consumer = None
 
     async def stop(self) -> None:
         """Stop the consumer and background task."""
@@ -65,7 +66,7 @@ class PromptCacheInvalidator:
         if self._consumer is not None:
             try:
                 await self._consumer.stop()
-            except (Exception, asyncio.TimeoutError) as exc:
+            except Exception as exc:
                 logger.warning("Error stopping PromptCacheInvalidator: %s", exc)
             self._consumer = None
 
@@ -76,7 +77,7 @@ class PromptCacheInvalidator:
                 await self.handle_event(msg.value)
         except asyncio.CancelledError:
             pass
-        except (Exception, asyncio.TimeoutError) as exc:
+        except Exception as exc:
             logger.error("PromptCacheInvalidator consume error: %s", exc)
 
     async def handle_event(self, event: dict) -> None:
@@ -107,5 +108,5 @@ class PromptCacheInvalidator:
                                 deleted,
                                 prompt_name,
                             )
-                except (Exception, asyncio.TimeoutError) as exc:
+                except Exception as exc:
                     logger.warning("Cache invalidation failed: %s", exc)

--- a/competitor-intel-agent-svc/app/prompts/invalidator.py
+++ b/competitor-intel-agent-svc/app/prompts/invalidator.py
@@ -43,14 +43,14 @@ class PromptCacheInvalidator:
                 auto_offset_reset="latest",
                 value_deserializer=lambda v: json.loads(v.decode("utf-8")),
             )
-            await self._consumer.start()
+            await asyncio.wait_for(self._consumer.start(), timeout=10.0)
             self._task = asyncio.create_task(self._consume_loop())
             logger.info(
                 "PromptCacheInvalidator started (topic=%s, group=%s)",
                 self.TOPIC,
                 self.GROUP_ID,
             )
-        except Exception as exc:
+        except (Exception, asyncio.TimeoutError) as exc:
             logger.warning("PromptCacheInvalidator failed: %s — no-op mode", exc)
 
     async def stop(self) -> None:
@@ -65,7 +65,7 @@ class PromptCacheInvalidator:
         if self._consumer is not None:
             try:
                 await self._consumer.stop()
-            except Exception as exc:
+            except (Exception, asyncio.TimeoutError) as exc:
                 logger.warning("Error stopping PromptCacheInvalidator: %s", exc)
             self._consumer = None
 
@@ -76,7 +76,7 @@ class PromptCacheInvalidator:
                 await self.handle_event(msg.value)
         except asyncio.CancelledError:
             pass
-        except Exception as exc:
+        except (Exception, asyncio.TimeoutError) as exc:
             logger.error("PromptCacheInvalidator consume error: %s", exc)
 
     async def handle_event(self, event: dict) -> None:
@@ -92,9 +92,7 @@ class PromptCacheInvalidator:
                     if r:
                         deleted = 0
                         batch = []
-                        async for key in r.scan_iter(
-                            match=f"prompt:{prompt_name}:*"
-                        ):
+                        async for key in r.scan_iter(match=f"prompt:{prompt_name}:*"):
                             batch.append(key)
                             if len(batch) >= 100:
                                 await r.delete(*batch)
@@ -109,5 +107,5 @@ class PromptCacheInvalidator:
                                 deleted,
                                 prompt_name,
                             )
-                except Exception as exc:
+                except (Exception, asyncio.TimeoutError) as exc:
                     logger.warning("Cache invalidation failed: %s", exc)

--- a/competitor-intel-agent-svc/app/prompts/loader.py
+++ b/competitor-intel-agent-svc/app/prompts/loader.py
@@ -11,6 +11,7 @@ Usage in an agent service:
     await loader.stop()
 """
 
+import asyncio
 import logging
 import re
 from typing import Any, Optional
@@ -46,9 +47,11 @@ class AgentPromptClient:
         """Initialize Redis and HTTP connections."""
         try:
             self._redis = aioredis.from_url(
-                self.redis_url, decode_responses=True
+                self.redis_url,
+                decode_responses=True,
+                socket_connect_timeout=5,
             )
-            await self._redis.ping()
+            await asyncio.wait_for(self._redis.ping(), timeout=5.0)
             logger.info("Prompt cache connected: %s", self.redis_url)
         except Exception as exc:
             logger.warning("Prompt cache unavailable: %s", exc)
@@ -56,9 +59,7 @@ class AgentPromptClient:
 
         if self.mlflow_uri:
             try:
-                self._http = httpx.AsyncClient(
-                    base_url=self.mlflow_uri, timeout=5.0
-                )
+                self._http = httpx.AsyncClient(base_url=self.mlflow_uri, timeout=5.0)
                 resp = await self._http.get("/health")
                 if resp.status_code == 200:
                     logger.info("MLflow connected: %s", self.mlflow_uri)
@@ -72,7 +73,9 @@ class AgentPromptClient:
                     await self._http.aclose()
                 self._http = None
         else:
-            logger.info("MLflow URI not configured — prompt loader in fallback-only mode")
+            logger.info(
+                "MLflow URI not configured — prompt loader in fallback-only mode"
+            )
 
         logger.info("Prompt loader initialized")
 
@@ -127,9 +130,7 @@ class AgentPromptClient:
 
     # --- Tier 1: Redis cache ---
 
-    async def _cache_get(
-        self, name: str, tenant_id: Optional[str]
-    ) -> Optional[str]:
+    async def _cache_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._redis is None:
             return None
         try:
@@ -163,17 +164,13 @@ class AgentPromptClient:
 
     # --- Tier 2: MLflow REST API ---
 
-    async def _mlflow_get(
-        self, name: str, tenant_id: Optional[str]
-    ) -> Optional[str]:
+    async def _mlflow_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._http is None:
             return None
         try:
             # Try tenant-specific named prompt first
             if tenant_id:
-                template = await self._fetch_prompt(
-                    f"{name}-tenant-{tenant_id}"
-                )
+                template = await self._fetch_prompt(f"{name}-tenant-{tenant_id}")
                 if template is not None:
                     return template
 
@@ -224,9 +221,7 @@ class AgentPromptClient:
                     )
                     if ver_resp.status_code == 200:
                         ver_data = ver_resp.json()
-                        return ver_data.get("prompt_version", {}).get(
-                            "template"
-                        )
+                        return ver_data.get("prompt_version", {}).get("template")
             return None
         except Exception:
             return None
@@ -234,9 +229,7 @@ class AgentPromptClient:
     # --- Template formatting ---
 
     @staticmethod
-    def _format(
-        template: str, variables: Optional[dict[str, Any]]
-    ) -> str:
+    def _format(template: str, variables: Optional[dict[str, Any]]) -> str:
         if not template or not variables:
             return template
 

--- a/competitor-intel-agent-svc/app/prompts/loader.py
+++ b/competitor-intel-agent-svc/app/prompts/loader.py
@@ -36,10 +36,12 @@ class AgentPromptClient:
         redis_url: str = "redis://localhost:6379/2",
         mlflow_uri: str = "http://mlflow-server:5000",
         default_ttl: int = 300,
+        critical_agent: bool = False,
     ) -> None:
         self.redis_url = redis_url
         self.mlflow_uri = mlflow_uri
         self.default_ttl = default_ttl
+        self.critical_agent = critical_agent
         self._redis: Optional[aioredis.Redis] = None
         self._http: Optional[httpx.AsyncClient] = None
 
@@ -123,7 +125,16 @@ class AgentPromptClient:
         # Tier 3: Fallback
         if template is None:
             if fallback:
-                logger.debug("Using fallback for prompt '%s'", name)
+                if self.critical_agent:
+                    logger.warning(
+                        "CRITICAL AGENT FALLBACK: prompt '%s' (tenant=%s) "
+                        "— MLflow and Redis both unreachable, using "
+                        "hardcoded fallback. This agent handles ad spend.",
+                        name,
+                        tenant_id,
+                    )
+                else:
+                    logger.debug("Using fallback for prompt '%s'", name)
             template = fallback
 
         return self._format(template, variables)

--- a/competitor-intel-agent-svc/app/prompts/loader.py
+++ b/competitor-intel-agent-svc/app/prompts/loader.py
@@ -7,7 +7,7 @@ and MLflow tracking server independently of the prompt-optimization-svc.
 Usage in an agent service:
     loader = AgentPromptClient(redis_url="redis://redis:6379/2", mlflow_uri="http://mlflow-server:5000")
     await loader.start()
-    prompt = await loader.load("zorven-wf1-mra-system", tenant_id="t-1", fallback="You are...")
+    prompt = await loader.load("zorven-<wf>-<agent>-system", tenant_id="t-1", fallback="You are...")
     await loader.stop()
 """
 
@@ -129,7 +129,7 @@ class AgentPromptClient:
                     logger.warning(
                         "CRITICAL AGENT FALLBACK: prompt '%s' (tenant=%s) "
                         "— MLflow and Redis both unreachable, using "
-                        "hardcoded fallback. This agent handles ad spend.",
+                        "hardcoded fallback.",
                         name,
                         tenant_id,
                     )

--- a/creative-generation-agent-svc/app/prompts/invalidator.py
+++ b/creative-generation-agent-svc/app/prompts/invalidator.py
@@ -50,8 +50,9 @@ class PromptCacheInvalidator:
                 self.TOPIC,
                 self.GROUP_ID,
             )
-        except (Exception, asyncio.TimeoutError) as exc:
+        except Exception as exc:
             logger.warning("PromptCacheInvalidator failed: %s — no-op mode", exc)
+            self._consumer = None
 
     async def stop(self) -> None:
         """Stop the consumer and background task."""
@@ -65,7 +66,7 @@ class PromptCacheInvalidator:
         if self._consumer is not None:
             try:
                 await self._consumer.stop()
-            except (Exception, asyncio.TimeoutError) as exc:
+            except Exception as exc:
                 logger.warning("Error stopping PromptCacheInvalidator: %s", exc)
             self._consumer = None
 
@@ -76,7 +77,7 @@ class PromptCacheInvalidator:
                 await self.handle_event(msg.value)
         except asyncio.CancelledError:
             pass
-        except (Exception, asyncio.TimeoutError) as exc:
+        except Exception as exc:
             logger.error("PromptCacheInvalidator consume error: %s", exc)
 
     async def handle_event(self, event: dict) -> None:
@@ -100,5 +101,5 @@ class PromptCacheInvalidator:
                                 len(keys),
                                 prompt_name,
                             )
-                except (Exception, asyncio.TimeoutError) as exc:
+                except Exception as exc:
                     logger.warning("Cache invalidation failed: %s", exc)

--- a/creative-generation-agent-svc/app/prompts/invalidator.py
+++ b/creative-generation-agent-svc/app/prompts/invalidator.py
@@ -43,14 +43,14 @@ class PromptCacheInvalidator:
                 auto_offset_reset="latest",
                 value_deserializer=lambda v: json.loads(v.decode("utf-8")),
             )
-            await self._consumer.start()
+            await asyncio.wait_for(self._consumer.start(), timeout=10.0)
             self._task = asyncio.create_task(self._consume_loop())
             logger.info(
                 "PromptCacheInvalidator started (topic=%s, group=%s)",
                 self.TOPIC,
                 self.GROUP_ID,
             )
-        except Exception as exc:
+        except (Exception, asyncio.TimeoutError) as exc:
             logger.warning("PromptCacheInvalidator failed: %s — no-op mode", exc)
 
     async def stop(self) -> None:
@@ -65,7 +65,7 @@ class PromptCacheInvalidator:
         if self._consumer is not None:
             try:
                 await self._consumer.stop()
-            except Exception as exc:
+            except (Exception, asyncio.TimeoutError) as exc:
                 logger.warning("Error stopping PromptCacheInvalidator: %s", exc)
             self._consumer = None
 
@@ -76,7 +76,7 @@ class PromptCacheInvalidator:
                 await self.handle_event(msg.value)
         except asyncio.CancelledError:
             pass
-        except Exception as exc:
+        except (Exception, asyncio.TimeoutError) as exc:
             logger.error("PromptCacheInvalidator consume error: %s", exc)
 
     async def handle_event(self, event: dict) -> None:
@@ -91,9 +91,7 @@ class PromptCacheInvalidator:
                     r = self.prompt_loader._redis
                     if r:
                         keys = []
-                        async for key in r.scan_iter(
-                            match=f"prompt:{prompt_name}:*"
-                        ):
+                        async for key in r.scan_iter(match=f"prompt:{prompt_name}:*"):
                             keys.append(key)
                         if keys:
                             await r.delete(*keys)
@@ -102,5 +100,5 @@ class PromptCacheInvalidator:
                                 len(keys),
                                 prompt_name,
                             )
-                except Exception as exc:
+                except (Exception, asyncio.TimeoutError) as exc:
                     logger.warning("Cache invalidation failed: %s", exc)

--- a/creative-generation-agent-svc/app/prompts/loader.py
+++ b/creative-generation-agent-svc/app/prompts/loader.py
@@ -36,10 +36,12 @@ class AgentPromptClient:
         redis_url: str = "redis://localhost:6379/2",
         mlflow_uri: str = "http://mlflow-server:5000",
         default_ttl: int = 300,
+        critical_agent: bool = False,
     ) -> None:
         self.redis_url = redis_url
         self.mlflow_uri = mlflow_uri
         self.default_ttl = default_ttl
+        self.critical_agent = critical_agent
         self._redis: Optional[aioredis.Redis] = None
         self._http: Optional[httpx.AsyncClient] = None
 
@@ -123,7 +125,16 @@ class AgentPromptClient:
         # Tier 3: Fallback
         if template is None:
             if fallback:
-                logger.debug("Using fallback for prompt '%s'", name)
+                if self.critical_agent:
+                    logger.warning(
+                        "CRITICAL AGENT FALLBACK: prompt '%s' (tenant=%s) "
+                        "— MLflow and Redis both unreachable, using "
+                        "hardcoded fallback. This agent handles ad spend.",
+                        name,
+                        tenant_id,
+                    )
+                else:
+                    logger.debug("Using fallback for prompt '%s'", name)
             template = fallback
 
         return self._format(template, variables)

--- a/creative-generation-agent-svc/app/prompts/loader.py
+++ b/creative-generation-agent-svc/app/prompts/loader.py
@@ -7,7 +7,7 @@ and MLflow tracking server independently of the prompt-optimization-svc.
 Usage in an agent service:
     loader = AgentPromptClient(redis_url="redis://redis:6379/2", mlflow_uri="http://mlflow-server:5000")
     await loader.start()
-    prompt = await loader.load("zorven-wf1-mra-system", tenant_id="t-1", fallback="You are...")
+    prompt = await loader.load("zorven-<wf>-<agent>-system", tenant_id="t-1", fallback="You are...")
     await loader.stop()
 """
 
@@ -129,7 +129,7 @@ class AgentPromptClient:
                     logger.warning(
                         "CRITICAL AGENT FALLBACK: prompt '%s' (tenant=%s) "
                         "— MLflow and Redis both unreachable, using "
-                        "hardcoded fallback. This agent handles ad spend.",
+                        "hardcoded fallback.",
                         name,
                         tenant_id,
                     )

--- a/creative-generation-agent-svc/app/prompts/loader.py
+++ b/creative-generation-agent-svc/app/prompts/loader.py
@@ -11,6 +11,7 @@ Usage in an agent service:
     await loader.stop()
 """
 
+import asyncio
 import logging
 import re
 from typing import Any, Optional
@@ -35,12 +36,10 @@ class AgentPromptClient:
         redis_url: str = "redis://localhost:6379/2",
         mlflow_uri: str = "http://mlflow-server:5000",
         default_ttl: int = 300,
-        critical_agent: bool = False,
     ) -> None:
         self.redis_url = redis_url
         self.mlflow_uri = mlflow_uri
         self.default_ttl = default_ttl
-        self.critical_agent = critical_agent
         self._redis: Optional[aioredis.Redis] = None
         self._http: Optional[httpx.AsyncClient] = None
 
@@ -48,9 +47,11 @@ class AgentPromptClient:
         """Initialize Redis and HTTP connections."""
         try:
             self._redis = aioredis.from_url(
-                self.redis_url, decode_responses=True
+                self.redis_url,
+                decode_responses=True,
+                socket_connect_timeout=5,
             )
-            await self._redis.ping()
+            await asyncio.wait_for(self._redis.ping(), timeout=5.0)
             logger.info("Prompt cache connected: %s", self.redis_url)
         except Exception as exc:
             logger.warning("Prompt cache unavailable: %s", exc)
@@ -58,9 +59,7 @@ class AgentPromptClient:
 
         if self.mlflow_uri:
             try:
-                self._http = httpx.AsyncClient(
-                    base_url=self.mlflow_uri, timeout=5.0
-                )
+                self._http = httpx.AsyncClient(base_url=self.mlflow_uri, timeout=5.0)
                 resp = await self._http.get("/health")
                 if resp.status_code == 200:
                     logger.info("MLflow connected: %s", self.mlflow_uri)
@@ -74,7 +73,9 @@ class AgentPromptClient:
                     await self._http.aclose()
                 self._http = None
         else:
-            logger.info("MLflow URI not configured — prompt loader in fallback-only mode")
+            logger.info(
+                "MLflow URI not configured — prompt loader in fallback-only mode"
+            )
 
         logger.info("Prompt loader initialized")
 
@@ -122,25 +123,14 @@ class AgentPromptClient:
         # Tier 3: Fallback
         if template is None:
             if fallback:
-                if self.critical_agent:
-                    logger.warning(
-                        "CRITICAL AGENT FALLBACK: prompt '%s' (tenant=%s) "
-                        "— MLflow and Redis both unreachable, using "
-                        "hardcoded fallback. This agent handles ad spend.",
-                        name,
-                        tenant_id,
-                    )
-                else:
-                    logger.debug("Using fallback for prompt '%s'", name)
+                logger.debug("Using fallback for prompt '%s'", name)
             template = fallback
 
         return self._format(template, variables)
 
     # --- Tier 1: Redis cache ---
 
-    async def _cache_get(
-        self, name: str, tenant_id: Optional[str]
-    ) -> Optional[str]:
+    async def _cache_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._redis is None:
             return None
         try:
@@ -174,17 +164,13 @@ class AgentPromptClient:
 
     # --- Tier 2: MLflow REST API ---
 
-    async def _mlflow_get(
-        self, name: str, tenant_id: Optional[str]
-    ) -> Optional[str]:
+    async def _mlflow_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._http is None:
             return None
         try:
             # Try tenant-specific named prompt first
             if tenant_id:
-                template = await self._fetch_prompt(
-                    f"{name}-tenant-{tenant_id}"
-                )
+                template = await self._fetch_prompt(f"{name}-tenant-{tenant_id}")
                 if template is not None:
                     return template
 
@@ -235,9 +221,7 @@ class AgentPromptClient:
                     )
                     if ver_resp.status_code == 200:
                         ver_data = ver_resp.json()
-                        return ver_data.get("prompt_version", {}).get(
-                            "template"
-                        )
+                        return ver_data.get("prompt_version", {}).get("template")
             return None
         except Exception:
             return None
@@ -245,9 +229,7 @@ class AgentPromptClient:
     # --- Template formatting ---
 
     @staticmethod
-    def _format(
-        template: str, variables: Optional[dict[str, Any]]
-    ) -> str:
+    def _format(template: str, variables: Optional[dict[str, Any]]) -> str:
         if not template or not variables:
             return template
 

--- a/intelligence-loop-agent-svc/app/prompts/invalidator.py
+++ b/intelligence-loop-agent-svc/app/prompts/invalidator.py
@@ -50,8 +50,9 @@ class PromptCacheInvalidator:
                 self.TOPIC,
                 self.GROUP_ID,
             )
-        except (Exception, asyncio.TimeoutError) as exc:
+        except Exception as exc:
             logger.warning("PromptCacheInvalidator failed: %s — no-op mode", exc)
+            self._consumer = None
 
     async def stop(self) -> None:
         """Stop the consumer and background task."""
@@ -65,7 +66,7 @@ class PromptCacheInvalidator:
         if self._consumer is not None:
             try:
                 await self._consumer.stop()
-            except (Exception, asyncio.TimeoutError) as exc:
+            except Exception as exc:
                 logger.warning("Error stopping PromptCacheInvalidator: %s", exc)
             self._consumer = None
 
@@ -76,7 +77,7 @@ class PromptCacheInvalidator:
                 await self.handle_event(msg.value)
         except asyncio.CancelledError:
             pass
-        except (Exception, asyncio.TimeoutError) as exc:
+        except Exception as exc:
             logger.error("PromptCacheInvalidator consume error: %s", exc)
 
     async def handle_event(self, event: dict) -> None:
@@ -100,5 +101,5 @@ class PromptCacheInvalidator:
                                 len(keys),
                                 prompt_name,
                             )
-                except (Exception, asyncio.TimeoutError) as exc:
+                except Exception as exc:
                     logger.warning("Cache invalidation failed: %s", exc)

--- a/intelligence-loop-agent-svc/app/prompts/invalidator.py
+++ b/intelligence-loop-agent-svc/app/prompts/invalidator.py
@@ -43,14 +43,14 @@ class PromptCacheInvalidator:
                 auto_offset_reset="latest",
                 value_deserializer=lambda v: json.loads(v.decode("utf-8")),
             )
-            await self._consumer.start()
+            await asyncio.wait_for(self._consumer.start(), timeout=10.0)
             self._task = asyncio.create_task(self._consume_loop())
             logger.info(
                 "PromptCacheInvalidator started (topic=%s, group=%s)",
                 self.TOPIC,
                 self.GROUP_ID,
             )
-        except Exception as exc:
+        except (Exception, asyncio.TimeoutError) as exc:
             logger.warning("PromptCacheInvalidator failed: %s — no-op mode", exc)
 
     async def stop(self) -> None:
@@ -65,7 +65,7 @@ class PromptCacheInvalidator:
         if self._consumer is not None:
             try:
                 await self._consumer.stop()
-            except Exception as exc:
+            except (Exception, asyncio.TimeoutError) as exc:
                 logger.warning("Error stopping PromptCacheInvalidator: %s", exc)
             self._consumer = None
 
@@ -76,7 +76,7 @@ class PromptCacheInvalidator:
                 await self.handle_event(msg.value)
         except asyncio.CancelledError:
             pass
-        except Exception as exc:
+        except (Exception, asyncio.TimeoutError) as exc:
             logger.error("PromptCacheInvalidator consume error: %s", exc)
 
     async def handle_event(self, event: dict) -> None:
@@ -91,9 +91,7 @@ class PromptCacheInvalidator:
                     r = self.prompt_loader._redis
                     if r:
                         keys = []
-                        async for key in r.scan_iter(
-                            match=f"prompt:{prompt_name}:*"
-                        ):
+                        async for key in r.scan_iter(match=f"prompt:{prompt_name}:*"):
                             keys.append(key)
                         if keys:
                             await r.delete(*keys)
@@ -102,5 +100,5 @@ class PromptCacheInvalidator:
                                 len(keys),
                                 prompt_name,
                             )
-                except Exception as exc:
+                except (Exception, asyncio.TimeoutError) as exc:
                     logger.warning("Cache invalidation failed: %s", exc)

--- a/intelligence-loop-agent-svc/app/prompts/loader.py
+++ b/intelligence-loop-agent-svc/app/prompts/loader.py
@@ -36,10 +36,12 @@ class AgentPromptClient:
         redis_url: str = "redis://localhost:6379/2",
         mlflow_uri: str = "http://mlflow-server:5000",
         default_ttl: int = 300,
+        critical_agent: bool = False,
     ) -> None:
         self.redis_url = redis_url
         self.mlflow_uri = mlflow_uri
         self.default_ttl = default_ttl
+        self.critical_agent = critical_agent
         self._redis: Optional[aioredis.Redis] = None
         self._http: Optional[httpx.AsyncClient] = None
 
@@ -123,7 +125,16 @@ class AgentPromptClient:
         # Tier 3: Fallback
         if template is None:
             if fallback:
-                logger.debug("Using fallback for prompt '%s'", name)
+                if self.critical_agent:
+                    logger.warning(
+                        "CRITICAL AGENT FALLBACK: prompt '%s' (tenant=%s) "
+                        "— MLflow and Redis both unreachable, using "
+                        "hardcoded fallback. This agent handles ad spend.",
+                        name,
+                        tenant_id,
+                    )
+                else:
+                    logger.debug("Using fallback for prompt '%s'", name)
             template = fallback
 
         return self._format(template, variables)

--- a/intelligence-loop-agent-svc/app/prompts/loader.py
+++ b/intelligence-loop-agent-svc/app/prompts/loader.py
@@ -7,7 +7,7 @@ and MLflow tracking server independently of the prompt-optimization-svc.
 Usage in an agent service:
     loader = AgentPromptClient(redis_url="redis://redis:6379/2", mlflow_uri="http://mlflow-server:5000")
     await loader.start()
-    prompt = await loader.load("zorven-wf1-mra-system", tenant_id="t-1", fallback="You are...")
+    prompt = await loader.load("zorven-<wf>-<agent>-system", tenant_id="t-1", fallback="You are...")
     await loader.stop()
 """
 
@@ -129,7 +129,7 @@ class AgentPromptClient:
                     logger.warning(
                         "CRITICAL AGENT FALLBACK: prompt '%s' (tenant=%s) "
                         "— MLflow and Redis both unreachable, using "
-                        "hardcoded fallback. This agent handles ad spend.",
+                        "hardcoded fallback.",
                         name,
                         tenant_id,
                     )

--- a/intelligence-loop-agent-svc/app/prompts/loader.py
+++ b/intelligence-loop-agent-svc/app/prompts/loader.py
@@ -11,6 +11,7 @@ Usage in an agent service:
     await loader.stop()
 """
 
+import asyncio
 import logging
 import re
 from typing import Any, Optional
@@ -35,12 +36,10 @@ class AgentPromptClient:
         redis_url: str = "redis://localhost:6379/2",
         mlflow_uri: str = "http://mlflow-server:5000",
         default_ttl: int = 300,
-        critical_agent: bool = False,
     ) -> None:
         self.redis_url = redis_url
         self.mlflow_uri = mlflow_uri
         self.default_ttl = default_ttl
-        self.critical_agent = critical_agent
         self._redis: Optional[aioredis.Redis] = None
         self._http: Optional[httpx.AsyncClient] = None
 
@@ -48,9 +47,11 @@ class AgentPromptClient:
         """Initialize Redis and HTTP connections."""
         try:
             self._redis = aioredis.from_url(
-                self.redis_url, decode_responses=True
+                self.redis_url,
+                decode_responses=True,
+                socket_connect_timeout=5,
             )
-            await self._redis.ping()
+            await asyncio.wait_for(self._redis.ping(), timeout=5.0)
             logger.info("Prompt cache connected: %s", self.redis_url)
         except Exception as exc:
             logger.warning("Prompt cache unavailable: %s", exc)
@@ -58,9 +59,7 @@ class AgentPromptClient:
 
         if self.mlflow_uri:
             try:
-                self._http = httpx.AsyncClient(
-                    base_url=self.mlflow_uri, timeout=5.0
-                )
+                self._http = httpx.AsyncClient(base_url=self.mlflow_uri, timeout=5.0)
                 resp = await self._http.get("/health")
                 if resp.status_code == 200:
                     logger.info("MLflow connected: %s", self.mlflow_uri)
@@ -74,7 +73,9 @@ class AgentPromptClient:
                     await self._http.aclose()
                 self._http = None
         else:
-            logger.info("MLflow URI not configured — prompt loader in fallback-only mode")
+            logger.info(
+                "MLflow URI not configured — prompt loader in fallback-only mode"
+            )
 
         logger.info("Prompt loader initialized")
 
@@ -122,25 +123,14 @@ class AgentPromptClient:
         # Tier 3: Fallback
         if template is None:
             if fallback:
-                if self.critical_agent:
-                    logger.warning(
-                        "CRITICAL AGENT FALLBACK: prompt '%s' (tenant=%s) "
-                        "— MLflow and Redis both unreachable, using "
-                        "hardcoded fallback. This agent handles ad spend.",
-                        name,
-                        tenant_id,
-                    )
-                else:
-                    logger.debug("Using fallback for prompt '%s'", name)
+                logger.debug("Using fallback for prompt '%s'", name)
             template = fallback
 
         return self._format(template, variables)
 
     # --- Tier 1: Redis cache ---
 
-    async def _cache_get(
-        self, name: str, tenant_id: Optional[str]
-    ) -> Optional[str]:
+    async def _cache_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._redis is None:
             return None
         try:
@@ -174,17 +164,13 @@ class AgentPromptClient:
 
     # --- Tier 2: MLflow REST API ---
 
-    async def _mlflow_get(
-        self, name: str, tenant_id: Optional[str]
-    ) -> Optional[str]:
+    async def _mlflow_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._http is None:
             return None
         try:
             # Try tenant-specific named prompt first
             if tenant_id:
-                template = await self._fetch_prompt(
-                    f"{name}-tenant-{tenant_id}"
-                )
+                template = await self._fetch_prompt(f"{name}-tenant-{tenant_id}")
                 if template is not None:
                     return template
 
@@ -235,9 +221,7 @@ class AgentPromptClient:
                     )
                     if ver_resp.status_code == 200:
                         ver_data = ver_resp.json()
-                        return ver_data.get("prompt_version", {}).get(
-                            "template"
-                        )
+                        return ver_data.get("prompt_version", {}).get("template")
             return None
         except Exception:
             return None
@@ -245,9 +229,7 @@ class AgentPromptClient:
     # --- Template formatting ---
 
     @staticmethod
-    def _format(
-        template: str, variables: Optional[dict[str, Any]]
-    ) -> str:
+    def _format(template: str, variables: Optional[dict[str, Any]]) -> str:
         if not template or not variables:
             return template
 

--- a/market-research-agent-svc/app/prompts/invalidator.py
+++ b/market-research-agent-svc/app/prompts/invalidator.py
@@ -50,8 +50,9 @@ class PromptCacheInvalidator:
                 self.TOPIC,
                 self.GROUP_ID,
             )
-        except (Exception, asyncio.TimeoutError) as exc:
+        except Exception as exc:
             logger.warning("PromptCacheInvalidator failed: %s — no-op mode", exc)
+            self._consumer = None
 
     async def stop(self) -> None:
         """Stop the consumer and background task."""
@@ -65,7 +66,7 @@ class PromptCacheInvalidator:
         if self._consumer is not None:
             try:
                 await self._consumer.stop()
-            except (Exception, asyncio.TimeoutError) as exc:
+            except Exception as exc:
                 logger.warning("Error stopping PromptCacheInvalidator: %s", exc)
             self._consumer = None
 
@@ -76,7 +77,7 @@ class PromptCacheInvalidator:
                 await self.handle_event(msg.value)
         except asyncio.CancelledError:
             pass
-        except (Exception, asyncio.TimeoutError) as exc:
+        except Exception as exc:
             logger.error("PromptCacheInvalidator consume error: %s", exc)
 
     async def handle_event(self, event: dict) -> None:
@@ -107,5 +108,5 @@ class PromptCacheInvalidator:
                                 deleted,
                                 prompt_name,
                             )
-                except (Exception, asyncio.TimeoutError) as exc:
+                except Exception as exc:
                     logger.warning("Cache invalidation failed: %s", exc)

--- a/market-research-agent-svc/app/prompts/invalidator.py
+++ b/market-research-agent-svc/app/prompts/invalidator.py
@@ -43,14 +43,14 @@ class PromptCacheInvalidator:
                 auto_offset_reset="latest",
                 value_deserializer=lambda v: json.loads(v.decode("utf-8")),
             )
-            await self._consumer.start()
+            await asyncio.wait_for(self._consumer.start(), timeout=10.0)
             self._task = asyncio.create_task(self._consume_loop())
             logger.info(
                 "PromptCacheInvalidator started (topic=%s, group=%s)",
                 self.TOPIC,
                 self.GROUP_ID,
             )
-        except Exception as exc:
+        except (Exception, asyncio.TimeoutError) as exc:
             logger.warning("PromptCacheInvalidator failed: %s — no-op mode", exc)
 
     async def stop(self) -> None:
@@ -65,7 +65,7 @@ class PromptCacheInvalidator:
         if self._consumer is not None:
             try:
                 await self._consumer.stop()
-            except Exception as exc:
+            except (Exception, asyncio.TimeoutError) as exc:
                 logger.warning("Error stopping PromptCacheInvalidator: %s", exc)
             self._consumer = None
 
@@ -76,7 +76,7 @@ class PromptCacheInvalidator:
                 await self.handle_event(msg.value)
         except asyncio.CancelledError:
             pass
-        except Exception as exc:
+        except (Exception, asyncio.TimeoutError) as exc:
             logger.error("PromptCacheInvalidator consume error: %s", exc)
 
     async def handle_event(self, event: dict) -> None:
@@ -92,9 +92,7 @@ class PromptCacheInvalidator:
                     if r:
                         deleted = 0
                         batch = []
-                        async for key in r.scan_iter(
-                            match=f"prompt:{prompt_name}:*"
-                        ):
+                        async for key in r.scan_iter(match=f"prompt:{prompt_name}:*"):
                             batch.append(key)
                             if len(batch) >= 100:
                                 await r.delete(*batch)
@@ -109,5 +107,5 @@ class PromptCacheInvalidator:
                                 deleted,
                                 prompt_name,
                             )
-                except Exception as exc:
+                except (Exception, asyncio.TimeoutError) as exc:
                     logger.warning("Cache invalidation failed: %s", exc)

--- a/market-research-agent-svc/app/prompts/loader.py
+++ b/market-research-agent-svc/app/prompts/loader.py
@@ -11,6 +11,7 @@ Usage in an agent service:
     await loader.stop()
 """
 
+import asyncio
 import logging
 import re
 from typing import Any, Optional
@@ -46,9 +47,11 @@ class AgentPromptClient:
         """Initialize Redis and HTTP connections."""
         try:
             self._redis = aioredis.from_url(
-                self.redis_url, decode_responses=True
+                self.redis_url,
+                decode_responses=True,
+                socket_connect_timeout=5,
             )
-            await self._redis.ping()
+            await asyncio.wait_for(self._redis.ping(), timeout=5.0)
             logger.info("Prompt cache connected: %s", self.redis_url)
         except Exception as exc:
             logger.warning("Prompt cache unavailable: %s", exc)
@@ -56,9 +59,7 @@ class AgentPromptClient:
 
         if self.mlflow_uri:
             try:
-                self._http = httpx.AsyncClient(
-                    base_url=self.mlflow_uri, timeout=5.0
-                )
+                self._http = httpx.AsyncClient(base_url=self.mlflow_uri, timeout=5.0)
                 resp = await self._http.get("/health")
                 if resp.status_code == 200:
                     logger.info("MLflow connected: %s", self.mlflow_uri)
@@ -72,7 +73,9 @@ class AgentPromptClient:
                     await self._http.aclose()
                 self._http = None
         else:
-            logger.info("MLflow URI not configured — prompt loader in fallback-only mode")
+            logger.info(
+                "MLflow URI not configured — prompt loader in fallback-only mode"
+            )
 
         logger.info("Prompt loader initialized")
 
@@ -127,9 +130,7 @@ class AgentPromptClient:
 
     # --- Tier 1: Redis cache ---
 
-    async def _cache_get(
-        self, name: str, tenant_id: Optional[str]
-    ) -> Optional[str]:
+    async def _cache_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._redis is None:
             return None
         try:
@@ -163,17 +164,13 @@ class AgentPromptClient:
 
     # --- Tier 2: MLflow REST API ---
 
-    async def _mlflow_get(
-        self, name: str, tenant_id: Optional[str]
-    ) -> Optional[str]:
+    async def _mlflow_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._http is None:
             return None
         try:
             # Try tenant-specific named prompt first
             if tenant_id:
-                template = await self._fetch_prompt(
-                    f"{name}-tenant-{tenant_id}"
-                )
+                template = await self._fetch_prompt(f"{name}-tenant-{tenant_id}")
                 if template is not None:
                     return template
 
@@ -224,9 +221,7 @@ class AgentPromptClient:
                     )
                     if ver_resp.status_code == 200:
                         ver_data = ver_resp.json()
-                        return ver_data.get("prompt_version", {}).get(
-                            "template"
-                        )
+                        return ver_data.get("prompt_version", {}).get("template")
             return None
         except Exception:
             return None
@@ -234,9 +229,7 @@ class AgentPromptClient:
     # --- Template formatting ---
 
     @staticmethod
-    def _format(
-        template: str, variables: Optional[dict[str, Any]]
-    ) -> str:
+    def _format(template: str, variables: Optional[dict[str, Any]]) -> str:
         if not template or not variables:
             return template
 

--- a/market-research-agent-svc/app/prompts/loader.py
+++ b/market-research-agent-svc/app/prompts/loader.py
@@ -36,10 +36,12 @@ class AgentPromptClient:
         redis_url: str = "redis://localhost:6379/2",
         mlflow_uri: str = "http://mlflow-server:5000",
         default_ttl: int = 300,
+        critical_agent: bool = False,
     ) -> None:
         self.redis_url = redis_url
         self.mlflow_uri = mlflow_uri
         self.default_ttl = default_ttl
+        self.critical_agent = critical_agent
         self._redis: Optional[aioredis.Redis] = None
         self._http: Optional[httpx.AsyncClient] = None
 
@@ -123,7 +125,16 @@ class AgentPromptClient:
         # Tier 3: Fallback
         if template is None:
             if fallback:
-                logger.debug("Using fallback for prompt '%s'", name)
+                if self.critical_agent:
+                    logger.warning(
+                        "CRITICAL AGENT FALLBACK: prompt '%s' (tenant=%s) "
+                        "— MLflow and Redis both unreachable, using "
+                        "hardcoded fallback. This agent handles ad spend.",
+                        name,
+                        tenant_id,
+                    )
+                else:
+                    logger.debug("Using fallback for prompt '%s'", name)
             template = fallback
 
         return self._format(template, variables)

--- a/market-research-agent-svc/app/prompts/loader.py
+++ b/market-research-agent-svc/app/prompts/loader.py
@@ -7,7 +7,7 @@ and MLflow tracking server independently of the prompt-optimization-svc.
 Usage in an agent service:
     loader = AgentPromptClient(redis_url="redis://redis:6379/2", mlflow_uri="http://mlflow-server:5000")
     await loader.start()
-    prompt = await loader.load("zorven-wf1-mra-system", tenant_id="t-1", fallback="You are...")
+    prompt = await loader.load("zorven-<wf>-<agent>-system", tenant_id="t-1", fallback="You are...")
     await loader.stop()
 """
 
@@ -129,7 +129,7 @@ class AgentPromptClient:
                     logger.warning(
                         "CRITICAL AGENT FALLBACK: prompt '%s' (tenant=%s) "
                         "— MLflow and Redis both unreachable, using "
-                        "hardcoded fallback. This agent handles ad spend.",
+                        "hardcoded fallback.",
                         name,
                         tenant_id,
                     )

--- a/tests/integration/phase1_contracts/test_testcontainers_integration.py
+++ b/tests/integration/phase1_contracts/test_testcontainers_integration.py
@@ -9,8 +9,14 @@ import os
 
 import pytest
 
+_SKIP_REASON = (
+    "Requires testcontainers infrastructure — " "POI_PROMPT_CACHE_REDIS_URL not set"
+)
+_HAS_TESTCONTAINERS = bool(os.environ.get("POI_PROMPT_CACHE_REDIS_URL"))
+
 
 @pytest.mark.integration
+@pytest.mark.skipif(not _HAS_TESTCONTAINERS, reason=_SKIP_REASON)
 class TestTestcontainersInfrastructure:
     """Validate testcontainer infrastructure is healthy."""
 

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,4 +1,4 @@
-httpx>=0.25.0
+httpx>=0.27.0
 pytest>=7.4.0
 pytest-asyncio>=0.23.0
 pytest-timeout>=2.2.0
@@ -6,5 +6,10 @@ aiohttp>=3.9.0
 redis>=5.0.0
 numpy>=1.26.0
 hypothesis>=6.0.0
-mlflow>=2.21.0
+mlflow-skinny>=2.21.0
 pyyaml>=6.0
+pydantic>=2.9.0
+pydantic-settings>=2.5.0
+anthropic>=0.84.0
+prometheus-client>=0.21.0
+sqlalchemy>=2.0.0

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -13,3 +13,4 @@ pydantic-settings>=2.5.0
 anthropic>=0.84.0
 prometheus-client>=0.21.0
 sqlalchemy>=2.0.0
+aiokafka>=0.11.0

--- a/trend-cultural-agent-svc/app/prompts/invalidator.py
+++ b/trend-cultural-agent-svc/app/prompts/invalidator.py
@@ -50,8 +50,9 @@ class PromptCacheInvalidator:
                 self.TOPIC,
                 self.GROUP_ID,
             )
-        except (Exception, asyncio.TimeoutError) as exc:
+        except Exception as exc:
             logger.warning("PromptCacheInvalidator failed: %s — no-op mode", exc)
+            self._consumer = None
 
     async def stop(self) -> None:
         """Stop the consumer and background task."""
@@ -65,7 +66,7 @@ class PromptCacheInvalidator:
         if self._consumer is not None:
             try:
                 await self._consumer.stop()
-            except (Exception, asyncio.TimeoutError) as exc:
+            except Exception as exc:
                 logger.warning("Error stopping PromptCacheInvalidator: %s", exc)
             self._consumer = None
 
@@ -76,7 +77,7 @@ class PromptCacheInvalidator:
                 await self.handle_event(msg.value)
         except asyncio.CancelledError:
             pass
-        except (Exception, asyncio.TimeoutError) as exc:
+        except Exception as exc:
             logger.error("PromptCacheInvalidator consume error: %s", exc)
 
     async def handle_event(self, event: dict) -> None:
@@ -107,5 +108,5 @@ class PromptCacheInvalidator:
                                 deleted,
                                 prompt_name,
                             )
-                except (Exception, asyncio.TimeoutError) as exc:
+                except Exception as exc:
                     logger.warning("Cache invalidation failed: %s", exc)

--- a/trend-cultural-agent-svc/app/prompts/invalidator.py
+++ b/trend-cultural-agent-svc/app/prompts/invalidator.py
@@ -43,14 +43,14 @@ class PromptCacheInvalidator:
                 auto_offset_reset="latest",
                 value_deserializer=lambda v: json.loads(v.decode("utf-8")),
             )
-            await self._consumer.start()
+            await asyncio.wait_for(self._consumer.start(), timeout=10.0)
             self._task = asyncio.create_task(self._consume_loop())
             logger.info(
                 "PromptCacheInvalidator started (topic=%s, group=%s)",
                 self.TOPIC,
                 self.GROUP_ID,
             )
-        except Exception as exc:
+        except (Exception, asyncio.TimeoutError) as exc:
             logger.warning("PromptCacheInvalidator failed: %s — no-op mode", exc)
 
     async def stop(self) -> None:
@@ -65,7 +65,7 @@ class PromptCacheInvalidator:
         if self._consumer is not None:
             try:
                 await self._consumer.stop()
-            except Exception as exc:
+            except (Exception, asyncio.TimeoutError) as exc:
                 logger.warning("Error stopping PromptCacheInvalidator: %s", exc)
             self._consumer = None
 
@@ -76,7 +76,7 @@ class PromptCacheInvalidator:
                 await self.handle_event(msg.value)
         except asyncio.CancelledError:
             pass
-        except Exception as exc:
+        except (Exception, asyncio.TimeoutError) as exc:
             logger.error("PromptCacheInvalidator consume error: %s", exc)
 
     async def handle_event(self, event: dict) -> None:
@@ -92,9 +92,7 @@ class PromptCacheInvalidator:
                     if r:
                         deleted = 0
                         batch = []
-                        async for key in r.scan_iter(
-                            match=f"prompt:{prompt_name}:*"
-                        ):
+                        async for key in r.scan_iter(match=f"prompt:{prompt_name}:*"):
                             batch.append(key)
                             if len(batch) >= 100:
                                 await r.delete(*batch)
@@ -109,5 +107,5 @@ class PromptCacheInvalidator:
                                 deleted,
                                 prompt_name,
                             )
-                except Exception as exc:
+                except (Exception, asyncio.TimeoutError) as exc:
                     logger.warning("Cache invalidation failed: %s", exc)

--- a/trend-cultural-agent-svc/app/prompts/loader.py
+++ b/trend-cultural-agent-svc/app/prompts/loader.py
@@ -11,6 +11,7 @@ Usage in an agent service:
     await loader.stop()
 """
 
+import asyncio
 import logging
 import re
 from typing import Any, Optional
@@ -46,9 +47,11 @@ class AgentPromptClient:
         """Initialize Redis and HTTP connections."""
         try:
             self._redis = aioredis.from_url(
-                self.redis_url, decode_responses=True
+                self.redis_url,
+                decode_responses=True,
+                socket_connect_timeout=5,
             )
-            await self._redis.ping()
+            await asyncio.wait_for(self._redis.ping(), timeout=5.0)
             logger.info("Prompt cache connected: %s", self.redis_url)
         except Exception as exc:
             logger.warning("Prompt cache unavailable: %s", exc)
@@ -56,9 +59,7 @@ class AgentPromptClient:
 
         if self.mlflow_uri:
             try:
-                self._http = httpx.AsyncClient(
-                    base_url=self.mlflow_uri, timeout=5.0
-                )
+                self._http = httpx.AsyncClient(base_url=self.mlflow_uri, timeout=5.0)
                 resp = await self._http.get("/health")
                 if resp.status_code == 200:
                     logger.info("MLflow connected: %s", self.mlflow_uri)
@@ -72,7 +73,9 @@ class AgentPromptClient:
                     await self._http.aclose()
                 self._http = None
         else:
-            logger.info("MLflow URI not configured — prompt loader in fallback-only mode")
+            logger.info(
+                "MLflow URI not configured — prompt loader in fallback-only mode"
+            )
 
         logger.info("Prompt loader initialized")
 
@@ -127,9 +130,7 @@ class AgentPromptClient:
 
     # --- Tier 1: Redis cache ---
 
-    async def _cache_get(
-        self, name: str, tenant_id: Optional[str]
-    ) -> Optional[str]:
+    async def _cache_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._redis is None:
             return None
         try:
@@ -163,17 +164,13 @@ class AgentPromptClient:
 
     # --- Tier 2: MLflow REST API ---
 
-    async def _mlflow_get(
-        self, name: str, tenant_id: Optional[str]
-    ) -> Optional[str]:
+    async def _mlflow_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._http is None:
             return None
         try:
             # Try tenant-specific named prompt first
             if tenant_id:
-                template = await self._fetch_prompt(
-                    f"{name}-tenant-{tenant_id}"
-                )
+                template = await self._fetch_prompt(f"{name}-tenant-{tenant_id}")
                 if template is not None:
                     return template
 
@@ -224,9 +221,7 @@ class AgentPromptClient:
                     )
                     if ver_resp.status_code == 200:
                         ver_data = ver_resp.json()
-                        return ver_data.get("prompt_version", {}).get(
-                            "template"
-                        )
+                        return ver_data.get("prompt_version", {}).get("template")
             return None
         except Exception:
             return None
@@ -234,9 +229,7 @@ class AgentPromptClient:
     # --- Template formatting ---
 
     @staticmethod
-    def _format(
-        template: str, variables: Optional[dict[str, Any]]
-    ) -> str:
+    def _format(template: str, variables: Optional[dict[str, Any]]) -> str:
         if not template or not variables:
             return template
 

--- a/trend-cultural-agent-svc/app/prompts/loader.py
+++ b/trend-cultural-agent-svc/app/prompts/loader.py
@@ -36,10 +36,12 @@ class AgentPromptClient:
         redis_url: str = "redis://localhost:6379/2",
         mlflow_uri: str = "http://mlflow-server:5000",
         default_ttl: int = 300,
+        critical_agent: bool = False,
     ) -> None:
         self.redis_url = redis_url
         self.mlflow_uri = mlflow_uri
         self.default_ttl = default_ttl
+        self.critical_agent = critical_agent
         self._redis: Optional[aioredis.Redis] = None
         self._http: Optional[httpx.AsyncClient] = None
 
@@ -123,7 +125,16 @@ class AgentPromptClient:
         # Tier 3: Fallback
         if template is None:
             if fallback:
-                logger.debug("Using fallback for prompt '%s'", name)
+                if self.critical_agent:
+                    logger.warning(
+                        "CRITICAL AGENT FALLBACK: prompt '%s' (tenant=%s) "
+                        "— MLflow and Redis both unreachable, using "
+                        "hardcoded fallback. This agent handles ad spend.",
+                        name,
+                        tenant_id,
+                    )
+                else:
+                    logger.debug("Using fallback for prompt '%s'", name)
             template = fallback
 
         return self._format(template, variables)

--- a/trend-cultural-agent-svc/app/prompts/loader.py
+++ b/trend-cultural-agent-svc/app/prompts/loader.py
@@ -7,7 +7,7 @@ and MLflow tracking server independently of the prompt-optimization-svc.
 Usage in an agent service:
     loader = AgentPromptClient(redis_url="redis://redis:6379/2", mlflow_uri="http://mlflow-server:5000")
     await loader.start()
-    prompt = await loader.load("zorven-wf1-mra-system", tenant_id="t-1", fallback="You are...")
+    prompt = await loader.load("zorven-<wf>-<agent>-system", tenant_id="t-1", fallback="You are...")
     await loader.stop()
 """
 
@@ -129,7 +129,7 @@ class AgentPromptClient:
                     logger.warning(
                         "CRITICAL AGENT FALLBACK: prompt '%s' (tenant=%s) "
                         "— MLflow and Redis both unreachable, using "
-                        "hardcoded fallback. This agent handles ad spend.",
+                        "hardcoded fallback.",
                         name,
                         tenant_id,
                     )

--- a/voc-agent-svc/app/prompts/invalidator.py
+++ b/voc-agent-svc/app/prompts/invalidator.py
@@ -50,8 +50,9 @@ class PromptCacheInvalidator:
                 self.TOPIC,
                 self.GROUP_ID,
             )
-        except (Exception, asyncio.TimeoutError) as exc:
+        except Exception as exc:
             logger.warning("PromptCacheInvalidator failed: %s — no-op mode", exc)
+            self._consumer = None
 
     async def stop(self) -> None:
         """Stop the consumer and background task."""
@@ -65,7 +66,7 @@ class PromptCacheInvalidator:
         if self._consumer is not None:
             try:
                 await self._consumer.stop()
-            except (Exception, asyncio.TimeoutError) as exc:
+            except Exception as exc:
                 logger.warning("Error stopping PromptCacheInvalidator: %s", exc)
             self._consumer = None
 
@@ -76,7 +77,7 @@ class PromptCacheInvalidator:
                 await self.handle_event(msg.value)
         except asyncio.CancelledError:
             pass
-        except (Exception, asyncio.TimeoutError) as exc:
+        except Exception as exc:
             logger.error("PromptCacheInvalidator consume error: %s", exc)
 
     async def handle_event(self, event: dict) -> None:
@@ -107,5 +108,5 @@ class PromptCacheInvalidator:
                                 deleted,
                                 prompt_name,
                             )
-                except (Exception, asyncio.TimeoutError) as exc:
+                except Exception as exc:
                     logger.warning("Cache invalidation failed: %s", exc)

--- a/voc-agent-svc/app/prompts/invalidator.py
+++ b/voc-agent-svc/app/prompts/invalidator.py
@@ -43,14 +43,14 @@ class PromptCacheInvalidator:
                 auto_offset_reset="latest",
                 value_deserializer=lambda v: json.loads(v.decode("utf-8")),
             )
-            await self._consumer.start()
+            await asyncio.wait_for(self._consumer.start(), timeout=10.0)
             self._task = asyncio.create_task(self._consume_loop())
             logger.info(
                 "PromptCacheInvalidator started (topic=%s, group=%s)",
                 self.TOPIC,
                 self.GROUP_ID,
             )
-        except Exception as exc:
+        except (Exception, asyncio.TimeoutError) as exc:
             logger.warning("PromptCacheInvalidator failed: %s — no-op mode", exc)
 
     async def stop(self) -> None:
@@ -65,7 +65,7 @@ class PromptCacheInvalidator:
         if self._consumer is not None:
             try:
                 await self._consumer.stop()
-            except Exception as exc:
+            except (Exception, asyncio.TimeoutError) as exc:
                 logger.warning("Error stopping PromptCacheInvalidator: %s", exc)
             self._consumer = None
 
@@ -76,7 +76,7 @@ class PromptCacheInvalidator:
                 await self.handle_event(msg.value)
         except asyncio.CancelledError:
             pass
-        except Exception as exc:
+        except (Exception, asyncio.TimeoutError) as exc:
             logger.error("PromptCacheInvalidator consume error: %s", exc)
 
     async def handle_event(self, event: dict) -> None:
@@ -92,9 +92,7 @@ class PromptCacheInvalidator:
                     if r:
                         deleted = 0
                         batch = []
-                        async for key in r.scan_iter(
-                            match=f"prompt:{prompt_name}:*"
-                        ):
+                        async for key in r.scan_iter(match=f"prompt:{prompt_name}:*"):
                             batch.append(key)
                             if len(batch) >= 100:
                                 await r.delete(*batch)
@@ -109,5 +107,5 @@ class PromptCacheInvalidator:
                                 deleted,
                                 prompt_name,
                             )
-                except Exception as exc:
+                except (Exception, asyncio.TimeoutError) as exc:
                     logger.warning("Cache invalidation failed: %s", exc)

--- a/voc-agent-svc/app/prompts/loader.py
+++ b/voc-agent-svc/app/prompts/loader.py
@@ -11,6 +11,7 @@ Usage in an agent service:
     await loader.stop()
 """
 
+import asyncio
 import logging
 import re
 from typing import Any, Optional
@@ -46,9 +47,11 @@ class AgentPromptClient:
         """Initialize Redis and HTTP connections."""
         try:
             self._redis = aioredis.from_url(
-                self.redis_url, decode_responses=True
+                self.redis_url,
+                decode_responses=True,
+                socket_connect_timeout=5,
             )
-            await self._redis.ping()
+            await asyncio.wait_for(self._redis.ping(), timeout=5.0)
             logger.info("Prompt cache connected: %s", self.redis_url)
         except Exception as exc:
             logger.warning("Prompt cache unavailable: %s", exc)
@@ -56,9 +59,7 @@ class AgentPromptClient:
 
         if self.mlflow_uri:
             try:
-                self._http = httpx.AsyncClient(
-                    base_url=self.mlflow_uri, timeout=5.0
-                )
+                self._http = httpx.AsyncClient(base_url=self.mlflow_uri, timeout=5.0)
                 resp = await self._http.get("/health")
                 if resp.status_code == 200:
                     logger.info("MLflow connected: %s", self.mlflow_uri)
@@ -72,7 +73,9 @@ class AgentPromptClient:
                     await self._http.aclose()
                 self._http = None
         else:
-            logger.info("MLflow URI not configured — prompt loader in fallback-only mode")
+            logger.info(
+                "MLflow URI not configured — prompt loader in fallback-only mode"
+            )
 
         logger.info("Prompt loader initialized")
 
@@ -127,9 +130,7 @@ class AgentPromptClient:
 
     # --- Tier 1: Redis cache ---
 
-    async def _cache_get(
-        self, name: str, tenant_id: Optional[str]
-    ) -> Optional[str]:
+    async def _cache_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._redis is None:
             return None
         try:
@@ -163,17 +164,13 @@ class AgentPromptClient:
 
     # --- Tier 2: MLflow REST API ---
 
-    async def _mlflow_get(
-        self, name: str, tenant_id: Optional[str]
-    ) -> Optional[str]:
+    async def _mlflow_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._http is None:
             return None
         try:
             # Try tenant-specific named prompt first
             if tenant_id:
-                template = await self._fetch_prompt(
-                    f"{name}-tenant-{tenant_id}"
-                )
+                template = await self._fetch_prompt(f"{name}-tenant-{tenant_id}")
                 if template is not None:
                     return template
 
@@ -224,9 +221,7 @@ class AgentPromptClient:
                     )
                     if ver_resp.status_code == 200:
                         ver_data = ver_resp.json()
-                        return ver_data.get("prompt_version", {}).get(
-                            "template"
-                        )
+                        return ver_data.get("prompt_version", {}).get("template")
             return None
         except Exception:
             return None
@@ -234,9 +229,7 @@ class AgentPromptClient:
     # --- Template formatting ---
 
     @staticmethod
-    def _format(
-        template: str, variables: Optional[dict[str, Any]]
-    ) -> str:
+    def _format(template: str, variables: Optional[dict[str, Any]]) -> str:
         if not template or not variables:
             return template
 

--- a/voc-agent-svc/app/prompts/loader.py
+++ b/voc-agent-svc/app/prompts/loader.py
@@ -36,10 +36,12 @@ class AgentPromptClient:
         redis_url: str = "redis://localhost:6379/2",
         mlflow_uri: str = "http://mlflow-server:5000",
         default_ttl: int = 300,
+        critical_agent: bool = False,
     ) -> None:
         self.redis_url = redis_url
         self.mlflow_uri = mlflow_uri
         self.default_ttl = default_ttl
+        self.critical_agent = critical_agent
         self._redis: Optional[aioredis.Redis] = None
         self._http: Optional[httpx.AsyncClient] = None
 
@@ -123,7 +125,16 @@ class AgentPromptClient:
         # Tier 3: Fallback
         if template is None:
             if fallback:
-                logger.debug("Using fallback for prompt '%s'", name)
+                if self.critical_agent:
+                    logger.warning(
+                        "CRITICAL AGENT FALLBACK: prompt '%s' (tenant=%s) "
+                        "— MLflow and Redis both unreachable, using "
+                        "hardcoded fallback. This agent handles ad spend.",
+                        name,
+                        tenant_id,
+                    )
+                else:
+                    logger.debug("Using fallback for prompt '%s'", name)
             template = fallback
 
         return self._format(template, variables)

--- a/voc-agent-svc/app/prompts/loader.py
+++ b/voc-agent-svc/app/prompts/loader.py
@@ -7,7 +7,7 @@ and MLflow tracking server independently of the prompt-optimization-svc.
 Usage in an agent service:
     loader = AgentPromptClient(redis_url="redis://redis:6379/2", mlflow_uri="http://mlflow-server:5000")
     await loader.start()
-    prompt = await loader.load("zorven-wf1-mra-system", tenant_id="t-1", fallback="You are...")
+    prompt = await loader.load("zorven-<wf>-<agent>-system", tenant_id="t-1", fallback="You are...")
     await loader.stop()
 """
 
@@ -129,7 +129,7 @@ class AgentPromptClient:
                     logger.warning(
                         "CRITICAL AGENT FALLBACK: prompt '%s' (tenant=%s) "
                         "— MLflow and Redis both unreachable, using "
-                        "hardcoded fallback. This agent handles ad spend.",
+                        "hardcoded fallback.",
                         name,
                         tenant_id,
                     )


### PR DESCRIPTION
## Summary

- **Root cause**: `PromptCacheInvalidator.start()` calls `await self._consumer.start()` with no timeout. When Kafka's `prompt-lifecycle-events` topic doesn't exist on Railway, this hangs indefinitely, blocking FastAPI lifespan. Agents never reach `yield`, crash-loop, and return stub responses (30% confidence, no LLM synthesis).
- **invalidator.py (15 agents)**: Wrap `consumer.start()` in `asyncio.wait_for(timeout=10.0)` — falls back to no-op mode on timeout
- **loader.py (15 agents)**: Add `socket_connect_timeout=5` to Redis connection and wrap `ping()` in `asyncio.wait_for(timeout=5.0)` — falls back to fallback-only mode on timeout

## Test plan

- [ ] Deploy to Railway and verify agents start successfully (no crash-loop)
- [ ] Run Brand Discovery workflow — confidence should be >30%
- [ ] Verify agents return LLM-synthesized results (TAM/SAM/SOM, competitive landscape) instead of stub data
- [ ] Verify agents gracefully degrade when Kafka/Redis are unreachable (log warning, continue serving)

🤖 Generated with [Claude Code](https://claude.com/claude-code)