### PR TITLE
fix: increase max_tokens to 16384 across remaining agents

### DIFF
--- a/ad-publishing-agent-svc/app/services/anthropic_client.py
+++ b/ad-publishing-agent-svc/app/services/anthropic_client.py
@@ -21,7 +21,7 @@ class AnthropicClient:
         self,
         system_prompt: str,
         user_prompt: str,
-        max_tokens: int = 4096,
+        max_tokens: int = 16384,
     ) -> str:
         """Send a prompt and return the text response."""
         if self._client is None:
@@ -39,7 +39,7 @@ class AnthropicClient:
         self,
         system_prompt: str,
         user_prompt: str,
-        max_tokens: int = 4096,
+        max_tokens: int = 16384,
     ) -> dict[str, Any]:
         """Send a prompt and parse the response as JSON."""
         text = await self.generate(

--- a/brand-equity-calculator-svc/app/services/claude_client.py
+++ b/brand-equity-calculator-svc/app/services/claude_client.py
@@ -157,7 +157,7 @@ class ClaudeClient:
 
         message = await self._client.messages.create(
             model=settings.CLAUDE_MODEL,
-            max_tokens=4096,
+            max_tokens=16384,
             thinking={"type": "disabled"},
             system=ISO_20671_SYSTEM_PROMPT,
             messages=[{"role": "user", "content": _build_user_prompt(request)}],

--- a/campaign-optimization-agent-svc/app/services/anthropic_client.py
+++ b/campaign-optimization-agent-svc/app/services/anthropic_client.py
@@ -21,7 +21,7 @@ class AnthropicClient:
         self,
         system_prompt: str,
         user_prompt: str,
-        max_tokens: int = 4096,
+        max_tokens: int = 16384,
     ) -> str:
         """Send a prompt and return the text response."""
         if self._client is None:
@@ -45,7 +45,7 @@ class AnthropicClient:
         self,
         system_prompt: str,
         user_prompt: str,
-        max_tokens: int = 4096,
+        max_tokens: int = 16384,
     ) -> dict[str, Any]:
         """Send a prompt and parse the response as JSON."""
         text = await self.generate(

--- a/trend-cultural-agent-svc/app/core/config.py
+++ b/trend-cultural-agent-svc/app/core/config.py
@@ -39,7 +39,7 @@ class Settings(BaseSettings):
     ANTHROPIC_API_KEY: str = ""
     LLM_MODEL: str = "claude-sonnet-5"
     LLM_TEMPERATURE: float = 0.3
-    LLM_MAX_TOKENS: int = 8192
+    LLM_MAX_TOKENS: int = 16384
 
     # Data sources
     TAVILY_API_KEY: str = ""

--- a/trend-cultural-agent-svc/app/skills/skl_tcia_07_cultural_relevance_scorer.py
+++ b/trend-cultural-agent-svc/app/skills/skl_tcia_07_cultural_relevance_scorer.py
@@ -130,7 +130,7 @@ class CulturalRelevanceScorer(BaseSkill):
         try:
             llm_kwargs = dict(
                 model="claude-sonnet-5",
-                max_tokens=4096,
+                max_tokens=16384,
                 thinking={"type": "disabled"},
                 messages=[{"role": "user", "content": prompt}],
             )

--- a/trend-cultural-agent-svc/app/skills/skl_tcia_08_trend_persona_mapper.py
+++ b/trend-cultural-agent-svc/app/skills/skl_tcia_08_trend_persona_mapper.py
@@ -112,7 +112,7 @@ class TrendPersonaMapper(BaseSkill):
         try:
             llm_kwargs = dict(
                 model="claude-sonnet-5",
-                max_tokens=4096,
+                max_tokens=16384,
                 thinking={"type": "disabled"},
                 messages=[{"role": "user", "content": prompt}],
             )

--- a/trend-cultural-agent-svc/app/skills/skl_tcia_10_trend_report_synthesizer.py
+++ b/trend-cultural-agent-svc/app/skills/skl_tcia_10_trend_report_synthesizer.py
@@ -167,7 +167,7 @@ class TrendReportSynthesizer(BaseSkill):
         try:
             llm_kwargs = dict(
                 model="claude-sonnet-5",
-                max_tokens=8192,
+                max_tokens=16384,
                 thinking={"type": "disabled"},
                 messages=[{"role": "user", "content": prompt}],
             )


### PR DESCRIPTION
## Summary
- Increases `max_tokens` from 4096 → 16384 in TCIA skills 07, 08, and 10 (was 8192)
- Increases `max_tokens` from 4096 → 16384 in COA and ADPUB `anthropic_client.py`
- Increases `max_tokens` from 4096 → 16384 in Brand Equity Calculator `claude_client.py`
- Updates TCIA config default from 8192 → 16384

Same root cause as PR #445: `claude-sonnet-5` produces more verbose JSON output than `sonnet-4`, causing truncation at 4096 tokens → `JSONDecodeError` → fallback to low-confidence stub results.

**This PR fixes TCIA (35% → expected 70%+).** The remaining issues require Railway env var checks:

| Agent | Issue | Fix |
|-------|-------|-----|
| CIA (30%) | Likely `CIA_ANTHROPIC_API_KEY` not set | Set env var on Railway |
| APA (404) | Service not reachable | Check Railway deployment logs |
| VoC (0%) | Likely `VOCA_ANTHROPIC_API_KEY` not set | Set env var on Railway |

## Test plan
- [ ] Merge and deploy to Railway
- [ ] Flush Redis cache
- [ ] Re-run workflow and verify TCIA confidence improves
- [ ] Check Railway env vars for CIA, APA, VoC (see table above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)