### PR TITLE
fix(gepa): fix canary metrics endpoint request parsing

### DIFF
--- a/prompt-optimization-svc/app/api/routes.py
+++ b/prompt-optimization-svc/app/api/routes.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Optional
 
-from fastapi import APIRouter, Depends, Header
+from fastapi import APIRouter, Depends, Header, Request
 from fastapi.responses import JSONResponse
 
 from fastapi import Query

--- a/prompt-optimization-svc/app/api/routes.py
+++ b/prompt-optimization-svc/app/api/routes.py
@@ -1376,7 +1376,7 @@ async def start_canary(request: Request):
 async def record_canary_metric(
     name: str,
     version: int,
-    request: "CanaryMetricRecordRequest",
+    raw_request: Request,
 ):
     """Record a scorer metric for a canary or production version."""
     from app.api.schemas import CanaryMetricRecordRequest
@@ -1385,13 +1385,13 @@ async def record_canary_metric(
         return JSONResponse(
             status_code=503, content={"detail": "Canary manager not initialized"}
         )
-    await canary_manager.record_canary_metric(
-        name, version, request.scorer_name, request.score
-    )
+    data = await raw_request.json()
+    req = CanaryMetricRecordRequest(**data)
+    await canary_manager.record_canary_metric(name, version, req.scorer_name, req.score)
     return JSONResponse(
         status_code=201,
         content={
-            "detail": f"Metric '{request.scorer_name}' recorded for {name} v{version}"
+            "detail": f"Metric '{req.scorer_name}' recorded for {name} v{version}"
         },
     )
 


### PR DESCRIPTION
## Summary

- Fix `POST /v1/prompts/{name}/versions/{version}/metrics` returning validation error
- The forward-reference string annotation `request: "CanaryMetricRecordRequest"` couldn't be resolved by FastAPI at runtime
- Now parses request body manually via `Request.json()` and validates with the Pydantic model

## Test plan

- [ ] After deploy, record metrics via curl and verify 201 response

🤖 Generated with [Claude Code](https://claude.com/claude-code)