### PR TITLE
fix: add defensive data guards to APA section

### DIFF
--- a/ai-brand-automator-frontend/src/components/pipelines/ResultDashboard.tsx
+++ b/ai-brand-automator-frontend/src/components/pipelines/ResultDashboard.tsx
@@ -2196,13 +2196,13 @@ function normalizeScore(v: number): number {
 
 function AudiencePersonaSection({
   executiveSummary,
-  personas,
-  journeyMaps,
-  segmentMatrix,
-  sources,
+  personas: rawPersonas,
+  journeyMaps: rawJourneyMaps,
+  segmentMatrix: rawSegmentMatrix,
+  sources: rawSources,
   confidenceScore,
-  findings,
-  recommendations,
+  findings: rawFindings,
+  recommendations: rawRecommendations,
 }: {
   executiveSummary?: string;
   personas?: PersonaProfileFE[];
@@ -2213,6 +2213,14 @@ function AudiencePersonaSection({
   findings?: string[];
   recommendations?: string[];
 }) {
+  // Defensive: ensure arrays are actually arrays (LLM data can be malformed)
+  const personas = Array.isArray(rawPersonas) ? rawPersonas : undefined;
+  const journeyMaps = Array.isArray(rawJourneyMaps) ? rawJourneyMaps : undefined;
+  const segmentMatrix = rawSegmentMatrix && typeof rawSegmentMatrix === 'object' && !Array.isArray(rawSegmentMatrix) ? rawSegmentMatrix : undefined;
+  const sources = Array.isArray(rawSources) ? rawSources : undefined;
+  const findings = Array.isArray(rawFindings) ? rawFindings : undefined;
+  const recommendations = Array.isArray(rawRecommendations) ? rawRecommendations : undefined;
+
   const [expandedPersona, setExpandedPersona] = useState<string | null>(null);
   const [expandedJourney, setExpandedJourney] = useState<string | null>(null);
 
@@ -2251,7 +2259,7 @@ function AudiencePersonaSection({
       </div>
 
       {/* Executive Summary */}
-      {executiveSummary && (
+      {executiveSummary && typeof executiveSummary === 'string' && (
         <section>
           <h5 className="font-heading text-xs font-semibold text-brand-silver/60 uppercase tracking-wider mb-2">
             Executive Summary

--- a/ai-brand-automator-frontend/src/components/pipelines/ResultDashboard.tsx
+++ b/ai-brand-automator-frontend/src/components/pipelines/ResultDashboard.tsx
@@ -37,6 +37,7 @@ import { linkFromChat } from '@/lib/workspace';
 import BrandEquityDashboard from './BrandEquityDashboard';
 import ApprovalPanel from './ApprovalPanel';
 import { MarkdownMessage } from '@/components/chat/MarkdownMessage';
+import { ErrorBoundary } from '@/components/common/ErrorBoundary';
 
 interface ResultDashboardProps {
   resultData: Record<string, unknown>;
@@ -2780,6 +2781,22 @@ interface VoCStrategyBridgeLocal {
   strategic_recommendations?: string[];
 }
 
+/* ── Section Error Fallback ──────────────────────────────────────── */
+
+function SectionErrorFallback({ section }: { section: string }) {
+  return (
+    <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-6 text-center">
+      <AlertCircle className="w-8 h-8 text-red-400 mx-auto mb-2" />
+      <h4 className="text-sm font-semibold text-white mb-1">
+        Could not render {section}
+      </h4>
+      <p className="text-xs text-brand-silver/60">
+        The data for this section could not be displayed. Other sections are unaffected.
+      </p>
+    </div>
+  );
+}
+
 /* ── BrandDiscoverySection — tabbed container for WF1 agents ────── */
 
 type BrandDiscoveryTab = 'market_research' | 'competitor_intel' | 'audience_persona' | 'trend_cultural' | 'voice_of_customer';
@@ -2867,79 +2884,89 @@ function BrandDiscoverySection(props: BrandDiscoverySectionProps) {
 
       {/* Tab content */}
       {activeTab === 'market_research' && props.hasMarketResearch && (
-        <MarketResearchSection
-          marketOverview={props.marketOverview}
-          marketSizing={props.marketSizing}
-          competitiveLandscape={props.competitiveLandscape}
-          industryTrends={props.industryTrends}
-          economicIndicators={props.economicIndicators}
-          sources={props.sources}
-          confidenceScore={cs.market_research ?? props.confidenceScore}
-          findings={props.findings}
-          recommendations={props.recommendations}
-        />
+        <ErrorBoundary fallback={<SectionErrorFallback section="Market Research" />}>
+          <MarketResearchSection
+            marketOverview={props.marketOverview}
+            marketSizing={props.marketSizing}
+            competitiveLandscape={props.competitiveLandscape}
+            industryTrends={props.industryTrends}
+            economicIndicators={props.economicIndicators}
+            sources={props.sources}
+            confidenceScore={cs.market_research ?? props.confidenceScore}
+            findings={props.findings}
+            recommendations={props.recommendations}
+          />
+        </ErrorBoundary>
       )}
 
       {activeTab === 'competitor_intel' && props.hasCompetitorIntelligence && (
-        <CompetitorIntelligenceSection
-          executiveSummary={props.ciaExecutiveSummary}
-          competitors={props.competitors}
-          competitorMatrix={props.competitorMatrix}
-          swotAnalyses={props.swotAnalyses}
-          positioningGaps={props.positioningGaps}
-          benchmarkingReport={props.benchmarkingReport}
-          sources={props.sources}
-          confidenceScore={cs.competitor_intelligence ?? props.confidenceScore}
-          findings={props.findings}
-          recommendations={props.recommendations}
-        />
+        <ErrorBoundary fallback={<SectionErrorFallback section="Competitor Intelligence" />}>
+          <CompetitorIntelligenceSection
+            executiveSummary={props.ciaExecutiveSummary}
+            competitors={props.competitors}
+            competitorMatrix={props.competitorMatrix}
+            swotAnalyses={props.swotAnalyses}
+            positioningGaps={props.positioningGaps}
+            benchmarkingReport={props.benchmarkingReport}
+            sources={props.sources}
+            confidenceScore={cs.competitor_intelligence ?? props.confidenceScore}
+            findings={props.findings}
+            recommendations={props.recommendations}
+          />
+        </ErrorBoundary>
       )}
 
       {activeTab === 'audience_persona' && props.hasAudiencePersona && (
-        <AudiencePersonaSection
-          executiveSummary={props.apaExecutiveSummary}
-          personas={props.personas}
-          journeyMaps={props.journeyMaps}
-          segmentMatrix={props.segmentMatrix}
-          sources={props.sources}
-          confidenceScore={cs.audience_persona ?? props.confidenceScore}
-          findings={props.findings}
-          recommendations={props.recommendations}
-        />
+        <ErrorBoundary fallback={<SectionErrorFallback section="Audience Personas" />}>
+          <AudiencePersonaSection
+            executiveSummary={props.apaExecutiveSummary}
+            personas={props.personas}
+            journeyMaps={props.journeyMaps}
+            segmentMatrix={props.segmentMatrix}
+            sources={props.sources}
+            confidenceScore={cs.audience_persona ?? props.confidenceScore}
+            findings={props.findings}
+            recommendations={props.recommendations}
+          />
+        </ErrorBoundary>
       )}
 
       {activeTab === 'trend_cultural' && props.hasTrendCultural && (
-        <TrendCulturalSection
-          trendReport={props.trendReport}
-          scoredTrends={props.scoredTrends}
-          trendPersonaMatrix={props.trendPersonaMatrix}
-          opportunityAlerts={props.opportunityAlerts}
-          viralPatterns={props.viralPatterns}
-          culturalShifts={props.culturalShifts}
-          generationalInsights={props.generationalInsights}
-          languageTrends={props.languageTrends}
-          sources={props.sources}
-          confidenceScore={cs.trend_cultural ?? props.confidenceScore}
-          findings={props.findings}
-          recommendations={props.recommendations}
-        />
+        <ErrorBoundary fallback={<SectionErrorFallback section="Trends & Culture" />}>
+          <TrendCulturalSection
+            trendReport={props.trendReport}
+            scoredTrends={props.scoredTrends}
+            trendPersonaMatrix={props.trendPersonaMatrix}
+            opportunityAlerts={props.opportunityAlerts}
+            viralPatterns={props.viralPatterns}
+            culturalShifts={props.culturalShifts}
+            generationalInsights={props.generationalInsights}
+            languageTrends={props.languageTrends}
+            sources={props.sources}
+            confidenceScore={cs.trend_cultural ?? props.confidenceScore}
+            findings={props.findings}
+            recommendations={props.recommendations}
+          />
+        </ErrorBoundary>
       )}
 
       {activeTab === 'voice_of_customer' && props.hasVoiceOfCustomer && (
-        <VoiceOfCustomerSection
-          vocHealthScore={props.vocHealthScore}
-          operatingMode={props.operatingMode}
-          dataCoverageScore={props.dataCoverageScore}
-          sentiment={props.sentiment}
-          themes={props.themes}
-          npsAnalysis={props.npsAnalysis}
-          painPointMatrix={props.painPointMatrix}
-          strategyBridge={props.strategyBridge}
-          sources={props.sources}
-          confidenceScore={cs.voice_of_customer ?? props.confidenceScore}
-          findings={props.findings}
-          recommendations={props.recommendations}
-        />
+        <ErrorBoundary fallback={<SectionErrorFallback section="Voice of Customer" />}>
+          <VoiceOfCustomerSection
+            vocHealthScore={props.vocHealthScore}
+            operatingMode={props.operatingMode}
+            dataCoverageScore={props.dataCoverageScore}
+            sentiment={props.sentiment}
+            themes={props.themes}
+            npsAnalysis={props.npsAnalysis}
+            painPointMatrix={props.painPointMatrix}
+            strategyBridge={props.strategyBridge}
+            sources={props.sources}
+            confidenceScore={cs.voice_of_customer ?? props.confidenceScore}
+            findings={props.findings}
+            recommendations={props.recommendations}
+          />
+        </ErrorBoundary>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- Validates all APA props at the top of `AudiencePersonaSection` before rendering
- `personas`, `journeyMaps`, `sources`, `findings`, `recommendations` checked with `Array.isArray()` — if not an array, treated as undefined
- `segmentMatrix` validated as non-array object
- `executiveSummary` type-checked as string before passing to `MarkdownMessage`
- Prevents crashes from malformed LLM data (truncated JSON, repaired JSON, unexpected types)

## Context
PR #451 added ErrorBoundary wrapping which confirmed the crash is inside `AudiencePersonaSection`. This PR fixes the root cause — LLM JSON parsing can produce unexpected data shapes that crash `.map()`, `.filter()`, `Object.entries()` etc.

## Test plan
- [ ] Merge and wait for Railway deploy
- [ ] Refresh the results page — APA section should render properly
- [ ] If still showing fallback, check browser DevTools console for exact error

🤖 Generated with [Claude Code](https://claude.com/claude-code)