### PR TITLE
fix(gepa): add pandas dependency for mlflow-skinny GEPA optimizer

### DIFF
--- a/prompt-optimization-svc/requirements.txt
+++ b/prompt-optimization-svc/requirements.txt
@@ -4,6 +4,7 @@ pydantic>=2.9.0
 pydantic-settings>=2.5.0
 httpx>=0.27.0
 mlflow-skinny>=2.21.0
+pandas>=2.0.0
 anthropic>=0.84.0
 redis>=5.0.0
 aiokafka>=0.11.0


### PR DESCRIPTION
## Summary

- Add `pandas>=2.0.0` to `prompt-optimization-svc/requirements.txt`
- `mlflow-skinny` doesn't bundle pandas, but `mlflow.genai.evaluation.utils` uses `pd.DataFrame` internally during `optimize_prompts()`, causing a `NameError` at runtime on Railway

## Test plan

- [x] Verified the error in Railway logs: `NameError: name 'pd' is not defined` at `mlflow/genai/evaluation/utils.py:114`
- [ ] After merge + redeploy, `POST /v1/execute` should no longer fail with pandas error

🤖 Generated with [Claude Code](https://claude.com/claude-code)