### PR TITLE
feat: activate prompt optimization (MLflow) across all 15 agents

### DIFF
--- a/ad-publishing-agent-svc/app/core/config.py
+++ b/ad-publishing-agent-svc/app/core/config.py
@@ -27,6 +27,7 @@ class Settings(BaseSettings):
     # Prompt optimization
     PROMPT_CACHE_REDIS_URL: str = "redis://localhost:6379/2"
     MLFLOW_TRACKING_URI: str = "http://mlflow-server:5000"
+    PROMPT_FALLBACK_ONLY: bool = False
 
     # Anthropic Claude Sonnet 4 (targeting translation)
     ANTHROPIC_API_KEY: str = ""

--- a/ad-publishing-agent-svc/app/main.py
+++ b/ad-publishing-agent-svc/app/main.py
@@ -77,6 +77,7 @@ async def lifespan(app: FastAPI):
         critical_agent=True,
         redis_url=settings.PROMPT_CACHE_REDIS_URL,
         mlflow_uri=settings.MLFLOW_TRACKING_URI,
+        fallback_only=settings.PROMPT_FALLBACK_ONLY,
     )
     await prompt_loader.start()
 

--- a/audience-persona-agent-svc/app/core/config.py
+++ b/audience-persona-agent-svc/app/core/config.py
@@ -21,6 +21,7 @@ class Settings(BaseSettings):
     # Prompt optimization
     PROMPT_CACHE_REDIS_URL: str = "redis://localhost:6379/2"
     MLFLOW_TRACKING_URI: str = "http://mlflow-server:5000"
+    PROMPT_FALLBACK_ONLY: bool = False
 
     # Kafka connection
     KAFKA_BOOTSTRAP_SERVERS: str = ""

--- a/audience-persona-agent-svc/app/main.py
+++ b/audience-persona-agent-svc/app/main.py
@@ -79,6 +79,7 @@ async def lifespan(app: FastAPI):
     prompt_loader = AgentPromptClient(
         redis_url=settings.PROMPT_CACHE_REDIS_URL,
         mlflow_uri=settings.MLFLOW_TRACKING_URI,
+        fallback_only=settings.PROMPT_FALLBACK_ONLY,
     )
     await prompt_loader.start()
 

--- a/brand-architecture-agent-svc/app/core/config.py
+++ b/brand-architecture-agent-svc/app/core/config.py
@@ -27,6 +27,7 @@ class Settings(BaseSettings):
     # Prompt optimization
     PROMPT_CACHE_REDIS_URL: str = "redis://localhost:6379/2"
     MLFLOW_TRACKING_URI: str = "http://mlflow-server:5000"
+    PROMPT_FALLBACK_ONLY: bool = False
 
     # LLM — Claude Sonnet 4
     ANTHROPIC_API_KEY: str = ""

--- a/brand-architecture-agent-svc/app/main.py
+++ b/brand-architecture-agent-svc/app/main.py
@@ -85,6 +85,7 @@ async def lifespan(app: FastAPI):
     prompt_loader = AgentPromptClient(
         redis_url=settings.PROMPT_CACHE_REDIS_URL,
         mlflow_uri=settings.MLFLOW_TRACKING_URI,
+        fallback_only=settings.PROMPT_FALLBACK_ONLY,
     )
     await prompt_loader.start()
 

--- a/brand-naming-agent-svc/app/core/config.py
+++ b/brand-naming-agent-svc/app/core/config.py
@@ -26,6 +26,7 @@ class Settings(BaseSettings):
     # Prompt optimization
     PROMPT_CACHE_REDIS_URL: str = "redis://localhost:6379/2"
     MLFLOW_TRACKING_URI: str = "http://mlflow-server:5000"
+    PROMPT_FALLBACK_ONLY: bool = False
 
     # Anthropic Claude Sonnet 4
     ANTHROPIC_API_KEY: str = ""

--- a/brand-naming-agent-svc/app/main.py
+++ b/brand-naming-agent-svc/app/main.py
@@ -71,6 +71,7 @@ async def lifespan(app: FastAPI):
     prompt_loader = AgentPromptClient(
         redis_url=settings.PROMPT_CACHE_REDIS_URL,
         mlflow_uri=settings.MLFLOW_TRACKING_URI,
+        fallback_only=settings.PROMPT_FALLBACK_ONLY,
     )
     await prompt_loader.start()
 

--- a/brand-personality-agent-svc/app/core/config.py
+++ b/brand-personality-agent-svc/app/core/config.py
@@ -26,6 +26,7 @@ class Settings(BaseSettings):
     # Prompt optimization
     PROMPT_CACHE_REDIS_URL: str = "redis://localhost:6379/2"
     MLFLOW_TRACKING_URI: str = "http://mlflow-server:5000"
+    PROMPT_FALLBACK_ONLY: bool = False
 
     # Anthropic Claude Sonnet 4
     ANTHROPIC_API_KEY: str = ""

--- a/brand-personality-agent-svc/app/main.py
+++ b/brand-personality-agent-svc/app/main.py
@@ -71,6 +71,7 @@ async def lifespan(app: FastAPI):
     prompt_loader = AgentPromptClient(
         redis_url=settings.PROMPT_CACHE_REDIS_URL,
         mlflow_uri=settings.MLFLOW_TRACKING_URI,
+        fallback_only=settings.PROMPT_FALLBACK_ONLY,
     )
     await prompt_loader.start()
 

--- a/brand-positioning-agent-svc/app/core/config.py
+++ b/brand-positioning-agent-svc/app/core/config.py
@@ -27,6 +27,7 @@ class Settings(BaseSettings):
     # Prompt optimization
     PROMPT_CACHE_REDIS_URL: str = "redis://localhost:6379/2"
     MLFLOW_TRACKING_URI: str = "http://mlflow-server:5000"
+    PROMPT_FALLBACK_ONLY: bool = False
 
     # LLM — Claude Sonnet 4
     ANTHROPIC_API_KEY: str = ""

--- a/brand-positioning-agent-svc/app/main.py
+++ b/brand-positioning-agent-svc/app/main.py
@@ -85,6 +85,7 @@ async def lifespan(app: FastAPI):
     prompt_loader = AgentPromptClient(
         redis_url=settings.PROMPT_CACHE_REDIS_URL,
         mlflow_uri=settings.MLFLOW_TRACKING_URI,
+        fallback_only=settings.PROMPT_FALLBACK_ONLY,
     )
     await prompt_loader.start()
 

--- a/brand-story-agent-svc/app/core/config.py
+++ b/brand-story-agent-svc/app/core/config.py
@@ -26,6 +26,7 @@ class Settings(BaseSettings):
     # Prompt optimization
     PROMPT_CACHE_REDIS_URL: str = "redis://localhost:6379/2"
     MLFLOW_TRACKING_URI: str = "http://mlflow-server:5000"
+    PROMPT_FALLBACK_ONLY: bool = False
 
     # Anthropic Claude Sonnet 4
     ANTHROPIC_API_KEY: str = ""

--- a/brand-story-agent-svc/app/main.py
+++ b/brand-story-agent-svc/app/main.py
@@ -80,6 +80,7 @@ async def lifespan(app: FastAPI):
     prompt_loader = AgentPromptClient(
         redis_url=settings.PROMPT_CACHE_REDIS_URL,
         mlflow_uri=settings.MLFLOW_TRACKING_URI,
+        fallback_only=settings.PROMPT_FALLBACK_ONLY,
     )
     await prompt_loader.start()
 

--- a/campaign-architecture-agent-svc/app/core/config.py
+++ b/campaign-architecture-agent-svc/app/core/config.py
@@ -26,6 +26,7 @@ class Settings(BaseSettings):
     # Prompt optimization
     PROMPT_CACHE_REDIS_URL: str = "redis://localhost:6379/2"
     MLFLOW_TRACKING_URI: str = "http://mlflow-server:5000"
+    PROMPT_FALLBACK_ONLY: bool = False
 
     # Anthropic Claude Sonnet 4
     ANTHROPIC_API_KEY: str = ""

--- a/campaign-architecture-agent-svc/app/main.py
+++ b/campaign-architecture-agent-svc/app/main.py
@@ -93,6 +93,7 @@ async def lifespan(app: FastAPI):
     prompt_loader = AgentPromptClient(
         redis_url=settings.PROMPT_CACHE_REDIS_URL,
         mlflow_uri=settings.MLFLOW_TRACKING_URI,
+        fallback_only=settings.PROMPT_FALLBACK_ONLY,
     )
     await prompt_loader.start()
 

--- a/campaign-optimization-agent-svc/app/core/config.py
+++ b/campaign-optimization-agent-svc/app/core/config.py
@@ -27,6 +27,7 @@ class Settings(BaseSettings):
     # Prompt optimization
     PROMPT_CACHE_REDIS_URL: str = "redis://localhost:6379/2"
     MLFLOW_TRACKING_URI: str = "http://mlflow-server:5000"
+    PROMPT_FALLBACK_ONLY: bool = False
 
     # Service auth
     SERVICE_TOKEN: str = "dev-service-token"

--- a/campaign-optimization-agent-svc/app/main.py
+++ b/campaign-optimization-agent-svc/app/main.py
@@ -107,6 +107,7 @@ async def lifespan(app: FastAPI):
         critical_agent=True,
         redis_url=settings.PROMPT_CACHE_REDIS_URL,
         mlflow_uri=settings.MLFLOW_TRACKING_URI,
+        fallback_only=settings.PROMPT_FALLBACK_ONLY,
     )
     await prompt_loader.start()
 

--- a/competitor-intel-agent-svc/app/core/config.py
+++ b/competitor-intel-agent-svc/app/core/config.py
@@ -21,6 +21,7 @@ class Settings(BaseSettings):
     # Prompt optimization
     PROMPT_CACHE_REDIS_URL: str = "redis://localhost:6379/2"
     MLFLOW_TRACKING_URI: str = "http://mlflow-server:5000"
+    PROMPT_FALLBACK_ONLY: bool = False
 
     # Kafka connection
     KAFKA_BOOTSTRAP_SERVERS: str = ""

--- a/competitor-intel-agent-svc/app/main.py
+++ b/competitor-intel-agent-svc/app/main.py
@@ -105,6 +105,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     prompt_loader = AgentPromptClient(
         redis_url=settings.PROMPT_CACHE_REDIS_URL,
         mlflow_uri=settings.MLFLOW_TRACKING_URI,
+        fallback_only=settings.PROMPT_FALLBACK_ONLY,
     )
     await prompt_loader.start()
 

--- a/creative-generation-agent-svc/app/core/config.py
+++ b/creative-generation-agent-svc/app/core/config.py
@@ -26,6 +26,7 @@ class Settings(BaseSettings):
     # Prompt optimization
     PROMPT_CACHE_REDIS_URL: str = "redis://localhost:6379/2"
     MLFLOW_TRACKING_URI: str = "http://mlflow-server:5000"
+    PROMPT_FALLBACK_ONLY: bool = False
 
     # Anthropic Claude Sonnet 4 (copy generation + assembly)
     ANTHROPIC_API_KEY: str = ""

--- a/creative-generation-agent-svc/app/main.py
+++ b/creative-generation-agent-svc/app/main.py
@@ -85,6 +85,7 @@ async def lifespan(app: FastAPI):
     prompt_loader = AgentPromptClient(
         redis_url=settings.PROMPT_CACHE_REDIS_URL,
         mlflow_uri=settings.MLFLOW_TRACKING_URI,
+        fallback_only=settings.PROMPT_FALLBACK_ONLY,
     )
     await prompt_loader.start()
 

--- a/intelligence-loop-agent-svc/app/core/config.py
+++ b/intelligence-loop-agent-svc/app/core/config.py
@@ -25,6 +25,7 @@ class Settings(BaseSettings):
     # Prompt optimization
     PROMPT_CACHE_REDIS_URL: str = "redis://localhost:6379/2"
     MLFLOW_TRACKING_URI: str = "http://mlflow-server:5000"
+    PROMPT_FALLBACK_ONLY: bool = False
 
     # Service auth
     SERVICE_TOKEN: str = "dev-service-token"

--- a/intelligence-loop-agent-svc/app/main.py
+++ b/intelligence-loop-agent-svc/app/main.py
@@ -46,6 +46,7 @@ async def lifespan(app: FastAPI):
     prompt_loader = AgentPromptClient(
         redis_url=settings.PROMPT_CACHE_REDIS_URL,
         mlflow_uri=settings.MLFLOW_TRACKING_URI,
+        fallback_only=settings.PROMPT_FALLBACK_ONLY,
     )
     await prompt_loader.start()
 

--- a/market-research-agent-svc/app/core/config.py
+++ b/market-research-agent-svc/app/core/config.py
@@ -21,6 +21,7 @@ class Settings(BaseSettings):
     # Prompt optimization
     PROMPT_CACHE_REDIS_URL: str = "redis://localhost:6379/2"
     MLFLOW_TRACKING_URI: str = "http://mlflow-server:5000"
+    PROMPT_FALLBACK_ONLY: bool = False
 
     # Kafka connection
     KAFKA_BOOTSTRAP_SERVERS: str = ""

--- a/market-research-agent-svc/app/main.py
+++ b/market-research-agent-svc/app/main.py
@@ -113,6 +113,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     prompt_loader = AgentPromptClient(
         redis_url=settings.PROMPT_CACHE_REDIS_URL,
         mlflow_uri=settings.MLFLOW_TRACKING_URI,
+        fallback_only=settings.PROMPT_FALLBACK_ONLY,
     )
     await prompt_loader.start()
 

--- a/scripts/seed_and_promote_prompts.sh
+++ b/scripts/seed_and_promote_prompts.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# seed_and_promote_prompts.sh — Seed all prompts into MLflow and promote to PRODUCTION.
+#
+# Usage:
+#   ./scripts/seed_and_promote_prompts.sh                          # default: http://localhost:8110
+#   ./scripts/seed_and_promote_prompts.sh https://poi.railway.app  # Railway URL
+#
+# The lifecycle requires: DRAFT → STAGING → CANARY → PRODUCTION (3 transitions per prompt).
+# Auth: X-User-Role: admin header (RBAC allows ADMIN to promote).
+
+set -euo pipefail
+
+BASE_URL="${1:-http://localhost:8110}"
+ROLE_HEADER="X-User-Role: admin"
+CONTENT_TYPE="Content-Type: application/json"
+
+# All 39 prompts from prompt_catalog.py
+PROMPTS=(
+  # WF1 — Brand Discovery (23)
+  "zorven-wf1-mra-planning"
+  "zorven-wf1-mra-synthesis"
+  "zorven-wf1-mra-skill-synthesis"
+  "zorven-wf1-mra-skill-report"
+  "zorven-wf1-cia-planning"
+  "zorven-wf1-cia-synthesis"
+  "zorven-wf1-cia-swot"
+  "zorven-wf1-cia-positioning-gap"
+  "zorven-wf1-cia-benchmarking"
+  "zorven-wf1-apa-planning"
+  "zorven-wf1-apa-synthesis"
+  "zorven-wf1-apa-demographic"
+  "zorven-wf1-apa-psychographic"
+  "zorven-wf1-apa-persona-synthesis"
+  "zorven-wf1-apa-journey"
+  "zorven-wf1-tcia-scoring"
+  "zorven-wf1-tcia-persona-mapping"
+  "zorven-wf1-tcia-report-synthesis"
+  "zorven-wf1-voca-synthesis"
+  "zorven-wf1-voca-sentiment-analysis"
+  "zorven-wf1-voca-theme-clustering"
+  "zorven-wf1-voca-nps-analysis"
+  "zorven-wf1-voca-strategy-bridge"
+  # WF2 — Brand Strategy (7)
+  "zorven-wf2-bpa-positioning"
+  "zorven-wf2-baa-hierarchy"
+  "zorven-wf2-bpv-personality"
+  "zorven-wf2-nta-naming"
+  "zorven-wf2-nta-tagline"
+  "zorven-wf2-bsa-origin"
+  "zorven-wf2-bsa-narrative"
+  # WF3 — Campaign Activation (9)
+  "zorven-wf3-caa-blueprint"
+  "zorven-wf3-caa-blueprint-synthesis"
+  "zorven-wf3-cga-creative-director"
+  "zorven-wf3-cga-copywriting"
+  "zorven-wf3-cga-compliance"
+  "zorven-wf3-adpub-publishing"
+  "zorven-wf3-coa-recommendation"
+  "zorven-wf3-coa-reporter"
+  "zorven-wf3-ila-extraction"
+)
+
+echo "=========================================="
+echo "Prompt Optimization — Seed & Promote"
+echo "=========================================="
+echo "Target: $BASE_URL"
+echo "Prompts: ${#PROMPTS[@]}"
+echo ""
+
+# ── Step 1: Seed all prompts into MLflow (creates as DRAFT) ──────
+echo "▶ Step 1: Seeding prompt catalog into MLflow..."
+SEED_RESPONSE=$(curl -sf -X POST "$BASE_URL/v1/prompts/seed" \
+  -H "$CONTENT_TYPE" 2>&1) || {
+  echo "✗ Seed request failed. Is prompt-optimization-svc running at $BASE_URL?"
+  echo "  Response: $SEED_RESPONSE"
+  exit 1
+}
+echo "  $SEED_RESPONSE"
+echo ""
+
+# ── Step 2: Promote each prompt through DRAFT → STAGING → CANARY → PRODUCTION ──
+SUCCEEDED=0
+FAILED=0
+SKIPPED=0
+
+promote() {
+  local name="$1"
+  local version="$2"
+  local target_state="$3"
+
+  local resp
+  resp=$(curl -sf -X PUT "$BASE_URL/v1/prompts/$name/versions/$version/promote" \
+    -H "$CONTENT_TYPE" \
+    -H "$ROLE_HEADER" \
+    -d "{\"target_state\": \"$target_state\"}" 2>&1) || true
+
+  # Check for success in response
+  if echo "$resp" | grep -q '"success":true\|"success": true'; then
+    return 0
+  else
+    echo "    ⚠ $name → $target_state: $resp"
+    return 1
+  fi
+}
+
+echo "▶ Step 2: Promoting all prompts to PRODUCTION..."
+echo "  (DRAFT → STAGING → CANARY → PRODUCTION, 3 transitions each)"
+echo ""
+
+for name in "${PROMPTS[@]}"; do
+  printf "  %-45s " "$name"
+
+  # Transition 1: DRAFT → STAGING
+  if ! promote "$name" 1 "STAGING"; then
+    echo "[FAILED at STAGING]"
+    FAILED=$((FAILED + 1))
+    continue
+  fi
+
+  # Transition 2: STAGING → CANARY
+  if ! promote "$name" 1 "CANARY"; then
+    echo "[FAILED at CANARY]"
+    FAILED=$((FAILED + 1))
+    continue
+  fi
+
+  # Transition 3: CANARY → PRODUCTION
+  if ! promote "$name" 1 "PRODUCTION"; then
+    echo "[FAILED at PRODUCTION]"
+    FAILED=$((FAILED + 1))
+    continue
+  fi
+
+  echo "[✓ PRODUCTION]"
+  SUCCEEDED=$((SUCCEEDED + 1))
+done
+
+echo ""
+echo "=========================================="
+echo "Results"
+echo "=========================================="
+echo "  Succeeded: $SUCCEEDED"
+echo "  Failed:    $FAILED"
+echo "  Total:     ${#PROMPTS[@]}"
+echo ""
+
+if [ "$FAILED" -gt 0 ]; then
+  echo "⚠ Some prompts failed to promote. Check the output above for details."
+  echo "  Failed prompts will continue using hardcoded fallback prompts."
+  exit 1
+else
+  echo "✓ All ${#PROMPTS[@]} prompts are now in PRODUCTION state."
+  echo "  Agents with PROMPT_FALLBACK_ONLY=False will load these from MLflow."
+fi

--- a/trend-cultural-agent-svc/app/core/config.py
+++ b/trend-cultural-agent-svc/app/core/config.py
@@ -21,6 +21,7 @@ class Settings(BaseSettings):
     # Prompt optimization
     PROMPT_CACHE_REDIS_URL: str = "redis://localhost:6379/2"
     MLFLOW_TRACKING_URI: str = "http://mlflow-server:5000"
+    PROMPT_FALLBACK_ONLY: bool = False
 
     # Kafka connection
     KAFKA_BOOTSTRAP_SERVERS: str = ""

--- a/trend-cultural-agent-svc/app/main.py
+++ b/trend-cultural-agent-svc/app/main.py
@@ -100,6 +100,7 @@ async def lifespan(app: FastAPI):
     prompt_loader = AgentPromptClient(
         redis_url=settings.PROMPT_CACHE_REDIS_URL,
         mlflow_uri=settings.MLFLOW_TRACKING_URI,
+        fallback_only=settings.PROMPT_FALLBACK_ONLY,
     )
     await prompt_loader.start()
 

--- a/voc-agent-svc/app/core/config.py
+++ b/voc-agent-svc/app/core/config.py
@@ -21,6 +21,7 @@ class Settings(BaseSettings):
     # Prompt optimization
     PROMPT_CACHE_REDIS_URL: str = "redis://localhost:6379/2"
     MLFLOW_TRACKING_URI: str = "http://mlflow-server:5000"
+    PROMPT_FALLBACK_ONLY: bool = False
 
     # Kafka connection
     KAFKA_BOOTSTRAP_SERVERS: str = ""

--- a/voc-agent-svc/app/main.py
+++ b/voc-agent-svc/app/main.py
@@ -83,6 +83,7 @@ async def lifespan(app: FastAPI):
     prompt_loader = AgentPromptClient(
         redis_url=settings.PROMPT_CACHE_REDIS_URL,
         mlflow_uri=settings.MLFLOW_TRACKING_URI,
+        fallback_only=settings.PROMPT_FALLBACK_ONLY,
     )
     await prompt_loader.start()
 


### PR DESCRIPTION
## Summary
- The `AgentPromptClient` was fully wired into all 15 agents but **permanently bypassed** — `fallback_only=True` (the default) caused every `.load()` call to return hardcoded fallback prompts without ever contacting Redis or MLflow
- Adds `PROMPT_FALLBACK_ONLY: bool = False` config setting to all 15 agents
- Passes `fallback_only=settings.PROMPT_FALLBACK_ONLY` to the `AgentPromptClient` constructor
- Agents now use three-tier prompt resolution: **Redis cache → MLflow → hardcoded fallback**
- Safety: can revert any individual agent by setting `{PREFIX}_PROMPT_FALLBACK_ONLY=true` env var

## Agents updated (15)
MRA, CIA, APA, TCIA, VoCA, BPA, BAA, BPV, NTA, BSA, CAA, CGA, ADPUB, COA, ILA

## Prerequisites before deploy
1. **Seed prompts**: `POST prompt-optimization-svc/v1/prompts/seed`
2. **Promote all to PRODUCTION**: `PUT /v1/prompts/{name}/versions/1/promote` for each prompt (37 total)

Without these steps, agents will fall back to hardcoded prompts (safe, but no optimization benefit).

## Test plan
- [ ] Seed prompts via prompt-optimization-svc API
- [ ] Promote prompts to PRODUCTION state
- [ ] Deploy agents and verify logs show "Loaded prompt from MLflow/Redis" instead of fallback
- [ ] Run WF1 pipeline and verify confidence scores improve with optimized prompts
- [ ] Verify fallback works: set `MRA_PROMPT_FALLBACK_ONLY=true` and confirm MRA still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)