### PR TITLE
fix(gepa): include version in MLflow prompt URIs

### DIFF
--- a/prompt-optimization-svc/app/api/routes.py
+++ b/prompt-optimization-svc/app/api/routes.py
@@ -679,10 +679,19 @@ async def execute(
     from app.scorers import COMMON_SCORERS
     from app.services.gepa_optimizer import ZorvenGepaOptimizer
 
+    # Resolve latest version — MLflow requires version in prompt URI
+    prompt_version = None
+    if mlflow_registry:
+        prompt_info = mlflow_registry.get_prompt(prompt_name)
+        if prompt_info:
+            prompt_version = prompt_info.version
+    if not prompt_version:
+        prompt_version = 1
+
     predict_fn = make_predict_fn(prompt_name)
     gepa = ZorvenGepaOptimizer()
     result = gepa.optimize(
-        prompt_uris=[f"prompts:/{prompt_name}"],
+        prompt_uris=[f"prompts:/{prompt_name}/{prompt_version}"],
         predict_fn=predict_fn,
         train_data=[{"inputs": request.input_context or {}}],
         scorers=COMMON_SCORERS,

--- a/prompt-optimization-svc/app/services/joint_optimizer.py
+++ b/prompt-optimization-svc/app/services/joint_optimizer.py
@@ -68,8 +68,15 @@ class JointOptimizer:
         except KeyError as exc:
             return JointOptimizationResult(group_name=group_name, error=str(exc))
 
-        # Build prompt URIs for all prompts in the group
-        prompt_uris = [f"prompts:/{name}" for name in group.prompt_names]
+        # Build prompt URIs for all prompts in the group (version required by MLflow)
+        prompt_uris = []
+        for name in group.prompt_names:
+            version = 1
+            if self.registry:
+                info = self.registry.get_prompt(name)
+                if info:
+                    version = info.version
+            prompt_uris.append(f"prompts:/{name}/{version}")
 
         logger.info(
             "Starting joint optimization: group=%s, prompts=%d, agents=%s",


### PR DESCRIPTION
## Summary

- MLflow's `parse_prompt_uri()` requires version suffix (e.g., `prompts:/name/1`)
- `/v1/execute` and `JointOptimizer.optimize_group()` were using `prompts:/name` without version, causing `MlflowException: Invalid prompt URI format` at runtime on Railway
- Now resolves latest version from MLflow registry before building URIs

## Test plan

- [x] 22 existing tests pass
- [ ] `POST /v1/execute` no longer fails with URI format error on Railway

🤖 Generated with [Claude Code](https://claude.com/claude-code)