### PR TITLE
fix(mra): move prompt_loader init before skill registry to fix startup crash

### DIFF
--- a/market-research-agent-svc/app/main.py
+++ b/market-research-agent-svc/app/main.py
@@ -109,6 +109,19 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # Initialize circuit breakers
     circuit_breakers = create_circuit_breakers(settings)
 
+    # Prompt loader + cache invalidator (must init before skills that use it)
+    prompt_loader = AgentPromptClient(
+        redis_url=settings.PROMPT_CACHE_REDIS_URL,
+        mlflow_uri=settings.MLFLOW_TRACKING_URI,
+    )
+    await prompt_loader.start()
+
+    cache_invalidator = PromptCacheInvalidator(
+        bootstrap_servers=getattr(settings, "KAFKA_BOOTSTRAP_SERVERS", ""),
+        prompt_loader=prompt_loader,
+    )
+    await cache_invalidator.start()
+
     # Initialize skill registry with all 8 skills
     skill_registry = SkillRegistry()
     skill_registry.register(WebMarketSearch(tavily_client, news_client))
@@ -149,19 +162,6 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     input_guardrails = InputGuardrails(redis_manager, settings)
     plan_guardrails = PlanToolGuardrails(rbac_engine, settings)
     output_guardrails = OutputGuardrails(settings)
-
-    # Prompt loader + cache invalidator (ZorvenPromptLoader integration)
-    prompt_loader = AgentPromptClient(
-        redis_url=settings.PROMPT_CACHE_REDIS_URL,
-        mlflow_uri=settings.MLFLOW_TRACKING_URI,
-    )
-    await prompt_loader.start()
-
-    cache_invalidator = PromptCacheInvalidator(
-        bootstrap_servers=getattr(settings, "KAFKA_BOOTSTRAP_SERVERS", ""),
-        prompt_loader=prompt_loader,
-    )
-    await cache_invalidator.start()
 
     # Initialize market researcher (skill-based PAOR engine)
     researcher = MarketResearcher(


### PR DESCRIPTION
## Summary

- Move `prompt_loader` initialization **before** the skill registry section in `market-research-agent-svc/app/main.py`
- Fixes `UnboundLocalError: cannot access local variable 'prompt_loader'` that crash-loops the service on every startup

## Root Cause

PR #434 wired `prompt_loader` into `MarketAnalysisSynthesis` and `ResearchReportGenerator` skill constructors (lines 122, 134) but left the `AgentPromptClient` initialization block **after** those registrations (line 154). Python raises `UnboundLocalError` because the variable is referenced before assignment.

## Fix

Moved the prompt_loader + cache_invalidator init block from after the skill registry to before it (after circuit breakers, before skill registration).

## Test plan

- [x] 221 MRA unit tests pass
- [x] Syntax validation passes
- [ ] Deploy to Railway and verify healthcheck responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)