### PR TITLE
feat(gepa): implement US-054 auto-generated baseline scorers

### DIFF
--- a/prompt-optimization-svc/app/scorers/scorer_generator.py
+++ b/prompt-optimization-svc/app/scorers/scorer_generator.py
@@ -1,0 +1,59 @@
+"""Auto-generate baseline scorers from skill output_schema (US-054).
+
+For each prompt in an optimization group, looks up the matching skill
+via SkillRegistryReader, then uses BaselineScorerFactory to create
+field-presence, max-length, enum-compliance, and schema-completeness
+scorers from the skill's output_schema.
+"""
+
+import logging
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def generate_baseline_scorers(
+    group_name: str,
+    skill_reader=None,
+) -> list[Callable]:
+    """Generate baseline scorers for all prompts in an optimization group.
+
+    Args:
+        group_name: Optimization group name (e.g., "wf1-discovery-pipeline").
+        skill_reader: Optional SkillRegistryReader instance. Created if None.
+
+    Returns:
+        Flat list of scorer callables generated from output schemas.
+        Returns empty list if no skills match or on any error.
+    """
+    from app.registries.optimization_groups import get_group
+    from app.scorers.baseline.factory import BaselineScorerFactory
+    from app.services.skill_registry_reader import SkillRegistryReader
+
+    reader = skill_reader or SkillRegistryReader()
+    factory = BaselineScorerFactory(reader)
+
+    group = get_group(group_name)
+    scorers: list[Callable] = []
+
+    for i, prompt_name in enumerate(group.prompt_names):
+        agent_code = group.agent_codes[min(i, len(group.agent_codes) - 1)]
+        try:
+            prompt_scorers = factory.create_scorers_for_prompt(agent_code, prompt_name)
+            if prompt_scorers:
+                scorers.extend(prompt_scorers)
+                logger.debug(
+                    "Generated %d baseline scorers for %s/%s",
+                    len(prompt_scorers),
+                    agent_code,
+                    prompt_name,
+                )
+        except Exception as exc:
+            logger.warning(
+                "Failed to generate baseline scorers for %s/%s: %s",
+                agent_code,
+                prompt_name,
+                exc,
+            )
+
+    return scorers

--- a/prompt-optimization-svc/app/tasks/optimization_runner.py
+++ b/prompt-optimization-svc/app/tasks/optimization_runner.py
@@ -59,7 +59,11 @@ async def _run_optimization_pipeline(
     so it blocks the event loop — acceptable in a Celery worker context
     where only one task runs per prefork.
     """
-    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+    from sqlalchemy.ext.asyncio import (
+        AsyncSession,
+        async_sessionmaker,
+        create_async_engine,
+    )
 
     from app.cache.prompt_cache import PromptCacheManager
     from app.core.config import settings
@@ -216,6 +220,20 @@ async def _run_optimization_pipeline(
         except Exception as exc:
             logger.warning("Reflection context enricher unavailable: %s", exc)
 
+        # US-054: Auto-generate baseline scorers from skill output schemas
+        try:
+            from app.scorers.scorer_generator import generate_baseline_scorers
+
+            baseline_scorers = generate_baseline_scorers(group_name, skill_reader)
+            if baseline_scorers:
+                scorers = list(scorers) + baseline_scorers
+                logger.info(
+                    "Added %d baseline scorers from output schemas",
+                    len(baseline_scorers),
+                )
+        except Exception as exc:
+            logger.warning("Baseline scorer generation failed (non-fatal): %s", exc)
+
         joint_opt = JointOptimizer(
             gepa_optimizer=gepa,
             registry=registry,
@@ -238,9 +256,11 @@ async def _run_optimization_pipeline(
         )
 
         # Extract best prompt text from joint result (primary prompt)
-        best_prompt_text = opt_result.prompt_results.get(
-            group.prompt_names[0], ""
-        ) if opt_result.prompt_results else ""
+        best_prompt_text = (
+            opt_result.prompt_results.get(group.prompt_names[0], "")
+            if opt_result.prompt_results
+            else ""
+        )
 
         if opt_result.error:
             await run_lcm.transition(

--- a/prompt-optimization-svc/tests/test_scorer_generator.py
+++ b/prompt-optimization-svc/tests/test_scorer_generator.py
@@ -1,0 +1,102 @@
+"""Tests for the auto-generated baseline scorer module (US-054)."""
+
+from app.registries.optimization_groups import OPTIMIZATION_GROUPS
+from app.scorers.scorer_generator import generate_baseline_scorers
+
+
+class TestScorerGeneratorModule:
+    """Verify scorer_generator module exists and has the correct API."""
+
+    def test_module_importable(self):
+        import importlib
+
+        mod = importlib.import_module("app.scorers.scorer_generator")
+        assert hasattr(mod, "generate_baseline_scorers")
+
+    def test_function_is_callable(self):
+        assert callable(generate_baseline_scorers)
+
+
+class TestGenerateBaselineScorers:
+    """Test generate_baseline_scorers for known optimization groups."""
+
+    def test_returns_list(self):
+        result = generate_baseline_scorers("wf1-discovery-pipeline")
+        assert isinstance(result, list)
+
+    def test_scorers_are_callable(self):
+        scorers = generate_baseline_scorers("wf1-discovery-pipeline")
+        for scorer in scorers:
+            assert callable(scorer), f"Scorer {scorer} is not callable"
+
+    def test_generates_for_all_groups(self):
+        """Each group should produce at least some baseline scorers."""
+        for group_name in OPTIMIZATION_GROUPS:
+            scorers = generate_baseline_scorers(group_name)
+            assert isinstance(scorers, list), f"Group {group_name} returned non-list"
+
+    def test_invalid_group_raises(self):
+        """Invalid group name should raise KeyError from get_group."""
+        import pytest
+
+        with pytest.raises(KeyError):
+            generate_baseline_scorers("nonexistent-group")
+
+
+class TestBaselineScorerOutput:
+    """Test that generated scorers produce valid Feedback objects."""
+
+    def test_scorer_returns_feedback(self):
+        scorers = generate_baseline_scorers("wf1-discovery-pipeline")
+        if not scorers:
+            return  # Skip if no skills matched
+
+        scorer = scorers[0]
+        feedback = scorer(
+            inputs={"key": "value"},
+            outputs='{"field": "value"}',
+            expectations="expected",
+        )
+        assert hasattr(feedback, "value")
+        assert hasattr(feedback, "name")
+        assert 0.0 <= feedback.value <= 1.0
+
+    def test_scorer_handles_empty_output(self):
+        scorers = generate_baseline_scorers("wf1-discovery-pipeline")
+        if not scorers:
+            return
+
+        scorer = scorers[0]
+        feedback = scorer(inputs={}, outputs="", expectations="")
+        assert feedback.value == 0.0
+
+    def test_scorer_handles_non_json_output(self):
+        scorers = generate_baseline_scorers("wf1-discovery-pipeline")
+        if not scorers:
+            return
+
+        scorer = scorers[0]
+        feedback = scorer(inputs={}, outputs="not json at all", expectations="")
+        assert feedback.value == 0.0
+
+
+class TestScorerGeneratorWiring:
+    """Verify scorer generator is wired into the optimization runner."""
+
+    def test_runner_imports_generator(self):
+        with open("app/tasks/optimization_runner.py") as f:
+            source = f.read()
+        assert "generate_baseline_scorers" in source
+        assert "from app.scorers.scorer_generator import" in source
+
+    def test_runner_adds_baseline_scorers(self):
+        with open("app/tasks/optimization_runner.py") as f:
+            source = f.read()
+        assert "baseline_scorers" in source
+        assert "Added %d baseline scorers" in source
+
+    def test_runner_handles_generator_failure(self):
+        """Generator failure must be non-fatal."""
+        with open("app/tasks/optimization_runner.py") as f:
+            source = f.read()
+        assert "Baseline scorer generation failed (non-fatal)" in source


### PR DESCRIPTION
## Summary

- Create `app/scorers/scorer_generator.py` — glue module connecting `BaselineScorerFactory` to the optimization runner
- Auto-generate field-presence, max-length, enum-compliance, and schema-completeness scorers from each skill's `output_schema`
- Wire into `optimization_runner.py` after `SkillRegistryReader` creation — baseline scorers appended to task scorer list before GEPA runs
- Non-fatal: if generation fails, optimization proceeds with manual scorers only

**Implements:** US-054 (Auto-generate baseline scorers)

## Test plan

- [x] 12 new tests covering module import, scorer generation for all groups, Feedback output, wiring verification
- [x] All existing optimization_runner tests still pass
- [ ] Integration test with real skills.yaml and MLflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)