### PR TITLE
feat(gepa): add Procfile for Celery worker and beat services

### DIFF
--- a/prompt-optimization-svc/Procfile
+++ b/prompt-optimization-svc/Procfile
@@ -1,0 +1,3 @@
+web: uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8110}
+worker: celery -A app.celery_app worker -l info --concurrency=2 --max-tasks-per-child=50
+beat: celery -A app.celery_app beat -l info


### PR DESCRIPTION
## Summary

- Add `Procfile` to prompt-optimization-svc with `web`, `worker`, and `beat` process types
- Enables Railway deployment of Celery worker (GEPA optimization tasks) and Beat scheduler (scheduled optimization runs, health checks)

## Test plan

- [ ] Railway worker service starts and connects to Redis broker
- [ ] Railway beat service starts and schedules tasks
- [ ] `POST /v1/optimize` dispatches task that worker picks up

🤖 Generated with [Claude Code](https://claude.com/claude-code)