### PR TITLE
fix: add strict=False to json.loads for LLM response parsing

### DIFF
--- a/ad-publishing-agent-svc/app/services/anthropic_client.py
+++ b/ad-publishing-agent-svc/app/services/anthropic_client.py
@@ -21,7 +21,7 @@ class AnthropicClient:
         self,
         system_prompt: str,
         user_prompt: str,
-        max_tokens: int = 4096,
+        max_tokens: int = 16384,
     ) -> str:
         """Send a prompt and return the text response."""
         if self._client is None:
@@ -39,7 +39,7 @@ class AnthropicClient:
         self,
         system_prompt: str,
         user_prompt: str,
-        max_tokens: int = 4096,
+        max_tokens: int = 16384,
     ) -> dict[str, Any]:
         """Send a prompt and parse the response as JSON."""
         text = await self.generate(

--- a/ad-publishing-agent-svc/app/services/anthropic_client.py
+++ b/ad-publishing-agent-svc/app/services/anthropic_client.py
@@ -53,7 +53,7 @@ class AnthropicClient:
                 text = text.split("```json")[1].split("```")[0].strip()
             elif "```" in text:
                 text = text.split("```")[1].split("```")[0].strip()
-            return json.loads(text)
+            return json.loads(text, strict=False)
         except (json.JSONDecodeError, IndexError) as exc:
             logger.warning("Failed to parse LLM JSON response: %s", exc)
             return {"raw_text": text, "parse_error": str(exc)}

--- a/audience-persona-agent-svc/app/logic/persona_analyzer.py
+++ b/audience-persona-agent-svc/app/logic/persona_analyzer.py
@@ -354,7 +354,7 @@ class PersonaAnalyzer:
                 if text.startswith("json"):
                     text = text[4:]
                 text = text.strip()
-            skill_ids = json.loads(text)
+            skill_ids = json.loads(text, strict=False)
             if isinstance(skill_ids, list):
                 # Filter to valid IDs
                 valid = [
@@ -653,7 +653,7 @@ class PersonaAnalyzer:
                 text = text.strip()
 
             try:
-                result = json.loads(text)
+                result = json.loads(text, strict=False)
             except json.JSONDecodeError:
                 result = _repair_truncated_json(text)
             result["_tokens_used"] = tokens
@@ -845,7 +845,7 @@ def _repair_truncated_json(text: str) -> dict:
             candidate += "]" * max(open_brackets, 0)
             candidate += "}" * max(open_braces, 0)
             try:
-                result = json.loads(candidate)
+                result = json.loads(candidate, strict=False)
                 if isinstance(result, dict):
                     logger.warning(
                         "Repaired truncated JSON (%d chars trimmed)",

--- a/audience-persona-agent-svc/app/skills/buying_journey_mapper.py
+++ b/audience-persona-agent-svc/app/skills/buying_journey_mapper.py
@@ -201,7 +201,7 @@ def _parse_json_response(text: str) -> dict:
             text = text[4:]
         text = text.strip()
     try:
-        return json.loads(text)
+        return json.loads(text, strict=False)
     except json.JSONDecodeError:
         return _repair_truncated_json(text)
 
@@ -217,7 +217,7 @@ def _repair_truncated_json(text: str) -> dict:
             candidate += "]" * max(open_brackets, 0)
             candidate += "}" * max(open_braces, 0)
             try:
-                result = json.loads(candidate)
+                result = json.loads(candidate, strict=False)
                 if isinstance(result, dict):
                     logger.warning(
                         "Repaired truncated JSON (%d chars trimmed)",

--- a/audience-persona-agent-svc/app/skills/demographic_profile_builder.py
+++ b/audience-persona-agent-svc/app/skills/demographic_profile_builder.py
@@ -173,7 +173,7 @@ def _parse_json_response(text: str) -> dict:
             text = text[4:]
         text = text.strip()
     try:
-        return json.loads(text)
+        return json.loads(text, strict=False)
     except json.JSONDecodeError:
         return _repair_truncated_json(text)
 
@@ -189,7 +189,7 @@ def _repair_truncated_json(text: str) -> dict:
             candidate += "]" * max(open_brackets, 0)
             candidate += "}" * max(open_braces, 0)
             try:
-                result = json.loads(candidate)
+                result = json.loads(candidate, strict=False)
                 if isinstance(result, dict):
                     logger.warning(
                         "Repaired truncated JSON (%d chars trimmed)",

--- a/audience-persona-agent-svc/app/skills/persona_synthesizer.py
+++ b/audience-persona-agent-svc/app/skills/persona_synthesizer.py
@@ -244,7 +244,7 @@ def _parse_json_response(text: str) -> dict:
             text = text[4:]
         text = text.strip()
     try:
-        return json.loads(text)
+        return json.loads(text, strict=False)
     except json.JSONDecodeError:
         # Attempt to repair truncated JSON by closing open structures
         return _repair_truncated_json(text)
@@ -266,7 +266,7 @@ def _repair_truncated_json(text: str) -> dict:
             candidate += "]" * max(open_brackets, 0)
             candidate += "}" * max(open_braces, 0)
             try:
-                result = json.loads(candidate)
+                result = json.loads(candidate, strict=False)
                 if isinstance(result, dict):
                     logger.warning(
                         "Repaired truncated JSON (%d chars trimmed)",

--- a/audience-persona-agent-svc/app/skills/psychographic_behavioral_profiler.py
+++ b/audience-persona-agent-svc/app/skills/psychographic_behavioral_profiler.py
@@ -186,7 +186,7 @@ def _parse_json_response(text: str) -> dict:
             text = text[4:]
         text = text.strip()
     try:
-        return json.loads(text)
+        return json.loads(text, strict=False)
     except json.JSONDecodeError:
         return _repair_truncated_json(text)
 
@@ -202,7 +202,7 @@ def _repair_truncated_json(text: str) -> dict:
             candidate += "]" * max(open_brackets, 0)
             candidate += "}" * max(open_braces, 0)
             try:
-                result = json.loads(candidate)
+                result = json.loads(candidate, strict=False)
                 if isinstance(result, dict):
                     logger.warning(
                         "Repaired truncated JSON (%d chars trimmed)",

--- a/brand-architecture-agent-svc/app/services/anthropic_client.py
+++ b/brand-architecture-agent-svc/app/services/anthropic_client.py
@@ -55,14 +55,14 @@ class AnthropicClient:
                 text = text.split("```")[1].split("```")[0].strip()
 
             try:
-                return json.loads(text)
+                return json.loads(text, strict=False)
             except json.JSONDecodeError:
                 # Try finding JSON object boundaries as fallback
                 start = raw_text.find("{")
                 end = raw_text.rfind("}")
                 if start != -1 and end > start:
                     try:
-                        return json.loads(raw_text[start : end + 1])
+                        return json.loads(raw_text[start : end + 1], strict=False)
                     except json.JSONDecodeError:
                         pass
 

--- a/brand-equity-calculator-svc/app/services/claude_client.py
+++ b/brand-equity-calculator-svc/app/services/claude_client.py
@@ -157,7 +157,7 @@ class ClaudeClient:
 
         message = await self._client.messages.create(
             model=settings.CLAUDE_MODEL,
-            max_tokens=4096,
+            max_tokens=16384,
             thinking={"type": "disabled"},
             system=ISO_20671_SYSTEM_PROMPT,
             messages=[{"role": "user", "content": _build_user_prompt(request)}],

--- a/brand-equity-calculator-svc/app/services/claude_client.py
+++ b/brand-equity-calculator-svc/app/services/claude_client.py
@@ -169,7 +169,7 @@ class ClaudeClient:
         cleaned = _strip_code_fences(raw_text)
 
         try:
-            result = json.loads(cleaned)
+            result = json.loads(cleaned, strict=False)
         except json.JSONDecodeError as exc:
             logger.error(
                 "Failed to parse Claude response as JSON: %s\nRaw: %s",

--- a/brand-naming-agent-svc/app/services/anthropic_client.py
+++ b/brand-naming-agent-svc/app/services/anthropic_client.py
@@ -38,7 +38,7 @@ class AnthropicClient:
                 response.usage.input_tokens,
                 response.usage.output_tokens,
             )
-            return json.loads(text)
+            return json.loads(text, strict=False)
         except json.JSONDecodeError:
             logger.error("Claude returned non-JSON, attempting extraction")
             text = next(
@@ -47,7 +47,7 @@ class AnthropicClient:
             start = text.find("{")
             end = text.rfind("}") + 1
             if start >= 0 and end > start:
-                return json.loads(text[start:end])
+                return json.loads(text[start:end], strict=False)
             return {"raw_response": text}
         except Exception as exc:
             logger.error(

--- a/brand-personality-agent-svc/app/services/anthropic_client.py
+++ b/brand-personality-agent-svc/app/services/anthropic_client.py
@@ -38,7 +38,7 @@ class AnthropicClient:
                 response.usage.input_tokens,
                 response.usage.output_tokens,
             )
-            return json.loads(text)
+            return json.loads(text, strict=False)
         except json.JSONDecodeError:
             logger.error("Claude returned non-JSON, attempting extraction")
             text = next(
@@ -47,7 +47,7 @@ class AnthropicClient:
             start = text.find("{")
             end = text.rfind("}") + 1
             if start >= 0 and end > start:
-                return json.loads(text[start:end])
+                return json.loads(text[start:end], strict=False)
             return {"raw_response": text}
         except Exception as exc:
             logger.error(

--- a/brand-positioning-agent-svc/app/services/anthropic_client.py
+++ b/brand-positioning-agent-svc/app/services/anthropic_client.py
@@ -52,7 +52,7 @@ class AnthropicClient:
             elif "```" in text:
                 text = text.split("```")[1].split("```")[0].strip()
 
-            return json.loads(text)
+            return json.loads(text, strict=False)
         except json.JSONDecodeError:
             logger.warning("Failed to parse JSON from Claude response")
             return {

--- a/brand-story-agent-svc/app/services/anthropic_client.py
+++ b/brand-story-agent-svc/app/services/anthropic_client.py
@@ -38,7 +38,7 @@ class AnthropicClient:
                 response.usage.input_tokens,
                 response.usage.output_tokens,
             )
-            return json.loads(text)
+            return json.loads(text, strict=False)
         except json.JSONDecodeError:
             logger.error("Claude returned non-JSON, attempting extraction")
             text = next(
@@ -47,7 +47,7 @@ class AnthropicClient:
             start = text.find("{")
             end = text.rfind("}") + 1
             if start >= 0 and end > start:
-                return json.loads(text[start:end])
+                return json.loads(text[start:end], strict=False)
             return {"raw_response": text}
         except Exception as exc:
             logger.error(

--- a/campaign-architecture-agent-svc/app/services/anthropic_client.py
+++ b/campaign-architecture-agent-svc/app/services/anthropic_client.py
@@ -49,7 +49,7 @@ class AnthropicClient:
                 response.usage.input_tokens,
                 response.usage.output_tokens,
             )
-            parsed = json.loads(text)
+            parsed = json.loads(text, strict=False)
             return _ensure_dict(parsed)
         except json.JSONDecodeError:
             logger.warning("Claude returned non-JSON, attempting extraction")
@@ -59,7 +59,7 @@ class AnthropicClient:
             start = text.find("{")
             end = text.rfind("}") + 1
             if start >= 0 and end > start:
-                parsed = json.loads(text[start:end])
+                parsed = json.loads(text[start:end], strict=False)
                 result = _ensure_dict(parsed)
                 logger.info(
                     "Extracted JSON keys: %s (type=%s)",

--- a/campaign-optimization-agent-svc/app/services/anthropic_client.py
+++ b/campaign-optimization-agent-svc/app/services/anthropic_client.py
@@ -59,7 +59,7 @@ class AnthropicClient:
                 text = text.split("```json")[1].split("```")[0].strip()
             elif "```" in text:
                 text = text.split("```")[1].split("```")[0].strip()
-            return json.loads(text)
+            return json.loads(text, strict=False)
         except (json.JSONDecodeError, IndexError) as exc:
             logger.warning("Failed to parse LLM JSON response: %s", exc)
             return {"raw_text": text, "parse_error": str(exc)}

--- a/campaign-optimization-agent-svc/app/services/anthropic_client.py
+++ b/campaign-optimization-agent-svc/app/services/anthropic_client.py
@@ -21,7 +21,7 @@ class AnthropicClient:
         self,
         system_prompt: str,
         user_prompt: str,
-        max_tokens: int = 4096,
+        max_tokens: int = 16384,
     ) -> str:
         """Send a prompt and return the text response."""
         if self._client is None:
@@ -45,7 +45,7 @@ class AnthropicClient:
         self,
         system_prompt: str,
         user_prompt: str,
-        max_tokens: int = 4096,
+        max_tokens: int = 16384,
     ) -> dict[str, Any]:
         """Send a prompt and parse the response as JSON."""
         text = await self.generate(

--- a/competitor-intel-agent-svc/app/logic/competitor_analyzer.py
+++ b/competitor-intel-agent-svc/app/logic/competitor_analyzer.py
@@ -516,7 +516,7 @@ class CompetitorAnalyzer:
                     content = content[4:]
                 content = content.strip()
 
-            plan = json.loads(content)
+            plan = json.loads(content, strict=False)
 
             # Ensure skill_sequence only contains available skills
             plan["skill_sequence"] = [
@@ -949,7 +949,7 @@ class CompetitorAnalyzer:
                     content = content[4:]
                 content = content.strip()
 
-            synthesis = json.loads(content)
+            synthesis = json.loads(content, strict=False)
             return synthesis
         except Exception as exc:
             logger.error(

--- a/competitor-intel-agent-svc/app/skills/competitive_benchmarking_synthesizer.py
+++ b/competitor-intel-agent-svc/app/skills/competitive_benchmarking_synthesizer.py
@@ -172,7 +172,7 @@ def _parse_json_response(text: str) -> dict:
         if text.startswith("json"):
             text = text[4:]
         text = text.strip()
-    return json.loads(text)
+    return json.loads(text, strict=False)
 
 
 def _count_tokens(message: Any) -> int:

--- a/competitor-intel-agent-svc/app/skills/positioning_gap_analyzer.py
+++ b/competitor-intel-agent-svc/app/skills/positioning_gap_analyzer.py
@@ -174,7 +174,7 @@ def _parse_json_response(text: str) -> dict:
         if text.startswith("json"):
             text = text[4:]
         text = text.strip()
-    return json.loads(text)
+    return json.loads(text, strict=False)
 
 
 def _count_tokens(message: Any) -> int:

--- a/competitor-intel-agent-svc/app/skills/swot_analysis_generator.py
+++ b/competitor-intel-agent-svc/app/skills/swot_analysis_generator.py
@@ -152,7 +152,7 @@ def _parse_json_response(text: str) -> dict:
         if text.startswith("json"):
             text = text[4:]
         text = text.strip()
-    return json.loads(text)
+    return json.loads(text, strict=False)
 
 
 def _count_tokens(message: Any) -> int:

--- a/content-agent-service/app/logic/aeo_formatter.py
+++ b/content-agent-service/app/logic/aeo_formatter.py
@@ -70,7 +70,7 @@ class AEOFormatter:
 
             import json
 
-            data = json.loads(text)
+            data = json.loads(text, strict=False)
             faq_items = data.get("faq_items", [])[:5]
 
             structured_data = self._build_jsonld(faq_items)

--- a/content-agent-service/app/logic/seo_optimizer.py
+++ b/content-agent-service/app/logic/seo_optimizer.py
@@ -75,7 +75,7 @@ class SEOOptimizer:
 
             import json
 
-            data = json.loads(text)
+            data = json.loads(text, strict=False)
 
             # Enforce constraints
             meta_title = str(data.get("meta_title", topic))[:60]

--- a/creative-generation-agent-svc/app/services/anthropic_client.py
+++ b/creative-generation-agent-svc/app/services/anthropic_client.py
@@ -148,7 +148,7 @@ class AnthropicClient:
                     max_tokens or settings.ANTHROPIC_MAX_TOKENS,
                 )
             try:
-                return _ensure_dict(json.loads(text))
+                return _ensure_dict(json.loads(text, strict=False))
             except json.JSONDecodeError:
                 pass
 
@@ -159,7 +159,7 @@ class AnthropicClient:
             )
             candidate = _strip_fences(text)
             try:
-                return _ensure_dict(json.loads(candidate))
+                return _ensure_dict(json.loads(candidate, strict=False))
             except json.JSONDecodeError:
                 pass
 
@@ -170,7 +170,7 @@ class AnthropicClient:
                     ("balanced+repair", _repair_json(balanced)),
                 ):
                     try:
-                        parsed = json.loads(attempt_text)
+                        parsed = json.loads(attempt_text, strict=False)
                         result = _ensure_dict(parsed)
                         logger.info(
                             "Extracted JSON via %s: keys=%s (type=%s)",
@@ -188,7 +188,7 @@ class AnthropicClient:
                         )
             # Last-ditch: repair the whole candidate
             try:
-                parsed = json.loads(_repair_json(candidate))
+                parsed = json.loads(_repair_json(candidate, strict=False))
                 result = _ensure_dict(parsed)
                 logger.info(
                     "Extracted JSON via full-repair: keys=%s",

--- a/intelligence-agent-svc/app/services/intelligence_executor.py
+++ b/intelligence-agent-svc/app/services/intelligence_executor.py
@@ -618,7 +618,7 @@ class IntelligenceExecutor:
             if text.startswith("```"):
                 text = text.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
 
-            data = _json.loads(text)
+            data = _json.loads(text, strict=False)
 
             # Validate required fields
             required = {

--- a/intelligence-loop-agent-svc/app/services/anthropic_client.py
+++ b/intelligence-loop-agent-svc/app/services/anthropic_client.py
@@ -98,7 +98,7 @@ def _safe_json_loads(text: str) -> dict[str, Any]:
             cleaned = cleaned[:-3].strip()
     # Try direct parse
     try:
-        return json.loads(cleaned)
+        return json.loads(cleaned, strict=False)
     except json.JSONDecodeError:
         pass
     # Last resort: extract first {...} block
@@ -106,7 +106,7 @@ def _safe_json_loads(text: str) -> dict[str, Any]:
     end = cleaned.rfind("}")
     if start != -1 and end != -1 and end > start:
         try:
-            return json.loads(cleaned[start : end + 1])
+            return json.loads(cleaned[start : end + 1], strict=False)
         except json.JSONDecodeError:
             pass
     logger.warning("Could not parse Anthropic JSON response")

--- a/market-research-agent-svc/app/logic/market_researcher.py
+++ b/market-research-agent-svc/app/logic/market_researcher.py
@@ -485,7 +485,7 @@ class MarketResearcher:
                     content = content[4:]
                 content = content.strip()
 
-            plan = json.loads(content)
+            plan = json.loads(content, strict=False)
 
             # Ensure skill_sequence only contains available skills
             plan["skill_sequence"] = [
@@ -834,7 +834,7 @@ class MarketResearcher:
                     content = content[4:]
                 content = content.strip()
 
-            synthesis = json.loads(content)
+            synthesis = json.loads(content, strict=False)
             return synthesis
         except Exception as exc:
             logger.error(

--- a/market-research-agent-svc/app/skills/market_analysis_synthesis.py
+++ b/market-research-agent-svc/app/skills/market_analysis_synthesis.py
@@ -138,7 +138,7 @@ class MarketAnalysisSynthesis(BaseSkill):
                     content = content[4:]
                 content = content.strip()
 
-            synthesis = json.loads(content)
+            synthesis = json.loads(content, strict=False)
             synthesis["analysis_type"] = analysis_type
 
             return SkillResult(

--- a/market-research-agent-svc/app/skills/research_report_generator.py
+++ b/market-research-agent-svc/app/skills/research_report_generator.py
@@ -140,7 +140,7 @@ class ResearchReportGenerator(BaseSkill):
                     content = content[4:]
                 content = content.strip()
 
-            report_data = json.loads(content)
+            report_data = json.loads(content, strict=False)
 
             return SkillResult(
                 skill_id=self.meta.skill_id,

--- a/trend-cultural-agent-svc/app/core/config.py
+++ b/trend-cultural-agent-svc/app/core/config.py
@@ -39,7 +39,7 @@ class Settings(BaseSettings):
     ANTHROPIC_API_KEY: str = ""
     LLM_MODEL: str = "claude-sonnet-5"
     LLM_TEMPERATURE: float = 0.3
-    LLM_MAX_TOKENS: int = 8192
+    LLM_MAX_TOKENS: int = 16384
 
     # Data sources
     TAVILY_API_KEY: str = ""

--- a/trend-cultural-agent-svc/app/skills/skl_tcia_05_slang_language_tracker.py
+++ b/trend-cultural-agent-svc/app/skills/skl_tcia_05_slang_language_tracker.py
@@ -295,7 +295,7 @@ class SlangLanguageTracker(BaseSkill):
         # Strip markdown fences if present
         if text.startswith("```"):
             text = text.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
-        terms = _json.loads(text)
+        terms = _json.loads(text, strict=False)
         if not isinstance(terms, list):
             return []
 

--- a/trend-cultural-agent-svc/app/skills/skl_tcia_07_cultural_relevance_scorer.py
+++ b/trend-cultural-agent-svc/app/skills/skl_tcia_07_cultural_relevance_scorer.py
@@ -130,7 +130,7 @@ class CulturalRelevanceScorer(BaseSkill):
         try:
             llm_kwargs = dict(
                 model="claude-sonnet-5",
-                max_tokens=4096,
+                max_tokens=16384,
                 thinking={"type": "disabled"},
                 messages=[{"role": "user", "content": prompt}],
             )

--- a/trend-cultural-agent-svc/app/skills/skl_tcia_07_cultural_relevance_scorer.py
+++ b/trend-cultural-agent-svc/app/skills/skl_tcia_07_cultural_relevance_scorer.py
@@ -204,7 +204,7 @@ class CulturalRelevanceScorer(BaseSkill):
                     json_lines.append(line)
             text = "\n".join(json_lines)
         try:
-            result = json.loads(text)
+            result = json.loads(text, strict=False)
             if isinstance(result, list):
                 return result
             return []

--- a/trend-cultural-agent-svc/app/skills/skl_tcia_08_trend_persona_mapper.py
+++ b/trend-cultural-agent-svc/app/skills/skl_tcia_08_trend_persona_mapper.py
@@ -112,7 +112,7 @@ class TrendPersonaMapper(BaseSkill):
         try:
             llm_kwargs = dict(
                 model="claude-sonnet-5",
-                max_tokens=4096,
+                max_tokens=16384,
                 thinking={"type": "disabled"},
                 messages=[{"role": "user", "content": prompt}],
             )

--- a/trend-cultural-agent-svc/app/skills/skl_tcia_08_trend_persona_mapper.py
+++ b/trend-cultural-agent-svc/app/skills/skl_tcia_08_trend_persona_mapper.py
@@ -156,7 +156,7 @@ class TrendPersonaMapper(BaseSkill):
                     json_lines.append(line)
             text = "\n".join(json_lines)
         try:
-            result = json.loads(text)
+            result = json.loads(text, strict=False)
             if isinstance(result, dict):
                 return result
             return {"mappings": []}

--- a/trend-cultural-agent-svc/app/skills/skl_tcia_10_trend_report_synthesizer.py
+++ b/trend-cultural-agent-svc/app/skills/skl_tcia_10_trend_report_synthesizer.py
@@ -167,7 +167,7 @@ class TrendReportSynthesizer(BaseSkill):
         try:
             llm_kwargs = dict(
                 model="claude-sonnet-5",
-                max_tokens=8192,
+                max_tokens=16384,
                 thinking={"type": "disabled"},
                 messages=[{"role": "user", "content": prompt}],
             )

--- a/trend-cultural-agent-svc/app/skills/skl_tcia_10_trend_report_synthesizer.py
+++ b/trend-cultural-agent-svc/app/skills/skl_tcia_10_trend_report_synthesizer.py
@@ -245,7 +245,7 @@ class TrendReportSynthesizer(BaseSkill):
                     json_lines.append(line)
             text = "\n".join(json_lines)
         try:
-            result = json.loads(text)
+            result = json.loads(text, strict=False)
             if isinstance(result, dict):
                 return result
             return {}

--- a/voc-agent-svc/app/skills/nps_trend_analyzer.py
+++ b/voc-agent-svc/app/skills/nps_trend_analyzer.py
@@ -292,7 +292,7 @@ class NPSTrendAnalyzer(BaseSkill):
                     json_lines.append(line)
             text = "\n".join(json_lines)
         try:
-            result = json.loads(text)
+            result = json.loads(text, strict=False)
             if isinstance(result, dict):
                 return result
             return {}

--- a/voc-agent-svc/app/skills/sentiment_analyzer.py
+++ b/voc-agent-svc/app/skills/sentiment_analyzer.py
@@ -332,7 +332,7 @@ class SentimentAnalyzer(BaseSkill):
                     json_lines.append(line)
             text = "\n".join(json_lines)
         try:
-            result = json.loads(text)
+            result = json.loads(text, strict=False)
             if isinstance(result, dict):
                 return result
             return {}

--- a/voc-agent-svc/app/skills/theme_cluster_builder.py
+++ b/voc-agent-svc/app/skills/theme_cluster_builder.py
@@ -256,7 +256,7 @@ class ThemeClusterBuilder(BaseSkill):
                     json_lines.append(line)
             text = "\n".join(json_lines)
         try:
-            result = json.loads(text)
+            result = json.loads(text, strict=False)
             if isinstance(result, dict):
                 return result
             return {}

--- a/voc-agent-svc/app/skills/voc_strategy_bridge.py
+++ b/voc-agent-svc/app/skills/voc_strategy_bridge.py
@@ -448,7 +448,7 @@ class VoCStrategyBridge(BaseSkill):
                     json_lines.append(line)
             text = "\n".join(json_lines)
         try:
-            result = json.loads(text)
+            result = json.loads(text, strict=False)
             if isinstance(result, dict):
                 return result
             return {}


### PR DESCRIPTION
## Summary
- `claude-sonnet-5` returns JSON with unescaped control characters (literal `\n`, `\t` inside string values)
- This causes `JSONDecodeError: Invalid control character at: line X column Y` across all agent services
- CIA logs confirmed: SKL-CIA-08 and SKL-CIA-10 both failed with this error, causing 30% fallback confidence
- The pipeline orchestrator uses **fail-stop** — when CIA fails, APA/TCIA/VoC never execute, explaining why only MRA results appear

### Fix
Added `strict=False` to all `json.loads()` calls that parse LLM responses across **34 files in all 15 agent services**. This is Python's built-in tolerance for control characters in JSON strings.

### Also included (from PR #446)
- `max_tokens` increase from 4096 → 16384 in TCIA, COA, ADPUB, Brand Equity

## Test plan
- [ ] Merge and deploy to Railway
- [ ] Flush Redis cache
- [ ] Re-run workflow — CIA should now parse JSON successfully
- [ ] All downstream agents (APA, TCIA, VoC) should now execute

🤖 Generated with [Claude Code](https://claude.com/claude-code)