### PR TITLE
fix(mlflow): upgrade MLflow server from 2.21.0 to 3.12.0

### DIFF
--- a/deployment/docker/mlflow/Dockerfile
+++ b/deployment/docker/mlflow/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/mlflow/mlflow:v2.21.0
+FROM ghcr.io/mlflow/mlflow:v3.12.0
 
 # Install PostgreSQL driver for backend store
 RUN pip install --no-cache-dir psycopg2-binary


### PR DESCRIPTION
## Summary

- Upgrade MLflow server Docker image from `v2.21.0` to `v3.12.0`
- The mlflow-skinny client resolves to 3.12.0 and uses the `logged-models/search` API (added in 2.22+) which the 2.21.0 server does not support, causing 404 errors after GEPA optimization completes

## Risk

- **High impact**: This is a major version upgrade for the MLflow tracking server
- MLflow 3.x has breaking changes from 2.x — prompts API and tracking APIs may have changed
- All 23 agent services that load prompts from MLflow will be affected
- **Recommend testing in staging first**

## Test plan

- [ ] MLflow server starts successfully with v3.12.0
- [ ] `GET /health` shows mlflow as "up" on prompt-optimization-svc
- [ ] All agent services can still load prompts from MLflow
- [ ] `POST /v1/execute` completes GEPA optimization without logged-models 404
- [ ] Existing prompts and runs are preserved after upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)