### PR TITLE
feat(gepa): add start.sh for multi-process Dockerfile

### DIFF
--- a/prompt-optimization-svc/Dockerfile
+++ b/prompt-optimization-svc/Dockerfile
@@ -17,4 +17,7 @@ COPY . .
 
 EXPOSE 8110
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8110"]
+# Start script reads PROCESS_TYPE env var to select web/worker/beat
+COPY start.sh .
+RUN chmod +x start.sh
+CMD ["./start.sh"]

--- a/prompt-optimization-svc/start.sh
+++ b/prompt-optimization-svc/start.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+PROCESS="${PROCESS_TYPE:-web}"
+
+case "$PROCESS" in
+  worker)
+    echo "Starting Celery worker..."
+    exec celery -A app.celery_app worker -l info --concurrency=2 --max-tasks-per-child=50
+    ;;
+  beat)
+    echo "Starting Celery beat scheduler..."
+    exec celery -A app.celery_app beat -l info
+    ;;
+  *)
+    echo "Starting FastAPI web server..."
+    exec uvicorn app.main:app --host 0.0.0.0 --port "${PORT:-8110}"
+    ;;
+esac


### PR DESCRIPTION
## Summary

- Replace hardcoded `uvicorn` CMD in Dockerfile with `start.sh` script
- `PROCESS_TYPE` env var selects: `web` (default), `worker` (Celery), or `beat` (scheduler)
- Enables deploying Celery worker and beat as separate Railway services from the same Dockerfile

## Test plan

- [ ] Main service still starts uvicorn (PROCESS_TYPE unset = web default)
- [ ] Worker service starts Celery worker (PROCESS_TYPE=worker)
- [ ] Beat service starts Celery beat (PROCESS_TYPE=beat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)