### PR TITLE
fix(cga): pass strict=False to json.loads instead of _repair_json

### DIFF
--- a/creative-generation-agent-svc/app/services/anthropic_client.py
+++ b/creative-generation-agent-svc/app/services/anthropic_client.py
@@ -189,7 +189,7 @@ class AnthropicClient:
                         )
             # Last-ditch: repair the whole candidate
             try:
-                parsed = json.loads(_repair_json(candidate, strict=False))
+                parsed = json.loads(_repair_json(candidate), strict=False)
                 result = _ensure_dict(parsed)
                 logger.info(
                     "Extracted JSON via full-repair: keys=%s",


### PR DESCRIPTION
## Summary
- Fixes `TypeError: _repair_json() got an unexpected keyword argument 'strict'` in CGA's `anthropic_client.py` line 192
- The `strict=False` was being passed to `_repair_json()` (which doesn't accept it) instead of `json.loads()`
- This caused CGA to crash on every JSON repair attempt, even when CAA successfully produced valid blueprints with ad_sets

## Root Cause
PR #462 added `_repair_json()` to CGA but the last-ditch repair call had the argument in the wrong position:
```python
# Before (broken):
json.loads(_repair_json(candidate, strict=False))

# After (fixed):
json.loads(_repair_json(candidate), strict=False)
```

## Test plan
- [ ] Merge and redeploy CGA on Railway
- [ ] Flush Redis DB 21/22/23 (CAA/CGA/ADPUB caches)
- [ ] Re-run Meta Ad Campaign workflow — CGA should no longer crash on JSON repair

🤖 Generated with [Claude Code](https://claude.com/claude-code)