### PR TITLE
docs(config): annotate dead config settings as reserved

### DIFF
--- a/prompt-optimization-svc/app/core/config.py
+++ b/prompt-optimization-svc/app/core/config.py
@@ -98,7 +98,8 @@ class Settings(BaseSettings):
     # Logging
     LOG_LEVEL: str = "INFO"
 
-    # Service auth
+    # Service auth — reserved for future JWT-based service authentication.
+    # Currently unused: RBAC uses X-User-Role header directly.
     SERVICE_TOKEN: str = ""
     JWT_SECRET: str = ""
 


### PR DESCRIPTION
## Summary

- Add clarifying comment to `SERVICE_TOKEN` and `JWT_SECRET` in `config.py` marking them as reserved for future JWT-based service authentication
- These settings are defined but never read by auth code — RBAC uses `X-User-Role` header directly
- Not removed to avoid breaking deployments that set `POI_SERVICE_TOKEN` in env vars

**Note on coverage:** Current test coverage is 65.46% (above the 60% threshold). US-058's 80% target requires separate targeted coverage work for uncovered modules like `optimization_runner.py` internals, `predict_fns/factory.py`, and `kafka/campaign_trigger.py`.

## Test plan

- [x] No functional changes — comment-only update
- [x] All 2,300 passing tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)