### PR TITLE
fix: add API key diagnostics and Railway env var docs for all agents

### DIFF
--- a/ad-publishing-agent-svc/app/main.py
+++ b/ad-publishing-agent-svc/app/main.py
@@ -36,8 +36,7 @@ async def lifespan(app: FastAPI):
     """Initialize and teardown all dependencies."""
     setup_logging()
     logger.info(
-        "Starting Ad Publishing Agent service on port %d "
-        "(sandbox=%s)",
+        "Starting Ad Publishing Agent service on port %d " "(sandbox=%s)",
         settings.PORT,
         settings.META_ADS_SANDBOX_MODE,
     )
@@ -54,19 +53,23 @@ async def lifespan(app: FastAPI):
 
     # 3. Anthropic client (Claude Sonnet 4 for targeting translation)
     anthropic_client = None
-    if settings.ANTHROPIC_API_KEY:
+    api_key = settings.ANTHROPIC_API_KEY
+    if api_key:
         try:
             import anthropic
 
-            anthropic_client = anthropic.AsyncAnthropic(
-                api_key=settings.ANTHROPIC_API_KEY
-            )
+            anthropic_client = anthropic.AsyncAnthropic(api_key=api_key)
+            masked = f"{api_key[:4]}...{api_key[-4:]}" if len(api_key) > 8 else "***"
             logger.info(
-                "Anthropic client initialized (model: %s)",
+                "Anthropic client initialized (model: %s, key: %s, len: %d)",
                 settings.ANTHROPIC_MODEL,
+                masked,
+                len(api_key),
             )
         except Exception as exc:
             logger.warning("Anthropic client init failed: %s", exc)
+    else:
+        logger.warning("Set ADPUB_ANTHROPIC_API_KEY on Railway for live results")
 
     # 4. LLM wrapper + targeting translator
     from app.services.anthropic_client import AnthropicClient
@@ -119,7 +122,6 @@ async def lifespan(app: FastAPI):
     app.state.redis_manager = redis_manager
 
     logger.info("Ad Publishing Agent service ready")
-
 
     # Prompt loader + cache invalidator (ZorvenPromptLoader integration)
     prompt_loader = AgentPromptClient(

--- a/ad-publishing-agent-svc/app/services/targeting_translator.py
+++ b/ad-publishing-agent-svc/app/services/targeting_translator.py
@@ -75,13 +75,9 @@ class TargetingTranslator:
         categories = special_ad_categories or []
 
         if self._llm is None:
-            targeting = self._fallback_translation(
-                persona, categories, placements
-            )
+            targeting = self._fallback_translation(persona, categories, placements)
         else:
-            user_prompt = self._build_prompt(
-                persona, industry, categories, placements
-            )
+            user_prompt = self._build_prompt(persona, industry, categories, placements)
             try:
                 targeting = await self._llm.generate_json(
                     system_prompt=TARGETING_SYSTEM_PROMPT,
@@ -89,19 +85,17 @@ class TargetingTranslator:
                     temperature=0.2,
                 )
             except Exception as exc:
-                logger.warning(
-                    "LLM targeting translation failed, using fallback: %s",
+                logger.error(
+                    "LLM targeting translation failed (%s), " "using fallback: %s",
+                    type(exc).__name__,
                     exc,
+                    exc_info=True,
                 )
-                targeting = self._fallback_translation(
-                    persona, categories, placements
-                )
+                targeting = self._fallback_translation(persona, categories, placements)
 
         # Enforce Special Ad Category restrictions
         if categories:
-            targeting = self._apply_category_restrictions(
-                targeting, categories
-            )
+            targeting = self._apply_category_restrictions(targeting, categories)
 
         # Validate minimum fields
         warnings = self._validate_targeting(targeting)
@@ -140,12 +134,8 @@ class TargetingTranslator:
 
         parts = [
             f"Industry: {industry}" if industry else "",
-            f"Special Ad Categories: {', '.join(categories)}"
-            if categories
-            else "",
-            f"Requested placements: {', '.join(placements)}"
-            if placements
-            else "",
+            f"Special Ad Categories: {', '.join(categories)}" if categories else "",
+            f"Requested placements: {', '.join(placements)}" if placements else "",
             f"Persona:\n{json.dumps(persona, indent=2)}",
         ]
         return "\n\n".join(p for p in parts if p)
@@ -184,12 +174,12 @@ class TargetingTranslator:
 
         # Map interests as estimated
         for interest in persona.get("interests", []):
-            name = interest if isinstance(interest, str) else interest.get(
-                "name", str(interest)
+            name = (
+                interest
+                if isinstance(interest, str)
+                else interest.get("name", str(interest))
             )
-            targeting["interests"].append(
-                {"name": name, "estimated": True}
-            )
+            targeting["interests"].append({"name": name, "estimated": True})
 
         # Placements
         if placements:
@@ -205,9 +195,7 @@ class TargetingTranslator:
                 if p in placement_map:
                     platform, position = placement_map[p]
                     platforms.add(platform)
-                    positions.setdefault(
-                        f"{platform}_positions", []
-                    ).append(position)
+                    positions.setdefault(f"{platform}_positions", []).append(position)
             if platforms:
                 targeting["publisher_platforms"] = sorted(platforms)
             targeting.update(positions)
@@ -221,7 +209,9 @@ class TargetingTranslator:
     ) -> dict[str, Any]:
         """Remove restricted targeting for Special Ad Categories."""
         restricted = {
-            "HOUSING", "CREDIT", "EMPLOYMENT",
+            "HOUSING",
+            "CREDIT",
+            "EMPLOYMENT",
             "EMPLOYMENT_OPPORTUNITY",
             "HOUSING_OPPORTUNITY",
             "CREDIT_OPPORTUNITY",
@@ -248,7 +238,6 @@ class TargetingTranslator:
             warnings.append("No geo targeting specified")
         if not targeting.get("interests") and not targeting.get("behaviors"):
             warnings.append(
-                "No interest or behavior targeting — audience may be "
-                "too broad"
+                "No interest or behavior targeting — audience may be " "too broad"
             )
         return warnings

--- a/audience-persona-agent-svc/app/logic/persona_analyzer.py
+++ b/audience-persona-agent-svc/app/logic/persona_analyzer.py
@@ -610,7 +610,7 @@ class PersonaAnalyzer:
             logger.warning("LLM circuit open during synthesis")
             return self._stub_synthesis(prompt, skill_results)
         except Exception:
-            logger.warning("Synthesis failed", exc_info=True)
+            logger.error("Synthesis failed", exc_info=True)
             return self._stub_synthesis(prompt, skill_results)
 
     @staticmethod

--- a/audience-persona-agent-svc/app/main.py
+++ b/audience-persona-agent-svc/app/main.py
@@ -59,9 +59,21 @@ async def lifespan(app: FastAPI):
             anthropic_client = anthropic.AsyncAnthropic(
                 api_key=settings.ANTHROPIC_API_KEY
             )
-            logger.info("Anthropic client initialized (model=%s)", settings.LLM_MODEL)
+            key = settings.ANTHROPIC_API_KEY
+            masked = f"{key[:4]}...{key[-4:]}" if len(key) > 8 else "***"
+            logger.info(
+                "Anthropic client initialized (key=%s, length=%d, model=%s)",
+                masked,
+                len(key),
+                settings.LLM_MODEL,
+            )
         except Exception as exc:
             logger.warning("Failed to initialize Anthropic client: %s", exc)
+    else:
+        logger.error(
+            "ANTHROPIC_API_KEY is not set — LLM skills will run in stub mode. "
+            "Set APA_ANTHROPIC_API_KEY on Railway"
+        )
 
     # 5. Circuit breakers
     breakers = create_breakers(settings)

--- a/brand-architecture-agent-svc/app/main.py
+++ b/brand-architecture-agent-svc/app/main.py
@@ -45,19 +45,23 @@ async def lifespan(app: FastAPI):
 
     # 3. Anthropic client (lazy)
     anthropic_client = None
-    if settings.ANTHROPIC_API_KEY:
+    api_key = settings.ANTHROPIC_API_KEY
+    if api_key:
         try:
             import anthropic
 
-            anthropic_client = anthropic.AsyncAnthropic(
-                api_key=settings.ANTHROPIC_API_KEY
-            )
+            anthropic_client = anthropic.AsyncAnthropic(api_key=api_key)
             logger.info(
-                "Anthropic client initialized (model=%s)",
+                "Anthropic client initialized (key=%s...%s, length=%d, model=%s)",
+                api_key[:4],
+                api_key[-4:],
+                len(api_key),
                 settings.ANTHROPIC_MODEL,
             )
         except Exception as exc:
             logger.warning("Failed to initialize Anthropic client: %s", exc)
+    else:
+        logger.warning("Set BAA_ANTHROPIC_API_KEY on Railway for live results")
 
     # 4. Anthropic wrapper
     from app.services.anthropic_client import AnthropicClient
@@ -102,7 +106,6 @@ async def lifespan(app: FastAPI):
         bool(anthropic_client),
         settings.BACKEND_URL,
     )
-
 
     # Prompt loader (ZorvenPromptLoader integration)
     prompt_loader = AgentPromptClient(

--- a/brand-architecture-agent-svc/app/services/anthropic_client.py
+++ b/brand-architecture-agent-svc/app/services/anthropic_client.py
@@ -67,7 +67,7 @@ class AnthropicClient:
                     except json.JSONDecodeError:
                         pass
 
-                logger.warning(
+                logger.error(
                     "Failed to parse JSON from Claude response "
                     "(length=%d, preview=%.200s)",
                     len(raw_text),
@@ -82,7 +82,12 @@ class AnthropicClient:
                     "confidence_score": 0.0,
                 }
         except Exception as exc:
-            logger.error("Anthropic API call failed: %s", exc)
+            logger.error(
+                "Anthropic API call failed (%s): %s",
+                type(exc).__name__,
+                exc,
+                exc_info=True,
+            )
             return {
                 "findings": [f"LLM API call failed: {str(exc)[:100]}"],
                 "confidence_score": 0.0,
@@ -110,5 +115,10 @@ class AnthropicClient:
             )
             return response.content[0].text
         except Exception as exc:
-            logger.error("Anthropic API call failed: %s", exc)
+            logger.error(
+                "Anthropic API call failed (%s): %s",
+                type(exc).__name__,
+                exc,
+                exc_info=True,
+            )
             return ""

--- a/brand-architecture-agent-svc/app/services/baa_analyzer.py
+++ b/brand-architecture-agent-svc/app/services/baa_analyzer.py
@@ -220,9 +220,11 @@ class BAAAnalyzer:
 
         # Detect parse failure (raw_text key present means JSON parsing failed)
         if "raw_text" in result and "recommendation" not in result:
-            logger.warning(
-                "Claude returned unparseable response for tenant %s",
+            logger.error(
+                "Claude returned unparseable response for tenant %s "
+                "(raw_text length=%d)",
                 tenant_id,
+                len(result.get("raw_text", "")),
             )
             return {
                 "recommendation": {},

--- a/brand-naming-agent-svc/app/main.py
+++ b/brand-naming-agent-svc/app/main.py
@@ -43,16 +43,23 @@ async def lifespan(app: FastAPI):
 
     # 3. Anthropic client (lazy)
     anthropic_client = None
-    if settings.ANTHROPIC_API_KEY:
+    api_key = settings.ANTHROPIC_API_KEY
+    if api_key:
         try:
             import anthropic
 
-            anthropic_client = anthropic.AsyncAnthropic(
-                api_key=settings.ANTHROPIC_API_KEY
+            anthropic_client = anthropic.AsyncAnthropic(api_key=api_key)
+            logger.info(
+                "Anthropic client initialized (key=%s...%s, length=%d, model=%s)",
+                api_key[:4],
+                api_key[-4:],
+                len(api_key),
+                settings.ANTHROPIC_MODEL,
             )
-            logger.info("Anthropic client initialized (model: %s)", settings.ANTHROPIC_MODEL)
         except Exception as exc:
             logger.warning("Anthropic client init failed: %s", exc)
+    else:
+        logger.warning("Set NTA_ANTHROPIC_API_KEY on Railway for live results")
 
     # 4. Event emitter
     event_emitter = EventEmitter(audit_producer)
@@ -84,7 +91,6 @@ async def lifespan(app: FastAPI):
     app.state.redis_manager = redis_manager
 
     logger.info("Naming & Tagline Agent service ready")
-
 
     # Prompt loader (ZorvenPromptLoader integration)
     prompt_loader = AgentPromptClient(

--- a/brand-naming-agent-svc/app/services/anthropic_client.py
+++ b/brand-naming-agent-svc/app/services/anthropic_client.py
@@ -39,7 +39,7 @@ class AnthropicClient:
             )
             return json.loads(text)
         except json.JSONDecodeError:
-            logger.warning("Claude returned non-JSON, attempting extraction")
+            logger.error("Claude returned non-JSON, attempting extraction")
             text = response.content[0].text
             start = text.find("{")
             end = text.rfind("}") + 1
@@ -47,5 +47,10 @@ class AnthropicClient:
                 return json.loads(text[start:end])
             return {"raw_response": text}
         except Exception as exc:
-            logger.error("Claude API error: %s", exc)
+            logger.error(
+                "Claude API error (%s): %s",
+                type(exc).__name__,
+                exc,
+                exc_info=True,
+            )
             raise

--- a/brand-personality-agent-svc/app/main.py
+++ b/brand-personality-agent-svc/app/main.py
@@ -43,16 +43,23 @@ async def lifespan(app: FastAPI):
 
     # 3. Anthropic client (lazy)
     anthropic_client = None
-    if settings.ANTHROPIC_API_KEY:
+    api_key = settings.ANTHROPIC_API_KEY
+    if api_key:
         try:
             import anthropic
 
-            anthropic_client = anthropic.AsyncAnthropic(
-                api_key=settings.ANTHROPIC_API_KEY
+            anthropic_client = anthropic.AsyncAnthropic(api_key=api_key)
+            logger.info(
+                "Anthropic client initialized (key=%s...%s, length=%d, model=%s)",
+                api_key[:4],
+                api_key[-4:],
+                len(api_key),
+                settings.ANTHROPIC_MODEL,
             )
-            logger.info("Anthropic client initialized (model: %s)", settings.ANTHROPIC_MODEL)
         except Exception as exc:
             logger.warning("Anthropic client init failed: %s", exc)
+    else:
+        logger.warning("Set BPV_ANTHROPIC_API_KEY on Railway for live results")
 
     # 4. Event emitter
     event_emitter = EventEmitter(audit_producer)
@@ -84,7 +91,6 @@ async def lifespan(app: FastAPI):
     app.state.redis_manager = redis_manager
 
     logger.info("Brand Personality Agent service ready")
-
 
     # Prompt loader (ZorvenPromptLoader integration)
     prompt_loader = AgentPromptClient(

--- a/brand-personality-agent-svc/app/services/anthropic_client.py
+++ b/brand-personality-agent-svc/app/services/anthropic_client.py
@@ -39,7 +39,7 @@ class AnthropicClient:
             )
             return json.loads(text)
         except json.JSONDecodeError:
-            logger.warning("Claude returned non-JSON, attempting extraction")
+            logger.error("Claude returned non-JSON, attempting extraction")
             text = response.content[0].text
             start = text.find("{")
             end = text.rfind("}") + 1
@@ -47,5 +47,10 @@ class AnthropicClient:
                 return json.loads(text[start:end])
             return {"raw_response": text}
         except Exception as exc:
-            logger.error("Claude API error: %s", exc)
+            logger.error(
+                "Claude API error (%s): %s",
+                type(exc).__name__,
+                exc,
+                exc_info=True,
+            )
             raise

--- a/brand-positioning-agent-svc/app/main.py
+++ b/brand-positioning-agent-svc/app/main.py
@@ -45,19 +45,23 @@ async def lifespan(app: FastAPI):
 
     # 3. Anthropic client (lazy)
     anthropic_client = None
-    if settings.ANTHROPIC_API_KEY:
+    api_key = settings.ANTHROPIC_API_KEY
+    if api_key:
         try:
             import anthropic
 
-            anthropic_client = anthropic.AsyncAnthropic(
-                api_key=settings.ANTHROPIC_API_KEY
-            )
+            anthropic_client = anthropic.AsyncAnthropic(api_key=api_key)
             logger.info(
-                "Anthropic client initialized (model=%s)",
+                "Anthropic client initialized (key=%s...%s, length=%d, model=%s)",
+                api_key[:4],
+                api_key[-4:],
+                len(api_key),
                 settings.ANTHROPIC_MODEL,
             )
         except Exception as exc:
             logger.warning("Failed to initialize Anthropic client: %s", exc)
+    else:
+        logger.warning("Set BPA_ANTHROPIC_API_KEY on Railway for live results")
 
     # 4. Anthropic wrapper
     from app.services.anthropic_client import AnthropicClient
@@ -102,7 +106,6 @@ async def lifespan(app: FastAPI):
         bool(anthropic_client),
         settings.BACKEND_URL,
     )
-
 
     # Prompt loader (ZorvenPromptLoader integration)
     prompt_loader = AgentPromptClient(

--- a/brand-positioning-agent-svc/app/services/anthropic_client.py
+++ b/brand-positioning-agent-svc/app/services/anthropic_client.py
@@ -58,7 +58,12 @@ class AnthropicClient:
             logger.warning("Failed to parse JSON from Claude response")
             return {"raw_text": response.content[0].text if response else ""}
         except Exception as exc:
-            logger.error("Anthropic API call failed: %s", exc)
+            logger.error(
+                "Anthropic API call failed (%s): %s",
+                type(exc).__name__,
+                exc,
+                exc_info=True,
+            )
             return {}
 
     async def generate_text(
@@ -83,5 +88,10 @@ class AnthropicClient:
             )
             return response.content[0].text
         except Exception as exc:
-            logger.error("Anthropic API call failed: %s", exc)
+            logger.error(
+                "Anthropic API call failed (%s): %s",
+                type(exc).__name__,
+                exc,
+                exc_info=True,
+            )
             return ""

--- a/brand-story-agent-svc/app/main.py
+++ b/brand-story-agent-svc/app/main.py
@@ -44,18 +44,23 @@ async def lifespan(app: FastAPI):
 
     # 3. Anthropic client (lazy)
     anthropic_client = None
-    if settings.ANTHROPIC_API_KEY:
+    api_key = settings.ANTHROPIC_API_KEY
+    if api_key:
         try:
             import anthropic
 
-            anthropic_client = anthropic.AsyncAnthropic(
-                api_key=settings.ANTHROPIC_API_KEY
-            )
+            anthropic_client = anthropic.AsyncAnthropic(api_key=api_key)
             logger.info(
-                "Anthropic client initialized (model: %s)", settings.ANTHROPIC_MODEL
+                "Anthropic client initialized (key=%s...%s, length=%d, model=%s)",
+                api_key[:4],
+                api_key[-4:],
+                len(api_key),
+                settings.ANTHROPIC_MODEL,
             )
         except Exception as exc:
             logger.warning("Anthropic client init failed: %s", exc)
+    else:
+        logger.warning("Set BSA_ANTHROPIC_API_KEY on Railway for live results")
 
     # 4. GCS client
     gcs_client = GCSClient(
@@ -98,7 +103,6 @@ async def lifespan(app: FastAPI):
     app.state.redis_manager = redis_manager
 
     logger.info("Brand Story Agent service ready")
-
 
     # Prompt loader (ZorvenPromptLoader integration)
     prompt_loader = AgentPromptClient(

--- a/brand-story-agent-svc/app/services/anthropic_client.py
+++ b/brand-story-agent-svc/app/services/anthropic_client.py
@@ -39,7 +39,7 @@ class AnthropicClient:
             )
             return json.loads(text)
         except json.JSONDecodeError:
-            logger.warning("Claude returned non-JSON, attempting extraction")
+            logger.error("Claude returned non-JSON, attempting extraction")
             text = response.content[0].text
             start = text.find("{")
             end = text.rfind("}") + 1
@@ -47,5 +47,10 @@ class AnthropicClient:
                 return json.loads(text[start:end])
             return {"raw_response": text}
         except Exception as exc:
-            logger.error("Claude API error: %s", exc)
+            logger.error(
+                "Claude API error (%s): %s",
+                type(exc).__name__,
+                exc,
+                exc_info=True,
+            )
             raise

--- a/campaign-architecture-agent-svc/app/main.py
+++ b/campaign-architecture-agent-svc/app/main.py
@@ -49,19 +49,23 @@ async def lifespan(app: FastAPI):
 
     # 3. Anthropic client (lazy)
     anthropic_client = None
-    if settings.ANTHROPIC_API_KEY:
+    api_key = settings.ANTHROPIC_API_KEY
+    if api_key:
         try:
             import anthropic
 
-            anthropic_client = anthropic.AsyncAnthropic(
-                api_key=settings.ANTHROPIC_API_KEY
-            )
+            anthropic_client = anthropic.AsyncAnthropic(api_key=api_key)
+            masked = f"{api_key[:4]}...{api_key[-4:]}" if len(api_key) > 8 else "***"
             logger.info(
-                "Anthropic client initialized (model: %s)",
+                "Anthropic client initialized (model: %s, key: %s, len: %d)",
                 settings.ANTHROPIC_MODEL,
+                masked,
+                len(api_key),
             )
         except Exception as exc:
             logger.warning("Anthropic client init failed: %s", exc)
+    else:
+        logger.warning("Set CAA_ANTHROPIC_API_KEY on Railway for live results")
 
     # 4. GCS client
     gcs_client = GCSClient(
@@ -113,7 +117,6 @@ async def lifespan(app: FastAPI):
     app.state.redis_manager = redis_manager
 
     logger.info("Campaign Architecture Agent service ready")
-
 
     # Prompt loader + cache invalidator (ZorvenPromptLoader integration)
     prompt_loader = AgentPromptClient(

--- a/campaign-architecture-agent-svc/app/services/caa_analyzer.py
+++ b/campaign-architecture-agent-svc/app/services/caa_analyzer.py
@@ -199,7 +199,12 @@ class CAAAnalyzer:
             try:
                 call1_result = await self._llm.generate_json(call1_system, call1_user)
             except Exception as exc:
-                logger.error("Claude call 1 failed: %s", exc)
+                logger.error(
+                    "Claude call 1 failed (%s): %s",
+                    type(exc).__name__,
+                    exc,
+                    exc_info=True,
+                )
                 call1_result = {}
 
         # Plan guardrails on call 1 output — defensive type checks
@@ -258,7 +263,12 @@ class CAAAnalyzer:
             try:
                 call2_result = await self._llm.generate_json(call2_system, call2_user)
             except Exception as exc:
-                logger.error("Claude call 2 failed: %s", exc)
+                logger.error(
+                    "Claude call 2 failed (%s): %s",
+                    type(exc).__name__,
+                    exc,
+                    exc_info=True,
+                )
                 call2_result = {}
 
         await self._events.emit(

--- a/campaign-optimization-agent-svc/app/main.py
+++ b/campaign-optimization-agent-svc/app/main.py
@@ -47,8 +47,7 @@ async def lifespan(app: FastAPI):
     """Initialize and teardown all dependencies."""
     setup_logging()
     logger.info(
-        "Starting Campaign Optimization Agent on port %d "
-        "(sandbox=%s)",
+        "Starting Campaign Optimization Agent on port %d " "(sandbox=%s)",
         settings.PORT,
         settings.META_ADS_SANDBOX_MODE,
     )
@@ -68,22 +67,26 @@ async def lifespan(app: FastAPI):
     # 3. Anthropic client (Claude Sonnet 4 for analysis narratives)
     anthropic_client = None
     llm_wrapper = None
-    if settings.ANTHROPIC_API_KEY:
+    api_key = settings.ANTHROPIC_API_KEY
+    if api_key:
         try:
             import anthropic
 
-            anthropic_client = anthropic.AsyncAnthropic(
-                api_key=settings.ANTHROPIC_API_KEY
-            )
+            anthropic_client = anthropic.AsyncAnthropic(api_key=api_key)
             llm_wrapper = AnthropicClient(
                 anthropic_client, model=settings.ANTHROPIC_MODEL
             )
+            masked = f"{api_key[:4]}...{api_key[-4:]}" if len(api_key) > 8 else "***"
             logger.info(
-                "Anthropic client initialized (model: %s)",
+                "Anthropic client initialized (model: %s, key: %s, len: %d)",
                 settings.ANTHROPIC_MODEL,
+                masked,
+                len(api_key),
             )
         except Exception as exc:
             logger.warning("Anthropic client init failed: %s", exc)
+    else:
+        logger.warning("Set COA_ANTHROPIC_API_KEY on Railway for live results")
 
     # 4. Event emitter
     event_emitter = EventEmitter(audit_producer)
@@ -136,7 +139,6 @@ async def lifespan(app: FastAPI):
 
     logger.info("Campaign Optimization Agent service ready")
 
-
     # Prompt loader + cache invalidator (ZorvenPromptLoader integration)
     prompt_loader = AgentPromptClient(
         critical_agent=True,
@@ -174,9 +176,7 @@ app = FastAPI(
 )
 
 # CORS
-origins = [
-    o.strip() for o in settings.CORS_ORIGINS.split(",") if o.strip()
-]
+origins = [o.strip() for o in settings.CORS_ORIGINS.split(",") if o.strip()]
 app.add_middleware(
     CORSMiddleware,
     allow_origins=origins,

--- a/campaign-optimization-agent-svc/app/services/performance_analyzer.py
+++ b/campaign-optimization-agent-svc/app/services/performance_analyzer.py
@@ -92,12 +92,8 @@ class PerformanceAnalyzer:
 
         # Aggregate health
         red = sum(1 for a in ad_set_analyses if a.overall_health == "RED")
-        yellow = sum(
-            1 for a in ad_set_analyses if a.overall_health == "YELLOW"
-        )
-        green = sum(
-            1 for a in ad_set_analyses if a.overall_health == "GREEN"
-        )
+        yellow = sum(1 for a in ad_set_analyses if a.overall_health == "YELLOW")
+        green = sum(1 for a in ad_set_analyses if a.overall_health == "GREEN")
 
         if red > len(ad_set_analyses) * 0.5:
             overall = "RED"
@@ -114,7 +110,12 @@ class PerformanceAnalyzer:
                     campaign, insights, ad_set_analyses, overall
                 )
             except Exception as exc:
-                logger.warning("Narrative generation failed: %s", exc)
+                logger.error(
+                    "Narrative generation failed (%s): %s",
+                    type(exc).__name__,
+                    exc,
+                    exc_info=True,
+                )
 
         return CampaignAnalysis(
             campaign_id=campaign.campaign_id,
@@ -181,21 +182,14 @@ class PerformanceAnalyzer:
         freq_status = "HIGH" if frequency > 3.0 else "OK"
         if frequency > 3.0:
             recommendations.append(
-                f"Frequency {frequency:.1f} is high. "
-                f"Consider creative refresh."
+                f"Frequency {frequency:.1f} is high. " f"Consider creative refresh."
             )
 
         # Spend pacing
-        spend_pct = (
-            (ad_set.spend / total_spend * 100)
-            if total_spend > 0
-            else 0
-        )
+        spend_pct = (ad_set.spend / total_spend * 100) if total_spend > 0 else 0
         if spend_pct > 60:
             pacing_status = "OVERSPENDING"
-            recommendations.append(
-                f"Ad set consuming {spend_pct:.0f}% of total spend."
-            )
+            recommendations.append(f"Ad set consuming {spend_pct:.0f}% of total spend.")
         elif spend_pct < 10 and len(recommendations) == 0:
             pacing_status = "UNDERSPENDING"
         else:

--- a/campaign-optimization-agent-svc/app/services/recommendation_generator.py
+++ b/campaign-optimization-agent-svc/app/services/recommendation_generator.py
@@ -107,9 +107,7 @@ class RecommendationGenerator:
                     },
                     proposed_values={"action": "request_creative_refresh"},
                     reason="creative_fatigue",
-                    priority=(
-                        "high" if ad.confidence == "HIGH" else "medium"
-                    ),
+                    priority=("high" if ad.confidence == "HIGH" else "medium"),
                     now=now,
                     expires=expires,
                 )
@@ -130,11 +128,7 @@ class RecommendationGenerator:
                         "daily_budget": budget_rec.proposed_budget,
                     },
                     reason=budget_rec.reason,
-                    priority=(
-                        "high"
-                        if abs(budget_rec.change_pct) > 30
-                        else "medium"
-                    ),
+                    priority=("high" if abs(budget_rec.change_pct) > 30 else "medium"),
                     now=now,
                     expires=expires,
                 )
@@ -145,7 +139,12 @@ class RecommendationGenerator:
             try:
                 await self._enrich_rationales(recommendations, campaign)
             except Exception as exc:
-                logger.warning("Rationale enrichment failed: %s", exc)
+                logger.error(
+                    "Rationale enrichment failed (%s): %s",
+                    type(exc).__name__,
+                    exc,
+                    exc_info=True,
+                )
 
         logger.info(
             "Generated %d recommendations for campaign %s",

--- a/campaign-optimization-agent-svc/app/services/reporter.py
+++ b/campaign-optimization-agent-svc/app/services/reporter.py
@@ -110,8 +110,11 @@ class Reporter:
                 self._breaker.record_success()
             except Exception as exc:
                 self._breaker.record_failure()
-                logger.warning(
-                    "Report narrative generation failed: %s", exc
+                logger.error(
+                    "Report narrative generation failed (%s): %s",
+                    type(exc).__name__,
+                    exc,
+                    exc_info=True,
                 )
 
         if not narrative:

--- a/competitor-intel-agent-svc/app/logic/competitor_analyzer.py
+++ b/competitor-intel-agent-svc/app/logic/competitor_analyzer.py
@@ -15,7 +15,11 @@ import logging
 import uuid
 from typing import Any, Optional
 
-from app.api.schemas import CompetitorIntelligenceResponse, CompetitorProfile, SourceItem
+from app.api.schemas import (
+    CompetitorIntelligenceResponse,
+    CompetitorProfile,
+    SourceItem,
+)
 from app.circuit_breaker.breaker import CircuitBreaker, CircuitBreakerOpen
 from app.events.catalog import EventCatalog, EventEmitter
 from app.logic.guardrails import (
@@ -254,8 +258,12 @@ class CompetitorAnalyzer:
 
             # Build input data based on skill type
             input_data = self._build_skill_input(
-                skill_id, plan, sanitized_prompt, skill_results,
-                mra_output, previous_outputs,
+                skill_id,
+                plan,
+                sanitized_prompt,
+                skill_results,
+                mra_output,
+                previous_outputs,
             )
 
             # Execute with circuit breaker
@@ -310,9 +318,7 @@ class CompetitorAnalyzer:
                 sanitized_prompt, raw_context, skill_context_text, mra_output
             )
         else:
-            logger.info(
-                "REFLECT phase skipped - role %s denied SKL-CIA-10", user_role
-            )
+            logger.info("REFLECT phase skipped - role %s denied SKL-CIA-10", user_role)
             synthesis = {
                 "executive_summary": raw_context[:500] if raw_context else "",
                 "findings": [
@@ -341,9 +347,7 @@ class CompetitorAnalyzer:
         # Also populate from competitor profile SWOT data if still empty
         if not swot_analyses:
             swot_analyses = [
-                {"competitor": c.name, **c.swot}
-                for c in competitors
-                if c.swot
+                {"competitor": c.name, **c.swot} for c in competitors if c.swot
             ]
 
         # Extract benchmarking report: prefer synthesis, fall back to skill
@@ -693,8 +697,7 @@ class CompetitorAnalyzer:
                     parts.append("## Website Profiles\n")
                     for p in profiles:
                         parts.append(
-                            f"### {p.get('name', 'N/A')}\n"
-                            f"{p.get('summary', '')}\n"
+                            f"### {p.get('name', 'N/A')}\n" f"{p.get('summary', '')}\n"
                         )
 
             # Social Media Analyzer (SKL-CIA-03)
@@ -703,7 +706,9 @@ class CompetitorAnalyzer:
                 if social:
                     parts.append("## Social Media Analysis\n")
                     for s in social:
-                        parts.append(f"### {s.get('name', 'N/A')}\n{s.get('summary', '')}\n")
+                        parts.append(
+                            f"### {s.get('name', 'N/A')}\n{s.get('summary', '')}\n"
+                        )
 
             # Review Aggregator (SKL-CIA-04)
             elif skill_id == "SKL-CIA-04":
@@ -711,7 +716,9 @@ class CompetitorAnalyzer:
                 if reviews:
                     parts.append("## Customer Reviews\n")
                     for r in reviews:
-                        parts.append(f"### {r.get('name', 'N/A')}\n{r.get('summary', '')}\n")
+                        parts.append(
+                            f"### {r.get('name', 'N/A')}\n{r.get('summary', '')}\n"
+                        )
 
             # Pricing Extractor (SKL-CIA-05)
             elif skill_id == "SKL-CIA-05":
@@ -719,7 +726,9 @@ class CompetitorAnalyzer:
                 if pricing:
                     parts.append("## Pricing Analysis\n")
                     for p in pricing:
-                        parts.append(f"### {p.get('name', 'N/A')}\n{p.get('summary', '')}\n")
+                        parts.append(
+                            f"### {p.get('name', 'N/A')}\n{p.get('summary', '')}\n"
+                        )
 
             # Market Share (SKL-CIA-06)
             elif skill_id == "SKL-CIA-06":
@@ -875,17 +884,13 @@ class CompetitorAnalyzer:
         try:
             system = _SYNTHESIS_SYSTEM_PROMPT
             if skill_context:
-                system += (
-                    f"\n\nAdditional methodology context:\n{skill_context[:2000]}"
-                )
+                system += f"\n\nAdditional methodology context:\n{skill_context[:2000]}"
 
             user_message = f"Competitive intelligence query: {prompt}\n\n"
             if mra_output:
                 mra_summary = mra_output.get("market_overview", "")[:1000]
                 if mra_summary:
-                    user_message += (
-                        f"Market research context:\n{mra_summary}\n\n"
-                    )
+                    user_message += f"Market research context:\n{mra_summary}\n\n"
             user_message += f"Raw competitive data:\n{raw_context[:30000]}"
 
             message = await self._anthropic_client.messages.create(
@@ -912,5 +917,10 @@ class CompetitorAnalyzer:
             synthesis = json.loads(content)
             return synthesis
         except Exception as exc:
-            logger.warning("Failed to synthesize via Claude: %s", exc)
+            logger.error(
+                "Failed to synthesize via Claude (%s): %s",
+                type(exc).__name__,
+                exc,
+                exc_info=True,
+            )
             return default_synthesis

--- a/competitor-intel-agent-svc/app/main.py
+++ b/competitor-intel-agent-svc/app/main.py
@@ -58,7 +58,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     # Initialize API clients
     tavily_client = TavilySearchClient(
-        settings.TAVILY_API_KEY, redis_manager,
+        settings.TAVILY_API_KEY,
+        redis_manager,
         mcp_server_url=settings.TAVILY_MCP_SERVER_URL,
     )
     web_scraper = WebScraperClient(max_pages_per_domain=settings.MAX_PAGES_PER_DOMAIN)
@@ -71,19 +72,30 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     # Initialize Anthropic client (lazy - only if API key present)
     anthropic_client = None
-    if settings.ANTHROPIC_API_KEY:
+    api_key = settings.ANTHROPIC_API_KEY
+    if api_key:
+        masked = f"{api_key[:4]}...{api_key[-4:]}" if len(api_key) > 8 else "***"
+        logger.info(
+            "CIA_ANTHROPIC_API_KEY loaded (%s, %d chars), model=%s",
+            masked,
+            len(api_key),
+            settings.LLM_MODEL,
+        )
         try:
             import anthropic
 
             anthropic_client = anthropic.AsyncAnthropic(
-                api_key=settings.ANTHROPIC_API_KEY,
+                api_key=api_key,
                 timeout=120.0,
             )
             logger.info("Anthropic client initialized - live LLM mode")
         except Exception as exc:
             logger.warning("Failed to initialize Anthropic client: %s", exc)
     else:
-        logger.warning("No Anthropic API key - running in stub mode")
+        logger.warning(
+            "No Anthropic API key - running in stub mode. "
+            "Set CIA_ANTHROPIC_API_KEY on Railway for live results."
+        )
 
     # Initialize circuit breakers
     circuit_breakers = create_circuit_breakers(settings)
@@ -118,20 +130,26 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     skill_registry.register(
         SWOTAnalysisGenerator(
-            anthropic_client, settings.LLM_MODEL,
-            settings.LLM_TEMPERATURE, settings.LLM_MAX_TOKENS,
+            anthropic_client,
+            settings.LLM_MODEL,
+            settings.LLM_TEMPERATURE,
+            settings.LLM_MAX_TOKENS,
         )
     )
     skill_registry.register(
         PositioningGapAnalyzer(
-            anthropic_client, settings.LLM_MODEL,
-            settings.LLM_TEMPERATURE, settings.LLM_MAX_TOKENS,
+            anthropic_client,
+            settings.LLM_MODEL,
+            settings.LLM_TEMPERATURE,
+            settings.LLM_MAX_TOKENS,
         )
     )
     skill_registry.register(
         CompetitiveBenchmarkingSynthesizer(
-            anthropic_client, settings.LLM_MODEL,
-            settings.LLM_TEMPERATURE, settings.LLM_MAX_TOKENS,
+            anthropic_client,
+            settings.LLM_MODEL,
+            settings.LLM_TEMPERATURE,
+            settings.LLM_MAX_TOKENS,
         )
     )
 
@@ -253,9 +271,7 @@ app = FastAPI(
 app.add_middleware(
     CORSMiddleware,
     allow_origins=[
-        origin.strip()
-        for origin in settings.CORS_ORIGINS.split(",")
-        if origin.strip()
+        origin.strip() for origin in settings.CORS_ORIGINS.split(",") if origin.strip()
     ],
     allow_credentials=True,
     allow_methods=["*"],

--- a/creative-generation-agent-svc/app/main.py
+++ b/creative-generation-agent-svc/app/main.py
@@ -32,9 +32,7 @@ logger = logging.getLogger(__name__)
 async def lifespan(app: FastAPI):
     """Initialize and teardown all dependencies."""
     setup_logging()
-    logger.info(
-        "Starting Creative Generation Agent service on port %d", settings.PORT
-    )
+    logger.info("Starting Creative Generation Agent service on port %d", settings.PORT)
 
     # 1. Redis
     redis_manager = RedisManager()
@@ -48,18 +46,23 @@ async def lifespan(app: FastAPI):
 
     # 3. Anthropic client (lazy — for copy generation)
     anthropic_client = None
-    if settings.ANTHROPIC_API_KEY:
+    api_key = settings.ANTHROPIC_API_KEY
+    if api_key:
         try:
             import anthropic
 
-            anthropic_client = anthropic.AsyncAnthropic(
-                api_key=settings.ANTHROPIC_API_KEY
-            )
+            anthropic_client = anthropic.AsyncAnthropic(api_key=api_key)
+            masked = f"{api_key[:4]}...{api_key[-4:]}" if len(api_key) > 8 else "***"
             logger.info(
-                "Anthropic client initialized (model: %s)", settings.ANTHROPIC_MODEL
+                "Anthropic client initialized (model: %s, key: %s, len: %d)",
+                settings.ANTHROPIC_MODEL,
+                masked,
+                len(api_key),
             )
         except Exception as exc:
             logger.warning("Anthropic client init failed: %s", exc)
+    else:
+        logger.warning("Set CGA_ANTHROPIC_API_KEY on Railway for live results")
 
     # 4. Nano Banana 2 image generation client
     image_gen_client = create_image_gen_client()
@@ -106,7 +109,6 @@ async def lifespan(app: FastAPI):
     app.state.redis_manager = redis_manager
 
     logger.info("Creative Generation Agent service ready")
-
 
     # Prompt loader + cache invalidator (ZorvenPromptLoader integration)
     prompt_loader = AgentPromptClient(

--- a/deployment/railway/RAILWAY_ENV_VARIABLES.md
+++ b/deployment/railway/RAILWAY_ENV_VARIABLES.md
@@ -257,3 +257,139 @@ MRA_RAG_ENABLED=false
 MRA_RAG_SERVICE_URL=http://rag-uploader-agent.railway.internal:8070
 MRA_CONFIDENCE_THRESHOLD=0.7
 MRA_TOKEN_BUDGET_PER_SESSION=50000
+
+# =============================================================================
+# Competitor Intelligence Agent (CIA_ prefix, Redis DB 12)
+# =============================================================================
+CIA_REDIS_URL=<railway-redis-url>/12
+CIA_KAFKA_BOOTSTRAP_SERVERS=
+CIA_ANTHROPIC_API_KEY=<anthropic-api-key>
+CIA_TAVILY_API_KEY=<tavily-api-key>
+CIA_LLM_MODEL=claude-sonnet-4-5-20250929
+CIA_LOG_LEVEL=INFO
+CIA_RBAC_ENABLED=true
+CIA_RAG_ENABLED=false
+CIA_RAG_SERVICE_URL=http://rag-uploader-agent.railway.internal:8070
+
+# =============================================================================
+# Audience Persona Agent (APA_ prefix, Redis DB 13)
+# =============================================================================
+APA_REDIS_URL=<railway-redis-url>/13
+APA_KAFKA_BOOTSTRAP_SERVERS=
+APA_ANTHROPIC_API_KEY=<anthropic-api-key>
+APA_TAVILY_API_KEY=<tavily-api-key>
+APA_LLM_MODEL=claude-sonnet-4-5-20250929
+APA_LOG_LEVEL=INFO
+APA_RBAC_ENABLED=true
+APA_RAG_ENABLED=false
+APA_RAG_SERVICE_URL=http://rag-uploader-agent.railway.internal:8070
+
+# =============================================================================
+# Trend & Cultural Insights Agent (TCIA_ prefix, Redis DB 14)
+# =============================================================================
+TCIA_REDIS_URL=<railway-redis-url>/14
+TCIA_KAFKA_BOOTSTRAP_SERVERS=
+TCIA_ANTHROPIC_API_KEY=<anthropic-api-key>
+TCIA_TAVILY_API_KEY=<tavily-api-key>
+TCIA_LLM_MODEL=claude-sonnet-4-5-20250929
+TCIA_LOG_LEVEL=INFO
+
+# =============================================================================
+# Voice of Customer Agent (VOCA_ prefix, Redis DB 15)
+# =============================================================================
+VOCA_REDIS_URL=<railway-redis-url>/15
+VOCA_KAFKA_BOOTSTRAP_SERVERS=
+VOCA_ANTHROPIC_API_KEY=<anthropic-api-key>
+VOCA_TAVILY_API_KEY=<tavily-api-key>
+VOCA_LLM_MODEL=claude-sonnet-4-5-20250929
+VOCA_LOG_LEVEL=INFO
+
+# =============================================================================
+# Brand Positioning Agent (BPA_ prefix, Redis DB 16)
+# =============================================================================
+BPA_REDIS_URL=<railway-redis-url>/16
+BPA_KAFKA_BOOTSTRAP_SERVERS=
+BPA_ANTHROPIC_API_KEY=<anthropic-api-key>
+BPA_ANTHROPIC_MODEL=claude-sonnet-4-5-20250929
+BPA_LOG_LEVEL=INFO
+
+# =============================================================================
+# Brand Architecture Agent (BAA_ prefix, Redis DB 17)
+# =============================================================================
+BAA_REDIS_URL=<railway-redis-url>/17
+BAA_KAFKA_BOOTSTRAP_SERVERS=
+BAA_ANTHROPIC_API_KEY=<anthropic-api-key>
+BAA_ANTHROPIC_MODEL=claude-sonnet-4-5-20250929
+BAA_LOG_LEVEL=INFO
+
+# =============================================================================
+# Brand Personality Agent (BPV_ prefix, Redis DB 18)
+# =============================================================================
+BPV_REDIS_URL=<railway-redis-url>/18
+BPV_KAFKA_BOOTSTRAP_SERVERS=
+BPV_ANTHROPIC_API_KEY=<anthropic-api-key>
+BPV_ANTHROPIC_MODEL=claude-sonnet-4-5-20250929
+BPV_LOG_LEVEL=INFO
+
+# =============================================================================
+# Brand Naming Agent (NTA_ prefix, Redis DB 19)
+# =============================================================================
+NTA_REDIS_URL=<railway-redis-url>/19
+NTA_KAFKA_BOOTSTRAP_SERVERS=
+NTA_ANTHROPIC_API_KEY=<anthropic-api-key>
+NTA_ANTHROPIC_MODEL=claude-sonnet-4-5-20250929
+NTA_LOG_LEVEL=INFO
+
+# =============================================================================
+# Brand Story Agent (BSA_ prefix, Redis DB 20)
+# =============================================================================
+BSA_REDIS_URL=<railway-redis-url>/20
+BSA_KAFKA_BOOTSTRAP_SERVERS=
+BSA_ANTHROPIC_API_KEY=<anthropic-api-key>
+BSA_ANTHROPIC_MODEL=claude-sonnet-4-5-20250929
+BSA_LOG_LEVEL=INFO
+
+# =============================================================================
+# Campaign Architecture Agent (CAA_ prefix, Redis DB 21)
+# =============================================================================
+CAA_REDIS_URL=<railway-redis-url>/21
+CAA_KAFKA_BOOTSTRAP_SERVERS=
+CAA_ANTHROPIC_API_KEY=<anthropic-api-key>
+CAA_ANTHROPIC_MODEL=claude-sonnet-4-5-20250929
+CAA_LOG_LEVEL=INFO
+
+# =============================================================================
+# Creative Generation Agent (CGA_ prefix, Redis DB 22)
+# =============================================================================
+CGA_REDIS_URL=<railway-redis-url>/22
+CGA_KAFKA_BOOTSTRAP_SERVERS=
+CGA_ANTHROPIC_API_KEY=<anthropic-api-key>
+CGA_ANTHROPIC_MODEL=claude-sonnet-4-5-20250929
+CGA_LOG_LEVEL=INFO
+
+# =============================================================================
+# Ad Publishing Agent (ADPUB_ prefix, Redis DB 23)
+# =============================================================================
+ADPUB_REDIS_URL=<railway-redis-url>/23
+ADPUB_KAFKA_BOOTSTRAP_SERVERS=
+ADPUB_ANTHROPIC_API_KEY=<anthropic-api-key>
+ADPUB_ANTHROPIC_MODEL=claude-sonnet-4-5-20250929
+ADPUB_LOG_LEVEL=INFO
+
+# =============================================================================
+# Campaign Optimization Agent (COA_ prefix, Redis DB 24)
+# =============================================================================
+COA_REDIS_URL=<railway-redis-url>/24
+COA_KAFKA_BOOTSTRAP_SERVERS=
+COA_ANTHROPIC_API_KEY=<anthropic-api-key>
+COA_ANTHROPIC_MODEL=claude-sonnet-4-5-20250929
+COA_LOG_LEVEL=INFO
+
+# =============================================================================
+# Intelligence Loop Agent (ILA_ prefix, Redis DB 25)
+# =============================================================================
+ILA_REDIS_URL=<railway-redis-url>/25
+ILA_KAFKA_BOOTSTRAP_SERVERS=
+ILA_ANTHROPIC_API_KEY=<anthropic-api-key>
+ILA_ANTHROPIC_MODEL=claude-sonnet-4-5-20250929
+ILA_LOG_LEVEL=INFO

--- a/intelligence-loop-agent-svc/app/services/anthropic_client.py
+++ b/intelligence-loop-agent-svc/app/services/anthropic_client.py
@@ -29,11 +29,20 @@ class AnthropicClient:
         self._temperature = temperature
         self._client: Any = None
         if api_key and anthropic is not None:
+            masked = f"{api_key[:4]}...{api_key[-4:]}" if len(api_key) >= 8 else "****"
+            logger.info(
+                "Anthropic key present: masked=%s, length=%d, model=%s",
+                masked,
+                len(api_key),
+                model,
+            )
             try:
                 self._client = anthropic.AsyncAnthropic(api_key=api_key)
                 logger.info("Anthropic client initialized (model=%s)", model)
             except Exception as exc:
                 logger.warning("Anthropic init failed (fail-open): %s", exc)
+        else:
+            logger.warning("Set ILA_ANTHROPIC_API_KEY on Railway for live results")
 
     @property
     def enabled(self) -> bool:
@@ -66,12 +75,14 @@ class AnthropicClient:
             parsed = _safe_json_loads(text)
             logger.info(
                 "Claude raw response: text_len=%d, parsed_keys=%s, learnings_count=%d, text=%s",
-                len(text), list(parsed.keys()), len(parsed.get("learnings", [])),
+                len(text),
+                list(parsed.keys()),
+                len(parsed.get("learnings", [])),
                 text[:1000],
             )
             return parsed
         except Exception as exc:
-            logger.warning("Anthropic call failed (fail-open): %s", exc)
+            logger.error("Anthropic call failed (fail-open): %s", exc, exc_info=True)
             return {}
 
 

--- a/market-research-agent-svc/app/logic/market_researcher.py
+++ b/market-research-agent-svc/app/logic/market_researcher.py
@@ -316,9 +316,7 @@ class MarketResearcher:
             )
 
         # ── REFLECT — Synthesize via Claude (RBAC: requires SKL-MRA-03 access) ──
-        synthesis_allowed = self.rbac_engine.check_permission(
-            "SKL-MRA-03", user_role
-        )
+        synthesis_allowed = self.rbac_engine.check_permission("SKL-MRA-03", user_role)
         if synthesis_allowed.decision == "ALLOW":
             logger.info("REFLECT phase starting — synthesizing findings")
             synthesis = await self._synthesize(
@@ -328,10 +326,16 @@ class MarketResearcher:
             logger.info("REFLECT phase skipped — role %s denied SKL-MRA-03", user_role)
             synthesis = {
                 "overview": raw_context[:500] if raw_context else "",
-                "findings": [r.data.get("summary", "") for r in skill_results.values() if r.success and r.data.get("summary")],
+                "findings": [
+                    r.data.get("summary", "")
+                    for r in skill_results.values()
+                    if r.success and r.data.get("summary")
+                ],
                 "recommendations": [],
                 "confidence": 0.4,
-                "methodology": ["LLM synthesis skipped (insufficient role permissions)"],
+                "methodology": [
+                    "LLM synthesis skipped (insufficient role permissions)"
+                ],
             }
 
         # Build response
@@ -471,7 +475,8 @@ class MarketResearcher:
             if not plan["skill_sequence"]:
                 # Fallback must also be filtered by available skills
                 plan["skill_sequence"] = [
-                    s for s in default_plan["skill_sequence"]
+                    s
+                    for s in default_plan["skill_sequence"]
                     if s in available_skill_ids
                 ]
 
@@ -786,5 +791,10 @@ class MarketResearcher:
             synthesis = json.loads(content)
             return synthesis
         except Exception as exc:
-            logger.warning("Failed to synthesize via Claude: %s", exc)
+            logger.error(
+                "Failed to synthesize via Claude: %s — %s",
+                type(exc).__name__,
+                exc,
+                exc_info=True,
+            )
             return default_synthesis

--- a/market-research-agent-svc/app/main.py
+++ b/market-research-agent-svc/app/main.py
@@ -66,7 +66,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     # Initialize API clients
     tavily_client = TavilySearchClient(
-        settings.TAVILY_API_KEY, redis_manager,
+        settings.TAVILY_API_KEY,
+        redis_manager,
         mcp_server_url=settings.TAVILY_MCP_SERVER_URL,
     )
     world_bank_client = WorldBankClient(settings.WORLD_BANK_BASE_URL, redis_manager)
@@ -80,19 +81,30 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     # Initialize Anthropic client (lazy — only if API key present)
     anthropic_client = None
-    if settings.ANTHROPIC_API_KEY:
+    api_key = settings.ANTHROPIC_API_KEY
+    if api_key:
+        masked = f"{api_key[:4]}...{api_key[-4:]}" if len(api_key) > 8 else "***"
+        logger.info(
+            "MRA_ANTHROPIC_API_KEY loaded (%s, %d chars), model=%s",
+            masked,
+            len(api_key),
+            settings.LLM_MODEL,
+        )
         try:
             import anthropic
 
             anthropic_client = anthropic.AsyncAnthropic(
-                api_key=settings.ANTHROPIC_API_KEY,
+                api_key=api_key,
                 timeout=120.0,
             )
             logger.info("Anthropic client initialized — live LLM mode")
         except Exception as exc:
             logger.warning("Failed to initialize Anthropic client: %s", exc)
     else:
-        logger.warning("No Anthropic API key — running in stub mode")
+        logger.warning(
+            "No Anthropic API key — running in stub mode. "
+            "Set MRA_ANTHROPIC_API_KEY on Railway for live results."
+        )
 
     # Initialize circuit breakers
     circuit_breakers = create_circuit_breakers(settings)

--- a/voc-agent-svc/app/main.py
+++ b/voc-agent-svc/app/main.py
@@ -33,18 +33,14 @@ logger = logging.getLogger(__name__)
 async def lifespan(app: FastAPI):
     """Initialize and teardown all dependencies."""
     setup_logging()
-    logger.info(
-        "Starting Voice of Customer Agent service on port %d", settings.PORT
-    )
+    logger.info("Starting Voice of Customer Agent service on port %d", settings.PORT)
 
     # 1. Redis
     redis_manager = RedisManager()
     await redis_manager.connect()
 
     # 2. API clients
-    tavily_client = TavilySearchClient(
-        mcp_server_url=settings.TAVILY_MCP_SERVER_URL
-    )
+    tavily_client = TavilySearchClient(mcp_server_url=settings.TAVILY_MCP_SERVER_URL)
     web_scraper = WebScraperClient()
     await web_scraper.start()
 
@@ -58,19 +54,27 @@ async def lifespan(app: FastAPI):
 
     # 4. Anthropic client (lazy)
     anthropic_client = None
-    if settings.ANTHROPIC_API_KEY:
+    api_key = settings.ANTHROPIC_API_KEY
+    if api_key:
+        masked = f"{api_key[:4]}...{api_key[-4:]}"
+        logger.info(
+            "Anthropic API key detected: %s (length=%d, model=%s)",
+            masked,
+            len(api_key),
+            settings.LLM_MODEL,
+        )
         try:
             import anthropic
 
-            anthropic_client = anthropic.AsyncAnthropic(
-                api_key=settings.ANTHROPIC_API_KEY
-            )
+            anthropic_client = anthropic.AsyncAnthropic(api_key=api_key)
             logger.info(
                 "Anthropic client initialized (model=%s)",
                 settings.LLM_MODEL,
             )
         except Exception as exc:
             logger.warning("Failed to initialize Anthropic client: %s", exc)
+    else:
+        logger.info("Set VOCA_ANTHROPIC_API_KEY on Railway for live results")
 
     # 5. Circuit breakers
     breakers = create_breakers(settings)
@@ -88,9 +92,7 @@ async def lifespan(app: FastAPI):
     skill_registry.register(SocialFeedbackCollector(tavily_client))
     skill_registry.register(ForumDiscussionMiner(tavily_client, web_scraper))
     skill_registry.register(
-        RAGContextRetrieval(
-            settings.RAG_SERVICE_URL, bool(settings.RAG_SERVICE_URL)
-        )
+        RAGContextRetrieval(settings.RAG_SERVICE_URL, bool(settings.RAG_SERVICE_URL))
     )
 
     # Odoo skills (SKL-VoCA-01..04) — conditionally registered
@@ -110,15 +112,9 @@ async def lifespan(app: FastAPI):
             username=settings.ODOO_USERNAME,
             password=settings.ODOO_PASSWORD,
         )
-        skill_registry.register(
-            OdooHelpdeskExtractor(odoo_client, redis_manager)
-        )
-        skill_registry.register(
-            OdooSurveyExtractor(odoo_client, redis_manager)
-        )
-        skill_registry.register(
-            OdooChatterExtractor(odoo_client, redis_manager)
-        )
+        skill_registry.register(OdooHelpdeskExtractor(odoo_client, redis_manager))
+        skill_registry.register(OdooSurveyExtractor(odoo_client, redis_manager))
+        skill_registry.register(OdooChatterExtractor(odoo_client, redis_manager))
         skill_registry.register(OdooCustomerSegmentLinker())
         logger.info("Odoo skills registered (01-04)")
 

--- a/voc-agent-svc/app/skills/voc_strategy_bridge.py
+++ b/voc-agent-svc/app/skills/voc_strategy_bridge.py
@@ -294,7 +294,7 @@ class VoCStrategyBridge(BaseSkill):
             )
 
         except Exception as exc:
-            logger.warning("VoC strategy bridge synthesis failed: %s", exc)
+            logger.error("VoC strategy bridge synthesis failed: %s", exc, exc_info=True)
             return SkillResult(
                 skill_id=self.meta.skill_id,
                 success=False,


### PR DESCRIPTION
## Summary

- **Diagnostic startup logging** across all 15 Anthropic-powered agent services: logs masked API key (first 4 + last 4 chars), key length, and model name at startup. When no key is found, logs the exact prefixed env var name needed (e.g., `Set MRA_ANTHROPIC_API_KEY on Railway for live results`)
- **Improved LLM error logging**: upgraded `logger.warning` to `logger.error` with `exc_info=True` on all synthesis/LLM call failures, so full stack traces surface in Railway logs instead of silent fallback to stub mode
- **Railway env var documentation**: added all 14 previously missing service sections (CIA, APA, TCIA, VOCA, BPA, BAA, BPV, NTA, BSA, CAA, CGA, ADPUB, COA, ILA) to `deployment/railway/RAILWAY_ENV_VARIABLES.md`

## Context

All agents except trend-cultural-agent-svc return 30% (WF1) or 0% (WF2) confidence — matching hardcoded stub fallback values. Each agent uses a Pydantic `env_prefix` (e.g., `MRA_`, `CIA_`) so Railway must set `MRA_ANTHROPIC_API_KEY`, not `ANTHROPIC_API_KEY`. The diagnostics will immediately reveal whether keys are loaded correctly on Railway.

## After deploying, check Railway logs for:
1. `MRA_ANTHROPIC_API_KEY loaded (sk-a...xyz1, 108 chars)` — key loaded ✅
2. `Set MRA_ANTHROPIC_API_KEY on Railway for live results` — key missing ❌
3. `Failed to synthesize via Claude: AuthenticationError` — key invalid ❌

## Test plan
- [ ] Deploy to Railway and verify diagnostic logs appear on each agent service
- [ ] Confirm TCIA still logs key loaded successfully (already working)
- [ ] For any service showing "stub mode", set the correct prefixed env var on Railway
- [ ] Flush Redis caches for services that cached stub responses (4h TTL)
- [ ] Re-run Brand Discovery and Brand Strategy workflows and verify confidence > 50%

🤖 Generated with [Claude Code](https://claude.com/claude-code)