### PR TITLE
fix(frontend): support ranked_pain_points from VoC agent

### DIFF
--- a/ai-brand-automator-frontend/src/components/pipelines/ResultDashboard.tsx
+++ b/ai-brand-automator-frontend/src/components/pipelines/ResultDashboard.tsx
@@ -5568,19 +5568,25 @@ function VoiceOfCustomerSection({
   const safeArr = (v: unknown): unknown[] => (Array.isArray(v) ? v : []);
   const safeObj = (v: unknown): Record<string, unknown> =>
     v != null && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {};
+  const safeNum = (v: unknown): number | undefined => {
+    if (typeof v === 'number') return v;
+    if (typeof v === 'string') { const n = Number(v); return isNaN(n) ? undefined : n; }
+    return undefined;
+  };
 
-  const overallSentiment = sentiment?.overall_sentiment;
-  const emotionProfile = sentiment?.emotion_profile != null && typeof sentiment.emotion_profile === 'object' && !Array.isArray(sentiment.emotion_profile) ? sentiment.emotion_profile : undefined;
-  const channelSentiments = safeArr(sentiment?.channel_sentiments) as Array<{
+  const overallSentiment = sentiment != null && typeof sentiment === 'object' && !Array.isArray(sentiment) ? (sentiment as VoCSentimentFELocal)?.overall_sentiment : undefined;
+  const emotionProfile = sentiment != null && typeof sentiment === 'object' && !Array.isArray(sentiment) && sentiment.emotion_profile != null && typeof sentiment.emotion_profile === 'object' && !Array.isArray(sentiment.emotion_profile) ? sentiment.emotion_profile : undefined;
+  const channelSentiments = safeArr(sentiment != null && typeof sentiment === 'object' && !Array.isArray(sentiment) ? (sentiment as VoCSentimentFELocal)?.channel_sentiments : undefined) as Array<{
     channel: string; provenance?: string; sentiment?: { positive?: number; neutral?: number; negative?: number }; feedback_count?: number; confidence?: number;
   }>;
-  const themeClusters = safeArr(themes?.themes) as VoCThemeClusterLocal[];
-  const painPoints = safeArr(painPointMatrix?.pain_points) as VoCPainPointLocal[];
-  const nps = npsAnalysis;
-  const activeNps = nps?.nps_available ? nps?.current_nps : nps?.proxy_nps;
-  const execSummary = typeof strategyBridge?.executive_summary === 'string' ? strategyBridge.executive_summary : undefined;
-  const crossAgentInsights = safeObj(strategyBridge?.cross_agent_insights) as Record<string, string>;
-  const stratRecs = safeArr(strategyBridge?.strategic_recommendations ?? recommendations) as string[];
+  const themeClusters = safeArr(themes != null && typeof themes === 'object' && !Array.isArray(themes) ? (themes as VoCThemeMapLocal)?.themes : undefined) as VoCThemeClusterLocal[];
+  const painPoints = safeArr(painPointMatrix != null && typeof painPointMatrix === 'object' && !Array.isArray(painPointMatrix) ? (painPointMatrix as { pain_points?: VoCPainPointLocal[] })?.pain_points : undefined) as VoCPainPointLocal[];
+  const nps = npsAnalysis != null && typeof npsAnalysis === 'object' && !Array.isArray(npsAnalysis) ? npsAnalysis : undefined;
+  const rawActiveNps = nps?.nps_available ? nps?.current_nps : nps?.proxy_nps;
+  const activeNps = rawActiveNps != null && typeof rawActiveNps === 'object' && !Array.isArray(rawActiveNps) ? rawActiveNps : undefined;
+  const execSummary = typeof strategyBridge === 'object' && strategyBridge != null && typeof (strategyBridge as VoCStrategyBridgeLocal)?.executive_summary === 'string' ? (strategyBridge as VoCStrategyBridgeLocal).executive_summary : undefined;
+  const crossAgentInsights = safeObj(typeof strategyBridge === 'object' && strategyBridge != null ? (strategyBridge as VoCStrategyBridgeLocal)?.cross_agent_insights : undefined) as Record<string, string>;
+  const stratRecs = safeArr(typeof strategyBridge === 'object' && strategyBridge != null ? (strategyBridge as VoCStrategyBridgeLocal)?.strategic_recommendations ?? recommendations : recommendations) as string[];
 
   return (
     <div className="space-y-6">
@@ -5763,9 +5769,9 @@ function VoiceOfCustomerSection({
                           {theme.feedback_count} mentions
                         </span>
                       )}
-                      {theme.severity_score != null && (
-                        <span className={`text-xs font-bold ${severityColor(theme.severity_score)}`}>
-                          {theme.severity_score.toFixed(1)}
+                      {safeNum(theme.severity_score) != null && (
+                        <span className={`text-xs font-bold ${severityColor(safeNum(theme.severity_score) as number)}`}>
+                          {(safeNum(theme.severity_score) as number).toFixed(1)}
                         </span>
                       )}
                     </div>
@@ -5786,7 +5792,7 @@ function VoiceOfCustomerSection({
                         <div>
                           <span className="text-[10px] text-brand-silver/50 uppercase">Sub-themes</span>
                           <div className="flex flex-wrap gap-1 mt-1">
-                            {theme.sub_themes.map((st, si) => (
+                            {theme.sub_themes.filter((st): st is NonNullable<typeof st> => st != null && typeof st === 'object').map((st, si) => (
                               <span key={si} className="text-xs px-2 py-0.5 rounded-full bg-white/10 text-brand-silver/70">
                                 {st.name}{st.feedback_count ? ` (${st.feedback_count})` : ''}
                               </span>
@@ -5835,8 +5841,8 @@ function VoiceOfCustomerSection({
                   <div className="text-[10px] text-brand-silver/50 uppercase">
                     {nps.nps_available ? 'NPS Score' : 'Proxy NPS'}
                   </div>
-                  <div className={`text-2xl font-bold ${(activeNps.nps_score ?? 0) >= 50 ? 'text-green-400' : (activeNps.nps_score ?? 0) >= 0 ? 'text-amber-400' : 'text-red-400'}`}>
-                    {activeNps.nps_score != null ? `${activeNps.nps_score >= 0 ? '+' : ''}${activeNps.nps_score.toFixed(0)}` : 'N/A'}
+                  <div className={`text-2xl font-bold ${(safeNum(activeNps.nps_score) ?? 0) >= 50 ? 'text-green-400' : (safeNum(activeNps.nps_score) ?? 0) >= 0 ? 'text-amber-400' : 'text-red-400'}`}>
+                    {safeNum(activeNps.nps_score) != null ? `${(safeNum(activeNps.nps_score) as number) >= 0 ? '+' : ''}${(safeNum(activeNps.nps_score) as number).toFixed(0)}` : 'N/A'}
                   </div>
                 </div>
                 <div className="flex-1 grid grid-cols-3 gap-2 text-center">
@@ -5922,8 +5928,8 @@ function VoiceOfCustomerSection({
                     <td className="py-2 px-3 text-brand-silver/40">{i + 1}</td>
                     <td className="py-2 px-3 text-white font-medium">{pp.name}</td>
                     <td className="py-2 px-3 text-center">
-                      <span className={`font-bold ${severityColor(pp.severity ?? 0)}`}>
-                        {pp.severity?.toFixed(1)}
+                      <span className={`font-bold ${severityColor(safeNum(pp.severity) ?? 0)}`}>
+                        {safeNum(pp.severity) != null ? (safeNum(pp.severity) as number).toFixed(1) : '-'}
                       </span>
                     </td>
                     <td className="py-2 px-3 text-center text-brand-silver/70">

--- a/ai-brand-automator-frontend/src/components/pipelines/ResultDashboard.tsx
+++ b/ai-brand-automator-frontend/src/components/pipelines/ResultDashboard.tsx
@@ -5580,7 +5580,7 @@ function VoiceOfCustomerSection({
     channel: string; provenance?: string; sentiment?: { positive?: number; neutral?: number; negative?: number }; feedback_count?: number; confidence?: number;
   }>;
   const themeClusters = safeArr(themes != null && typeof themes === 'object' && !Array.isArray(themes) ? (themes as VoCThemeMapLocal)?.themes : undefined) as VoCThemeClusterLocal[];
-  const painPoints = safeArr(painPointMatrix != null && typeof painPointMatrix === 'object' && !Array.isArray(painPointMatrix) ? (painPointMatrix as { pain_points?: VoCPainPointLocal[] })?.pain_points : undefined) as VoCPainPointLocal[];
+  const painPoints = safeArr(painPointMatrix != null && typeof painPointMatrix === 'object' && !Array.isArray(painPointMatrix) ? ((painPointMatrix as Record<string, unknown>)?.pain_points ?? (painPointMatrix as Record<string, unknown>)?.ranked_pain_points) : undefined) as VoCPainPointLocal[];
   const nps = npsAnalysis != null && typeof npsAnalysis === 'object' && !Array.isArray(npsAnalysis) ? npsAnalysis : undefined;
   const rawActiveNps = nps?.nps_available ? nps?.current_nps : nps?.proxy_nps;
   const activeNps = rawActiveNps != null && typeof rawActiveNps === 'object' && !Array.isArray(rawActiveNps) ? rawActiveNps : undefined;

--- a/ai-brand-automator-frontend/src/components/pipelines/ResultDashboard.tsx
+++ b/ai-brand-automator-frontend/src/components/pipelines/ResultDashboard.tsx
@@ -5565,16 +5565,22 @@ function VoiceOfCustomerSection({
     );
   }
 
+  const safeArr = (v: unknown): unknown[] => (Array.isArray(v) ? v : []);
+  const safeObj = (v: unknown): Record<string, unknown> =>
+    v != null && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {};
+
   const overallSentiment = sentiment?.overall_sentiment;
-  const emotionProfile = sentiment?.emotion_profile;
-  const channelSentiments = sentiment?.channel_sentiments ?? [];
-  const themeClusters = themes?.themes ?? [];
-  const painPoints = painPointMatrix?.pain_points ?? [];
+  const emotionProfile = sentiment?.emotion_profile != null && typeof sentiment.emotion_profile === 'object' && !Array.isArray(sentiment.emotion_profile) ? sentiment.emotion_profile : undefined;
+  const channelSentiments = safeArr(sentiment?.channel_sentiments) as Array<{
+    channel: string; provenance?: string; sentiment?: { positive?: number; neutral?: number; negative?: number }; feedback_count?: number; confidence?: number;
+  }>;
+  const themeClusters = safeArr(themes?.themes) as VoCThemeClusterLocal[];
+  const painPoints = safeArr(painPointMatrix?.pain_points) as VoCPainPointLocal[];
   const nps = npsAnalysis;
   const activeNps = nps?.nps_available ? nps?.current_nps : nps?.proxy_nps;
-  const execSummary = strategyBridge?.executive_summary;
-  const crossAgentInsights = strategyBridge?.cross_agent_insights;
-  const stratRecs = strategyBridge?.strategic_recommendations ?? recommendations ?? [];
+  const execSummary = typeof strategyBridge?.executive_summary === 'string' ? strategyBridge.executive_summary : undefined;
+  const crossAgentInsights = safeObj(strategyBridge?.cross_agent_insights) as Record<string, string>;
+  const stratRecs = safeArr(strategyBridge?.strategic_recommendations ?? recommendations) as string[];
 
   return (
     <div className="space-y-6">
@@ -5776,7 +5782,7 @@ function VoiceOfCustomerSection({
                   {isExpanded && (
                     <div className="mt-3 pt-3 border-t border-white/10 space-y-2">
                       {/* Sub-themes */}
-                      {theme.sub_themes && theme.sub_themes.length > 0 && (
+                      {Array.isArray(theme.sub_themes) && theme.sub_themes.length > 0 && (
                         <div>
                           <span className="text-[10px] text-brand-silver/50 uppercase">Sub-themes</span>
                           <div className="flex flex-wrap gap-1 mt-1">
@@ -5789,7 +5795,7 @@ function VoiceOfCustomerSection({
                         </div>
                       )}
                       {/* Representative quotes */}
-                      {theme.representative_quotes && theme.representative_quotes.length > 0 && (
+                      {Array.isArray(theme.representative_quotes) && theme.representative_quotes.length > 0 && (
                         <div>
                           <span className="text-[10px] text-brand-silver/50 uppercase">Quotes</span>
                           {theme.representative_quotes.slice(0, 3).map((q, qi) => (
@@ -5856,7 +5862,7 @@ function VoiceOfCustomerSection({
               {nps.data_source && (
                 <p className="text-xs text-brand-silver/40 mt-1">Source: {nps.data_source}</p>
               )}
-              {nps.drivers && nps.drivers.length > 0 && (
+              {Array.isArray(nps.drivers) && nps.drivers.length > 0 && (
                 <div className="mt-3">
                   <span className="text-[10px] text-brand-silver/50 uppercase">NPS Drivers</span>
                   <div className="flex flex-wrap gap-1 mt-1">
@@ -5868,7 +5874,7 @@ function VoiceOfCustomerSection({
                   </div>
                 </div>
               )}
-              {nps.detractor_themes && nps.detractor_themes.length > 0 && (
+              {Array.isArray(nps.detractor_themes) && nps.detractor_themes.length > 0 && (
                 <div className="mt-2">
                   <span className="text-[10px] text-brand-silver/50 uppercase">Detractor Themes</span>
                   <div className="flex flex-wrap gap-1 mt-1">
@@ -5925,7 +5931,7 @@ function VoiceOfCustomerSection({
                     </td>
                     <td className="py-2 px-3">
                       <div className="flex flex-wrap gap-1">
-                        {pp.persona_impact?.slice(0, 3).map((p) => (
+                        {Array.isArray(pp.persona_impact) && pp.persona_impact.slice(0, 3).map((p) => (
                           <span key={p} className="text-[10px] px-1.5 py-0.5 rounded bg-white/10 text-brand-silver/60">
                             {p}
                           </span>


### PR DESCRIPTION
## Summary
- Fixes VoC pain point matrix not rendering because the VoC agent returns `ranked_pain_points` key, not `pain_points`
- Now checks both keys as fallback

## Context
After inspecting the production database for job `0450c935`, confirmed that VoC data IS being returned correctly (7 themes, 7 channel sentiments, NPS proxy, strategy bridge). The pain points were just under a different key name.

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Verify VoC tab renders sentiment, themes, NPS data

🤖 Generated with [Claude Code](https://claude.com/claude-code)