### PR TITLE
fix(gepa): add gepa package dependency

### DIFF
--- a/prompt-optimization-svc/requirements.txt
+++ b/prompt-optimization-svc/requirements.txt
@@ -5,6 +5,7 @@ pydantic-settings>=2.5.0
 httpx>=0.27.0
 mlflow-skinny>=2.21.0
 pandas>=2.0.0
+gepa>=0.0.26
 anthropic>=0.84.0
 redis>=5.0.0
 aiokafka>=0.11.0


### PR DESCRIPTION
## Summary

- Add `gepa>=0.0.26` to requirements.txt
- `mlflow.genai.optimize.optimize_prompts()` requires gepa at runtime but mlflow-skinny doesn't bundle it

## Test plan

- [ ] `POST /v1/execute` no longer fails with "GEPA >= 0.0.26 is required" on Railway

🤖 Generated with [Claude Code](https://claude.com/claude-code)