### PR TITLE
feat(discovery): wire prompt loader and cache invalidator

### DIFF
--- a/discovery-agent-svc/app/core/config.py
+++ b/discovery-agent-svc/app/core/config.py
@@ -43,6 +43,11 @@ class Settings(BaseSettings):
     # Rate limiting
     RATE_LIMIT_PER_MINUTE: int = 10
 
+    # Prompt optimization (empty MLFLOW_TRACKING_URI = fallback-only mode)
+    PROMPT_CACHE_REDIS_URL: str = "redis://localhost:6379/2"
+    MLFLOW_TRACKING_URI: str = ""
+    PROMPT_FALLBACK_ONLY: bool = True
+
     # GCS (empty = stub mode)
     GCS_PROJECT_ID: str = ""
     GCS_BUCKET_NAME: str = ""

--- a/discovery-agent-svc/app/main.py
+++ b/discovery-agent-svc/app/main.py
@@ -19,6 +19,8 @@ from app.cache.redis_manager import RedisManager
 from app.core.config import settings
 from app.core.logging_config import setup_logging
 from app.messaging.kafka_producer import TraceProducer
+from app.prompts.invalidator import PromptCacheInvalidator
+from app.prompts.loader import AgentPromptClient
 from app.scrapers.factory import ScraperFactory
 from app.services.discovery_executor import DiscoveryExecutor
 
@@ -47,6 +49,21 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     trace_producer = TraceProducer(settings.KAFKA_BOOTSTRAP_SERVERS)
     await trace_producer.start()
 
+    # Initialize prompt loader (three-tier: Redis cache → MLflow → fallback)
+    prompt_loader = AgentPromptClient(
+        redis_url=settings.PROMPT_CACHE_REDIS_URL,
+        mlflow_uri=settings.MLFLOW_TRACKING_URI,
+        fallback_only=settings.PROMPT_FALLBACK_ONLY,
+    )
+    await prompt_loader.start()
+
+    # Initialize prompt cache invalidator (Kafka consumer)
+    prompt_invalidator = PromptCacheInvalidator(
+        bootstrap_servers=settings.KAFKA_BOOTSTRAP_SERVERS,
+        prompt_loader=prompt_loader,
+    )
+    await prompt_invalidator.start()
+
     # Initialize executor
     executor = DiscoveryExecutor(
         search_engine=search_engine,
@@ -65,6 +82,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     yield
 
     # Shutdown
+    await prompt_invalidator.stop()
+    await prompt_loader.stop()
     await executor.close()
     routes.executor = None
     logger.info("Discovery Agent shut down")

--- a/discovery-agent-svc/app/prompts/invalidator.py
+++ b/discovery-agent-svc/app/prompts/invalidator.py
@@ -1,0 +1,117 @@
+"""Prompt cache invalidation consumer (AC-3).
+
+Subscribes to prompt-lifecycle-events Kafka topic and invalidates
+local prompt cache when a prompt is promoted to PRODUCTION.
+"""
+
+import asyncio
+import json
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class PromptCacheInvalidator:
+    """Kafka consumer that invalidates cached prompts on promotion events."""
+
+    TOPIC = "prompt-lifecycle-events"
+    GROUP_ID = "prompt-cache-invalidator-discovery"
+
+    def __init__(
+        self,
+        bootstrap_servers: str,
+        prompt_loader: Any,
+    ) -> None:
+        self.bootstrap_servers = bootstrap_servers
+        self.prompt_loader = prompt_loader
+        self._consumer: Any = None
+        self._task: Optional[asyncio.Task] = None
+
+    async def start(self) -> None:
+        """Start consuming prompt lifecycle events."""
+        if not self.bootstrap_servers:
+            logger.info("Kafka disabled — PromptCacheInvalidator in no-op mode")
+            return
+        try:
+            from aiokafka import AIOKafkaConsumer
+
+            self._consumer = AIOKafkaConsumer(
+                self.TOPIC,
+                bootstrap_servers=self.bootstrap_servers,
+                group_id=self.GROUP_ID,
+                auto_offset_reset="latest",
+                value_deserializer=lambda v: json.loads(v.decode("utf-8")),
+            )
+            await asyncio.wait_for(self._consumer.start(), timeout=10.0)
+            self._task = asyncio.create_task(self._consume_loop())
+            logger.info(
+                "PromptCacheInvalidator started (topic=%s, group=%s)",
+                self.TOPIC,
+                self.GROUP_ID,
+            )
+        except Exception as exc:
+            logger.warning("PromptCacheInvalidator failed: %s — no-op mode", exc)
+            if self._consumer is not None:
+                try:
+                    await self._consumer.stop()
+                except Exception:
+                    pass
+            self._consumer = None
+
+    async def stop(self) -> None:
+        """Stop the consumer and background task."""
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+        if self._consumer is not None:
+            try:
+                await self._consumer.stop()
+            except Exception as exc:
+                logger.warning("Error stopping PromptCacheInvalidator: %s", exc)
+            self._consumer = None
+
+    async def _consume_loop(self) -> None:
+        """Background loop that polls Kafka and handles events."""
+        try:
+            async for msg in self._consumer:
+                await self.handle_event(msg.value)
+        except asyncio.CancelledError:
+            pass
+        except Exception as exc:
+            logger.error("PromptCacheInvalidator consume error: %s", exc)
+
+    async def handle_event(self, event: dict) -> None:
+        """Handle a prompt lifecycle event."""
+        event_type = event.get("event_type", "")
+        prompt_name = event.get("prompt_name", "")
+
+        if event_type == "prompt.promoted" and prompt_name:
+            logger.info("Invalidating cache for promoted prompt: %s", prompt_name)
+            if self.prompt_loader and hasattr(self.prompt_loader, "_redis"):
+                try:
+                    r = self.prompt_loader._redis
+                    if r:
+                        deleted = 0
+                        batch = []
+                        async for key in r.scan_iter(match=f"prompt:{prompt_name}:*"):
+                            batch.append(key)
+                            if len(batch) >= 100:
+                                await r.delete(*batch)
+                                deleted += len(batch)
+                                batch = []
+                        if batch:
+                            await r.delete(*batch)
+                            deleted += len(batch)
+                        if deleted:
+                            logger.info(
+                                "Invalidated %d cache keys for %s",
+                                deleted,
+                                prompt_name,
+                            )
+                except Exception as exc:
+                    logger.warning("Cache invalidation failed: %s", exc)

--- a/discovery-agent-svc/app/prompts/loader.py
+++ b/discovery-agent-svc/app/prompts/loader.py
@@ -1,0 +1,258 @@
+"""Lightweight prompt loader client for agent services.
+
+This module provides a self-contained async prompt loader that agents
+copy into their own codebase. It connects to Redis DB 2 (prompt cache)
+and MLflow tracking server independently of the prompt-optimization-svc.
+
+Usage in an agent service:
+    loader = AgentPromptClient(redis_url="redis://redis:6379/2", mlflow_uri="http://mlflow-server:5000")
+    await loader.start()
+    prompt = await loader.load("zorven-<wf>-<agent>-system", tenant_id="t-1", fallback="You are...")
+    await loader.stop()
+"""
+
+import asyncio
+import logging
+import re
+from typing import Any, Optional
+
+import httpx
+import redis.asyncio as aioredis
+
+logger = logging.getLogger(__name__)
+
+_MLFLOW_VAR_PATTERN = re.compile(r"\{\{(\w[\w.]*)\}\}")
+_PLACEHOLDER_PATTERN = re.compile(r"\{([\w.]+)\}")
+
+
+class AgentPromptClient:
+    """Async prompt loader for agent services.
+
+    Three-tier resolution: Redis cache → MLflow API → fallback.
+    """
+
+    def __init__(
+        self,
+        redis_url: str = "redis://localhost:6379/2",
+        mlflow_uri: str = "http://mlflow-server:5000",
+        default_ttl: int = 300,
+        critical_agent: bool = False,
+        fallback_only: bool = True,
+    ) -> None:
+        self.redis_url = redis_url
+        self.mlflow_uri = mlflow_uri
+        self.default_ttl = default_ttl
+        self.critical_agent = critical_agent
+        self.fallback_only = fallback_only
+        self._redis: Optional[aioredis.Redis] = None
+        self._http: Optional[httpx.AsyncClient] = None
+
+    async def start(self) -> None:
+        """Initialize Redis and HTTP connections."""
+        try:
+            self._redis = aioredis.from_url(
+                self.redis_url,
+                decode_responses=True,
+                socket_connect_timeout=5,
+            )
+            await asyncio.wait_for(self._redis.ping(), timeout=5.0)
+            logger.info("Prompt cache connected: %s", self.redis_url)
+        except Exception as exc:
+            logger.warning("Prompt cache unavailable: %s", exc)
+            self._redis = None
+
+        if self.mlflow_uri:
+            try:
+                self._http = httpx.AsyncClient(base_url=self.mlflow_uri, timeout=5.0)
+                resp = await self._http.get("/health")
+                if resp.status_code == 200:
+                    logger.info("Prompt service connected: %s", self.mlflow_uri)
+                else:
+                    logger.warning(
+                        "Prompt service unhealthy (%d) — disabled", resp.status_code
+                    )
+                    await self._http.aclose()
+                    self._http = None
+            except Exception as exc:
+                logger.warning("Prompt service unavailable: %s — disabled", exc)
+                if self._http:
+                    await self._http.aclose()
+                self._http = None
+        else:
+            logger.info(
+                "Prompt service URI not configured — prompt loader in fallback-only mode"
+            )
+
+        logger.info(
+            "Prompt loader initialized (fallback_only=%s, redis=%s, mlflow=%s)",
+            self.fallback_only,
+            self._redis is not None,
+            self._http is not None,
+        )
+
+    async def stop(self) -> None:
+        """Close connections."""
+        if self._redis:
+            await self._redis.aclose()
+            self._redis = None
+        if self._http:
+            await self._http.aclose()
+            self._http = None
+
+    async def load(
+        self,
+        name: str,
+        tenant_id: Optional[str] = None,
+        variables: Optional[dict[str, Any]] = None,
+        fallback: str = "",
+        ttl: Optional[int] = None,
+    ) -> str:
+        """Load a prompt with three-tier resolution.
+
+        Args:
+            name: Prompt name (§3.1 convention).
+            tenant_id: Optional tenant for override.
+            variables: Template variables.
+            fallback: Hardcoded fallback if all tiers fail.
+            ttl: Cache TTL in seconds.
+
+        Returns:
+            Formatted prompt string.
+        """
+        # Fallback-only mode: bypass Redis cache and MLflow entirely.
+        # Guarantees behavior identical to pre-prompt-loader code.
+        if self.fallback_only:
+            return self._format(fallback, variables) if fallback else ""
+
+        resolve_ttl = self.default_ttl if ttl is None else ttl
+        template = None
+
+        # Tier 1: Redis cache
+        template = await self._cache_get(name, tenant_id)
+        if template is not None:
+            logger.info(
+                "Loaded prompt '%s' from Redis cache (tenant=%s)", name, tenant_id
+            )
+
+        # Tier 2: MLflow API
+        if template is None:
+            template = await self._mlflow_get(name, tenant_id)
+            if template is not None:
+                logger.info(
+                    "Loaded prompt '%s' from MLflow (tenant=%s)", name, tenant_id
+                )
+                await self._cache_set(name, template, resolve_ttl, tenant_id)
+
+        # Tier 3: Fallback
+        if template is None:
+            logger.info(
+                "Prompt '%s' not found in cache/MLflow, using fallback (tenant=%s)",
+                name,
+                tenant_id,
+            )
+            if fallback:
+                if self.critical_agent:
+                    logger.warning(
+                        "CRITICAL AGENT FALLBACK: prompt '%s' (tenant=%s) "
+                        "— MLflow and Redis both unreachable, using "
+                        "hardcoded fallback.",
+                        name,
+                        tenant_id,
+                    )
+                else:
+                    logger.debug("Using fallback for prompt '%s'", name)
+            template = fallback
+
+        return self._format(template, variables)
+
+    # --- Tier 1: Redis cache ---
+
+    async def _cache_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
+        if self._redis is None:
+            return None
+        try:
+            if tenant_id:
+                key = f"prompt:{name}:tenant:{tenant_id}"
+                val = await self._redis.get(key)
+                if val is not None:
+                    return val
+            key = f"prompt:{name}:production"
+            return await self._redis.get(key)
+        except Exception:
+            return None
+
+    async def _cache_set(
+        self,
+        name: str,
+        template: str,
+        ttl: int,
+        tenant_id: Optional[str],
+    ) -> None:
+        if self._redis is None:
+            return
+        try:
+            if tenant_id:
+                key = f"prompt:{name}:tenant:{tenant_id}"
+            else:
+                key = f"prompt:{name}:production"
+            await self._redis.set(key, template, ex=ttl)
+        except Exception:
+            pass
+
+    # --- Tier 2: Prompt Optimization Service API ---
+
+    async def _mlflow_get(self, name: str, tenant_id: Optional[str]) -> Optional[str]:
+        if self._http is None:
+            return None
+        try:
+            # Try tenant-specific prompt first
+            if tenant_id:
+                template = await self._fetch_prompt(name, tenant_id=tenant_id)
+                if template is not None:
+                    return template
+
+            # Try base prompt (no tenant override)
+            return await self._fetch_prompt(name)
+        except Exception as exc:
+            logger.warning("Prompt service fetch failed for '%s': %s", name, exc)
+            return None
+
+    async def _fetch_prompt(
+        self, name: str, tenant_id: Optional[str] = None
+    ) -> Optional[str]:
+        """Fetch a prompt template from the prompt-optimization-svc API.
+
+        Calls GET /v1/prompts/{name}/production which returns the
+        PRODUCTION-state template directly.
+        """
+        try:
+            headers = {}
+            if tenant_id:
+                headers["X-Tenant-ID"] = str(tenant_id)
+
+            resp = await self._http.get(
+                f"/v1/prompts/{name}/production",
+                headers=headers,
+            )
+            if resp.status_code == 200:
+                data = resp.json()
+                return data.get("template")
+            return None
+        except Exception:
+            return None
+
+    # --- Template formatting ---
+
+    @staticmethod
+    def _format(template: str, variables: Optional[dict[str, Any]]) -> str:
+        if not template or not variables:
+            return template
+
+        converted = _MLFLOW_VAR_PATTERN.sub(r"{\1}", template)
+        stringified = {k: str(v) for k, v in variables.items()}
+
+        def _replace(match: re.Match) -> str:
+            key = match.group(1)
+            return stringified.get(key, match.group(0))
+
+        return _PLACEHOLDER_PATTERN.sub(_replace, converted)


### PR DESCRIPTION
## Summary

- Add `AgentPromptClient` and `PromptCacheInvalidator` to `discovery-agent-svc` — the only agent service without prompt optimization integration
- Copy self-contained loader from `market-research-agent-svc` (three-tier: Redis cache -> MLflow API -> fallback)
- Add `DISCOVERY_PROMPT_CACHE_REDIS_URL`, `DISCOVERY_MLFLOW_TRACKING_URI`, `DISCOVERY_PROMPT_FALLBACK_ONLY` config settings
- Default to `PROMPT_FALLBACK_ONLY=True` (safe rollout — identical to pre-loader behavior)
- Wire into lifespan with proper startup/shutdown ordering

All 15 agents now have prompt optimization loader integration.

## Test plan

- [x] All 126 existing discovery-agent-svc tests pass
- [x] Syntax verification on all modified files
- [ ] Integration test: verify prompt loading from Redis cache with `PROMPT_FALLBACK_ONLY=False`

🤖 Generated with [Claude Code](https://claude.com/claude-code)