### PR TITLE
fix(agents): bypass Redis/MLflow prompt loading with fallback_only mode

### DIFF
--- a/ad-publishing-agent-svc/app/prompts/loader.py
+++ b/ad-publishing-agent-svc/app/prompts/loader.py
@@ -37,11 +37,13 @@ class AgentPromptClient:
         mlflow_uri: str = "http://mlflow-server:5000",
         default_ttl: int = 300,
         critical_agent: bool = False,
+        fallback_only: bool = True,
     ) -> None:
         self.redis_url = redis_url
         self.mlflow_uri = mlflow_uri
         self.default_ttl = default_ttl
         self.critical_agent = critical_agent
+        self.fallback_only = fallback_only
         self._redis: Optional[aioredis.Redis] = None
         self._http: Optional[httpx.AsyncClient] = None
 
@@ -110,6 +112,11 @@ class AgentPromptClient:
         Returns:
             Formatted prompt string.
         """
+        # Fallback-only mode: bypass Redis cache and MLflow entirely.
+        # Guarantees behavior identical to pre-prompt-loader code.
+        if self.fallback_only:
+            return self._format(fallback, variables) if fallback else ""
+
         resolve_ttl = self.default_ttl if ttl is None else ttl
         template = None
 

--- a/ad-publishing-agent-svc/tests/test_prompt_loading.py
+++ b/ad-publishing-agent-svc/tests/test_prompt_loading.py
@@ -35,6 +35,7 @@ class TestAgentPromptClient:
         c = AgentPromptClient(
             redis_url="redis://localhost:6379/2",
             mlflow_uri="http://localhost:5000",
+            fallback_only=False,
         )
         c._redis = AsyncMock()
         c._http = AsyncMock()
@@ -88,6 +89,7 @@ class TestCriticalAgentWarning:
             redis_url="redis://localhost:6379/2",
             mlflow_uri="",
             critical_agent=True,
+            fallback_only=False,
         )
         client._redis = None
         client._http = None

--- a/audience-persona-agent-svc/app/prompts/loader.py
+++ b/audience-persona-agent-svc/app/prompts/loader.py
@@ -37,11 +37,13 @@ class AgentPromptClient:
         mlflow_uri: str = "http://mlflow-server:5000",
         default_ttl: int = 300,
         critical_agent: bool = False,
+        fallback_only: bool = True,
     ) -> None:
         self.redis_url = redis_url
         self.mlflow_uri = mlflow_uri
         self.default_ttl = default_ttl
         self.critical_agent = critical_agent
+        self.fallback_only = fallback_only
         self._redis: Optional[aioredis.Redis] = None
         self._http: Optional[httpx.AsyncClient] = None
 
@@ -110,6 +112,11 @@ class AgentPromptClient:
         Returns:
             Formatted prompt string.
         """
+        # Fallback-only mode: bypass Redis cache and MLflow entirely.
+        # Guarantees behavior identical to pre-prompt-loader code.
+        if self.fallback_only:
+            return self._format(fallback, variables) if fallback else ""
+
         resolve_ttl = self.default_ttl if ttl is None else ttl
         template = None
 

--- a/audience-persona-agent-svc/tests/test_prompt_loading.py
+++ b/audience-persona-agent-svc/tests/test_prompt_loading.py
@@ -46,6 +46,7 @@ class TestAgentPromptClient:
         c = AgentPromptClient(
             redis_url="redis://localhost:6379/2",
             mlflow_uri="http://localhost:5000",
+            fallback_only=False,
         )
         c._redis = AsyncMock()
         c._http = AsyncMock()

--- a/brand-architecture-agent-svc/app/prompts/loader.py
+++ b/brand-architecture-agent-svc/app/prompts/loader.py
@@ -37,11 +37,13 @@ class AgentPromptClient:
         mlflow_uri: str = "http://mlflow-server:5000",
         default_ttl: int = 300,
         critical_agent: bool = False,
+        fallback_only: bool = True,
     ) -> None:
         self.redis_url = redis_url
         self.mlflow_uri = mlflow_uri
         self.default_ttl = default_ttl
         self.critical_agent = critical_agent
+        self.fallback_only = fallback_only
         self._redis: Optional[aioredis.Redis] = None
         self._http: Optional[httpx.AsyncClient] = None
 
@@ -110,6 +112,11 @@ class AgentPromptClient:
         Returns:
             Formatted prompt string.
         """
+        # Fallback-only mode: bypass Redis cache and MLflow entirely.
+        # Guarantees behavior identical to pre-prompt-loader code.
+        if self.fallback_only:
+            return self._format(fallback, variables) if fallback else ""
+
         resolve_ttl = self.default_ttl if ttl is None else ttl
         template = None
 

--- a/brand-architecture-agent-svc/tests/test_prompt_loading.py
+++ b/brand-architecture-agent-svc/tests/test_prompt_loading.py
@@ -37,6 +37,7 @@ class TestAgentPromptClient:
         c = AgentPromptClient(
             redis_url="redis://localhost:6379/2",
             mlflow_uri="http://localhost:5000",
+            fallback_only=False,
         )
         c._redis = AsyncMock()
         c._http = AsyncMock()

--- a/brand-naming-agent-svc/app/prompts/loader.py
+++ b/brand-naming-agent-svc/app/prompts/loader.py
@@ -37,11 +37,13 @@ class AgentPromptClient:
         mlflow_uri: str = "http://mlflow-server:5000",
         default_ttl: int = 300,
         critical_agent: bool = False,
+        fallback_only: bool = True,
     ) -> None:
         self.redis_url = redis_url
         self.mlflow_uri = mlflow_uri
         self.default_ttl = default_ttl
         self.critical_agent = critical_agent
+        self.fallback_only = fallback_only
         self._redis: Optional[aioredis.Redis] = None
         self._http: Optional[httpx.AsyncClient] = None
 
@@ -110,6 +112,11 @@ class AgentPromptClient:
         Returns:
             Formatted prompt string.
         """
+        # Fallback-only mode: bypass Redis cache and MLflow entirely.
+        # Guarantees behavior identical to pre-prompt-loader code.
+        if self.fallback_only:
+            return self._format(fallback, variables) if fallback else ""
+
         resolve_ttl = self.default_ttl if ttl is None else ttl
         template = None
 

--- a/brand-naming-agent-svc/tests/test_prompt_loading.py
+++ b/brand-naming-agent-svc/tests/test_prompt_loading.py
@@ -46,6 +46,7 @@ class TestAgentPromptClient:
         c = AgentPromptClient(
             redis_url="redis://localhost:6379/2",
             mlflow_uri="http://localhost:5000",
+            fallback_only=False,
         )
         c._redis = AsyncMock()
         c._http = AsyncMock()

--- a/brand-personality-agent-svc/app/prompts/loader.py
+++ b/brand-personality-agent-svc/app/prompts/loader.py
@@ -37,11 +37,13 @@ class AgentPromptClient:
         mlflow_uri: str = "http://mlflow-server:5000",
         default_ttl: int = 300,
         critical_agent: bool = False,
+        fallback_only: bool = True,
     ) -> None:
         self.redis_url = redis_url
         self.mlflow_uri = mlflow_uri
         self.default_ttl = default_ttl
         self.critical_agent = critical_agent
+        self.fallback_only = fallback_only
         self._redis: Optional[aioredis.Redis] = None
         self._http: Optional[httpx.AsyncClient] = None
 
@@ -110,6 +112,11 @@ class AgentPromptClient:
         Returns:
             Formatted prompt string.
         """
+        # Fallback-only mode: bypass Redis cache and MLflow entirely.
+        # Guarantees behavior identical to pre-prompt-loader code.
+        if self.fallback_only:
+            return self._format(fallback, variables) if fallback else ""
+
         resolve_ttl = self.default_ttl if ttl is None else ttl
         template = None
 

--- a/brand-personality-agent-svc/tests/test_prompt_loading.py
+++ b/brand-personality-agent-svc/tests/test_prompt_loading.py
@@ -37,6 +37,7 @@ class TestAgentPromptClient:
         c = AgentPromptClient(
             redis_url="redis://localhost:6379/2",
             mlflow_uri="http://localhost:5000",
+            fallback_only=False,
         )
         c._redis = AsyncMock()
         c._http = AsyncMock()

--- a/brand-positioning-agent-svc/app/prompts/loader.py
+++ b/brand-positioning-agent-svc/app/prompts/loader.py
@@ -37,11 +37,13 @@ class AgentPromptClient:
         mlflow_uri: str = "http://mlflow-server:5000",
         default_ttl: int = 300,
         critical_agent: bool = False,
+        fallback_only: bool = True,
     ) -> None:
         self.redis_url = redis_url
         self.mlflow_uri = mlflow_uri
         self.default_ttl = default_ttl
         self.critical_agent = critical_agent
+        self.fallback_only = fallback_only
         self._redis: Optional[aioredis.Redis] = None
         self._http: Optional[httpx.AsyncClient] = None
 
@@ -110,6 +112,11 @@ class AgentPromptClient:
         Returns:
             Formatted prompt string.
         """
+        # Fallback-only mode: bypass Redis cache and MLflow entirely.
+        # Guarantees behavior identical to pre-prompt-loader code.
+        if self.fallback_only:
+            return self._format(fallback, variables) if fallback else ""
+
         resolve_ttl = self.default_ttl if ttl is None else ttl
         template = None
 

--- a/brand-positioning-agent-svc/tests/test_prompt_loading.py
+++ b/brand-positioning-agent-svc/tests/test_prompt_loading.py
@@ -37,6 +37,7 @@ class TestAgentPromptClient:
         c = AgentPromptClient(
             redis_url="redis://localhost:6379/2",
             mlflow_uri="http://localhost:5000",
+            fallback_only=False,
         )
         c._redis = AsyncMock()
         c._http = AsyncMock()

--- a/brand-story-agent-svc/app/prompts/loader.py
+++ b/brand-story-agent-svc/app/prompts/loader.py
@@ -37,11 +37,13 @@ class AgentPromptClient:
         mlflow_uri: str = "http://mlflow-server:5000",
         default_ttl: int = 300,
         critical_agent: bool = False,
+        fallback_only: bool = True,
     ) -> None:
         self.redis_url = redis_url
         self.mlflow_uri = mlflow_uri
         self.default_ttl = default_ttl
         self.critical_agent = critical_agent
+        self.fallback_only = fallback_only
         self._redis: Optional[aioredis.Redis] = None
         self._http: Optional[httpx.AsyncClient] = None
 
@@ -110,6 +112,11 @@ class AgentPromptClient:
         Returns:
             Formatted prompt string.
         """
+        # Fallback-only mode: bypass Redis cache and MLflow entirely.
+        # Guarantees behavior identical to pre-prompt-loader code.
+        if self.fallback_only:
+            return self._format(fallback, variables) if fallback else ""
+
         resolve_ttl = self.default_ttl if ttl is None else ttl
         template = None
 

--- a/brand-story-agent-svc/tests/test_prompt_loading.py
+++ b/brand-story-agent-svc/tests/test_prompt_loading.py
@@ -46,6 +46,7 @@ class TestAgentPromptClient:
         c = AgentPromptClient(
             redis_url="redis://localhost:6379/2",
             mlflow_uri="http://localhost:5000",
+            fallback_only=False,
         )
         c._redis = AsyncMock()
         c._http = AsyncMock()

--- a/campaign-architecture-agent-svc/app/prompts/loader.py
+++ b/campaign-architecture-agent-svc/app/prompts/loader.py
@@ -37,11 +37,13 @@ class AgentPromptClient:
         mlflow_uri: str = "http://mlflow-server:5000",
         default_ttl: int = 300,
         critical_agent: bool = False,
+        fallback_only: bool = True,
     ) -> None:
         self.redis_url = redis_url
         self.mlflow_uri = mlflow_uri
         self.default_ttl = default_ttl
         self.critical_agent = critical_agent
+        self.fallback_only = fallback_only
         self._redis: Optional[aioredis.Redis] = None
         self._http: Optional[httpx.AsyncClient] = None
 
@@ -110,6 +112,11 @@ class AgentPromptClient:
         Returns:
             Formatted prompt string.
         """
+        # Fallback-only mode: bypass Redis cache and MLflow entirely.
+        # Guarantees behavior identical to pre-prompt-loader code.
+        if self.fallback_only:
+            return self._format(fallback, variables) if fallback else ""
+
         resolve_ttl = self.default_ttl if ttl is None else ttl
         template = None
 

--- a/campaign-architecture-agent-svc/tests/test_prompt_loading.py
+++ b/campaign-architecture-agent-svc/tests/test_prompt_loading.py
@@ -42,6 +42,7 @@ class TestAgentPromptClient:
         c = AgentPromptClient(
             redis_url="redis://localhost:6379/2",
             mlflow_uri="http://localhost:5000",
+            fallback_only=False,
         )
         c._redis = AsyncMock()
         c._http = AsyncMock()

--- a/campaign-optimization-agent-svc/app/prompts/loader.py
+++ b/campaign-optimization-agent-svc/app/prompts/loader.py
@@ -37,11 +37,13 @@ class AgentPromptClient:
         mlflow_uri: str = "http://mlflow-server:5000",
         default_ttl: int = 300,
         critical_agent: bool = False,
+        fallback_only: bool = True,
     ) -> None:
         self.redis_url = redis_url
         self.mlflow_uri = mlflow_uri
         self.default_ttl = default_ttl
         self.critical_agent = critical_agent
+        self.fallback_only = fallback_only
         self._redis: Optional[aioredis.Redis] = None
         self._http: Optional[httpx.AsyncClient] = None
 
@@ -110,6 +112,11 @@ class AgentPromptClient:
         Returns:
             Formatted prompt string.
         """
+        # Fallback-only mode: bypass Redis cache and MLflow entirely.
+        # Guarantees behavior identical to pre-prompt-loader code.
+        if self.fallback_only:
+            return self._format(fallback, variables) if fallback else ""
+
         resolve_ttl = self.default_ttl if ttl is None else ttl
         template = None
 

--- a/campaign-optimization-agent-svc/tests/test_prompt_loading.py
+++ b/campaign-optimization-agent-svc/tests/test_prompt_loading.py
@@ -43,6 +43,7 @@ class TestAgentPromptClient:
         c = AgentPromptClient(
             redis_url="redis://localhost:6379/2",
             mlflow_uri="http://localhost:5000",
+            fallback_only=False,
         )
         c._redis = AsyncMock()
         c._http = AsyncMock()
@@ -96,6 +97,7 @@ class TestCriticalAgentWarning:
             redis_url="redis://localhost:6379/2",
             mlflow_uri="",
             critical_agent=True,
+            fallback_only=False,
         )
         client._redis = None
         client._http = None

--- a/competitor-intel-agent-svc/app/prompts/loader.py
+++ b/competitor-intel-agent-svc/app/prompts/loader.py
@@ -37,11 +37,13 @@ class AgentPromptClient:
         mlflow_uri: str = "http://mlflow-server:5000",
         default_ttl: int = 300,
         critical_agent: bool = False,
+        fallback_only: bool = True,
     ) -> None:
         self.redis_url = redis_url
         self.mlflow_uri = mlflow_uri
         self.default_ttl = default_ttl
         self.critical_agent = critical_agent
+        self.fallback_only = fallback_only
         self._redis: Optional[aioredis.Redis] = None
         self._http: Optional[httpx.AsyncClient] = None
 
@@ -110,6 +112,11 @@ class AgentPromptClient:
         Returns:
             Formatted prompt string.
         """
+        # Fallback-only mode: bypass Redis cache and MLflow entirely.
+        # Guarantees behavior identical to pre-prompt-loader code.
+        if self.fallback_only:
+            return self._format(fallback, variables) if fallback else ""
+
         resolve_ttl = self.default_ttl if ttl is None else ttl
         template = None
 

--- a/competitor-intel-agent-svc/tests/test_prompt_loading.py
+++ b/competitor-intel-agent-svc/tests/test_prompt_loading.py
@@ -46,6 +46,7 @@ class TestAgentPromptClient:
         c = AgentPromptClient(
             redis_url="redis://localhost:6379/2",
             mlflow_uri="http://localhost:5000",
+            fallback_only=False,
         )
         c._redis = AsyncMock()
         c._http = AsyncMock()

--- a/creative-generation-agent-svc/app/prompts/loader.py
+++ b/creative-generation-agent-svc/app/prompts/loader.py
@@ -37,11 +37,13 @@ class AgentPromptClient:
         mlflow_uri: str = "http://mlflow-server:5000",
         default_ttl: int = 300,
         critical_agent: bool = False,
+        fallback_only: bool = True,
     ) -> None:
         self.redis_url = redis_url
         self.mlflow_uri = mlflow_uri
         self.default_ttl = default_ttl
         self.critical_agent = critical_agent
+        self.fallback_only = fallback_only
         self._redis: Optional[aioredis.Redis] = None
         self._http: Optional[httpx.AsyncClient] = None
 
@@ -110,6 +112,11 @@ class AgentPromptClient:
         Returns:
             Formatted prompt string.
         """
+        # Fallback-only mode: bypass Redis cache and MLflow entirely.
+        # Guarantees behavior identical to pre-prompt-loader code.
+        if self.fallback_only:
+            return self._format(fallback, variables) if fallback else ""
+
         resolve_ttl = self.default_ttl if ttl is None else ttl
         template = None
 

--- a/creative-generation-agent-svc/tests/test_prompt_loading.py
+++ b/creative-generation-agent-svc/tests/test_prompt_loading.py
@@ -42,6 +42,7 @@ class TestAgentPromptClient:
         c = AgentPromptClient(
             redis_url="redis://localhost:6379/2",
             mlflow_uri="http://localhost:5000",
+            fallback_only=False,
         )
         c._redis = AsyncMock()
         c._http = AsyncMock()

--- a/intelligence-loop-agent-svc/app/prompts/loader.py
+++ b/intelligence-loop-agent-svc/app/prompts/loader.py
@@ -37,11 +37,13 @@ class AgentPromptClient:
         mlflow_uri: str = "http://mlflow-server:5000",
         default_ttl: int = 300,
         critical_agent: bool = False,
+        fallback_only: bool = True,
     ) -> None:
         self.redis_url = redis_url
         self.mlflow_uri = mlflow_uri
         self.default_ttl = default_ttl
         self.critical_agent = critical_agent
+        self.fallback_only = fallback_only
         self._redis: Optional[aioredis.Redis] = None
         self._http: Optional[httpx.AsyncClient] = None
 
@@ -110,6 +112,11 @@ class AgentPromptClient:
         Returns:
             Formatted prompt string.
         """
+        # Fallback-only mode: bypass Redis cache and MLflow entirely.
+        # Guarantees behavior identical to pre-prompt-loader code.
+        if self.fallback_only:
+            return self._format(fallback, variables) if fallback else ""
+
         resolve_ttl = self.default_ttl if ttl is None else ttl
         template = None
 

--- a/intelligence-loop-agent-svc/tests/test_prompt_loading.py
+++ b/intelligence-loop-agent-svc/tests/test_prompt_loading.py
@@ -34,6 +34,7 @@ class TestAgentPromptClient:
         c = AgentPromptClient(
             redis_url="redis://localhost:6379/2",
             mlflow_uri="http://localhost:5000",
+            fallback_only=False,
         )
         c._redis = AsyncMock()
         c._http = AsyncMock()

--- a/market-research-agent-svc/app/prompts/loader.py
+++ b/market-research-agent-svc/app/prompts/loader.py
@@ -37,11 +37,13 @@ class AgentPromptClient:
         mlflow_uri: str = "http://mlflow-server:5000",
         default_ttl: int = 300,
         critical_agent: bool = False,
+        fallback_only: bool = True,
     ) -> None:
         self.redis_url = redis_url
         self.mlflow_uri = mlflow_uri
         self.default_ttl = default_ttl
         self.critical_agent = critical_agent
+        self.fallback_only = fallback_only
         self._redis: Optional[aioredis.Redis] = None
         self._http: Optional[httpx.AsyncClient] = None
 
@@ -110,6 +112,11 @@ class AgentPromptClient:
         Returns:
             Formatted prompt string.
         """
+        # Fallback-only mode: bypass Redis cache and MLflow entirely.
+        # Guarantees behavior identical to pre-prompt-loader code.
+        if self.fallback_only:
+            return self._format(fallback, variables) if fallback else ""
+
         resolve_ttl = self.default_ttl if ttl is None else ttl
         template = None
 

--- a/market-research-agent-svc/tests/test_prompt_loading.py
+++ b/market-research-agent-svc/tests/test_prompt_loading.py
@@ -45,6 +45,7 @@ class TestAgentPromptClient:
         c = AgentPromptClient(
             redis_url="redis://localhost:6379/2",
             mlflow_uri="http://localhost:5000",
+            fallback_only=False,
         )
         c._redis = AsyncMock()
         c._http = AsyncMock()

--- a/trend-cultural-agent-svc/app/prompts/loader.py
+++ b/trend-cultural-agent-svc/app/prompts/loader.py
@@ -37,11 +37,13 @@ class AgentPromptClient:
         mlflow_uri: str = "http://mlflow-server:5000",
         default_ttl: int = 300,
         critical_agent: bool = False,
+        fallback_only: bool = True,
     ) -> None:
         self.redis_url = redis_url
         self.mlflow_uri = mlflow_uri
         self.default_ttl = default_ttl
         self.critical_agent = critical_agent
+        self.fallback_only = fallback_only
         self._redis: Optional[aioredis.Redis] = None
         self._http: Optional[httpx.AsyncClient] = None
 
@@ -110,6 +112,11 @@ class AgentPromptClient:
         Returns:
             Formatted prompt string.
         """
+        # Fallback-only mode: bypass Redis cache and MLflow entirely.
+        # Guarantees behavior identical to pre-prompt-loader code.
+        if self.fallback_only:
+            return self._format(fallback, variables) if fallback else ""
+
         resolve_ttl = self.default_ttl if ttl is None else ttl
         template = None
 

--- a/trend-cultural-agent-svc/tests/test_prompt_loading.py
+++ b/trend-cultural-agent-svc/tests/test_prompt_loading.py
@@ -46,6 +46,7 @@ class TestAgentPromptClient:
         c = AgentPromptClient(
             redis_url="redis://localhost:6379/2",
             mlflow_uri="http://localhost:5000",
+            fallback_only=False,
         )
         c._redis = AsyncMock()
         c._http = AsyncMock()

--- a/voc-agent-svc/app/prompts/loader.py
+++ b/voc-agent-svc/app/prompts/loader.py
@@ -37,11 +37,13 @@ class AgentPromptClient:
         mlflow_uri: str = "http://mlflow-server:5000",
         default_ttl: int = 300,
         critical_agent: bool = False,
+        fallback_only: bool = True,
     ) -> None:
         self.redis_url = redis_url
         self.mlflow_uri = mlflow_uri
         self.default_ttl = default_ttl
         self.critical_agent = critical_agent
+        self.fallback_only = fallback_only
         self._redis: Optional[aioredis.Redis] = None
         self._http: Optional[httpx.AsyncClient] = None
 
@@ -110,6 +112,11 @@ class AgentPromptClient:
         Returns:
             Formatted prompt string.
         """
+        # Fallback-only mode: bypass Redis cache and MLflow entirely.
+        # Guarantees behavior identical to pre-prompt-loader code.
+        if self.fallback_only:
+            return self._format(fallback, variables) if fallback else ""
+
         resolve_ttl = self.default_ttl if ttl is None else ttl
         template = None
 

--- a/voc-agent-svc/tests/test_prompt_loading.py
+++ b/voc-agent-svc/tests/test_prompt_loading.py
@@ -46,6 +46,7 @@ class TestAgentPromptClient:
         c = AgentPromptClient(
             redis_url="redis://localhost:6379/2",
             mlflow_uri="http://localhost:5000",
+            fallback_only=False,
         )
         c._redis = AsyncMock()
         c._http = AsyncMock()


### PR DESCRIPTION
## Summary

- Adds `fallback_only=True` default to `AgentPromptClient` across all 15 agent services
- When enabled, `load()` bypasses Redis cache (DB 2) and MLflow API entirely, returning hardcoded fallback prompts with variable substitution applied
- This guarantees agent behavior identical to the pre-prompt-loader state when all agents worked correctly

## Root Cause

After thorough investigation, the prompt content and variable substitution logic are correct in code. The degraded results (MRA no results, CIA 5%, rest 30%) are caused by runtime interactions with the external prompt infrastructure — likely stale Redis DB 2 cache entries or MLflow returning templates that produce unexpected behavior at runtime.

## What Changed (30 files)

| Files | Change |
|-------|--------|
| 15x `*/app/prompts/loader.py` | Added `fallback_only` param (default `True`) + early return in `load()` |
| 15x `*/tests/test_prompt_loading.py` | Test fixtures pass `fallback_only=False` to exercise Redis/MLflow tiers |

## Re-enabling MLflow

When ready to use MLflow prompt loading:
1. Verify prompts are seeded and promoted to PRODUCTION in MLflow
2. Flush Redis DB 2 to clear any stale entries
3. Set `fallback_only=False` in `AgentPromptClient` constructor
4. Test one agent at a time (start with MRA)

## Test plan

- [x] All 15 agent test suites pass (prompt loading tests updated)
- [x] MRA: 221 passed
- [x] CIA: 242 passed (8 pre-existing auth failures unrelated)
- [x] APA: 180 passed
- [x] TCIA: 247 passed
- [x] VoCA: 109 passed
- [x] All WF2 agents pass
- [x] All WF3 agents pass
- [ ] Deploy to Railway and re-run Brand Discovery workflow
- [ ] Verify all agents produce proper results (not 30% defaults)

🤖 Generated with [Claude Code](https://claude.com/claude-code)