### PR TITLE
fix(cga): increase max_tokens to prevent truncated JSON

### DIFF
--- a/creative-generation-agent-svc/app/core/config.py
+++ b/creative-generation-agent-svc/app/core/config.py
@@ -31,7 +31,7 @@ class Settings(BaseSettings):
     # Anthropic Claude Sonnet 4 (copy generation + assembly)
     ANTHROPIC_API_KEY: str = ""
     ANTHROPIC_MODEL: str = "claude-sonnet-5"
-    ANTHROPIC_MAX_TOKENS: int = 8192
+    ANTHROPIC_MAX_TOKENS: int = 16384
     ANTHROPIC_TEMPERATURE: float = 0.4
 
     # Nano Banana 2 image generation (google-genai)

--- a/creative-generation-agent-svc/app/services/cga_analyzer.py
+++ b/creative-generation-agent-svc/app/services/cga_analyzer.py
@@ -215,7 +215,9 @@ class CGAAnalyzer:
                 f"{json.dumps(learnings, default=str)[:2000]}\n"
             )
 
-        call1_result = await self._llm.generate_json(call1_system, call1_user)
+        call1_result = await self._llm.generate_json(
+            call1_system, call1_user, max_tokens=16384
+        )
 
         creative_profiles = call1_result.get("creative_profiles", [])
         image_prompts = call1_result.get("image_prompts", [])
@@ -345,7 +347,9 @@ class CGAAnalyzer:
             f"{cta_section}"
         )
 
-        call2_result = await self._llm.generate_json(call2_system, call2_user)
+        call2_result = await self._llm.generate_json(
+            call2_system, call2_user, max_tokens=16384
+        )
 
         hooks = call2_result.get("hooks", [])
         primary_copy = call2_result.get("primary_copy", [])


### PR DESCRIPTION
## Summary
- CGA Calls 1 & 2 were using the default `max_tokens=8192`, but generating creative profiles + image prompts + ad copy for 8 ad sets produces 20KB+ JSON responses
- Claude hit the token limit mid-output, truncating the JSON and causing parse failures
- Result: **zero images generated, zero ad copy, confidence 0.05** — complete WF3 failure

## Fix
- Set `max_tokens=16384` explicitly for Call 1 (creative profiling) and Call 2 (copywriting), matching Call 3 which already used 16384
- Bump the config default `ANTHROPIC_MAX_TOKENS` from 8192 → 16384 as a safety net

## Evidence from logs
```
Claude response hit max_tokens (8192) — JSON likely truncated
JSON extraction failed (text_len=21468, stop_reason=max_tokens)  # Call 1
JSON extraction failed (text_len=23110, stop_reason=max_tokens)  # Call 2
CGA analysis complete: 0 images, 0 units, confidence 0.05
```

## Test plan
- [ ] Merge and let Railway auto-deploy CGA
- [ ] Clear Redis WF3 cache keys
- [ ] Re-run WF3 Meta Ad Campaign — should generate images and copy successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)