### PR TITLE
fix: add diagnostic logging to prompt loader (all 15 agents)

### DIFF
--- a/ad-publishing-agent-svc/app/prompts/loader.py
+++ b/ad-publishing-agent-svc/app/prompts/loader.py
@@ -81,7 +81,12 @@ class AgentPromptClient:
                 "MLflow URI not configured — prompt loader in fallback-only mode"
             )
 
-        logger.info("Prompt loader initialized")
+        logger.info(
+            "Prompt loader initialized (fallback_only=%s, redis=%s, mlflow=%s)",
+            self.fallback_only,
+            self._redis is not None,
+            self._http is not None,
+        )
 
     async def stop(self) -> None:
         """Close connections."""
@@ -122,15 +127,19 @@ class AgentPromptClient:
 
         # Tier 1: Redis cache
         template = await self._cache_get(name, tenant_id)
+        if template is not None:
+            logger.info("Loaded prompt '%s' from Redis cache (tenant=%s)", name, tenant_id)
 
         # Tier 2: MLflow API
         if template is None:
             template = await self._mlflow_get(name, tenant_id)
             if template is not None:
+                logger.info("Loaded prompt '%s' from MLflow (tenant=%s)", name, tenant_id)
                 await self._cache_set(name, template, resolve_ttl, tenant_id)
 
         # Tier 3: Fallback
         if template is None:
+            logger.info("Prompt '%s' not found in cache/MLflow, using fallback (tenant=%s)", name, tenant_id)
             if fallback:
                 if self.critical_agent:
                     logger.warning(

--- a/audience-persona-agent-svc/app/prompts/loader.py
+++ b/audience-persona-agent-svc/app/prompts/loader.py
@@ -81,7 +81,12 @@ class AgentPromptClient:
                 "MLflow URI not configured — prompt loader in fallback-only mode"
             )
 
-        logger.info("Prompt loader initialized")
+        logger.info(
+            "Prompt loader initialized (fallback_only=%s, redis=%s, mlflow=%s)",
+            self.fallback_only,
+            self._redis is not None,
+            self._http is not None,
+        )
 
     async def stop(self) -> None:
         """Close connections."""
@@ -122,15 +127,19 @@ class AgentPromptClient:
 
         # Tier 1: Redis cache
         template = await self._cache_get(name, tenant_id)
+        if template is not None:
+            logger.info("Loaded prompt '%s' from Redis cache (tenant=%s)", name, tenant_id)
 
         # Tier 2: MLflow API
         if template is None:
             template = await self._mlflow_get(name, tenant_id)
             if template is not None:
+                logger.info("Loaded prompt '%s' from MLflow (tenant=%s)", name, tenant_id)
                 await self._cache_set(name, template, resolve_ttl, tenant_id)
 
         # Tier 3: Fallback
         if template is None:
+            logger.info("Prompt '%s' not found in cache/MLflow, using fallback (tenant=%s)", name, tenant_id)
             if fallback:
                 if self.critical_agent:
                     logger.warning(

--- a/brand-architecture-agent-svc/app/prompts/loader.py
+++ b/brand-architecture-agent-svc/app/prompts/loader.py
@@ -81,7 +81,12 @@ class AgentPromptClient:
                 "MLflow URI not configured — prompt loader in fallback-only mode"
             )
 
-        logger.info("Prompt loader initialized")
+        logger.info(
+            "Prompt loader initialized (fallback_only=%s, redis=%s, mlflow=%s)",
+            self.fallback_only,
+            self._redis is not None,
+            self._http is not None,
+        )
 
     async def stop(self) -> None:
         """Close connections."""
@@ -122,15 +127,19 @@ class AgentPromptClient:
 
         # Tier 1: Redis cache
         template = await self._cache_get(name, tenant_id)
+        if template is not None:
+            logger.info("Loaded prompt '%s' from Redis cache (tenant=%s)", name, tenant_id)
 
         # Tier 2: MLflow API
         if template is None:
             template = await self._mlflow_get(name, tenant_id)
             if template is not None:
+                logger.info("Loaded prompt '%s' from MLflow (tenant=%s)", name, tenant_id)
                 await self._cache_set(name, template, resolve_ttl, tenant_id)
 
         # Tier 3: Fallback
         if template is None:
+            logger.info("Prompt '%s' not found in cache/MLflow, using fallback (tenant=%s)", name, tenant_id)
             if fallback:
                 if self.critical_agent:
                     logger.warning(

--- a/brand-naming-agent-svc/app/prompts/loader.py
+++ b/brand-naming-agent-svc/app/prompts/loader.py
@@ -81,7 +81,12 @@ class AgentPromptClient:
                 "MLflow URI not configured — prompt loader in fallback-only mode"
             )
 
-        logger.info("Prompt loader initialized")
+        logger.info(
+            "Prompt loader initialized (fallback_only=%s, redis=%s, mlflow=%s)",
+            self.fallback_only,
+            self._redis is not None,
+            self._http is not None,
+        )
 
     async def stop(self) -> None:
         """Close connections."""
@@ -122,15 +127,19 @@ class AgentPromptClient:
 
         # Tier 1: Redis cache
         template = await self._cache_get(name, tenant_id)
+        if template is not None:
+            logger.info("Loaded prompt '%s' from Redis cache (tenant=%s)", name, tenant_id)
 
         # Tier 2: MLflow API
         if template is None:
             template = await self._mlflow_get(name, tenant_id)
             if template is not None:
+                logger.info("Loaded prompt '%s' from MLflow (tenant=%s)", name, tenant_id)
                 await self._cache_set(name, template, resolve_ttl, tenant_id)
 
         # Tier 3: Fallback
         if template is None:
+            logger.info("Prompt '%s' not found in cache/MLflow, using fallback (tenant=%s)", name, tenant_id)
             if fallback:
                 if self.critical_agent:
                     logger.warning(

--- a/brand-personality-agent-svc/app/prompts/loader.py
+++ b/brand-personality-agent-svc/app/prompts/loader.py
@@ -81,7 +81,12 @@ class AgentPromptClient:
                 "MLflow URI not configured — prompt loader in fallback-only mode"
             )
 
-        logger.info("Prompt loader initialized")
+        logger.info(
+            "Prompt loader initialized (fallback_only=%s, redis=%s, mlflow=%s)",
+            self.fallback_only,
+            self._redis is not None,
+            self._http is not None,
+        )
 
     async def stop(self) -> None:
         """Close connections."""
@@ -122,15 +127,19 @@ class AgentPromptClient:
 
         # Tier 1: Redis cache
         template = await self._cache_get(name, tenant_id)
+        if template is not None:
+            logger.info("Loaded prompt '%s' from Redis cache (tenant=%s)", name, tenant_id)
 
         # Tier 2: MLflow API
         if template is None:
             template = await self._mlflow_get(name, tenant_id)
             if template is not None:
+                logger.info("Loaded prompt '%s' from MLflow (tenant=%s)", name, tenant_id)
                 await self._cache_set(name, template, resolve_ttl, tenant_id)
 
         # Tier 3: Fallback
         if template is None:
+            logger.info("Prompt '%s' not found in cache/MLflow, using fallback (tenant=%s)", name, tenant_id)
             if fallback:
                 if self.critical_agent:
                     logger.warning(

--- a/brand-positioning-agent-svc/app/prompts/loader.py
+++ b/brand-positioning-agent-svc/app/prompts/loader.py
@@ -81,7 +81,12 @@ class AgentPromptClient:
                 "MLflow URI not configured — prompt loader in fallback-only mode"
             )
 
-        logger.info("Prompt loader initialized")
+        logger.info(
+            "Prompt loader initialized (fallback_only=%s, redis=%s, mlflow=%s)",
+            self.fallback_only,
+            self._redis is not None,
+            self._http is not None,
+        )
 
     async def stop(self) -> None:
         """Close connections."""
@@ -122,15 +127,19 @@ class AgentPromptClient:
 
         # Tier 1: Redis cache
         template = await self._cache_get(name, tenant_id)
+        if template is not None:
+            logger.info("Loaded prompt '%s' from Redis cache (tenant=%s)", name, tenant_id)
 
         # Tier 2: MLflow API
         if template is None:
             template = await self._mlflow_get(name, tenant_id)
             if template is not None:
+                logger.info("Loaded prompt '%s' from MLflow (tenant=%s)", name, tenant_id)
                 await self._cache_set(name, template, resolve_ttl, tenant_id)
 
         # Tier 3: Fallback
         if template is None:
+            logger.info("Prompt '%s' not found in cache/MLflow, using fallback (tenant=%s)", name, tenant_id)
             if fallback:
                 if self.critical_agent:
                     logger.warning(

--- a/brand-story-agent-svc/app/prompts/loader.py
+++ b/brand-story-agent-svc/app/prompts/loader.py
@@ -81,7 +81,12 @@ class AgentPromptClient:
                 "MLflow URI not configured — prompt loader in fallback-only mode"
             )
 
-        logger.info("Prompt loader initialized")
+        logger.info(
+            "Prompt loader initialized (fallback_only=%s, redis=%s, mlflow=%s)",
+            self.fallback_only,
+            self._redis is not None,
+            self._http is not None,
+        )
 
     async def stop(self) -> None:
         """Close connections."""
@@ -122,15 +127,19 @@ class AgentPromptClient:
 
         # Tier 1: Redis cache
         template = await self._cache_get(name, tenant_id)
+        if template is not None:
+            logger.info("Loaded prompt '%s' from Redis cache (tenant=%s)", name, tenant_id)
 
         # Tier 2: MLflow API
         if template is None:
             template = await self._mlflow_get(name, tenant_id)
             if template is not None:
+                logger.info("Loaded prompt '%s' from MLflow (tenant=%s)", name, tenant_id)
                 await self._cache_set(name, template, resolve_ttl, tenant_id)
 
         # Tier 3: Fallback
         if template is None:
+            logger.info("Prompt '%s' not found in cache/MLflow, using fallback (tenant=%s)", name, tenant_id)
             if fallback:
                 if self.critical_agent:
                     logger.warning(

--- a/campaign-architecture-agent-svc/app/prompts/loader.py
+++ b/campaign-architecture-agent-svc/app/prompts/loader.py
@@ -81,7 +81,12 @@ class AgentPromptClient:
                 "MLflow URI not configured — prompt loader in fallback-only mode"
             )
 
-        logger.info("Prompt loader initialized")
+        logger.info(
+            "Prompt loader initialized (fallback_only=%s, redis=%s, mlflow=%s)",
+            self.fallback_only,
+            self._redis is not None,
+            self._http is not None,
+        )
 
     async def stop(self) -> None:
         """Close connections."""
@@ -122,15 +127,19 @@ class AgentPromptClient:
 
         # Tier 1: Redis cache
         template = await self._cache_get(name, tenant_id)
+        if template is not None:
+            logger.info("Loaded prompt '%s' from Redis cache (tenant=%s)", name, tenant_id)
 
         # Tier 2: MLflow API
         if template is None:
             template = await self._mlflow_get(name, tenant_id)
             if template is not None:
+                logger.info("Loaded prompt '%s' from MLflow (tenant=%s)", name, tenant_id)
                 await self._cache_set(name, template, resolve_ttl, tenant_id)
 
         # Tier 3: Fallback
         if template is None:
+            logger.info("Prompt '%s' not found in cache/MLflow, using fallback (tenant=%s)", name, tenant_id)
             if fallback:
                 if self.critical_agent:
                     logger.warning(

--- a/campaign-optimization-agent-svc/app/prompts/loader.py
+++ b/campaign-optimization-agent-svc/app/prompts/loader.py
@@ -81,7 +81,12 @@ class AgentPromptClient:
                 "MLflow URI not configured — prompt loader in fallback-only mode"
             )
 
-        logger.info("Prompt loader initialized")
+        logger.info(
+            "Prompt loader initialized (fallback_only=%s, redis=%s, mlflow=%s)",
+            self.fallback_only,
+            self._redis is not None,
+            self._http is not None,
+        )
 
     async def stop(self) -> None:
         """Close connections."""
@@ -122,15 +127,19 @@ class AgentPromptClient:
 
         # Tier 1: Redis cache
         template = await self._cache_get(name, tenant_id)
+        if template is not None:
+            logger.info("Loaded prompt '%s' from Redis cache (tenant=%s)", name, tenant_id)
 
         # Tier 2: MLflow API
         if template is None:
             template = await self._mlflow_get(name, tenant_id)
             if template is not None:
+                logger.info("Loaded prompt '%s' from MLflow (tenant=%s)", name, tenant_id)
                 await self._cache_set(name, template, resolve_ttl, tenant_id)
 
         # Tier 3: Fallback
         if template is None:
+            logger.info("Prompt '%s' not found in cache/MLflow, using fallback (tenant=%s)", name, tenant_id)
             if fallback:
                 if self.critical_agent:
                     logger.warning(

--- a/competitor-intel-agent-svc/app/prompts/loader.py
+++ b/competitor-intel-agent-svc/app/prompts/loader.py
@@ -81,7 +81,12 @@ class AgentPromptClient:
                 "MLflow URI not configured — prompt loader in fallback-only mode"
             )
 
-        logger.info("Prompt loader initialized")
+        logger.info(
+            "Prompt loader initialized (fallback_only=%s, redis=%s, mlflow=%s)",
+            self.fallback_only,
+            self._redis is not None,
+            self._http is not None,
+        )
 
     async def stop(self) -> None:
         """Close connections."""
@@ -122,15 +127,19 @@ class AgentPromptClient:
 
         # Tier 1: Redis cache
         template = await self._cache_get(name, tenant_id)
+        if template is not None:
+            logger.info("Loaded prompt '%s' from Redis cache (tenant=%s)", name, tenant_id)
 
         # Tier 2: MLflow API
         if template is None:
             template = await self._mlflow_get(name, tenant_id)
             if template is not None:
+                logger.info("Loaded prompt '%s' from MLflow (tenant=%s)", name, tenant_id)
                 await self._cache_set(name, template, resolve_ttl, tenant_id)
 
         # Tier 3: Fallback
         if template is None:
+            logger.info("Prompt '%s' not found in cache/MLflow, using fallback (tenant=%s)", name, tenant_id)
             if fallback:
                 if self.critical_agent:
                     logger.warning(

--- a/creative-generation-agent-svc/app/prompts/loader.py
+++ b/creative-generation-agent-svc/app/prompts/loader.py
@@ -81,7 +81,12 @@ class AgentPromptClient:
                 "MLflow URI not configured — prompt loader in fallback-only mode"
             )
 
-        logger.info("Prompt loader initialized")
+        logger.info(
+            "Prompt loader initialized (fallback_only=%s, redis=%s, mlflow=%s)",
+            self.fallback_only,
+            self._redis is not None,
+            self._http is not None,
+        )
 
     async def stop(self) -> None:
         """Close connections."""
@@ -122,15 +127,19 @@ class AgentPromptClient:
 
         # Tier 1: Redis cache
         template = await self._cache_get(name, tenant_id)
+        if template is not None:
+            logger.info("Loaded prompt '%s' from Redis cache (tenant=%s)", name, tenant_id)
 
         # Tier 2: MLflow API
         if template is None:
             template = await self._mlflow_get(name, tenant_id)
             if template is not None:
+                logger.info("Loaded prompt '%s' from MLflow (tenant=%s)", name, tenant_id)
                 await self._cache_set(name, template, resolve_ttl, tenant_id)
 
         # Tier 3: Fallback
         if template is None:
+            logger.info("Prompt '%s' not found in cache/MLflow, using fallback (tenant=%s)", name, tenant_id)
             if fallback:
                 if self.critical_agent:
                     logger.warning(

--- a/intelligence-loop-agent-svc/app/prompts/loader.py
+++ b/intelligence-loop-agent-svc/app/prompts/loader.py
@@ -81,7 +81,12 @@ class AgentPromptClient:
                 "MLflow URI not configured — prompt loader in fallback-only mode"
             )
 
-        logger.info("Prompt loader initialized")
+        logger.info(
+            "Prompt loader initialized (fallback_only=%s, redis=%s, mlflow=%s)",
+            self.fallback_only,
+            self._redis is not None,
+            self._http is not None,
+        )
 
     async def stop(self) -> None:
         """Close connections."""
@@ -122,15 +127,19 @@ class AgentPromptClient:
 
         # Tier 1: Redis cache
         template = await self._cache_get(name, tenant_id)
+        if template is not None:
+            logger.info("Loaded prompt '%s' from Redis cache (tenant=%s)", name, tenant_id)
 
         # Tier 2: MLflow API
         if template is None:
             template = await self._mlflow_get(name, tenant_id)
             if template is not None:
+                logger.info("Loaded prompt '%s' from MLflow (tenant=%s)", name, tenant_id)
                 await self._cache_set(name, template, resolve_ttl, tenant_id)
 
         # Tier 3: Fallback
         if template is None:
+            logger.info("Prompt '%s' not found in cache/MLflow, using fallback (tenant=%s)", name, tenant_id)
             if fallback:
                 if self.critical_agent:
                     logger.warning(

--- a/market-research-agent-svc/app/prompts/loader.py
+++ b/market-research-agent-svc/app/prompts/loader.py
@@ -81,7 +81,12 @@ class AgentPromptClient:
                 "MLflow URI not configured — prompt loader in fallback-only mode"
             )
 
-        logger.info("Prompt loader initialized")
+        logger.info(
+            "Prompt loader initialized (fallback_only=%s, redis=%s, mlflow=%s)",
+            self.fallback_only,
+            self._redis is not None,
+            self._http is not None,
+        )
 
     async def stop(self) -> None:
         """Close connections."""
@@ -122,15 +127,19 @@ class AgentPromptClient:
 
         # Tier 1: Redis cache
         template = await self._cache_get(name, tenant_id)
+        if template is not None:
+            logger.info("Loaded prompt '%s' from Redis cache (tenant=%s)", name, tenant_id)
 
         # Tier 2: MLflow API
         if template is None:
             template = await self._mlflow_get(name, tenant_id)
             if template is not None:
+                logger.info("Loaded prompt '%s' from MLflow (tenant=%s)", name, tenant_id)
                 await self._cache_set(name, template, resolve_ttl, tenant_id)
 
         # Tier 3: Fallback
         if template is None:
+            logger.info("Prompt '%s' not found in cache/MLflow, using fallback (tenant=%s)", name, tenant_id)
             if fallback:
                 if self.critical_agent:
                     logger.warning(

--- a/trend-cultural-agent-svc/app/prompts/loader.py
+++ b/trend-cultural-agent-svc/app/prompts/loader.py
@@ -81,7 +81,12 @@ class AgentPromptClient:
                 "MLflow URI not configured — prompt loader in fallback-only mode"
             )
 
-        logger.info("Prompt loader initialized")
+        logger.info(
+            "Prompt loader initialized (fallback_only=%s, redis=%s, mlflow=%s)",
+            self.fallback_only,
+            self._redis is not None,
+            self._http is not None,
+        )
 
     async def stop(self) -> None:
         """Close connections."""
@@ -122,15 +127,19 @@ class AgentPromptClient:
 
         # Tier 1: Redis cache
         template = await self._cache_get(name, tenant_id)
+        if template is not None:
+            logger.info("Loaded prompt '%s' from Redis cache (tenant=%s)", name, tenant_id)
 
         # Tier 2: MLflow API
         if template is None:
             template = await self._mlflow_get(name, tenant_id)
             if template is not None:
+                logger.info("Loaded prompt '%s' from MLflow (tenant=%s)", name, tenant_id)
                 await self._cache_set(name, template, resolve_ttl, tenant_id)
 
         # Tier 3: Fallback
         if template is None:
+            logger.info("Prompt '%s' not found in cache/MLflow, using fallback (tenant=%s)", name, tenant_id)
             if fallback:
                 if self.critical_agent:
                     logger.warning(

--- a/voc-agent-svc/app/prompts/loader.py
+++ b/voc-agent-svc/app/prompts/loader.py
@@ -81,7 +81,12 @@ class AgentPromptClient:
                 "MLflow URI not configured — prompt loader in fallback-only mode"
             )
 
-        logger.info("Prompt loader initialized")
+        logger.info(
+            "Prompt loader initialized (fallback_only=%s, redis=%s, mlflow=%s)",
+            self.fallback_only,
+            self._redis is not None,
+            self._http is not None,
+        )
 
     async def stop(self) -> None:
         """Close connections."""
@@ -122,15 +127,19 @@ class AgentPromptClient:
 
         # Tier 1: Redis cache
         template = await self._cache_get(name, tenant_id)
+        if template is not None:
+            logger.info("Loaded prompt '%s' from Redis cache (tenant=%s)", name, tenant_id)
 
         # Tier 2: MLflow API
         if template is None:
             template = await self._mlflow_get(name, tenant_id)
             if template is not None:
+                logger.info("Loaded prompt '%s' from MLflow (tenant=%s)", name, tenant_id)
                 await self._cache_set(name, template, resolve_ttl, tenant_id)
 
         # Tier 3: Fallback
         if template is None:
+            logger.info("Prompt '%s' not found in cache/MLflow, using fallback (tenant=%s)", name, tenant_id)
             if fallback:
                 if self.critical_agent:
                     logger.warning(


### PR DESCRIPTION
## Summary
- Adds startup log showing `fallback_only` value, Redis connection status, and MLflow connection status
- Adds per-prompt-load log showing which tier served the prompt (Redis cache hit, MLflow fetch, or fallback)
- No behavior change — logging only

## Why
After activating prompt optimization (PR #455), we need to confirm agents are actually loading prompts from MLflow vs falling back to hardcoded prompts. The previous logs showed Redis/MLflow connected but no indication of actual prompt resolution.

## Expected log output after deploy
```
Prompt loader initialized (fallback_only=False, redis=True, mlflow=True)
Loaded prompt 'zorven-wf1-mra-planning' from MLflow (tenant=11)
Loaded prompt 'zorven-wf1-mra-synthesis' from Redis cache (tenant=11)
```

## Test plan
- [ ] Merge and deploy
- [ ] Run `railway logs -s market-research-agent` and confirm `fallback_only=False` in startup log
- [ ] Run a pipeline and confirm prompts are loaded from MLflow/Redis (not fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)