### PR TITLE
fix(wf3): robust JSON repair for CAA + defensive guardrails for CGA

### DIFF
--- a/campaign-architecture-agent-svc/app/services/anthropic_client.py
+++ b/campaign-architecture-agent-svc/app/services/anthropic_client.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import re
 from typing import Any
 
 from app.core.config import settings
@@ -18,6 +19,47 @@ def _ensure_dict(value: Any) -> dict[str, Any]:
     if isinstance(value, list):
         return {"items": value}
     return {"raw_response": value}
+
+
+def _repair_json(text: str) -> dict[str, Any] | None:
+    """Attempt common JSON repairs on malformed text.
+
+    Returns parsed dict/list on success, None if all repairs fail.
+    """
+    # Repair 1: Remove trailing commas before } or ]
+    repaired = re.sub(r",\s*([}\]])", r"\1", text)
+    try:
+        return json.loads(repaired, strict=False)
+    except json.JSONDecodeError:
+        pass
+
+    # Repair 2: Fix missing commas between values
+    # Pattern: "value" followed by whitespace then "key" (missing comma)
+    repaired = re.sub(r'(")\s*\n\s*(")', r'\1,\n\2', repaired)
+    # Also handle: } followed by whitespace then { or "
+    repaired = re.sub(r"(})\s*\n\s*({)", r"\1,\n\2", repaired)
+    repaired = re.sub(r'(})\s*\n\s*(")', r'\1,\n\2', repaired)
+    # Handle: ] followed by whitespace then { or "
+    repaired = re.sub(r"(])\s*\n\s*({)", r"\1,\n\2", repaired)
+    try:
+        return json.loads(repaired, strict=False)
+    except json.JSONDecodeError:
+        pass
+
+    # Repair 3: Truncate at last valid closing brace if unterminated string
+    # Find the last } that produces valid JSON when we slice up to it
+    last_pos = len(repaired)
+    for _ in range(5):  # Try up to 5 truncation attempts
+        last_pos = repaired.rfind("}", 0, last_pos)
+        if last_pos < 0:
+            break
+        candidate = repaired[: last_pos + 1]
+        try:
+            return json.loads(candidate, strict=False)
+        except json.JSONDecodeError:
+            continue
+
+    return None
 
 
 class AnthropicClient:
@@ -50,6 +92,7 @@ class AnthropicClient:
                 response.usage.input_tokens,
                 response.usage.output_tokens,
             )
+            # Step 1: Try strict parse on full text
             parsed = json.loads(text, strict=False)
             return _ensure_dict(parsed)
         except json.JSONDecodeError:
@@ -59,8 +102,15 @@ class AnthropicClient:
             )
             start = text.find("{")
             end = text.rfind("}") + 1
-            if start >= 0 and end > start:
-                parsed = json.loads(text[start:end], strict=False)
+            if start < 0 or end <= start:
+                logger.warning("No JSON object found in response")
+                return {"raw_response": text}
+
+            extracted = text[start:end]
+
+            # Step 2: Try parsing the extracted block directly
+            try:
+                parsed = json.loads(extracted, strict=False)
                 result = _ensure_dict(parsed)
                 logger.info(
                     "Extracted JSON keys: %s (type=%s)",
@@ -68,7 +118,28 @@ class AnthropicClient:
                     type(parsed).__name__,
                 )
                 return result
-            logger.warning("No JSON object found in response")
+            except json.JSONDecodeError:
+                pass
+
+            # Step 3: Attempt repairs on extracted text
+            logger.warning(
+                "Extracted JSON is malformed, attempting repair "
+                "(%d chars)", len(extracted)
+            )
+            repaired = _repair_json(extracted)
+            if repaired is not None:
+                result = _ensure_dict(repaired)
+                logger.info(
+                    "Repaired JSON keys: %s (type=%s)",
+                    list(result.keys())[:10],
+                    type(repaired).__name__,
+                )
+                return result
+
+            # Step 4: All repairs failed
+            logger.warning(
+                "All JSON repair attempts failed, returning raw response"
+            )
             return {"raw_response": text}
         except Exception as exc:
             logger.error("Claude API error: %s", exc)

--- a/creative-generation-agent-svc/app/logic/guardrails.py
+++ b/creative-generation-agent-svc/app/logic/guardrails.py
@@ -139,8 +139,12 @@ class PlanGuardrails:
 
         # Check hooks (<= 125 chars)
         for hook_set in copy_result.get("hooks", []):
+            if not isinstance(hook_set, dict):
+                continue
             ad_set = hook_set.get("ad_set_name", "unknown")
             for hook in hook_set.get("hooks", []):
+                if not isinstance(hook, dict):
+                    continue
                 text = hook.get("hook_text", "")
                 if len(text) > 125:
                     issues.append(
@@ -150,8 +154,12 @@ class PlanGuardrails:
 
         # Check primary copy lengths
         for copy_set in copy_result.get("primary_copy", []):
+            if not isinstance(copy_set, dict):
+                continue
             ad_set = copy_set.get("ad_set_name", "unknown")
             for variant in copy_set.get("variants", []):
+                if not isinstance(variant, dict):
+                    continue
                 vid = variant.get("variant_id", "")
 
                 short_text = variant.get("short", {}).get("text", "")
@@ -184,6 +192,8 @@ class PlanGuardrails:
             bp = blueprint
         expected: dict[str, int] = {}
         for ad_set in bp.get("ad_sets", []):
+            if not isinstance(ad_set, dict):
+                continue
             name = ad_set.get("name", "")
             count = ad_set.get("variant_count", 3)
             if name:
@@ -191,6 +201,8 @@ class PlanGuardrails:
 
         # Check hooks per ad set
         for hook_set in copy_result.get("hooks", []):
+            if not isinstance(hook_set, dict):
+                continue
             ad_set = hook_set.get("ad_set_name", "")
             actual = len(hook_set.get("hooks", []))
             min_expected = expected.get(ad_set, 3)
@@ -242,6 +254,8 @@ class OutputGuardrails:
         issues: list[str] = []
 
         for pkg in result.get("ad_set_packages", []):
+            if not isinstance(pkg, dict):
+                continue
             ad_set = pkg.get("ad_set_name", "unknown")
             compliance = pkg.get("compliance_results", [])
 
@@ -282,6 +296,8 @@ class OutputGuardrails:
             return issues
 
         for pkg in packages:
+            if not isinstance(pkg, dict):
+                continue
             ad_set = pkg.get("ad_set_name", "unknown")
 
             images = pkg.get("images", [])


### PR DESCRIPTION
## Summary
- **CAA (`campaign-architecture-agent-svc`)**: Added `_repair_json()` helper with 3 repair strategies for Claude's malformed JSON responses (trailing comma removal, missing comma insertion, progressive truncation). The previous execution failed because a ~20KB blueprint JSON had a missing comma at position 20047, causing `call2_result = {}` → empty blueprint → 0 ad_sets → cascading failures in CGA and ADPUB.
- **CGA (`creative-generation-agent-svc`)**: Added `isinstance(item, dict)` guards in 7 locations across 4 guardrail methods (`_check_copy_lengths`, `_check_variant_counts`, `_check_compliance`, `_check_minimum_package`). Claude sometimes returns strings instead of dicts in arrays, causing `AttributeError: 'str' object has no attribute 'get'`.

## Test plan
- [x] Python syntax validation passes for both files
- [ ] Merge and re-run Meta Ad Campaign workflow to verify blueprint generates with ad_sets
- [ ] Verify CGA produces creative packages without guardrail crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)