### PR TITLE
fix(gepa): prevent canary check from crashing production endpoint

### DIFF
--- a/prompt-optimization-svc/app/api/routes.py
+++ b/prompt-optimization-svc/app/api/routes.py
@@ -430,25 +430,29 @@ async def get_production_prompt(
         return JSONResponse(status_code=503, content={"detail": "Not initialized"})
 
     # Check for active canary routing
+    # Wrapped in try/except: canary check must never break the production hot path
     if canary_manager and x_tenant_id:
-        from app.logic.canary_manager import is_canary_request
+        try:
+            from app.logic.canary_manager import is_canary_request
 
-        canary_state = await canary_manager.get_canary_state(name)
-        if canary_state and canary_state.active:
-            if is_canary_request(x_tenant_id):
-                # Route to canary version
-                if mlflow_registry:
-                    canary_prompt = mlflow_registry.get_prompt_version(
-                        name, canary_state.canary_version
-                    )
-                    if canary_prompt:
-                        return ProductionPromptResponse(
-                            name=name,
-                            version=canary_prompt.version,
-                            template=canary_prompt.template,
-                            state="CANARY",
-                            tags={**canary_prompt.tags, "is_canary": "true"},
+            canary_state = await canary_manager.get_canary_state(name)
+            if canary_state and canary_state.active:
+                if is_canary_request(x_tenant_id):
+                    # Route to canary version
+                    if mlflow_registry:
+                        canary_prompt = mlflow_registry.get_prompt_version(
+                            name, canary_state.canary_version
                         )
+                        if canary_prompt:
+                            return ProductionPromptResponse(
+                                name=name,
+                                version=canary_prompt.version,
+                                template=canary_prompt.template,
+                                state="CANARY",
+                                tags={**canary_prompt.tags, "is_canary": "true"},
+                            )
+        except Exception as exc:
+            logger.warning("Canary check failed (falling through): %s", exc)
 
     # Normal production resolution
     prod = lifecycle_manager.get_production_version(name, tenant_id=x_tenant_id)


### PR DESCRIPTION
## Summary

- **Critical fix**: The canary routing check in `get_production_prompt()` was crashing with `ConnectionRefusedError` when Redis was unreachable, returning 500 errors to all agent services trying to load prompts
- Wrapped canary check in try/except so it gracefully falls through to normal production resolution on failure
- Root cause: `POI_PROMPT_CACHE_REDIS_URL` was not set on Railway — defaulted to `localhost:6379`

## Railway env vars also set

| Service | Variable | Value |
|---------|----------|-------|
| prompt-optimization-svc | `POI_PROMPT_CACHE_REDIS_URL` | `redis://...@redis.railway.internal:6379/2` |
| prompt-optimization-svc | `POI_REDIS_URL` | Fixed to use `/26` suffix |
| prompt-optimization-svc | `POI_CORS_ORIGINS` | Added `https://frontend-production-9b6e.up.railway.app` |
| frontend | `NEXT_PUBLIC_PROMPT_OPS_API_URL` | `https://prompt-optimization-svc-production.up.railway.app` |

## Test plan

- [x] Verified 500 errors in Railway deploy logs caused by `redis.exceptions.ConnectionError: Error 111 connecting to localhost:6379`
- [ ] After merge + deploy: verify `/v1/prompts/{name}/production` returns 200 (not 500)
- [ ] Verify `/prompt-ops` dashboard loads without "failed to fetch" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)