### PR TITLE
fix: route prompt loader through prompt-optimization-svc API

### DIFF
--- a/ad-publishing-agent-svc/app/core/config.py
+++ b/ad-publishing-agent-svc/app/core/config.py
@@ -26,7 +26,7 @@ class Settings(BaseSettings):
     REDIS_URL: str = "redis://localhost:6379/23"
     # Prompt optimization
     PROMPT_CACHE_REDIS_URL: str = "redis://localhost:6379/2"
-    MLFLOW_TRACKING_URI: str = "http://mlflow-server:5000"
+    MLFLOW_TRACKING_URI: str = "http://prompt-optimization-svc:8110"
     PROMPT_FALLBACK_ONLY: bool = False
 
     # Anthropic Claude Sonnet 4 (targeting translation)

--- a/ad-publishing-agent-svc/app/prompts/loader.py
+++ b/ad-publishing-agent-svc/app/prompts/loader.py
@@ -66,19 +66,19 @@ class AgentPromptClient:
                 self._http = httpx.AsyncClient(base_url=self.mlflow_uri, timeout=5.0)
                 resp = await self._http.get("/health")
                 if resp.status_code == 200:
-                    logger.info("MLflow connected: %s", self.mlflow_uri)
+                    logger.info("Prompt service connected: %s", self.mlflow_uri)
                 else:
-                    logger.warning("MLflow unhealthy (%d) — disabled", resp.status_code)
+                    logger.warning("Prompt service unhealthy (%d) — disabled", resp.status_code)
                     await self._http.aclose()
                     self._http = None
             except Exception as exc:
-                logger.warning("MLflow unavailable: %s — disabled", exc)
+                logger.warning("Prompt service unavailable: %s — disabled", exc)
                 if self._http:
                     await self._http.aclose()
                 self._http = None
         else:
             logger.info(
-                "MLflow URI not configured — prompt loader in fallback-only mode"
+                "Prompt service URI not configured — prompt loader in fallback-only mode"
             )
 
         logger.info(
@@ -189,66 +189,42 @@ class AgentPromptClient:
         except Exception:
             pass
 
-    # --- Tier 2: MLflow REST API ---
+    # --- Tier 2: Prompt Optimization Service API ---
 
     async def _mlflow_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._http is None:
             return None
         try:
-            # Try tenant-specific named prompt first
+            # Try tenant-specific prompt first
             if tenant_id:
-                template = await self._fetch_prompt(f"{name}-tenant-{tenant_id}")
+                template = await self._fetch_prompt(name, tenant_id=tenant_id)
                 if template is not None:
                     return template
 
-            # Try base prompt
+            # Try base prompt (no tenant override)
             return await self._fetch_prompt(name)
         except Exception as exc:
-            logger.warning("MLflow prompt fetch failed for '%s': %s", name, exc)
+            logger.warning("Prompt service fetch failed for '%s': %s", name, exc)
             return None
 
-    async def _fetch_prompt(self, name: str) -> Optional[str]:
-        """Fetch a prompt template from MLflow REST API.
+    async def _fetch_prompt(self, name: str, tenant_id: Optional[str] = None) -> Optional[str]:
+        """Fetch a prompt template from the prompt-optimization-svc API.
 
-        Prefers PRODUCTION-tagged versions over latest to match
-        the lifecycle-based resolution of ZorvenPromptLoader.
+        Calls GET /v1/prompts/{name}/production which returns the
+        PRODUCTION-state template directly.
         """
         try:
-            # Search for versions and prefer PRODUCTION state
-            resp = await self._http.get(
-                "/api/2.0/mlflow/prompts/versions/search",
-                params={"name": name},
-            )
-            if resp.status_code == 200:
-                data = resp.json()
-                versions = data.get("prompt_versions", [])
-                # Find PRODUCTION version first
-                for v in versions:
-                    tags = v.get("tags", {})
-                    if isinstance(tags, list):
-                        tag_dict = {t["key"]: t["value"] for t in tags}
-                    else:
-                        tag_dict = tags
-                    if tag_dict.get("state") == "PRODUCTION":
-                        return v.get("template")
+            headers = {}
+            if tenant_id:
+                headers["X-Tenant-ID"] = str(tenant_id)
 
-            # Fallback: get latest version if no PRODUCTION found
             resp = await self._http.get(
-                "/api/2.0/mlflow/prompts/get",
-                params={"name": name},
+                f"/v1/prompts/{name}/production",
+                headers=headers,
             )
             if resp.status_code == 200:
                 data = resp.json()
-                prompt = data.get("prompt", {})
-                latest = prompt.get("latest_version")
-                if latest:
-                    ver_resp = await self._http.get(
-                        "/api/2.0/mlflow/prompts/versions/get",
-                        params={"name": name, "version": latest},
-                    )
-                    if ver_resp.status_code == 200:
-                        ver_data = ver_resp.json()
-                        return ver_data.get("prompt_version", {}).get("template")
+                return data.get("template")
             return None
         except Exception:
             return None

--- a/audience-persona-agent-svc/app/core/config.py
+++ b/audience-persona-agent-svc/app/core/config.py
@@ -20,7 +20,7 @@ class Settings(BaseSettings):
     REDIS_URL: str = "redis://localhost:6379/13"
     # Prompt optimization
     PROMPT_CACHE_REDIS_URL: str = "redis://localhost:6379/2"
-    MLFLOW_TRACKING_URI: str = "http://mlflow-server:5000"
+    MLFLOW_TRACKING_URI: str = "http://prompt-optimization-svc:8110"
     PROMPT_FALLBACK_ONLY: bool = False
 
     # Kafka connection

--- a/audience-persona-agent-svc/app/prompts/loader.py
+++ b/audience-persona-agent-svc/app/prompts/loader.py
@@ -66,19 +66,19 @@ class AgentPromptClient:
                 self._http = httpx.AsyncClient(base_url=self.mlflow_uri, timeout=5.0)
                 resp = await self._http.get("/health")
                 if resp.status_code == 200:
-                    logger.info("MLflow connected: %s", self.mlflow_uri)
+                    logger.info("Prompt service connected: %s", self.mlflow_uri)
                 else:
-                    logger.warning("MLflow unhealthy (%d) — disabled", resp.status_code)
+                    logger.warning("Prompt service unhealthy (%d) — disabled", resp.status_code)
                     await self._http.aclose()
                     self._http = None
             except Exception as exc:
-                logger.warning("MLflow unavailable: %s — disabled", exc)
+                logger.warning("Prompt service unavailable: %s — disabled", exc)
                 if self._http:
                     await self._http.aclose()
                 self._http = None
         else:
             logger.info(
-                "MLflow URI not configured — prompt loader in fallback-only mode"
+                "Prompt service URI not configured — prompt loader in fallback-only mode"
             )
 
         logger.info(
@@ -189,66 +189,42 @@ class AgentPromptClient:
         except Exception:
             pass
 
-    # --- Tier 2: MLflow REST API ---
+    # --- Tier 2: Prompt Optimization Service API ---
 
     async def _mlflow_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._http is None:
             return None
         try:
-            # Try tenant-specific named prompt first
+            # Try tenant-specific prompt first
             if tenant_id:
-                template = await self._fetch_prompt(f"{name}-tenant-{tenant_id}")
+                template = await self._fetch_prompt(name, tenant_id=tenant_id)
                 if template is not None:
                     return template
 
-            # Try base prompt
+            # Try base prompt (no tenant override)
             return await self._fetch_prompt(name)
         except Exception as exc:
-            logger.warning("MLflow prompt fetch failed for '%s': %s", name, exc)
+            logger.warning("Prompt service fetch failed for '%s': %s", name, exc)
             return None
 
-    async def _fetch_prompt(self, name: str) -> Optional[str]:
-        """Fetch a prompt template from MLflow REST API.
+    async def _fetch_prompt(self, name: str, tenant_id: Optional[str] = None) -> Optional[str]:
+        """Fetch a prompt template from the prompt-optimization-svc API.
 
-        Prefers PRODUCTION-tagged versions over latest to match
-        the lifecycle-based resolution of ZorvenPromptLoader.
+        Calls GET /v1/prompts/{name}/production which returns the
+        PRODUCTION-state template directly.
         """
         try:
-            # Search for versions and prefer PRODUCTION state
-            resp = await self._http.get(
-                "/api/2.0/mlflow/prompts/versions/search",
-                params={"name": name},
-            )
-            if resp.status_code == 200:
-                data = resp.json()
-                versions = data.get("prompt_versions", [])
-                # Find PRODUCTION version first
-                for v in versions:
-                    tags = v.get("tags", {})
-                    if isinstance(tags, list):
-                        tag_dict = {t["key"]: t["value"] for t in tags}
-                    else:
-                        tag_dict = tags
-                    if tag_dict.get("state") == "PRODUCTION":
-                        return v.get("template")
+            headers = {}
+            if tenant_id:
+                headers["X-Tenant-ID"] = str(tenant_id)
 
-            # Fallback: get latest version if no PRODUCTION found
             resp = await self._http.get(
-                "/api/2.0/mlflow/prompts/get",
-                params={"name": name},
+                f"/v1/prompts/{name}/production",
+                headers=headers,
             )
             if resp.status_code == 200:
                 data = resp.json()
-                prompt = data.get("prompt", {})
-                latest = prompt.get("latest_version")
-                if latest:
-                    ver_resp = await self._http.get(
-                        "/api/2.0/mlflow/prompts/versions/get",
-                        params={"name": name, "version": latest},
-                    )
-                    if ver_resp.status_code == 200:
-                        ver_data = ver_resp.json()
-                        return ver_data.get("prompt_version", {}).get("template")
+                return data.get("template")
             return None
         except Exception:
             return None

--- a/brand-architecture-agent-svc/app/core/config.py
+++ b/brand-architecture-agent-svc/app/core/config.py
@@ -26,7 +26,7 @@ class Settings(BaseSettings):
     REDIS_URL: str = "redis://localhost:6379/17"
     # Prompt optimization
     PROMPT_CACHE_REDIS_URL: str = "redis://localhost:6379/2"
-    MLFLOW_TRACKING_URI: str = "http://mlflow-server:5000"
+    MLFLOW_TRACKING_URI: str = "http://prompt-optimization-svc:8110"
     PROMPT_FALLBACK_ONLY: bool = False
 
     # LLM — Claude Sonnet 4

--- a/brand-architecture-agent-svc/app/prompts/loader.py
+++ b/brand-architecture-agent-svc/app/prompts/loader.py
@@ -66,19 +66,19 @@ class AgentPromptClient:
                 self._http = httpx.AsyncClient(base_url=self.mlflow_uri, timeout=5.0)
                 resp = await self._http.get("/health")
                 if resp.status_code == 200:
-                    logger.info("MLflow connected: %s", self.mlflow_uri)
+                    logger.info("Prompt service connected: %s", self.mlflow_uri)
                 else:
-                    logger.warning("MLflow unhealthy (%d) — disabled", resp.status_code)
+                    logger.warning("Prompt service unhealthy (%d) — disabled", resp.status_code)
                     await self._http.aclose()
                     self._http = None
             except Exception as exc:
-                logger.warning("MLflow unavailable: %s — disabled", exc)
+                logger.warning("Prompt service unavailable: %s — disabled", exc)
                 if self._http:
                     await self._http.aclose()
                 self._http = None
         else:
             logger.info(
-                "MLflow URI not configured — prompt loader in fallback-only mode"
+                "Prompt service URI not configured — prompt loader in fallback-only mode"
             )
 
         logger.info(
@@ -189,66 +189,42 @@ class AgentPromptClient:
         except Exception:
             pass
 
-    # --- Tier 2: MLflow REST API ---
+    # --- Tier 2: Prompt Optimization Service API ---
 
     async def _mlflow_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._http is None:
             return None
         try:
-            # Try tenant-specific named prompt first
+            # Try tenant-specific prompt first
             if tenant_id:
-                template = await self._fetch_prompt(f"{name}-tenant-{tenant_id}")
+                template = await self._fetch_prompt(name, tenant_id=tenant_id)
                 if template is not None:
                     return template
 
-            # Try base prompt
+            # Try base prompt (no tenant override)
             return await self._fetch_prompt(name)
         except Exception as exc:
-            logger.warning("MLflow prompt fetch failed for '%s': %s", name, exc)
+            logger.warning("Prompt service fetch failed for '%s': %s", name, exc)
             return None
 
-    async def _fetch_prompt(self, name: str) -> Optional[str]:
-        """Fetch a prompt template from MLflow REST API.
+    async def _fetch_prompt(self, name: str, tenant_id: Optional[str] = None) -> Optional[str]:
+        """Fetch a prompt template from the prompt-optimization-svc API.
 
-        Prefers PRODUCTION-tagged versions over latest to match
-        the lifecycle-based resolution of ZorvenPromptLoader.
+        Calls GET /v1/prompts/{name}/production which returns the
+        PRODUCTION-state template directly.
         """
         try:
-            # Search for versions and prefer PRODUCTION state
-            resp = await self._http.get(
-                "/api/2.0/mlflow/prompts/versions/search",
-                params={"name": name},
-            )
-            if resp.status_code == 200:
-                data = resp.json()
-                versions = data.get("prompt_versions", [])
-                # Find PRODUCTION version first
-                for v in versions:
-                    tags = v.get("tags", {})
-                    if isinstance(tags, list):
-                        tag_dict = {t["key"]: t["value"] for t in tags}
-                    else:
-                        tag_dict = tags
-                    if tag_dict.get("state") == "PRODUCTION":
-                        return v.get("template")
+            headers = {}
+            if tenant_id:
+                headers["X-Tenant-ID"] = str(tenant_id)
 
-            # Fallback: get latest version if no PRODUCTION found
             resp = await self._http.get(
-                "/api/2.0/mlflow/prompts/get",
-                params={"name": name},
+                f"/v1/prompts/{name}/production",
+                headers=headers,
             )
             if resp.status_code == 200:
                 data = resp.json()
-                prompt = data.get("prompt", {})
-                latest = prompt.get("latest_version")
-                if latest:
-                    ver_resp = await self._http.get(
-                        "/api/2.0/mlflow/prompts/versions/get",
-                        params={"name": name, "version": latest},
-                    )
-                    if ver_resp.status_code == 200:
-                        ver_data = ver_resp.json()
-                        return ver_data.get("prompt_version", {}).get("template")
+                return data.get("template")
             return None
         except Exception:
             return None

--- a/brand-naming-agent-svc/app/core/config.py
+++ b/brand-naming-agent-svc/app/core/config.py
@@ -25,7 +25,7 @@ class Settings(BaseSettings):
     REDIS_URL: str = "redis://localhost:6379/19"
     # Prompt optimization
     PROMPT_CACHE_REDIS_URL: str = "redis://localhost:6379/2"
-    MLFLOW_TRACKING_URI: str = "http://mlflow-server:5000"
+    MLFLOW_TRACKING_URI: str = "http://prompt-optimization-svc:8110"
     PROMPT_FALLBACK_ONLY: bool = False
 
     # Anthropic Claude Sonnet 4

--- a/brand-naming-agent-svc/app/prompts/loader.py
+++ b/brand-naming-agent-svc/app/prompts/loader.py
@@ -66,19 +66,19 @@ class AgentPromptClient:
                 self._http = httpx.AsyncClient(base_url=self.mlflow_uri, timeout=5.0)
                 resp = await self._http.get("/health")
                 if resp.status_code == 200:
-                    logger.info("MLflow connected: %s", self.mlflow_uri)
+                    logger.info("Prompt service connected: %s", self.mlflow_uri)
                 else:
-                    logger.warning("MLflow unhealthy (%d) — disabled", resp.status_code)
+                    logger.warning("Prompt service unhealthy (%d) — disabled", resp.status_code)
                     await self._http.aclose()
                     self._http = None
             except Exception as exc:
-                logger.warning("MLflow unavailable: %s — disabled", exc)
+                logger.warning("Prompt service unavailable: %s — disabled", exc)
                 if self._http:
                     await self._http.aclose()
                 self._http = None
         else:
             logger.info(
-                "MLflow URI not configured — prompt loader in fallback-only mode"
+                "Prompt service URI not configured — prompt loader in fallback-only mode"
             )
 
         logger.info(
@@ -189,66 +189,42 @@ class AgentPromptClient:
         except Exception:
             pass
 
-    # --- Tier 2: MLflow REST API ---
+    # --- Tier 2: Prompt Optimization Service API ---
 
     async def _mlflow_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._http is None:
             return None
         try:
-            # Try tenant-specific named prompt first
+            # Try tenant-specific prompt first
             if tenant_id:
-                template = await self._fetch_prompt(f"{name}-tenant-{tenant_id}")
+                template = await self._fetch_prompt(name, tenant_id=tenant_id)
                 if template is not None:
                     return template
 
-            # Try base prompt
+            # Try base prompt (no tenant override)
             return await self._fetch_prompt(name)
         except Exception as exc:
-            logger.warning("MLflow prompt fetch failed for '%s': %s", name, exc)
+            logger.warning("Prompt service fetch failed for '%s': %s", name, exc)
             return None
 
-    async def _fetch_prompt(self, name: str) -> Optional[str]:
-        """Fetch a prompt template from MLflow REST API.
+    async def _fetch_prompt(self, name: str, tenant_id: Optional[str] = None) -> Optional[str]:
+        """Fetch a prompt template from the prompt-optimization-svc API.
 
-        Prefers PRODUCTION-tagged versions over latest to match
-        the lifecycle-based resolution of ZorvenPromptLoader.
+        Calls GET /v1/prompts/{name}/production which returns the
+        PRODUCTION-state template directly.
         """
         try:
-            # Search for versions and prefer PRODUCTION state
-            resp = await self._http.get(
-                "/api/2.0/mlflow/prompts/versions/search",
-                params={"name": name},
-            )
-            if resp.status_code == 200:
-                data = resp.json()
-                versions = data.get("prompt_versions", [])
-                # Find PRODUCTION version first
-                for v in versions:
-                    tags = v.get("tags", {})
-                    if isinstance(tags, list):
-                        tag_dict = {t["key"]: t["value"] for t in tags}
-                    else:
-                        tag_dict = tags
-                    if tag_dict.get("state") == "PRODUCTION":
-                        return v.get("template")
+            headers = {}
+            if tenant_id:
+                headers["X-Tenant-ID"] = str(tenant_id)
 
-            # Fallback: get latest version if no PRODUCTION found
             resp = await self._http.get(
-                "/api/2.0/mlflow/prompts/get",
-                params={"name": name},
+                f"/v1/prompts/{name}/production",
+                headers=headers,
             )
             if resp.status_code == 200:
                 data = resp.json()
-                prompt = data.get("prompt", {})
-                latest = prompt.get("latest_version")
-                if latest:
-                    ver_resp = await self._http.get(
-                        "/api/2.0/mlflow/prompts/versions/get",
-                        params={"name": name, "version": latest},
-                    )
-                    if ver_resp.status_code == 200:
-                        ver_data = ver_resp.json()
-                        return ver_data.get("prompt_version", {}).get("template")
+                return data.get("template")
             return None
         except Exception:
             return None

--- a/brand-personality-agent-svc/app/core/config.py
+++ b/brand-personality-agent-svc/app/core/config.py
@@ -25,7 +25,7 @@ class Settings(BaseSettings):
     REDIS_URL: str = "redis://localhost:6379/18"
     # Prompt optimization
     PROMPT_CACHE_REDIS_URL: str = "redis://localhost:6379/2"
-    MLFLOW_TRACKING_URI: str = "http://mlflow-server:5000"
+    MLFLOW_TRACKING_URI: str = "http://prompt-optimization-svc:8110"
     PROMPT_FALLBACK_ONLY: bool = False
 
     # Anthropic Claude Sonnet 4

--- a/brand-personality-agent-svc/app/prompts/loader.py
+++ b/brand-personality-agent-svc/app/prompts/loader.py
@@ -66,19 +66,19 @@ class AgentPromptClient:
                 self._http = httpx.AsyncClient(base_url=self.mlflow_uri, timeout=5.0)
                 resp = await self._http.get("/health")
                 if resp.status_code == 200:
-                    logger.info("MLflow connected: %s", self.mlflow_uri)
+                    logger.info("Prompt service connected: %s", self.mlflow_uri)
                 else:
-                    logger.warning("MLflow unhealthy (%d) — disabled", resp.status_code)
+                    logger.warning("Prompt service unhealthy (%d) — disabled", resp.status_code)
                     await self._http.aclose()
                     self._http = None
             except Exception as exc:
-                logger.warning("MLflow unavailable: %s — disabled", exc)
+                logger.warning("Prompt service unavailable: %s — disabled", exc)
                 if self._http:
                     await self._http.aclose()
                 self._http = None
         else:
             logger.info(
-                "MLflow URI not configured — prompt loader in fallback-only mode"
+                "Prompt service URI not configured — prompt loader in fallback-only mode"
             )
 
         logger.info(
@@ -189,66 +189,42 @@ class AgentPromptClient:
         except Exception:
             pass
 
-    # --- Tier 2: MLflow REST API ---
+    # --- Tier 2: Prompt Optimization Service API ---
 
     async def _mlflow_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._http is None:
             return None
         try:
-            # Try tenant-specific named prompt first
+            # Try tenant-specific prompt first
             if tenant_id:
-                template = await self._fetch_prompt(f"{name}-tenant-{tenant_id}")
+                template = await self._fetch_prompt(name, tenant_id=tenant_id)
                 if template is not None:
                     return template
 
-            # Try base prompt
+            # Try base prompt (no tenant override)
             return await self._fetch_prompt(name)
         except Exception as exc:
-            logger.warning("MLflow prompt fetch failed for '%s': %s", name, exc)
+            logger.warning("Prompt service fetch failed for '%s': %s", name, exc)
             return None
 
-    async def _fetch_prompt(self, name: str) -> Optional[str]:
-        """Fetch a prompt template from MLflow REST API.
+    async def _fetch_prompt(self, name: str, tenant_id: Optional[str] = None) -> Optional[str]:
+        """Fetch a prompt template from the prompt-optimization-svc API.
 
-        Prefers PRODUCTION-tagged versions over latest to match
-        the lifecycle-based resolution of ZorvenPromptLoader.
+        Calls GET /v1/prompts/{name}/production which returns the
+        PRODUCTION-state template directly.
         """
         try:
-            # Search for versions and prefer PRODUCTION state
-            resp = await self._http.get(
-                "/api/2.0/mlflow/prompts/versions/search",
-                params={"name": name},
-            )
-            if resp.status_code == 200:
-                data = resp.json()
-                versions = data.get("prompt_versions", [])
-                # Find PRODUCTION version first
-                for v in versions:
-                    tags = v.get("tags", {})
-                    if isinstance(tags, list):
-                        tag_dict = {t["key"]: t["value"] for t in tags}
-                    else:
-                        tag_dict = tags
-                    if tag_dict.get("state") == "PRODUCTION":
-                        return v.get("template")
+            headers = {}
+            if tenant_id:
+                headers["X-Tenant-ID"] = str(tenant_id)
 
-            # Fallback: get latest version if no PRODUCTION found
             resp = await self._http.get(
-                "/api/2.0/mlflow/prompts/get",
-                params={"name": name},
+                f"/v1/prompts/{name}/production",
+                headers=headers,
             )
             if resp.status_code == 200:
                 data = resp.json()
-                prompt = data.get("prompt", {})
-                latest = prompt.get("latest_version")
-                if latest:
-                    ver_resp = await self._http.get(
-                        "/api/2.0/mlflow/prompts/versions/get",
-                        params={"name": name, "version": latest},
-                    )
-                    if ver_resp.status_code == 200:
-                        ver_data = ver_resp.json()
-                        return ver_data.get("prompt_version", {}).get("template")
+                return data.get("template")
             return None
         except Exception:
             return None

--- a/brand-positioning-agent-svc/app/core/config.py
+++ b/brand-positioning-agent-svc/app/core/config.py
@@ -26,7 +26,7 @@ class Settings(BaseSettings):
     REDIS_URL: str = "redis://localhost:6379/16"
     # Prompt optimization
     PROMPT_CACHE_REDIS_URL: str = "redis://localhost:6379/2"
-    MLFLOW_TRACKING_URI: str = "http://mlflow-server:5000"
+    MLFLOW_TRACKING_URI: str = "http://prompt-optimization-svc:8110"
     PROMPT_FALLBACK_ONLY: bool = False
 
     # LLM — Claude Sonnet 4

--- a/brand-positioning-agent-svc/app/prompts/loader.py
+++ b/brand-positioning-agent-svc/app/prompts/loader.py
@@ -66,19 +66,19 @@ class AgentPromptClient:
                 self._http = httpx.AsyncClient(base_url=self.mlflow_uri, timeout=5.0)
                 resp = await self._http.get("/health")
                 if resp.status_code == 200:
-                    logger.info("MLflow connected: %s", self.mlflow_uri)
+                    logger.info("Prompt service connected: %s", self.mlflow_uri)
                 else:
-                    logger.warning("MLflow unhealthy (%d) — disabled", resp.status_code)
+                    logger.warning("Prompt service unhealthy (%d) — disabled", resp.status_code)
                     await self._http.aclose()
                     self._http = None
             except Exception as exc:
-                logger.warning("MLflow unavailable: %s — disabled", exc)
+                logger.warning("Prompt service unavailable: %s — disabled", exc)
                 if self._http:
                     await self._http.aclose()
                 self._http = None
         else:
             logger.info(
-                "MLflow URI not configured — prompt loader in fallback-only mode"
+                "Prompt service URI not configured — prompt loader in fallback-only mode"
             )
 
         logger.info(
@@ -189,66 +189,42 @@ class AgentPromptClient:
         except Exception:
             pass
 
-    # --- Tier 2: MLflow REST API ---
+    # --- Tier 2: Prompt Optimization Service API ---
 
     async def _mlflow_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._http is None:
             return None
         try:
-            # Try tenant-specific named prompt first
+            # Try tenant-specific prompt first
             if tenant_id:
-                template = await self._fetch_prompt(f"{name}-tenant-{tenant_id}")
+                template = await self._fetch_prompt(name, tenant_id=tenant_id)
                 if template is not None:
                     return template
 
-            # Try base prompt
+            # Try base prompt (no tenant override)
             return await self._fetch_prompt(name)
         except Exception as exc:
-            logger.warning("MLflow prompt fetch failed for '%s': %s", name, exc)
+            logger.warning("Prompt service fetch failed for '%s': %s", name, exc)
             return None
 
-    async def _fetch_prompt(self, name: str) -> Optional[str]:
-        """Fetch a prompt template from MLflow REST API.
+    async def _fetch_prompt(self, name: str, tenant_id: Optional[str] = None) -> Optional[str]:
+        """Fetch a prompt template from the prompt-optimization-svc API.
 
-        Prefers PRODUCTION-tagged versions over latest to match
-        the lifecycle-based resolution of ZorvenPromptLoader.
+        Calls GET /v1/prompts/{name}/production which returns the
+        PRODUCTION-state template directly.
         """
         try:
-            # Search for versions and prefer PRODUCTION state
-            resp = await self._http.get(
-                "/api/2.0/mlflow/prompts/versions/search",
-                params={"name": name},
-            )
-            if resp.status_code == 200:
-                data = resp.json()
-                versions = data.get("prompt_versions", [])
-                # Find PRODUCTION version first
-                for v in versions:
-                    tags = v.get("tags", {})
-                    if isinstance(tags, list):
-                        tag_dict = {t["key"]: t["value"] for t in tags}
-                    else:
-                        tag_dict = tags
-                    if tag_dict.get("state") == "PRODUCTION":
-                        return v.get("template")
+            headers = {}
+            if tenant_id:
+                headers["X-Tenant-ID"] = str(tenant_id)
 
-            # Fallback: get latest version if no PRODUCTION found
             resp = await self._http.get(
-                "/api/2.0/mlflow/prompts/get",
-                params={"name": name},
+                f"/v1/prompts/{name}/production",
+                headers=headers,
             )
             if resp.status_code == 200:
                 data = resp.json()
-                prompt = data.get("prompt", {})
-                latest = prompt.get("latest_version")
-                if latest:
-                    ver_resp = await self._http.get(
-                        "/api/2.0/mlflow/prompts/versions/get",
-                        params={"name": name, "version": latest},
-                    )
-                    if ver_resp.status_code == 200:
-                        ver_data = ver_resp.json()
-                        return ver_data.get("prompt_version", {}).get("template")
+                return data.get("template")
             return None
         except Exception:
             return None

--- a/brand-story-agent-svc/app/core/config.py
+++ b/brand-story-agent-svc/app/core/config.py
@@ -25,7 +25,7 @@ class Settings(BaseSettings):
     REDIS_URL: str = "redis://localhost:6379/20"
     # Prompt optimization
     PROMPT_CACHE_REDIS_URL: str = "redis://localhost:6379/2"
-    MLFLOW_TRACKING_URI: str = "http://mlflow-server:5000"
+    MLFLOW_TRACKING_URI: str = "http://prompt-optimization-svc:8110"
     PROMPT_FALLBACK_ONLY: bool = False
 
     # Anthropic Claude Sonnet 4

--- a/brand-story-agent-svc/app/prompts/loader.py
+++ b/brand-story-agent-svc/app/prompts/loader.py
@@ -66,19 +66,19 @@ class AgentPromptClient:
                 self._http = httpx.AsyncClient(base_url=self.mlflow_uri, timeout=5.0)
                 resp = await self._http.get("/health")
                 if resp.status_code == 200:
-                    logger.info("MLflow connected: %s", self.mlflow_uri)
+                    logger.info("Prompt service connected: %s", self.mlflow_uri)
                 else:
-                    logger.warning("MLflow unhealthy (%d) — disabled", resp.status_code)
+                    logger.warning("Prompt service unhealthy (%d) — disabled", resp.status_code)
                     await self._http.aclose()
                     self._http = None
             except Exception as exc:
-                logger.warning("MLflow unavailable: %s — disabled", exc)
+                logger.warning("Prompt service unavailable: %s — disabled", exc)
                 if self._http:
                     await self._http.aclose()
                 self._http = None
         else:
             logger.info(
-                "MLflow URI not configured — prompt loader in fallback-only mode"
+                "Prompt service URI not configured — prompt loader in fallback-only mode"
             )
 
         logger.info(
@@ -189,66 +189,42 @@ class AgentPromptClient:
         except Exception:
             pass
 
-    # --- Tier 2: MLflow REST API ---
+    # --- Tier 2: Prompt Optimization Service API ---
 
     async def _mlflow_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._http is None:
             return None
         try:
-            # Try tenant-specific named prompt first
+            # Try tenant-specific prompt first
             if tenant_id:
-                template = await self._fetch_prompt(f"{name}-tenant-{tenant_id}")
+                template = await self._fetch_prompt(name, tenant_id=tenant_id)
                 if template is not None:
                     return template
 
-            # Try base prompt
+            # Try base prompt (no tenant override)
             return await self._fetch_prompt(name)
         except Exception as exc:
-            logger.warning("MLflow prompt fetch failed for '%s': %s", name, exc)
+            logger.warning("Prompt service fetch failed for '%s': %s", name, exc)
             return None
 
-    async def _fetch_prompt(self, name: str) -> Optional[str]:
-        """Fetch a prompt template from MLflow REST API.
+    async def _fetch_prompt(self, name: str, tenant_id: Optional[str] = None) -> Optional[str]:
+        """Fetch a prompt template from the prompt-optimization-svc API.
 
-        Prefers PRODUCTION-tagged versions over latest to match
-        the lifecycle-based resolution of ZorvenPromptLoader.
+        Calls GET /v1/prompts/{name}/production which returns the
+        PRODUCTION-state template directly.
         """
         try:
-            # Search for versions and prefer PRODUCTION state
-            resp = await self._http.get(
-                "/api/2.0/mlflow/prompts/versions/search",
-                params={"name": name},
-            )
-            if resp.status_code == 200:
-                data = resp.json()
-                versions = data.get("prompt_versions", [])
-                # Find PRODUCTION version first
-                for v in versions:
-                    tags = v.get("tags", {})
-                    if isinstance(tags, list):
-                        tag_dict = {t["key"]: t["value"] for t in tags}
-                    else:
-                        tag_dict = tags
-                    if tag_dict.get("state") == "PRODUCTION":
-                        return v.get("template")
+            headers = {}
+            if tenant_id:
+                headers["X-Tenant-ID"] = str(tenant_id)
 
-            # Fallback: get latest version if no PRODUCTION found
             resp = await self._http.get(
-                "/api/2.0/mlflow/prompts/get",
-                params={"name": name},
+                f"/v1/prompts/{name}/production",
+                headers=headers,
             )
             if resp.status_code == 200:
                 data = resp.json()
-                prompt = data.get("prompt", {})
-                latest = prompt.get("latest_version")
-                if latest:
-                    ver_resp = await self._http.get(
-                        "/api/2.0/mlflow/prompts/versions/get",
-                        params={"name": name, "version": latest},
-                    )
-                    if ver_resp.status_code == 200:
-                        ver_data = ver_resp.json()
-                        return ver_data.get("prompt_version", {}).get("template")
+                return data.get("template")
             return None
         except Exception:
             return None

--- a/campaign-architecture-agent-svc/app/core/config.py
+++ b/campaign-architecture-agent-svc/app/core/config.py
@@ -25,7 +25,7 @@ class Settings(BaseSettings):
     REDIS_URL: str = "redis://localhost:6379/21"
     # Prompt optimization
     PROMPT_CACHE_REDIS_URL: str = "redis://localhost:6379/2"
-    MLFLOW_TRACKING_URI: str = "http://mlflow-server:5000"
+    MLFLOW_TRACKING_URI: str = "http://prompt-optimization-svc:8110"
     PROMPT_FALLBACK_ONLY: bool = False
 
     # Anthropic Claude Sonnet 4

--- a/campaign-architecture-agent-svc/app/prompts/loader.py
+++ b/campaign-architecture-agent-svc/app/prompts/loader.py
@@ -66,19 +66,19 @@ class AgentPromptClient:
                 self._http = httpx.AsyncClient(base_url=self.mlflow_uri, timeout=5.0)
                 resp = await self._http.get("/health")
                 if resp.status_code == 200:
-                    logger.info("MLflow connected: %s", self.mlflow_uri)
+                    logger.info("Prompt service connected: %s", self.mlflow_uri)
                 else:
-                    logger.warning("MLflow unhealthy (%d) — disabled", resp.status_code)
+                    logger.warning("Prompt service unhealthy (%d) — disabled", resp.status_code)
                     await self._http.aclose()
                     self._http = None
             except Exception as exc:
-                logger.warning("MLflow unavailable: %s — disabled", exc)
+                logger.warning("Prompt service unavailable: %s — disabled", exc)
                 if self._http:
                     await self._http.aclose()
                 self._http = None
         else:
             logger.info(
-                "MLflow URI not configured — prompt loader in fallback-only mode"
+                "Prompt service URI not configured — prompt loader in fallback-only mode"
             )
 
         logger.info(
@@ -189,66 +189,42 @@ class AgentPromptClient:
         except Exception:
             pass
 
-    # --- Tier 2: MLflow REST API ---
+    # --- Tier 2: Prompt Optimization Service API ---
 
     async def _mlflow_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._http is None:
             return None
         try:
-            # Try tenant-specific named prompt first
+            # Try tenant-specific prompt first
             if tenant_id:
-                template = await self._fetch_prompt(f"{name}-tenant-{tenant_id}")
+                template = await self._fetch_prompt(name, tenant_id=tenant_id)
                 if template is not None:
                     return template
 
-            # Try base prompt
+            # Try base prompt (no tenant override)
             return await self._fetch_prompt(name)
         except Exception as exc:
-            logger.warning("MLflow prompt fetch failed for '%s': %s", name, exc)
+            logger.warning("Prompt service fetch failed for '%s': %s", name, exc)
             return None
 
-    async def _fetch_prompt(self, name: str) -> Optional[str]:
-        """Fetch a prompt template from MLflow REST API.
+    async def _fetch_prompt(self, name: str, tenant_id: Optional[str] = None) -> Optional[str]:
+        """Fetch a prompt template from the prompt-optimization-svc API.
 
-        Prefers PRODUCTION-tagged versions over latest to match
-        the lifecycle-based resolution of ZorvenPromptLoader.
+        Calls GET /v1/prompts/{name}/production which returns the
+        PRODUCTION-state template directly.
         """
         try:
-            # Search for versions and prefer PRODUCTION state
-            resp = await self._http.get(
-                "/api/2.0/mlflow/prompts/versions/search",
-                params={"name": name},
-            )
-            if resp.status_code == 200:
-                data = resp.json()
-                versions = data.get("prompt_versions", [])
-                # Find PRODUCTION version first
-                for v in versions:
-                    tags = v.get("tags", {})
-                    if isinstance(tags, list):
-                        tag_dict = {t["key"]: t["value"] for t in tags}
-                    else:
-                        tag_dict = tags
-                    if tag_dict.get("state") == "PRODUCTION":
-                        return v.get("template")
+            headers = {}
+            if tenant_id:
+                headers["X-Tenant-ID"] = str(tenant_id)
 
-            # Fallback: get latest version if no PRODUCTION found
             resp = await self._http.get(
-                "/api/2.0/mlflow/prompts/get",
-                params={"name": name},
+                f"/v1/prompts/{name}/production",
+                headers=headers,
             )
             if resp.status_code == 200:
                 data = resp.json()
-                prompt = data.get("prompt", {})
-                latest = prompt.get("latest_version")
-                if latest:
-                    ver_resp = await self._http.get(
-                        "/api/2.0/mlflow/prompts/versions/get",
-                        params={"name": name, "version": latest},
-                    )
-                    if ver_resp.status_code == 200:
-                        ver_data = ver_resp.json()
-                        return ver_data.get("prompt_version", {}).get("template")
+                return data.get("template")
             return None
         except Exception:
             return None

--- a/campaign-optimization-agent-svc/app/core/config.py
+++ b/campaign-optimization-agent-svc/app/core/config.py
@@ -26,7 +26,7 @@ class Settings(BaseSettings):
     REDIS_URL: str = "redis://localhost:6379/24"
     # Prompt optimization
     PROMPT_CACHE_REDIS_URL: str = "redis://localhost:6379/2"
-    MLFLOW_TRACKING_URI: str = "http://mlflow-server:5000"
+    MLFLOW_TRACKING_URI: str = "http://prompt-optimization-svc:8110"
     PROMPT_FALLBACK_ONLY: bool = False
 
     # Service auth

--- a/campaign-optimization-agent-svc/app/prompts/loader.py
+++ b/campaign-optimization-agent-svc/app/prompts/loader.py
@@ -66,19 +66,19 @@ class AgentPromptClient:
                 self._http = httpx.AsyncClient(base_url=self.mlflow_uri, timeout=5.0)
                 resp = await self._http.get("/health")
                 if resp.status_code == 200:
-                    logger.info("MLflow connected: %s", self.mlflow_uri)
+                    logger.info("Prompt service connected: %s", self.mlflow_uri)
                 else:
-                    logger.warning("MLflow unhealthy (%d) — disabled", resp.status_code)
+                    logger.warning("Prompt service unhealthy (%d) — disabled", resp.status_code)
                     await self._http.aclose()
                     self._http = None
             except Exception as exc:
-                logger.warning("MLflow unavailable: %s — disabled", exc)
+                logger.warning("Prompt service unavailable: %s — disabled", exc)
                 if self._http:
                     await self._http.aclose()
                 self._http = None
         else:
             logger.info(
-                "MLflow URI not configured — prompt loader in fallback-only mode"
+                "Prompt service URI not configured — prompt loader in fallback-only mode"
             )
 
         logger.info(
@@ -189,66 +189,42 @@ class AgentPromptClient:
         except Exception:
             pass
 
-    # --- Tier 2: MLflow REST API ---
+    # --- Tier 2: Prompt Optimization Service API ---
 
     async def _mlflow_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._http is None:
             return None
         try:
-            # Try tenant-specific named prompt first
+            # Try tenant-specific prompt first
             if tenant_id:
-                template = await self._fetch_prompt(f"{name}-tenant-{tenant_id}")
+                template = await self._fetch_prompt(name, tenant_id=tenant_id)
                 if template is not None:
                     return template
 
-            # Try base prompt
+            # Try base prompt (no tenant override)
             return await self._fetch_prompt(name)
         except Exception as exc:
-            logger.warning("MLflow prompt fetch failed for '%s': %s", name, exc)
+            logger.warning("Prompt service fetch failed for '%s': %s", name, exc)
             return None
 
-    async def _fetch_prompt(self, name: str) -> Optional[str]:
-        """Fetch a prompt template from MLflow REST API.
+    async def _fetch_prompt(self, name: str, tenant_id: Optional[str] = None) -> Optional[str]:
+        """Fetch a prompt template from the prompt-optimization-svc API.
 
-        Prefers PRODUCTION-tagged versions over latest to match
-        the lifecycle-based resolution of ZorvenPromptLoader.
+        Calls GET /v1/prompts/{name}/production which returns the
+        PRODUCTION-state template directly.
         """
         try:
-            # Search for versions and prefer PRODUCTION state
-            resp = await self._http.get(
-                "/api/2.0/mlflow/prompts/versions/search",
-                params={"name": name},
-            )
-            if resp.status_code == 200:
-                data = resp.json()
-                versions = data.get("prompt_versions", [])
-                # Find PRODUCTION version first
-                for v in versions:
-                    tags = v.get("tags", {})
-                    if isinstance(tags, list):
-                        tag_dict = {t["key"]: t["value"] for t in tags}
-                    else:
-                        tag_dict = tags
-                    if tag_dict.get("state") == "PRODUCTION":
-                        return v.get("template")
+            headers = {}
+            if tenant_id:
+                headers["X-Tenant-ID"] = str(tenant_id)
 
-            # Fallback: get latest version if no PRODUCTION found
             resp = await self._http.get(
-                "/api/2.0/mlflow/prompts/get",
-                params={"name": name},
+                f"/v1/prompts/{name}/production",
+                headers=headers,
             )
             if resp.status_code == 200:
                 data = resp.json()
-                prompt = data.get("prompt", {})
-                latest = prompt.get("latest_version")
-                if latest:
-                    ver_resp = await self._http.get(
-                        "/api/2.0/mlflow/prompts/versions/get",
-                        params={"name": name, "version": latest},
-                    )
-                    if ver_resp.status_code == 200:
-                        ver_data = ver_resp.json()
-                        return ver_data.get("prompt_version", {}).get("template")
+                return data.get("template")
             return None
         except Exception:
             return None

--- a/competitor-intel-agent-svc/app/core/config.py
+++ b/competitor-intel-agent-svc/app/core/config.py
@@ -20,7 +20,7 @@ class Settings(BaseSettings):
     REDIS_URL: str = "redis://localhost:6379/12"
     # Prompt optimization
     PROMPT_CACHE_REDIS_URL: str = "redis://localhost:6379/2"
-    MLFLOW_TRACKING_URI: str = "http://mlflow-server:5000"
+    MLFLOW_TRACKING_URI: str = "http://prompt-optimization-svc:8110"
     PROMPT_FALLBACK_ONLY: bool = False
 
     # Kafka connection

--- a/competitor-intel-agent-svc/app/prompts/loader.py
+++ b/competitor-intel-agent-svc/app/prompts/loader.py
@@ -66,19 +66,19 @@ class AgentPromptClient:
                 self._http = httpx.AsyncClient(base_url=self.mlflow_uri, timeout=5.0)
                 resp = await self._http.get("/health")
                 if resp.status_code == 200:
-                    logger.info("MLflow connected: %s", self.mlflow_uri)
+                    logger.info("Prompt service connected: %s", self.mlflow_uri)
                 else:
-                    logger.warning("MLflow unhealthy (%d) — disabled", resp.status_code)
+                    logger.warning("Prompt service unhealthy (%d) — disabled", resp.status_code)
                     await self._http.aclose()
                     self._http = None
             except Exception as exc:
-                logger.warning("MLflow unavailable: %s — disabled", exc)
+                logger.warning("Prompt service unavailable: %s — disabled", exc)
                 if self._http:
                     await self._http.aclose()
                 self._http = None
         else:
             logger.info(
-                "MLflow URI not configured — prompt loader in fallback-only mode"
+                "Prompt service URI not configured — prompt loader in fallback-only mode"
             )
 
         logger.info(
@@ -189,66 +189,42 @@ class AgentPromptClient:
         except Exception:
             pass
 
-    # --- Tier 2: MLflow REST API ---
+    # --- Tier 2: Prompt Optimization Service API ---
 
     async def _mlflow_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._http is None:
             return None
         try:
-            # Try tenant-specific named prompt first
+            # Try tenant-specific prompt first
             if tenant_id:
-                template = await self._fetch_prompt(f"{name}-tenant-{tenant_id}")
+                template = await self._fetch_prompt(name, tenant_id=tenant_id)
                 if template is not None:
                     return template
 
-            # Try base prompt
+            # Try base prompt (no tenant override)
             return await self._fetch_prompt(name)
         except Exception as exc:
-            logger.warning("MLflow prompt fetch failed for '%s': %s", name, exc)
+            logger.warning("Prompt service fetch failed for '%s': %s", name, exc)
             return None
 
-    async def _fetch_prompt(self, name: str) -> Optional[str]:
-        """Fetch a prompt template from MLflow REST API.
+    async def _fetch_prompt(self, name: str, tenant_id: Optional[str] = None) -> Optional[str]:
+        """Fetch a prompt template from the prompt-optimization-svc API.
 
-        Prefers PRODUCTION-tagged versions over latest to match
-        the lifecycle-based resolution of ZorvenPromptLoader.
+        Calls GET /v1/prompts/{name}/production which returns the
+        PRODUCTION-state template directly.
         """
         try:
-            # Search for versions and prefer PRODUCTION state
-            resp = await self._http.get(
-                "/api/2.0/mlflow/prompts/versions/search",
-                params={"name": name},
-            )
-            if resp.status_code == 200:
-                data = resp.json()
-                versions = data.get("prompt_versions", [])
-                # Find PRODUCTION version first
-                for v in versions:
-                    tags = v.get("tags", {})
-                    if isinstance(tags, list):
-                        tag_dict = {t["key"]: t["value"] for t in tags}
-                    else:
-                        tag_dict = tags
-                    if tag_dict.get("state") == "PRODUCTION":
-                        return v.get("template")
+            headers = {}
+            if tenant_id:
+                headers["X-Tenant-ID"] = str(tenant_id)
 
-            # Fallback: get latest version if no PRODUCTION found
             resp = await self._http.get(
-                "/api/2.0/mlflow/prompts/get",
-                params={"name": name},
+                f"/v1/prompts/{name}/production",
+                headers=headers,
             )
             if resp.status_code == 200:
                 data = resp.json()
-                prompt = data.get("prompt", {})
-                latest = prompt.get("latest_version")
-                if latest:
-                    ver_resp = await self._http.get(
-                        "/api/2.0/mlflow/prompts/versions/get",
-                        params={"name": name, "version": latest},
-                    )
-                    if ver_resp.status_code == 200:
-                        ver_data = ver_resp.json()
-                        return ver_data.get("prompt_version", {}).get("template")
+                return data.get("template")
             return None
         except Exception:
             return None

--- a/creative-generation-agent-svc/app/core/config.py
+++ b/creative-generation-agent-svc/app/core/config.py
@@ -25,7 +25,7 @@ class Settings(BaseSettings):
     REDIS_URL: str = "redis://localhost:6379/22"
     # Prompt optimization
     PROMPT_CACHE_REDIS_URL: str = "redis://localhost:6379/2"
-    MLFLOW_TRACKING_URI: str = "http://mlflow-server:5000"
+    MLFLOW_TRACKING_URI: str = "http://prompt-optimization-svc:8110"
     PROMPT_FALLBACK_ONLY: bool = False
 
     # Anthropic Claude Sonnet 4 (copy generation + assembly)

--- a/creative-generation-agent-svc/app/prompts/loader.py
+++ b/creative-generation-agent-svc/app/prompts/loader.py
@@ -66,19 +66,19 @@ class AgentPromptClient:
                 self._http = httpx.AsyncClient(base_url=self.mlflow_uri, timeout=5.0)
                 resp = await self._http.get("/health")
                 if resp.status_code == 200:
-                    logger.info("MLflow connected: %s", self.mlflow_uri)
+                    logger.info("Prompt service connected: %s", self.mlflow_uri)
                 else:
-                    logger.warning("MLflow unhealthy (%d) — disabled", resp.status_code)
+                    logger.warning("Prompt service unhealthy (%d) — disabled", resp.status_code)
                     await self._http.aclose()
                     self._http = None
             except Exception as exc:
-                logger.warning("MLflow unavailable: %s — disabled", exc)
+                logger.warning("Prompt service unavailable: %s — disabled", exc)
                 if self._http:
                     await self._http.aclose()
                 self._http = None
         else:
             logger.info(
-                "MLflow URI not configured — prompt loader in fallback-only mode"
+                "Prompt service URI not configured — prompt loader in fallback-only mode"
             )
 
         logger.info(
@@ -189,66 +189,42 @@ class AgentPromptClient:
         except Exception:
             pass
 
-    # --- Tier 2: MLflow REST API ---
+    # --- Tier 2: Prompt Optimization Service API ---
 
     async def _mlflow_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._http is None:
             return None
         try:
-            # Try tenant-specific named prompt first
+            # Try tenant-specific prompt first
             if tenant_id:
-                template = await self._fetch_prompt(f"{name}-tenant-{tenant_id}")
+                template = await self._fetch_prompt(name, tenant_id=tenant_id)
                 if template is not None:
                     return template
 
-            # Try base prompt
+            # Try base prompt (no tenant override)
             return await self._fetch_prompt(name)
         except Exception as exc:
-            logger.warning("MLflow prompt fetch failed for '%s': %s", name, exc)
+            logger.warning("Prompt service fetch failed for '%s': %s", name, exc)
             return None
 
-    async def _fetch_prompt(self, name: str) -> Optional[str]:
-        """Fetch a prompt template from MLflow REST API.
+    async def _fetch_prompt(self, name: str, tenant_id: Optional[str] = None) -> Optional[str]:
+        """Fetch a prompt template from the prompt-optimization-svc API.
 
-        Prefers PRODUCTION-tagged versions over latest to match
-        the lifecycle-based resolution of ZorvenPromptLoader.
+        Calls GET /v1/prompts/{name}/production which returns the
+        PRODUCTION-state template directly.
         """
         try:
-            # Search for versions and prefer PRODUCTION state
-            resp = await self._http.get(
-                "/api/2.0/mlflow/prompts/versions/search",
-                params={"name": name},
-            )
-            if resp.status_code == 200:
-                data = resp.json()
-                versions = data.get("prompt_versions", [])
-                # Find PRODUCTION version first
-                for v in versions:
-                    tags = v.get("tags", {})
-                    if isinstance(tags, list):
-                        tag_dict = {t["key"]: t["value"] for t in tags}
-                    else:
-                        tag_dict = tags
-                    if tag_dict.get("state") == "PRODUCTION":
-                        return v.get("template")
+            headers = {}
+            if tenant_id:
+                headers["X-Tenant-ID"] = str(tenant_id)
 
-            # Fallback: get latest version if no PRODUCTION found
             resp = await self._http.get(
-                "/api/2.0/mlflow/prompts/get",
-                params={"name": name},
+                f"/v1/prompts/{name}/production",
+                headers=headers,
             )
             if resp.status_code == 200:
                 data = resp.json()
-                prompt = data.get("prompt", {})
-                latest = prompt.get("latest_version")
-                if latest:
-                    ver_resp = await self._http.get(
-                        "/api/2.0/mlflow/prompts/versions/get",
-                        params={"name": name, "version": latest},
-                    )
-                    if ver_resp.status_code == 200:
-                        ver_data = ver_resp.json()
-                        return ver_data.get("prompt_version", {}).get("template")
+                return data.get("template")
             return None
         except Exception:
             return None

--- a/intelligence-loop-agent-svc/app/core/config.py
+++ b/intelligence-loop-agent-svc/app/core/config.py
@@ -24,7 +24,7 @@ class Settings(BaseSettings):
     REDIS_URL: str = "redis://localhost:6379/25"
     # Prompt optimization
     PROMPT_CACHE_REDIS_URL: str = "redis://localhost:6379/2"
-    MLFLOW_TRACKING_URI: str = "http://mlflow-server:5000"
+    MLFLOW_TRACKING_URI: str = "http://prompt-optimization-svc:8110"
     PROMPT_FALLBACK_ONLY: bool = False
 
     # Service auth

--- a/intelligence-loop-agent-svc/app/prompts/loader.py
+++ b/intelligence-loop-agent-svc/app/prompts/loader.py
@@ -66,19 +66,19 @@ class AgentPromptClient:
                 self._http = httpx.AsyncClient(base_url=self.mlflow_uri, timeout=5.0)
                 resp = await self._http.get("/health")
                 if resp.status_code == 200:
-                    logger.info("MLflow connected: %s", self.mlflow_uri)
+                    logger.info("Prompt service connected: %s", self.mlflow_uri)
                 else:
-                    logger.warning("MLflow unhealthy (%d) — disabled", resp.status_code)
+                    logger.warning("Prompt service unhealthy (%d) — disabled", resp.status_code)
                     await self._http.aclose()
                     self._http = None
             except Exception as exc:
-                logger.warning("MLflow unavailable: %s — disabled", exc)
+                logger.warning("Prompt service unavailable: %s — disabled", exc)
                 if self._http:
                     await self._http.aclose()
                 self._http = None
         else:
             logger.info(
-                "MLflow URI not configured — prompt loader in fallback-only mode"
+                "Prompt service URI not configured — prompt loader in fallback-only mode"
             )
 
         logger.info(
@@ -189,66 +189,42 @@ class AgentPromptClient:
         except Exception:
             pass
 
-    # --- Tier 2: MLflow REST API ---
+    # --- Tier 2: Prompt Optimization Service API ---
 
     async def _mlflow_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._http is None:
             return None
         try:
-            # Try tenant-specific named prompt first
+            # Try tenant-specific prompt first
             if tenant_id:
-                template = await self._fetch_prompt(f"{name}-tenant-{tenant_id}")
+                template = await self._fetch_prompt(name, tenant_id=tenant_id)
                 if template is not None:
                     return template
 
-            # Try base prompt
+            # Try base prompt (no tenant override)
             return await self._fetch_prompt(name)
         except Exception as exc:
-            logger.warning("MLflow prompt fetch failed for '%s': %s", name, exc)
+            logger.warning("Prompt service fetch failed for '%s': %s", name, exc)
             return None
 
-    async def _fetch_prompt(self, name: str) -> Optional[str]:
-        """Fetch a prompt template from MLflow REST API.
+    async def _fetch_prompt(self, name: str, tenant_id: Optional[str] = None) -> Optional[str]:
+        """Fetch a prompt template from the prompt-optimization-svc API.
 
-        Prefers PRODUCTION-tagged versions over latest to match
-        the lifecycle-based resolution of ZorvenPromptLoader.
+        Calls GET /v1/prompts/{name}/production which returns the
+        PRODUCTION-state template directly.
         """
         try:
-            # Search for versions and prefer PRODUCTION state
-            resp = await self._http.get(
-                "/api/2.0/mlflow/prompts/versions/search",
-                params={"name": name},
-            )
-            if resp.status_code == 200:
-                data = resp.json()
-                versions = data.get("prompt_versions", [])
-                # Find PRODUCTION version first
-                for v in versions:
-                    tags = v.get("tags", {})
-                    if isinstance(tags, list):
-                        tag_dict = {t["key"]: t["value"] for t in tags}
-                    else:
-                        tag_dict = tags
-                    if tag_dict.get("state") == "PRODUCTION":
-                        return v.get("template")
+            headers = {}
+            if tenant_id:
+                headers["X-Tenant-ID"] = str(tenant_id)
 
-            # Fallback: get latest version if no PRODUCTION found
             resp = await self._http.get(
-                "/api/2.0/mlflow/prompts/get",
-                params={"name": name},
+                f"/v1/prompts/{name}/production",
+                headers=headers,
             )
             if resp.status_code == 200:
                 data = resp.json()
-                prompt = data.get("prompt", {})
-                latest = prompt.get("latest_version")
-                if latest:
-                    ver_resp = await self._http.get(
-                        "/api/2.0/mlflow/prompts/versions/get",
-                        params={"name": name, "version": latest},
-                    )
-                    if ver_resp.status_code == 200:
-                        ver_data = ver_resp.json()
-                        return ver_data.get("prompt_version", {}).get("template")
+                return data.get("template")
             return None
         except Exception:
             return None

--- a/market-research-agent-svc/app/core/config.py
+++ b/market-research-agent-svc/app/core/config.py
@@ -20,7 +20,7 @@ class Settings(BaseSettings):
     REDIS_URL: str = "redis://localhost:6379/11"
     # Prompt optimization
     PROMPT_CACHE_REDIS_URL: str = "redis://localhost:6379/2"
-    MLFLOW_TRACKING_URI: str = "http://mlflow-server:5000"
+    MLFLOW_TRACKING_URI: str = "http://prompt-optimization-svc:8110"
     PROMPT_FALLBACK_ONLY: bool = False
 
     # Kafka connection

--- a/market-research-agent-svc/app/logic/market_researcher.py
+++ b/market-research-agent-svc/app/logic/market_researcher.py
@@ -836,7 +836,28 @@ class MarketResearcher:
                     content = content[4:]
                 content = content.strip()
 
-            synthesis = json.loads(content, strict=False)
+            # Handle extra text after JSON (e.g., Claude adding explanation)
+            try:
+                synthesis = json.loads(content, strict=False)
+            except json.JSONDecodeError:
+                # Try extracting first JSON object from content
+                brace_start = content.find("{")
+                if brace_start >= 0:
+                    depth = 0
+                    for i, ch in enumerate(content[brace_start:], brace_start):
+                        if ch == "{":
+                            depth += 1
+                        elif ch == "}":
+                            depth -= 1
+                            if depth == 0:
+                                synthesis = json.loads(
+                                    content[brace_start : i + 1], strict=False
+                                )
+                                break
+                    else:
+                        raise
+                else:
+                    raise
             return synthesis
         except Exception as exc:
             logger.error(

--- a/market-research-agent-svc/app/prompts/loader.py
+++ b/market-research-agent-svc/app/prompts/loader.py
@@ -66,19 +66,19 @@ class AgentPromptClient:
                 self._http = httpx.AsyncClient(base_url=self.mlflow_uri, timeout=5.0)
                 resp = await self._http.get("/health")
                 if resp.status_code == 200:
-                    logger.info("MLflow connected: %s", self.mlflow_uri)
+                    logger.info("Prompt service connected: %s", self.mlflow_uri)
                 else:
-                    logger.warning("MLflow unhealthy (%d) — disabled", resp.status_code)
+                    logger.warning("Prompt service unhealthy (%d) — disabled", resp.status_code)
                     await self._http.aclose()
                     self._http = None
             except Exception as exc:
-                logger.warning("MLflow unavailable: %s — disabled", exc)
+                logger.warning("Prompt service unavailable: %s — disabled", exc)
                 if self._http:
                     await self._http.aclose()
                 self._http = None
         else:
             logger.info(
-                "MLflow URI not configured — prompt loader in fallback-only mode"
+                "Prompt service URI not configured — prompt loader in fallback-only mode"
             )
 
         logger.info(
@@ -189,66 +189,42 @@ class AgentPromptClient:
         except Exception:
             pass
 
-    # --- Tier 2: MLflow REST API ---
+    # --- Tier 2: Prompt Optimization Service API ---
 
     async def _mlflow_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._http is None:
             return None
         try:
-            # Try tenant-specific named prompt first
+            # Try tenant-specific prompt first
             if tenant_id:
-                template = await self._fetch_prompt(f"{name}-tenant-{tenant_id}")
+                template = await self._fetch_prompt(name, tenant_id=tenant_id)
                 if template is not None:
                     return template
 
-            # Try base prompt
+            # Try base prompt (no tenant override)
             return await self._fetch_prompt(name)
         except Exception as exc:
-            logger.warning("MLflow prompt fetch failed for '%s': %s", name, exc)
+            logger.warning("Prompt service fetch failed for '%s': %s", name, exc)
             return None
 
-    async def _fetch_prompt(self, name: str) -> Optional[str]:
-        """Fetch a prompt template from MLflow REST API.
+    async def _fetch_prompt(self, name: str, tenant_id: Optional[str] = None) -> Optional[str]:
+        """Fetch a prompt template from the prompt-optimization-svc API.
 
-        Prefers PRODUCTION-tagged versions over latest to match
-        the lifecycle-based resolution of ZorvenPromptLoader.
+        Calls GET /v1/prompts/{name}/production which returns the
+        PRODUCTION-state template directly.
         """
         try:
-            # Search for versions and prefer PRODUCTION state
-            resp = await self._http.get(
-                "/api/2.0/mlflow/prompts/versions/search",
-                params={"name": name},
-            )
-            if resp.status_code == 200:
-                data = resp.json()
-                versions = data.get("prompt_versions", [])
-                # Find PRODUCTION version first
-                for v in versions:
-                    tags = v.get("tags", {})
-                    if isinstance(tags, list):
-                        tag_dict = {t["key"]: t["value"] for t in tags}
-                    else:
-                        tag_dict = tags
-                    if tag_dict.get("state") == "PRODUCTION":
-                        return v.get("template")
+            headers = {}
+            if tenant_id:
+                headers["X-Tenant-ID"] = str(tenant_id)
 
-            # Fallback: get latest version if no PRODUCTION found
             resp = await self._http.get(
-                "/api/2.0/mlflow/prompts/get",
-                params={"name": name},
+                f"/v1/prompts/{name}/production",
+                headers=headers,
             )
             if resp.status_code == 200:
                 data = resp.json()
-                prompt = data.get("prompt", {})
-                latest = prompt.get("latest_version")
-                if latest:
-                    ver_resp = await self._http.get(
-                        "/api/2.0/mlflow/prompts/versions/get",
-                        params={"name": name, "version": latest},
-                    )
-                    if ver_resp.status_code == 200:
-                        ver_data = ver_resp.json()
-                        return ver_data.get("prompt_version", {}).get("template")
+                return data.get("template")
             return None
         except Exception:
             return None

--- a/trend-cultural-agent-svc/app/core/config.py
+++ b/trend-cultural-agent-svc/app/core/config.py
@@ -20,7 +20,7 @@ class Settings(BaseSettings):
     REDIS_URL: str = "redis://localhost:6379/14"
     # Prompt optimization
     PROMPT_CACHE_REDIS_URL: str = "redis://localhost:6379/2"
-    MLFLOW_TRACKING_URI: str = "http://mlflow-server:5000"
+    MLFLOW_TRACKING_URI: str = "http://prompt-optimization-svc:8110"
     PROMPT_FALLBACK_ONLY: bool = False
 
     # Kafka connection

--- a/trend-cultural-agent-svc/app/prompts/loader.py
+++ b/trend-cultural-agent-svc/app/prompts/loader.py
@@ -66,19 +66,19 @@ class AgentPromptClient:
                 self._http = httpx.AsyncClient(base_url=self.mlflow_uri, timeout=5.0)
                 resp = await self._http.get("/health")
                 if resp.status_code == 200:
-                    logger.info("MLflow connected: %s", self.mlflow_uri)
+                    logger.info("Prompt service connected: %s", self.mlflow_uri)
                 else:
-                    logger.warning("MLflow unhealthy (%d) — disabled", resp.status_code)
+                    logger.warning("Prompt service unhealthy (%d) — disabled", resp.status_code)
                     await self._http.aclose()
                     self._http = None
             except Exception as exc:
-                logger.warning("MLflow unavailable: %s — disabled", exc)
+                logger.warning("Prompt service unavailable: %s — disabled", exc)
                 if self._http:
                     await self._http.aclose()
                 self._http = None
         else:
             logger.info(
-                "MLflow URI not configured — prompt loader in fallback-only mode"
+                "Prompt service URI not configured — prompt loader in fallback-only mode"
             )
 
         logger.info(
@@ -189,66 +189,42 @@ class AgentPromptClient:
         except Exception:
             pass
 
-    # --- Tier 2: MLflow REST API ---
+    # --- Tier 2: Prompt Optimization Service API ---
 
     async def _mlflow_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._http is None:
             return None
         try:
-            # Try tenant-specific named prompt first
+            # Try tenant-specific prompt first
             if tenant_id:
-                template = await self._fetch_prompt(f"{name}-tenant-{tenant_id}")
+                template = await self._fetch_prompt(name, tenant_id=tenant_id)
                 if template is not None:
                     return template
 
-            # Try base prompt
+            # Try base prompt (no tenant override)
             return await self._fetch_prompt(name)
         except Exception as exc:
-            logger.warning("MLflow prompt fetch failed for '%s': %s", name, exc)
+            logger.warning("Prompt service fetch failed for '%s': %s", name, exc)
             return None
 
-    async def _fetch_prompt(self, name: str) -> Optional[str]:
-        """Fetch a prompt template from MLflow REST API.
+    async def _fetch_prompt(self, name: str, tenant_id: Optional[str] = None) -> Optional[str]:
+        """Fetch a prompt template from the prompt-optimization-svc API.
 
-        Prefers PRODUCTION-tagged versions over latest to match
-        the lifecycle-based resolution of ZorvenPromptLoader.
+        Calls GET /v1/prompts/{name}/production which returns the
+        PRODUCTION-state template directly.
         """
         try:
-            # Search for versions and prefer PRODUCTION state
-            resp = await self._http.get(
-                "/api/2.0/mlflow/prompts/versions/search",
-                params={"name": name},
-            )
-            if resp.status_code == 200:
-                data = resp.json()
-                versions = data.get("prompt_versions", [])
-                # Find PRODUCTION version first
-                for v in versions:
-                    tags = v.get("tags", {})
-                    if isinstance(tags, list):
-                        tag_dict = {t["key"]: t["value"] for t in tags}
-                    else:
-                        tag_dict = tags
-                    if tag_dict.get("state") == "PRODUCTION":
-                        return v.get("template")
+            headers = {}
+            if tenant_id:
+                headers["X-Tenant-ID"] = str(tenant_id)
 
-            # Fallback: get latest version if no PRODUCTION found
             resp = await self._http.get(
-                "/api/2.0/mlflow/prompts/get",
-                params={"name": name},
+                f"/v1/prompts/{name}/production",
+                headers=headers,
             )
             if resp.status_code == 200:
                 data = resp.json()
-                prompt = data.get("prompt", {})
-                latest = prompt.get("latest_version")
-                if latest:
-                    ver_resp = await self._http.get(
-                        "/api/2.0/mlflow/prompts/versions/get",
-                        params={"name": name, "version": latest},
-                    )
-                    if ver_resp.status_code == 200:
-                        ver_data = ver_resp.json()
-                        return ver_data.get("prompt_version", {}).get("template")
+                return data.get("template")
             return None
         except Exception:
             return None

--- a/voc-agent-svc/app/core/config.py
+++ b/voc-agent-svc/app/core/config.py
@@ -20,7 +20,7 @@ class Settings(BaseSettings):
     REDIS_URL: str = "redis://localhost:6379/15"
     # Prompt optimization
     PROMPT_CACHE_REDIS_URL: str = "redis://localhost:6379/2"
-    MLFLOW_TRACKING_URI: str = "http://mlflow-server:5000"
+    MLFLOW_TRACKING_URI: str = "http://prompt-optimization-svc:8110"
     PROMPT_FALLBACK_ONLY: bool = False
 
     # Kafka connection

--- a/voc-agent-svc/app/prompts/loader.py
+++ b/voc-agent-svc/app/prompts/loader.py
@@ -66,19 +66,19 @@ class AgentPromptClient:
                 self._http = httpx.AsyncClient(base_url=self.mlflow_uri, timeout=5.0)
                 resp = await self._http.get("/health")
                 if resp.status_code == 200:
-                    logger.info("MLflow connected: %s", self.mlflow_uri)
+                    logger.info("Prompt service connected: %s", self.mlflow_uri)
                 else:
-                    logger.warning("MLflow unhealthy (%d) — disabled", resp.status_code)
+                    logger.warning("Prompt service unhealthy (%d) — disabled", resp.status_code)
                     await self._http.aclose()
                     self._http = None
             except Exception as exc:
-                logger.warning("MLflow unavailable: %s — disabled", exc)
+                logger.warning("Prompt service unavailable: %s — disabled", exc)
                 if self._http:
                     await self._http.aclose()
                 self._http = None
         else:
             logger.info(
-                "MLflow URI not configured — prompt loader in fallback-only mode"
+                "Prompt service URI not configured — prompt loader in fallback-only mode"
             )
 
         logger.info(
@@ -189,66 +189,42 @@ class AgentPromptClient:
         except Exception:
             pass
 
-    # --- Tier 2: MLflow REST API ---
+    # --- Tier 2: Prompt Optimization Service API ---
 
     async def _mlflow_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
         if self._http is None:
             return None
         try:
-            # Try tenant-specific named prompt first
+            # Try tenant-specific prompt first
             if tenant_id:
-                template = await self._fetch_prompt(f"{name}-tenant-{tenant_id}")
+                template = await self._fetch_prompt(name, tenant_id=tenant_id)
                 if template is not None:
                     return template
 
-            # Try base prompt
+            # Try base prompt (no tenant override)
             return await self._fetch_prompt(name)
         except Exception as exc:
-            logger.warning("MLflow prompt fetch failed for '%s': %s", name, exc)
+            logger.warning("Prompt service fetch failed for '%s': %s", name, exc)
             return None
 
-    async def _fetch_prompt(self, name: str) -> Optional[str]:
-        """Fetch a prompt template from MLflow REST API.
+    async def _fetch_prompt(self, name: str, tenant_id: Optional[str] = None) -> Optional[str]:
+        """Fetch a prompt template from the prompt-optimization-svc API.
 
-        Prefers PRODUCTION-tagged versions over latest to match
-        the lifecycle-based resolution of ZorvenPromptLoader.
+        Calls GET /v1/prompts/{name}/production which returns the
+        PRODUCTION-state template directly.
         """
         try:
-            # Search for versions and prefer PRODUCTION state
-            resp = await self._http.get(
-                "/api/2.0/mlflow/prompts/versions/search",
-                params={"name": name},
-            )
-            if resp.status_code == 200:
-                data = resp.json()
-                versions = data.get("prompt_versions", [])
-                # Find PRODUCTION version first
-                for v in versions:
-                    tags = v.get("tags", {})
-                    if isinstance(tags, list):
-                        tag_dict = {t["key"]: t["value"] for t in tags}
-                    else:
-                        tag_dict = tags
-                    if tag_dict.get("state") == "PRODUCTION":
-                        return v.get("template")
+            headers = {}
+            if tenant_id:
+                headers["X-Tenant-ID"] = str(tenant_id)
 
-            # Fallback: get latest version if no PRODUCTION found
             resp = await self._http.get(
-                "/api/2.0/mlflow/prompts/get",
-                params={"name": name},
+                f"/v1/prompts/{name}/production",
+                headers=headers,
             )
             if resp.status_code == 200:
                 data = resp.json()
-                prompt = data.get("prompt", {})
-                latest = prompt.get("latest_version")
-                if latest:
-                    ver_resp = await self._http.get(
-                        "/api/2.0/mlflow/prompts/versions/get",
-                        params={"name": name, "version": latest},
-                    )
-                    if ver_resp.status_code == 200:
-                        ver_data = ver_resp.json()
-                        return ver_data.get("prompt_version", {}).get("template")
+                return data.get("template")
             return None
         except Exception:
             return None


### PR DESCRIPTION
## Summary

- **Root cause**: MLflow 2.21.0 does not expose Prompt Registry REST API endpoints. The Python SDK (`MlflowClient.register_prompt()`) stores prompts via direct database access, but there are no REST endpoints for external clients. All 15 agents were hitting `/api/2.0/mlflow/prompts/*` (which returns 404), causing every prompt load to fall through to hardcoded fallbacks.
- **Fix**: Changed `AgentPromptClient._fetch_prompt()` to call `GET /v1/prompts/{name}/production` on the prompt-optimization-svc, which has a working endpoint that returns PRODUCTION-state templates.
- **Config update**: Changed `MLFLOW_TRACKING_URI` default in all 15 agents from `http://mlflow-server:5000` to `http://prompt-optimization-svc:8110`. Railway env vars also updated.
- **MRA JSON fix**: Added robust JSON extraction to handle Claude returning extra text after JSON (was causing `JSONDecodeError: Extra data` → 30% confidence fallback).

## Test plan

- [ ] Deploy all agents and prompt-optimization-svc
- [ ] Check MRA startup logs for "Prompt service connected: http://prompt-optimization-svc..."
- [ ] Run a WF1 workflow and verify logs show "Loaded prompt 'zorven-wf1-mra-*' from Redis cache" or "from MLflow" (NOT "using fallback")
- [ ] Confirm confidence scores improve from 30% to expected range (60-85%)
- [ ] Verify no regression in WF2/WF3 agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)