### PR TITLE
fix(gepa): use correct MLflow model URI format

### DIFF
--- a/prompt-optimization-svc/app/services/gepa_optimizer.py
+++ b/prompt-optimization-svc/app/services/gepa_optimizer.py
@@ -41,7 +41,7 @@ class ZorvenGepaOptimizer:
     reflection model and per-agent budget limits.
     """
 
-    DEFAULT_REFLECTION_MODEL = "anthropic/claude-sonnet-4-6"
+    DEFAULT_REFLECTION_MODEL = "anthropic:/claude-sonnet-4-6"
 
     def __init__(
         self,


### PR DESCRIPTION
## Summary

- Fix reflection model URI from `anthropic/claude-sonnet-4-6` to `anthropic:/claude-sonnet-4-6`
- MLflow requires `<provider>:/<model-name>` format

## Test plan

- [ ] `POST /v1/execute` no longer fails with "Malformed model uri" on Railway

🤖 Generated with [Claude Code](https://claude.com/claude-code)