### PR TITLE
fix(gepa): add missing Request import causing startup crash

### DIFF
--- a/prompt-optimization-svc/app/api/routes.py
+++ b/prompt-optimization-svc/app/api/routes.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Optional
 
-from fastapi import APIRouter, Depends, Header
+from fastapi import APIRouter, Depends, Header, Request
 from fastapi.responses import JSONResponse
 
 from fastapi import Query


### PR DESCRIPTION
## Summary

- Adds missing `Request` import to `from fastapi import APIRouter, Depends, Header, Request`
- The `start_canary` endpoint added in PR #471 uses `Request` but it wasn't imported, causing `NameError` on service startup

## Test plan

- [ ] Service starts without crash after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)