### PR TITLE
feat(docker): GHCR publishing pipeline with production compose

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,387 @@
+# ==============================================================================
+# Build and publish all Docker images to GitHub Container Registry (GHCR)
+# Triggered on push to main or manual dispatch
+# ==============================================================================
+name: Publish Docker Images
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'ai-brand-automator/**'
+      - 'ai-brand-automator-frontend/**'
+      - 'pipeline-orchestrator-svc/**'
+      - 'discovery-agent-svc/**'
+      - 'intelligence-agent-svc/**'
+      - 'chat-titling-worker/**'
+      - 'content-agent-service/**'
+      - 'social-agent-service/**'
+      - 'rag-uploader-agent-service/**'
+      - 'brand-equity-calculator-svc/**'
+      - 'market-research-agent-svc/**'
+      - 'competitor-intel-agent-svc/**'
+      - 'audience-persona-agent-svc/**'
+      - 'trend-cultural-agent-svc/**'
+      - 'voc-agent-svc/**'
+      - 'brand-positioning-agent-svc/**'
+      - 'brand-architecture-agent-svc/**'
+      - 'brand-personality-agent-svc/**'
+      - 'brand-naming-agent-svc/**'
+      - 'brand-story-agent-svc/**'
+      - 'campaign-architecture-agent-svc/**'
+      - 'creative-generation-agent-svc/**'
+      - 'ad-publishing-agent-svc/**'
+      - 'campaign-optimization-agent-svc/**'
+      - 'intelligence-loop-agent-svc/**'
+      - 'odoo-mcp-server-svc/**'
+      - 'odoo-worker-agent-svc/**'
+      - 'prompt-optimization-svc/**'
+      - 'deployment/docker/**'
+  workflow_dispatch:
+    inputs:
+      build_all:
+        description: 'Build all images regardless of changes'
+        required: false
+        default: 'true'
+        type: boolean
+
+env:
+  REGISTRY: ghcr.io
+  REGISTRY_PREFIX: ghcr.io/naveenah
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  # --------------------------------------------------------------------------
+  # Detect which services changed (skip on workflow_dispatch with build_all)
+  # --------------------------------------------------------------------------
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+      orchestrator: ${{ steps.filter.outputs.orchestrator }}
+      discovery: ${{ steps.filter.outputs.discovery }}
+      intelligence: ${{ steps.filter.outputs.intelligence }}
+      titling: ${{ steps.filter.outputs.titling }}
+      content: ${{ steps.filter.outputs.content }}
+      social: ${{ steps.filter.outputs.social }}
+      rag-uploader: ${{ steps.filter.outputs.rag-uploader }}
+      brand-equity: ${{ steps.filter.outputs.brand-equity }}
+      market-research: ${{ steps.filter.outputs.market-research }}
+      competitor-intel: ${{ steps.filter.outputs.competitor-intel }}
+      audience-persona: ${{ steps.filter.outputs.audience-persona }}
+      trend-cultural: ${{ steps.filter.outputs.trend-cultural }}
+      voc: ${{ steps.filter.outputs.voc }}
+      brand-positioning: ${{ steps.filter.outputs.brand-positioning }}
+      brand-architecture: ${{ steps.filter.outputs.brand-architecture }}
+      brand-personality: ${{ steps.filter.outputs.brand-personality }}
+      brand-naming: ${{ steps.filter.outputs.brand-naming }}
+      brand-story: ${{ steps.filter.outputs.brand-story }}
+      campaign-architecture: ${{ steps.filter.outputs.campaign-architecture }}
+      creative-generation: ${{ steps.filter.outputs.creative-generation }}
+      ad-publishing: ${{ steps.filter.outputs.ad-publishing }}
+      campaign-optimization: ${{ steps.filter.outputs.campaign-optimization }}
+      intelligence-loop: ${{ steps.filter.outputs.intelligence-loop }}
+      odoo-mcp: ${{ steps.filter.outputs.odoo-mcp }}
+      odoo-worker: ${{ steps.filter.outputs.odoo-worker }}
+      prompt-optimization: ${{ steps.filter.outputs.prompt-optimization }}
+      kong: ${{ steps.filter.outputs.kong }}
+      mlflow: ${{ steps.filter.outputs.mlflow }}
+      build_all: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.build_all == 'true' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'ai-brand-automator/**'
+              - 'deployment/docker/backend/**'
+              - 'deployment/docker/celery-worker/**'
+              - 'deployment/docker/celery-beat/**'
+            frontend:
+              - 'ai-brand-automator-frontend/**'
+              - 'deployment/docker/frontend/**'
+            orchestrator:
+              - 'pipeline-orchestrator-svc/**'
+            discovery:
+              - 'discovery-agent-svc/**'
+            intelligence:
+              - 'intelligence-agent-svc/**'
+            titling:
+              - 'chat-titling-worker/**'
+            content:
+              - 'content-agent-service/**'
+            social:
+              - 'social-agent-service/**'
+            rag-uploader:
+              - 'rag-uploader-agent-service/**'
+            brand-equity:
+              - 'brand-equity-calculator-svc/**'
+            market-research:
+              - 'market-research-agent-svc/**'
+            competitor-intel:
+              - 'competitor-intel-agent-svc/**'
+            audience-persona:
+              - 'audience-persona-agent-svc/**'
+            trend-cultural:
+              - 'trend-cultural-agent-svc/**'
+            voc:
+              - 'voc-agent-svc/**'
+            brand-positioning:
+              - 'brand-positioning-agent-svc/**'
+            brand-architecture:
+              - 'brand-architecture-agent-svc/**'
+            brand-personality:
+              - 'brand-personality-agent-svc/**'
+            brand-naming:
+              - 'brand-naming-agent-svc/**'
+            brand-story:
+              - 'brand-story-agent-svc/**'
+            campaign-architecture:
+              - 'campaign-architecture-agent-svc/**'
+            creative-generation:
+              - 'creative-generation-agent-svc/**'
+            ad-publishing:
+              - 'ad-publishing-agent-svc/**'
+            campaign-optimization:
+              - 'campaign-optimization-agent-svc/**'
+            intelligence-loop:
+              - 'intelligence-loop-agent-svc/**'
+            odoo-mcp:
+              - 'odoo-mcp-server-svc/**'
+            odoo-worker:
+              - 'odoo-worker-agent-svc/**'
+            prompt-optimization:
+              - 'prompt-optimization-svc/**'
+            kong:
+              - 'deployment/docker/kong/**'
+            mlflow:
+              - 'deployment/docker/mlflow/**'
+
+  # --------------------------------------------------------------------------
+  # Build and push images (only changed services, or all on manual trigger)
+  # --------------------------------------------------------------------------
+  build-and-push:
+    runs-on: ubuntu-latest
+    needs: changes
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Backend (shared image for backend, backend-ws, celery, mcp-server, consumers)
+          - service: backend
+            image: zorven-backend
+            context: .
+            dockerfile: deployment/docker/backend/Dockerfile
+            changed: ${{ needs.changes.outputs.backend }}
+          - service: celery-worker
+            image: zorven-celery-worker
+            context: .
+            dockerfile: deployment/docker/celery-worker/Dockerfile
+            changed: ${{ needs.changes.outputs.backend }}
+          - service: celery-beat
+            image: zorven-celery-beat
+            context: .
+            dockerfile: deployment/docker/celery-beat/Dockerfile
+            changed: ${{ needs.changes.outputs.backend }}
+          # Frontend
+          - service: frontend
+            image: zorven-frontend
+            context: .
+            dockerfile: deployment/docker/frontend/Dockerfile
+            changed: ${{ needs.changes.outputs.frontend }}
+          # Infrastructure
+          - service: kong
+            image: zorven-kong
+            context: deployment
+            dockerfile: deployment/docker/kong/Dockerfile
+            changed: ${{ needs.changes.outputs.kong }}
+          - service: mlflow-server
+            image: zorven-mlflow-server
+            context: deployment
+            dockerfile: deployment/docker/mlflow/Dockerfile
+            changed: ${{ needs.changes.outputs.mlflow }}
+          # Orchestrator
+          - service: orchestrator
+            image: zorven-orchestrator
+            context: pipeline-orchestrator-svc
+            dockerfile: pipeline-orchestrator-svc/Dockerfile
+            changed: ${{ needs.changes.outputs.orchestrator }}
+          # WF1 Agents
+          - service: discovery-agent
+            image: zorven-discovery-agent
+            context: discovery-agent-svc
+            dockerfile: discovery-agent-svc/Dockerfile
+            changed: ${{ needs.changes.outputs.discovery }}
+          - service: market-research-agent
+            image: zorven-market-research-agent
+            context: market-research-agent-svc
+            dockerfile: market-research-agent-svc/Dockerfile
+            changed: ${{ needs.changes.outputs.market-research }}
+          - service: competitor-intel-agent
+            image: zorven-competitor-intel-agent
+            context: competitor-intel-agent-svc
+            dockerfile: competitor-intel-agent-svc/Dockerfile
+            changed: ${{ needs.changes.outputs.competitor-intel }}
+          - service: audience-persona-agent
+            image: zorven-audience-persona-agent
+            context: audience-persona-agent-svc
+            dockerfile: audience-persona-agent-svc/Dockerfile
+            changed: ${{ needs.changes.outputs.audience-persona }}
+          - service: trend-cultural-agent
+            image: zorven-trend-cultural-agent
+            context: trend-cultural-agent-svc
+            dockerfile: trend-cultural-agent-svc/Dockerfile
+            changed: ${{ needs.changes.outputs.trend-cultural }}
+          - service: voc-agent
+            image: zorven-voc-agent
+            context: voc-agent-svc
+            dockerfile: voc-agent-svc/Dockerfile
+            changed: ${{ needs.changes.outputs.voc }}
+          - service: intelligence-agent
+            image: zorven-intelligence-agent
+            context: intelligence-agent-svc
+            dockerfile: intelligence-agent-svc/Dockerfile
+            changed: ${{ needs.changes.outputs.intelligence }}
+          # WF2 Agents
+          - service: brand-positioning-agent
+            image: zorven-brand-positioning-agent
+            context: brand-positioning-agent-svc
+            dockerfile: brand-positioning-agent-svc/Dockerfile
+            changed: ${{ needs.changes.outputs.brand-positioning }}
+          - service: brand-architecture-agent
+            image: zorven-brand-architecture-agent
+            context: brand-architecture-agent-svc
+            dockerfile: brand-architecture-agent-svc/Dockerfile
+            changed: ${{ needs.changes.outputs.brand-architecture }}
+          - service: brand-personality-agent
+            image: zorven-brand-personality-agent
+            context: brand-personality-agent-svc
+            dockerfile: brand-personality-agent-svc/Dockerfile
+            changed: ${{ needs.changes.outputs.brand-personality }}
+          - service: brand-naming-agent
+            image: zorven-brand-naming-agent
+            context: brand-naming-agent-svc
+            dockerfile: brand-naming-agent-svc/Dockerfile
+            changed: ${{ needs.changes.outputs.brand-naming }}
+          - service: brand-story-agent
+            image: zorven-brand-story-agent
+            context: brand-story-agent-svc
+            dockerfile: brand-story-agent-svc/Dockerfile
+            changed: ${{ needs.changes.outputs.brand-story }}
+          # WF3 Agents
+          - service: campaign-architecture-agent
+            image: zorven-campaign-architecture-agent
+            context: campaign-architecture-agent-svc
+            dockerfile: campaign-architecture-agent-svc/Dockerfile
+            changed: ${{ needs.changes.outputs.campaign-architecture }}
+          - service: creative-generation-agent
+            image: zorven-creative-generation-agent
+            context: creative-generation-agent-svc
+            dockerfile: creative-generation-agent-svc/Dockerfile
+            changed: ${{ needs.changes.outputs.creative-generation }}
+          - service: ad-publishing-agent
+            image: zorven-ad-publishing-agent
+            context: ad-publishing-agent-svc
+            dockerfile: ad-publishing-agent-svc/Dockerfile
+            changed: ${{ needs.changes.outputs.ad-publishing }}
+          - service: campaign-optimization-agent
+            image: zorven-campaign-optimization-agent
+            context: campaign-optimization-agent-svc
+            dockerfile: campaign-optimization-agent-svc/Dockerfile
+            changed: ${{ needs.changes.outputs.campaign-optimization }}
+          - service: intelligence-loop-agent
+            image: zorven-intelligence-loop-agent
+            context: intelligence-loop-agent-svc
+            dockerfile: intelligence-loop-agent-svc/Dockerfile
+            changed: ${{ needs.changes.outputs.intelligence-loop }}
+          # Support Services
+          - service: chat-titling-worker
+            image: zorven-chat-titling-worker
+            context: chat-titling-worker
+            dockerfile: chat-titling-worker/Dockerfile
+            changed: ${{ needs.changes.outputs.titling }}
+          - service: content-agent
+            image: zorven-content-agent
+            context: content-agent-service
+            dockerfile: content-agent-service/Dockerfile
+            changed: ${{ needs.changes.outputs.content }}
+          - service: social-agent
+            image: zorven-social-agent
+            context: social-agent-service
+            dockerfile: social-agent-service/Dockerfile
+            changed: ${{ needs.changes.outputs.social }}
+          - service: rag-uploader-agent
+            image: zorven-rag-uploader-agent
+            context: rag-uploader-agent-service
+            dockerfile: rag-uploader-agent-service/Dockerfile
+            changed: ${{ needs.changes.outputs.rag-uploader }}
+          - service: brand-equity-calculator
+            image: zorven-brand-equity-calculator
+            context: brand-equity-calculator-svc
+            dockerfile: brand-equity-calculator-svc/Dockerfile
+            changed: ${{ needs.changes.outputs.brand-equity }}
+          # Odoo Integration
+          - service: odoo-mcp-server
+            image: zorven-odoo-mcp-server
+            context: odoo-mcp-server-svc
+            dockerfile: odoo-mcp-server-svc/Dockerfile
+            changed: ${{ needs.changes.outputs.odoo-mcp }}
+          - service: odoo-worker-agent
+            image: zorven-odoo-worker-agent
+            context: odoo-worker-agent-svc
+            dockerfile: odoo-worker-agent-svc/Dockerfile
+            changed: ${{ needs.changes.outputs.odoo-worker }}
+          # Prompt Optimization
+          - service: prompt-optimization
+            image: zorven-prompt-optimization
+            context: prompt-optimization-svc
+            dockerfile: prompt-optimization-svc/Dockerfile
+            changed: ${{ needs.changes.outputs.prompt-optimization }}
+    steps:
+      - name: Skip if unchanged
+        if: matrix.changed != 'true' && needs.changes.outputs.build_all != 'true'
+        run: echo "Skipping ${{ matrix.service }} — no changes detected"
+
+      - name: Checkout
+        if: matrix.changed == 'true' || needs.changes.outputs.build_all == 'true'
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        if: matrix.changed == 'true' || needs.changes.outputs.build_all == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: matrix.changed == 'true' || needs.changes.outputs.build_all == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        if: matrix.changed == 'true' || needs.changes.outputs.build_all == 'true'
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_PREFIX }}/${{ matrix.image }}
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix=
+            type=ref,event=branch
+
+      - name: Build and push
+        if: matrix.changed == 'true' || needs.changes.outputs.build_all == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/ad-publishing-agent-svc/.dockerignore
+++ b/ad-publishing-agent-svc/.dockerignore
@@ -1,0 +1,16 @@
+__pycache__
+*.pyc
+*.pyo
+.git
+.gitignore
+.env
+.env.*
+.venv
+venv/
+tests/
+*.md
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.DS_Store
+docker-compose.yml

--- a/audience-persona-agent-svc/.dockerignore
+++ b/audience-persona-agent-svc/.dockerignore
@@ -1,0 +1,16 @@
+__pycache__
+*.pyc
+*.pyo
+.git
+.gitignore
+.env
+.env.*
+.venv
+venv/
+tests/
+*.md
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.DS_Store
+docker-compose.yml

--- a/brand-architecture-agent-svc/.dockerignore
+++ b/brand-architecture-agent-svc/.dockerignore
@@ -1,0 +1,16 @@
+__pycache__
+*.pyc
+*.pyo
+.git
+.gitignore
+.env
+.env.*
+.venv
+venv/
+tests/
+*.md
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.DS_Store
+docker-compose.yml

--- a/brand-equity-calculator-svc/.dockerignore
+++ b/brand-equity-calculator-svc/.dockerignore
@@ -1,0 +1,16 @@
+__pycache__
+*.pyc
+*.pyo
+.git
+.gitignore
+.env
+.env.*
+.venv
+venv/
+tests/
+*.md
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.DS_Store
+docker-compose.yml

--- a/brand-naming-agent-svc/.dockerignore
+++ b/brand-naming-agent-svc/.dockerignore
@@ -1,0 +1,16 @@
+__pycache__
+*.pyc
+*.pyo
+.git
+.gitignore
+.env
+.env.*
+.venv
+venv/
+tests/
+*.md
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.DS_Store
+docker-compose.yml

--- a/brand-personality-agent-svc/.dockerignore
+++ b/brand-personality-agent-svc/.dockerignore
@@ -1,0 +1,16 @@
+__pycache__
+*.pyc
+*.pyo
+.git
+.gitignore
+.env
+.env.*
+.venv
+venv/
+tests/
+*.md
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.DS_Store
+docker-compose.yml

--- a/brand-positioning-agent-svc/.dockerignore
+++ b/brand-positioning-agent-svc/.dockerignore
@@ -1,0 +1,16 @@
+__pycache__
+*.pyc
+*.pyo
+.git
+.gitignore
+.env
+.env.*
+.venv
+venv/
+tests/
+*.md
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.DS_Store
+docker-compose.yml

--- a/brand-story-agent-svc/.dockerignore
+++ b/brand-story-agent-svc/.dockerignore
@@ -1,0 +1,16 @@
+__pycache__
+*.pyc
+*.pyo
+.git
+.gitignore
+.env
+.env.*
+.venv
+venv/
+tests/
+*.md
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.DS_Store
+docker-compose.yml

--- a/campaign-architecture-agent-svc/.dockerignore
+++ b/campaign-architecture-agent-svc/.dockerignore
@@ -1,0 +1,16 @@
+__pycache__
+*.pyc
+*.pyo
+.git
+.gitignore
+.env
+.env.*
+.venv
+venv/
+tests/
+*.md
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.DS_Store
+docker-compose.yml

--- a/campaign-optimization-agent-svc/.dockerignore
+++ b/campaign-optimization-agent-svc/.dockerignore
@@ -1,0 +1,16 @@
+__pycache__
+*.pyc
+*.pyo
+.git
+.gitignore
+.env
+.env.*
+.venv
+venv/
+tests/
+*.md
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.DS_Store
+docker-compose.yml

--- a/chat-titling-worker/.dockerignore
+++ b/chat-titling-worker/.dockerignore
@@ -1,0 +1,16 @@
+__pycache__
+*.pyc
+*.pyo
+.git
+.gitignore
+.env
+.env.*
+.venv
+venv/
+tests/
+*.md
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.DS_Store
+docker-compose.yml

--- a/competitor-intel-agent-svc/.dockerignore
+++ b/competitor-intel-agent-svc/.dockerignore
@@ -1,0 +1,16 @@
+__pycache__
+*.pyc
+*.pyo
+.git
+.gitignore
+.env
+.env.*
+.venv
+venv/
+tests/
+*.md
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.DS_Store
+docker-compose.yml

--- a/content-agent-service/.dockerignore
+++ b/content-agent-service/.dockerignore
@@ -1,0 +1,16 @@
+__pycache__
+*.pyc
+*.pyo
+.git
+.gitignore
+.env
+.env.*
+.venv
+venv/
+tests/
+*.md
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.DS_Store
+docker-compose.yml

--- a/creative-generation-agent-svc/.dockerignore
+++ b/creative-generation-agent-svc/.dockerignore
@@ -1,0 +1,16 @@
+__pycache__
+*.pyc
+*.pyo
+.git
+.gitignore
+.env
+.env.*
+.venv
+venv/
+tests/
+*.md
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.DS_Store
+docker-compose.yml

--- a/deployment/.env.production.template
+++ b/deployment/.env.production.template
@@ -19,8 +19,9 @@ DEBUG=False
 # Allowed hosts - Comma separated list
 ALLOWED_HOSTS=*.railway.app,your-custom-domain.com
 
-# Database - Neon PostgreSQL connection string
-DATABASE_URL=postgresql://user:password@host:5432/dbname?sslmode=require
+# Database - Neon PostgreSQL (PRODUCTION branch)
+# Dev branch uses ep-delicate-unit-* pooler; prod uses ep-lively-sun-* pooler
+DATABASE_URL=postgresql://neondb_owner:<password>@ep-lively-sun-aek04lw0-pooler.c-2.us-east-2.aws.neon.tech/neondb?sslmode=require&channel_binding=require
 
 # ==========================================================================
 # Redis / Celery

--- a/deployment/docker-compose.production.yml
+++ b/deployment/docker-compose.production.yml
@@ -1,0 +1,854 @@
+# ==============================================================================
+# Production Docker Compose — Pull-only deployment
+# No build contexts needed. Just: docker compose -f docker-compose.production.yml pull && up -d
+# Requires: .env with all API keys and DATABASE_URL set
+# ==============================================================================
+
+services:
+  # --- Infrastructure ---
+  redis:
+    image: redis:7-alpine
+    container_name: zorven-redis
+    command: redis-server --appendonly yes --maxmemory 512mb --maxmemory-policy allkeys-lru --databases 27
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_volume:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  mlflow-db:
+    image: postgres:15-alpine
+    container_name: zorven-mlflow-db
+    environment:
+      - POSTGRES_DB=mlflow
+      - POSTGRES_USER=mlflow
+      - POSTGRES_PASSWORD=${MLFLOW_DB_PASSWORD:-mlflow}
+    volumes:
+      - mlflow_postgres_volume:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U mlflow -d mlflow"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  mlflow-server:
+    image: ghcr.io/naveenah/zorven-mlflow-server:latest
+    container_name: zorven-mlflow
+    environment:
+      - MLFLOW_BACKEND_STORE_URI=postgresql://mlflow:${MLFLOW_DB_PASSWORD:-mlflow}@mlflow-db:5432/mlflow
+      - MLFLOW_DEFAULT_ARTIFACT_ROOT=/mlflow/artifacts
+    ports:
+      - "${MLFLOW_HOST_PORT:-5050}:5000"
+    volumes:
+      - mlflow_artifacts_volume:/mlflow/artifacts
+    depends_on:
+      mlflow-db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:5000/health')"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  # --- Kong Gateway ---
+  kong:
+    image: ghcr.io/naveenah/zorven-kong:latest
+    container_name: zorven-kong
+    environment:
+      - KONG_DATABASE=off
+      - KONG_DECLARATIVE_CONFIG=/usr/local/kong/declarative/kong.yaml
+      - KONG_PROXY_LISTEN=0.0.0.0:8000
+      - KONG_ADMIN_LISTEN=0.0.0.0:8001
+      - KONG_PROXY_ACCESS_LOG=/dev/stdout
+      - KONG_PROXY_ERROR_LOG=/dev/stderr
+      - KONG_PLUGINS=bundled,jwt,cors,request-transformer,rate-limiting,response-transformer
+      - JWT_SECRET_KEY=${SECRET_KEY}
+      - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:3000}
+    ports:
+      - "8000:8000"
+      - "8001:8001"
+    depends_on:
+      backend:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "kong", "health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  # --- Django Backend ---
+  backend:
+    image: ghcr.io/naveenah/zorven-backend:latest
+    container_name: zorven-backend
+    environment:
+      - DEBUG=False
+      - SECRET_KEY=${SECRET_KEY}
+      - DATABASE_URL=${DATABASE_URL}
+      - REDIS_URL=redis://redis:6379/0
+      - CELERY_BROKER_URL=redis://redis:6379/0
+      - CELERY_RESULT_BACKEND=redis://redis:6379/0
+      - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
+      - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY:-}
+      - STRIPE_WEBHOOK_SECRET=${STRIPE_WEBHOOK_SECRET:-}
+      - ALLOWED_HOSTS=${ALLOWED_HOSTS:-localhost,backend,kong}
+      - KONG_ENABLED=true
+      - PORT=8001
+      - ORCHESTRATOR_URL=http://orchestrator:8010
+      - ORCHESTRATOR_SERVICE_TOKEN=${ORCHESTRATOR_SERVICE_TOKEN}
+      - ORCHESTRATOR_CALLBACK_TOKEN=${ORCHESTRATOR_CALLBACK_TOKEN}
+      - BACKEND_URL=http://backend:8001
+      - CALLBACK_BASE_URL=http://backend:8001
+      - WORKER_TOKEN=${WORKER_TOKEN:-dev-worker-token}
+      - MAILGUN_API_KEY=${MAILGUN_API_KEY:-}
+      - MAILGUN_DOMAIN=${MAILGUN_DOMAIN:-}
+    expose:
+      - "8001"
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8001/health/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  backend-ws:
+    image: ghcr.io/naveenah/zorven-backend:latest
+    container_name: zorven-backend-ws
+    command: ["daphne", "brand_automator.asgi:application", "--port", "8002", "--bind", "0.0.0.0"]
+    environment:
+      - DEBUG=False
+      - SECRET_KEY=${SECRET_KEY}
+      - DATABASE_URL=${DATABASE_URL}
+      - REDIS_URL=redis://redis:6379/0
+      - CHANNELS_REDIS_URL=redis://redis:6379/0
+      - ALLOWED_HOSTS=${ALLOWED_HOSTS:-localhost,backend-ws,kong}
+      - KONG_ENABLED=true
+      - PORT=8002
+    expose:
+      - "8002"
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8002/health/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  # --- Frontend ---
+  frontend:
+    image: ghcr.io/naveenah/zorven-frontend:latest
+    container_name: zorven-frontend
+    environment:
+      - NODE_ENV=production
+      - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-http://localhost:8000}
+      - NEXT_PUBLIC_BRAND_EQUITY_API_URL=${NEXT_PUBLIC_BRAND_EQUITY_API_URL:-http://localhost:8090}
+    ports:
+      - "3000:3000"
+    depends_on:
+      kong:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/"]
+      interval: 60s
+      timeout: 30s
+      retries: 5
+      start_period: 60s
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  # --- Celery ---
+  celery-worker:
+    image: ghcr.io/naveenah/zorven-celery-worker:latest
+    container_name: zorven-celery-worker
+    environment:
+      - DEBUG=False
+      - SECRET_KEY=${SECRET_KEY}
+      - DATABASE_URL=${DATABASE_URL}
+      - REDIS_URL=redis://redis:6379/0
+      - CELERY_BROKER_URL=redis://redis:6379/0
+      - CELERY_RESULT_BACKEND=redis://redis:6379/0
+      - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
+      - ORCHESTRATOR_URL=http://orchestrator:8010
+      - ORCHESTRATOR_SERVICE_TOKEN=${ORCHESTRATOR_SERVICE_TOKEN}
+      - ORCHESTRATOR_CALLBACK_TOKEN=${ORCHESTRATOR_CALLBACK_TOKEN}
+      - BACKEND_URL=http://backend:8001
+    depends_on:
+      backend:
+        condition: service_healthy
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  celery-beat:
+    image: ghcr.io/naveenah/zorven-celery-beat:latest
+    container_name: zorven-celery-beat
+    environment:
+      - DEBUG=False
+      - SECRET_KEY=${SECRET_KEY}
+      - DATABASE_URL=${DATABASE_URL}
+      - CELERY_BROKER_URL=redis://redis:6379/0
+      - CELERY_RESULT_BACKEND=redis://redis:6379/0
+    depends_on:
+      backend:
+        condition: service_healthy
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  # --- Pipeline Orchestrator ---
+  orchestrator:
+    image: ghcr.io/naveenah/zorven-orchestrator:latest
+    container_name: zorven-orchestrator
+    environment:
+      - ORCHESTRATOR_SERVICE_TOKEN=${ORCHESTRATOR_SERVICE_TOKEN}
+      - ORCHESTRATOR_CALLBACK_TOKEN=${ORCHESTRATOR_CALLBACK_TOKEN}
+      - ORCHESTRATOR_CALLBACK_BASE_URL=http://backend:8001
+      - ORCHESTRATOR_REDIS_URL=redis://redis:6379/1
+      - ORCHESTRATOR_KAFKA_BOOTSTRAP_SERVERS=
+      - ORCHESTRATOR_GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
+      - ORCHESTRATOR_ODOO_WORKER_AGENT_URL=http://odoo-worker-agent:8100
+      - ORCHESTRATOR_MARKET_RESEARCH_AGENT_URL=http://market-research-agent:8021
+      - ORCHESTRATOR_COMPETITOR_INTEL_AGENT_URL=http://competitor-intel-agent:8022
+      - ORCHESTRATOR_AUDIENCE_PERSONA_AGENT_URL=http://audience-persona-agent:8023
+      - ORCHESTRATOR_TREND_CULTURAL_AGENT_URL=http://trend-cultural-agent:8024
+      - ORCHESTRATOR_VOC_AGENT_URL=http://voc-agent:8025
+    ports:
+      - "8010:8010"
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8010/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  # --- WF1 Agents ---
+  discovery-agent:
+    image: ghcr.io/naveenah/zorven-discovery-agent:latest
+    container_name: zorven-discovery-agent
+    environment:
+      - DISCOVERY_REDIS_URL=redis://redis:6379/2
+      - DISCOVERY_TAVILY_API_KEY=${TAVILY_API_KEY:-}
+      - DISCOVERY_GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
+      - DISCOVERY_TAVILY_MCP_SERVER_URL=${TAVILY_MCP_SERVER_URL:-}
+    ports:
+      - "8020:8020"
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8020/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  market-research-agent:
+    image: ghcr.io/naveenah/zorven-market-research-agent:latest
+    container_name: zorven-market-research-agent
+    environment:
+      - MRA_REDIS_URL=redis://redis:6379/11
+      - MRA_PROMPT_CACHE_REDIS_URL=redis://redis:6379/2
+      - MRA_MLFLOW_TRACKING_URI=http://mlflow-server:5000
+      - MRA_ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - MRA_TAVILY_API_KEY=${TAVILY_API_KEY:-}
+      - MRA_GNEWS_API_KEY=${GNEWS_API_KEY:-}
+      - MRA_TAVILY_MCP_SERVER_URL=${TAVILY_MCP_SERVER_URL:-}
+    ports:
+      - "8021:8021"
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8021/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  competitor-intel-agent:
+    image: ghcr.io/naveenah/zorven-competitor-intel-agent:latest
+    container_name: zorven-competitor-intel-agent
+    environment:
+      - CIA_REDIS_URL=redis://redis:6379/12
+      - CIA_PROMPT_CACHE_REDIS_URL=redis://redis:6379/2
+      - CIA_MLFLOW_TRACKING_URI=http://mlflow-server:5000
+      - CIA_ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - CIA_TAVILY_API_KEY=${TAVILY_API_KEY:-}
+      - CIA_TAVILY_MCP_SERVER_URL=${TAVILY_MCP_SERVER_URL:-}
+    ports:
+      - "8022:8022"
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8022/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  audience-persona-agent:
+    image: ghcr.io/naveenah/zorven-audience-persona-agent:latest
+    container_name: zorven-audience-persona-agent
+    environment:
+      - APA_REDIS_URL=redis://redis:6379/13
+      - APA_PROMPT_CACHE_REDIS_URL=redis://redis:6379/2
+      - APA_MLFLOW_TRACKING_URI=http://mlflow-server:5000
+      - APA_ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - APA_TAVILY_API_KEY=${TAVILY_API_KEY:-}
+      - APA_TAVILY_MCP_SERVER_URL=${TAVILY_MCP_SERVER_URL:-}
+    ports:
+      - "8023:8023"
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8023/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  trend-cultural-agent:
+    image: ghcr.io/naveenah/zorven-trend-cultural-agent:latest
+    container_name: zorven-trend-cultural-agent
+    environment:
+      - TCIA_REDIS_URL=redis://redis:6379/14
+      - TCIA_PROMPT_CACHE_REDIS_URL=redis://redis:6379/2
+      - TCIA_MLFLOW_TRACKING_URI=http://mlflow-server:5000
+      - TCIA_ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - TCIA_TAVILY_API_KEY=${TAVILY_API_KEY:-}
+      - TCIA_CORE_API_URL=http://backend:8001
+      - TCIA_TAVILY_MCP_SERVER_URL=${TAVILY_MCP_SERVER_URL:-}
+    ports:
+      - "8024:8024"
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8024/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  voc-agent:
+    image: ghcr.io/naveenah/zorven-voc-agent:latest
+    container_name: zorven-voc-agent
+    environment:
+      - VOCA_REDIS_URL=redis://redis:6379/15
+      - VOCA_PROMPT_CACHE_REDIS_URL=redis://redis:6379/2
+      - VOCA_MLFLOW_TRACKING_URI=http://mlflow-server:5000
+      - VOCA_ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - VOCA_TAVILY_API_KEY=${TAVILY_API_KEY:-}
+      - VOCA_CORE_API_URL=http://backend:8001
+      - VOCA_TAVILY_MCP_SERVER_URL=${TAVILY_MCP_SERVER_URL:-}
+    ports:
+      - "8025:8025"
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8025/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  intelligence-agent:
+    image: ghcr.io/naveenah/zorven-intelligence-agent:latest
+    container_name: zorven-intelligence-agent
+    environment:
+      - INTELLIGENCE_REDIS_URL=redis://redis:6379/3
+      - INTELLIGENCE_GEMINI_API_KEY=${GOOGLE_API_KEY:-}
+    ports:
+      - "8030:8030"
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8030/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  # --- WF2 Agents ---
+  brand-positioning-agent:
+    image: ghcr.io/naveenah/zorven-brand-positioning-agent:latest
+    container_name: zorven-brand-positioning
+    environment:
+      - BPA_REDIS_URL=redis://redis:6379/16
+      - BPA_PROMPT_CACHE_REDIS_URL=redis://redis:6379/2
+      - BPA_MLFLOW_TRACKING_URI=http://mlflow-server:5000
+      - BPA_ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - BPA_BACKEND_URL=http://backend:8001
+    ports:
+      - "8031:8031"
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8031/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  brand-architecture-agent:
+    image: ghcr.io/naveenah/zorven-brand-architecture-agent:latest
+    container_name: zorven-brand-architecture
+    environment:
+      - BAA_REDIS_URL=redis://redis:6379/17
+      - BAA_PROMPT_CACHE_REDIS_URL=redis://redis:6379/2
+      - BAA_MLFLOW_TRACKING_URI=http://mlflow-server:5000
+      - BAA_ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - BAA_BACKEND_URL=http://backend:8001
+    ports:
+      - "8032:8032"
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8032/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  brand-personality-agent:
+    image: ghcr.io/naveenah/zorven-brand-personality-agent:latest
+    container_name: zorven-brand-personality
+    environment:
+      - BPV_REDIS_URL=redis://redis:6379/18
+      - BPV_PROMPT_CACHE_REDIS_URL=redis://redis:6379/2
+      - BPV_MLFLOW_TRACKING_URI=http://mlflow-server:5000
+      - BPV_ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - BPV_BACKEND_URL=http://backend:8001
+    ports:
+      - "8033:8033"
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8033/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  brand-naming-agent:
+    image: ghcr.io/naveenah/zorven-brand-naming-agent:latest
+    container_name: zorven-brand-naming
+    environment:
+      - NTA_REDIS_URL=redis://redis:6379/19
+      - NTA_PROMPT_CACHE_REDIS_URL=redis://redis:6379/2
+      - NTA_MLFLOW_TRACKING_URI=http://mlflow-server:5000
+      - NTA_ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - NTA_BACKEND_URL=http://backend:8001
+    ports:
+      - "8034:8034"
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8034/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  brand-story-agent:
+    image: ghcr.io/naveenah/zorven-brand-story-agent:latest
+    container_name: zorven-brand-story
+    environment:
+      - BSA_REDIS_URL=redis://redis:6379/20
+      - BSA_PROMPT_CACHE_REDIS_URL=redis://redis:6379/2
+      - BSA_MLFLOW_TRACKING_URI=http://mlflow-server:5000
+      - BSA_ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - BSA_BACKEND_URL=http://backend:8001
+    ports:
+      - "8035:8035"
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8035/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  # --- WF3 Agents ---
+  campaign-architecture-agent:
+    image: ghcr.io/naveenah/zorven-campaign-architecture-agent:latest
+    container_name: zorven-campaign-architecture
+    environment:
+      - CAA_REDIS_URL=redis://redis:6379/21
+      - CAA_PROMPT_CACHE_REDIS_URL=redis://redis:6379/2
+      - CAA_MLFLOW_TRACKING_URI=http://mlflow-server:5000
+      - CAA_ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - CAA_BACKEND_URL=http://backend:8001
+    ports:
+      - "8041:8041"
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8041/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  creative-generation-agent:
+    image: ghcr.io/naveenah/zorven-creative-generation-agent:latest
+    container_name: zorven-creative-generation
+    environment:
+      - CGA_REDIS_URL=redis://redis:6379/22
+      - CGA_PROMPT_CACHE_REDIS_URL=redis://redis:6379/2
+      - CGA_MLFLOW_TRACKING_URI=http://mlflow-server:5000
+      - CGA_ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - CGA_GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
+      - CGA_BACKEND_URL=http://backend:8001
+    ports:
+      - "8042:8042"
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8042/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  ad-publishing-agent:
+    image: ghcr.io/naveenah/zorven-ad-publishing-agent:latest
+    container_name: zorven-ad-publishing
+    environment:
+      - ADPUB_REDIS_URL=redis://redis:6379/23
+      - ADPUB_PROMPT_CACHE_REDIS_URL=redis://redis:6379/2
+      - ADPUB_MLFLOW_TRACKING_URI=http://mlflow-server:5000
+      - ADPUB_ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - ADPUB_BACKEND_URL=http://backend:8001
+      - ADPUB_META_ADS_SANDBOX_MODE=true
+    ports:
+      - "8043:8043"
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8043/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  campaign-optimization-agent:
+    image: ghcr.io/naveenah/zorven-campaign-optimization-agent:latest
+    container_name: zorven-campaign-optimization
+    environment:
+      - COA_REDIS_URL=redis://redis:6379/24
+      - COA_PROMPT_CACHE_REDIS_URL=redis://redis:6379/2
+      - COA_MLFLOW_TRACKING_URI=http://mlflow-server:5000
+      - COA_ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - COA_BACKEND_URL=http://backend:8001
+      - COA_META_ADS_SANDBOX_MODE=true
+      - COA_CELERY_BROKER_URL=redis://redis:6379/24
+    ports:
+      - "8044:8044"
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8044/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  intelligence-loop-agent:
+    image: ghcr.io/naveenah/zorven-intelligence-loop-agent:latest
+    container_name: zorven-intelligence-loop
+    environment:
+      - ILA_REDIS_URL=redis://redis:6379/25
+      - ILA_PROMPT_CACHE_REDIS_URL=redis://redis:6379/2
+      - ILA_MLFLOW_TRACKING_URI=http://mlflow-server:5000
+      - ILA_ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - ILA_BACKEND_URL=http://backend:8001
+    ports:
+      - "8045:8045"
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8045/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  # --- Support Services ---
+  chat-titling-worker:
+    image: ghcr.io/naveenah/zorven-chat-titling-worker:latest
+    container_name: zorven-titling-worker
+    environment:
+      - TITLING_REDIS_URL=redis://redis:6379/4
+      - TITLING_GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
+      - TITLING_CORE_API_URL=http://backend:8001
+      - TITLING_WORKER_TOKEN=${WORKER_TOKEN:-dev-worker-token}
+    ports:
+      - "8040:8040"
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8040/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  content-agent:
+    image: ghcr.io/naveenah/zorven-content-agent:latest
+    container_name: zorven-content-agent
+    environment:
+      - CONTENT_REDIS_URL=redis://redis:6379/5
+      - CONTENT_GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
+      - CONTENT_CORE_API_URL=http://backend:8001
+      - CONTENT_CORE_API_TOKEN=${ORCHESTRATOR_SERVICE_TOKEN}
+    ports:
+      - "8050:8050"
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8050/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  social-agent:
+    image: ghcr.io/naveenah/zorven-social-agent:latest
+    container_name: zorven-social-agent
+    environment:
+      - SOCIAL_REDIS_URL=redis://redis:6379/6
+      - SOCIAL_GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
+      - SOCIAL_CORE_API_URL=http://backend:8001
+      - SOCIAL_CORE_API_TOKEN=${ORCHESTRATOR_SERVICE_TOKEN}
+    ports:
+      - "8060:8060"
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8060/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  rag-uploader-agent:
+    image: ghcr.io/naveenah/zorven-rag-uploader-agent:latest
+    container_name: zorven-rag-uploader
+    environment:
+      - UPLOADER_REDIS_URL=redis://redis:6379/7
+      - UPLOADER_GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
+      - UPLOADER_CORE_API_URL=http://backend:8001
+      - UPLOADER_CORE_API_TOKEN=${ORCHESTRATOR_SERVICE_TOKEN}
+    ports:
+      - "8070:8070"
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8070/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  brand-equity-calculator:
+    image: ghcr.io/naveenah/zorven-brand-equity-calculator:latest
+    container_name: zorven-brand-equity
+    environment:
+      - BRAND_EQUITY_REDIS_URL=redis://redis:6379/8
+      - BRAND_EQUITY_ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - BRAND_EQUITY_CORS_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:3000}
+    ports:
+      - "8090:8090"
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8090/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  # --- Odoo Integration ---
+  odoo-mcp-server:
+    image: ghcr.io/naveenah/zorven-odoo-mcp-server:latest
+    container_name: zorven-odoo-mcp
+    environment:
+      - ODOO_MCP_REDIS_URL=redis://redis:6379/9
+      - ODOO_MCP_ODOO_URL=${ODOO_URL:-http://odoo:8069}
+      - ODOO_MCP_DATABASE_URL=${DATABASE_URL}
+    ports:
+      - "8095:8095"
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8095/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  odoo-worker-agent:
+    image: ghcr.io/naveenah/zorven-odoo-worker-agent:latest
+    container_name: zorven-odoo-worker
+    environment:
+      - ODOO_WORKER_REDIS_URL=redis://redis:6379/10
+      - ODOO_WORKER_MCP_SERVER_URL=http://odoo-mcp-server:8095
+      - ODOO_WORKER_GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
+    ports:
+      - "8100:8100"
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8100/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+    networks:
+      - app-network
+
+  # --- Prompt Optimization ---
+  prompt-optimization:
+    image: ghcr.io/naveenah/zorven-prompt-optimization:latest
+    container_name: zorven-prompt-optimization
+    environment:
+      - POI_REDIS_URL=redis://redis:6379/26
+      - POI_PROMPT_CACHE_REDIS_URL=redis://redis:6379/2
+      - POI_ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - POI_MLFLOW_TRACKING_URI=http://mlflow-server:5000
+      - POI_DATABASE_URL=postgresql://mlflow:${MLFLOW_DB_PASSWORD:-mlflow}@mlflow-db:5432/mlflow
+    ports:
+      - "8110:8110"
+    depends_on:
+      redis:
+        condition: service_healthy
+      mlflow-server:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8110/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+    restart: unless-stopped
+    networks:
+      - app-network
+
+volumes:
+  redis_volume:
+  mlflow_postgres_volume:
+  mlflow_artifacts_volume:
+
+networks:
+  app-network:
+    driver: bridge

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     build:
       context: .
       dockerfile: docker/kong/Dockerfile
+    image: ghcr.io/naveenah/zorven-kong:latest
     container_name: ai-brand-automator-kong
     environment:
       - KONG_DATABASE=off
@@ -55,6 +56,7 @@ services:
     build:
       context: ..
       dockerfile: deployment/docker/backend/Dockerfile
+    image: ghcr.io/naveenah/zorven-backend:latest
     container_name: ai-brand-automator-backend
     command: ["bash", "/scripts/start.sh"]
     environment:
@@ -142,6 +144,7 @@ services:
     build:
       context: ..
       dockerfile: deployment/docker/backend/Dockerfile
+    image: ghcr.io/naveenah/zorven-backend:latest
     container_name: ai-brand-automator-backend-ws
     command: ["daphne", "brand_automator.asgi:application", "--port", "8002", "--bind", "0.0.0.0"]
     environment:
@@ -183,6 +186,7 @@ services:
         # Frontend now talks to Kong on port 8000
         - NEXT_PUBLIC_API_URL=http://localhost:8000
         - NEXT_PUBLIC_BRAND_EQUITY_API_URL=http://localhost:8090
+    image: ghcr.io/naveenah/zorven-frontend:latest
     container_name: ai-brand-automator-frontend
     command: ["sh", "-c", "npm install && npm run dev"]
     environment:
@@ -216,6 +220,7 @@ services:
     build:
       context: ..
       dockerfile: deployment/docker/celery-worker/Dockerfile
+    image: ghcr.io/naveenah/zorven-celery-worker:latest
     container_name: ai-brand-automator-celery-worker
     command: ["bash", "/scripts/start.sh"]
     environment:
@@ -278,6 +283,7 @@ services:
     build:
       context: ..
       dockerfile: deployment/docker/celery-beat/Dockerfile
+    image: ghcr.io/naveenah/zorven-celery-beat:latest
     container_name: ai-brand-automator-celery-beat
     command: ["bash", "/scripts/start.sh"]
     environment:
@@ -333,6 +339,7 @@ services:
     build:
       context: ..
       dockerfile: deployment/docker/nginx/Dockerfile
+    image: ghcr.io/naveenah/zorven-nginx:latest
     container_name: ai-brand-automator-nginx
     ports:
       - "80:80"
@@ -468,6 +475,7 @@ services:
     build:
       context: ..
       dockerfile: deployment/docker/backend/Dockerfile
+    image: ghcr.io/naveenah/zorven-backend:latest
     container_name: ai-brand-automator-ingestion-consumer
     command: ["python", "manage.py", "run_ingestion", "--batch-size", "10", "--poll-timeout", "1.0"]
     healthcheck:
@@ -510,6 +518,7 @@ services:
     build:
       context: ..
       dockerfile: deployment/docker/backend/Dockerfile
+    image: ghcr.io/naveenah/zorven-backend:latest
     container_name: ai-brand-automator-curation-consumer
     command: ["python", "manage.py", "run_curation_consumer", "--batch-size", "10", "--poll-timeout", "1.0"]
     healthcheck:
@@ -553,6 +562,7 @@ services:
     build:
       context: ..
       dockerfile: deployment/docker/backend/Dockerfile
+    image: ghcr.io/naveenah/zorven-backend:latest
     container_name: ai-brand-automator-rag-index-consumer
     command: ["python", "manage.py", "consume_sync_events", "--topic", "rag-sync-ready-topic", "--group", "rag-index-consumers", "--poll-timeout", "1.0"]
     healthcheck:
@@ -603,6 +613,7 @@ services:
     build:
       context: ../pipeline-orchestrator-svc
       dockerfile: Dockerfile
+    image: ghcr.io/naveenah/zorven-orchestrator:latest
     container_name: ai-brand-automator-orchestrator
     environment:
       - ORCHESTRATOR_SERVICE_TOKEN=${ORCHESTRATOR_SERVICE_TOKEN:-dev-service-token}
@@ -649,6 +660,7 @@ services:
     build:
       context: ../market-research-agent-svc
       dockerfile: Dockerfile
+    image: ghcr.io/naveenah/zorven-market-research-agent:latest
     container_name: ai-brand-automator-market-research-agent
     environment:
       - MRA_REDIS_URL=redis://redis:6379/11
@@ -692,6 +704,7 @@ services:
     build:
       context: ../competitor-intel-agent-svc
       dockerfile: Dockerfile
+    image: ghcr.io/naveenah/zorven-competitor-intel-agent:latest
     container_name: ai-brand-automator-competitor-intel-agent
     environment:
       - CIA_REDIS_URL=redis://redis:6379/12
@@ -738,6 +751,7 @@ services:
     build:
       context: ../audience-persona-agent-svc
       dockerfile: Dockerfile
+    image: ghcr.io/naveenah/zorven-audience-persona-agent:latest
     container_name: ai-brand-automator-audience-persona-agent
     environment:
       - APA_REDIS_URL=redis://redis:6379/13
@@ -786,6 +800,7 @@ services:
     build:
       context: ../trend-cultural-agent-svc
       dockerfile: Dockerfile
+    image: ghcr.io/naveenah/zorven-trend-cultural-agent:latest
     container_name: ai-brand-automator-trend-cultural-agent
     environment:
       - TCIA_REDIS_URL=redis://redis:6379/14
@@ -836,6 +851,7 @@ services:
     build:
       context: ../voc-agent-svc
       dockerfile: Dockerfile
+    image: ghcr.io/naveenah/zorven-voc-agent:latest
     container_name: ai-brand-automator-voc-agent
     environment:
       - VOCA_REDIS_URL=redis://redis:6379/15
@@ -883,6 +899,7 @@ services:
     build:
       context: ../discovery-agent-svc
       dockerfile: Dockerfile
+    image: ghcr.io/naveenah/zorven-discovery-agent:latest
     container_name: ai-brand-automator-discovery-agent
     environment:
       - DISCOVERY_REDIS_URL=redis://redis:6379/2
@@ -920,6 +937,7 @@ services:
     build:
       context: ../intelligence-agent-svc
       dockerfile: Dockerfile
+    image: ghcr.io/naveenah/zorven-intelligence-agent:latest
     container_name: ai-brand-automator-intelligence-agent
     environment:
       - INTELLIGENCE_REDIS_URL=redis://redis:6379/3
@@ -957,6 +975,7 @@ services:
     build:
       context: ../chat-titling-worker
       dockerfile: Dockerfile
+    image: ghcr.io/naveenah/zorven-chat-titling-worker:latest
     container_name: ai-brand-automator-titling-worker
     environment:
       - TITLING_REDIS_URL=redis://redis:6379/4
@@ -989,6 +1008,7 @@ services:
     build:
       context: ../content-agent-service
       dockerfile: Dockerfile
+    image: ghcr.io/naveenah/zorven-content-agent:latest
     container_name: ai-brand-automator-content-agent
     environment:
       - CONTENT_REDIS_URL=redis://redis:6379/5
@@ -1031,6 +1051,7 @@ services:
     build:
       context: ..
       dockerfile: deployment/docker/backend/Dockerfile
+    image: ghcr.io/naveenah/zorven-backend:latest
     container_name: ai-brand-automator-mcp-server
     command: ["python", "run_mcp_server.py", "--transport", "sse", "--port", "8085", "--host", "0.0.0.0"]
     environment:
@@ -1068,6 +1089,7 @@ services:
     build:
       context: ../social-agent-service
       dockerfile: Dockerfile
+    image: ghcr.io/naveenah/zorven-social-agent:latest
     container_name: ai-brand-automator-social-agent
     environment:
       - SOCIAL_REDIS_URL=redis://redis:6379/6
@@ -1106,6 +1128,7 @@ services:
     build:
       context: ../rag-uploader-agent-service
       dockerfile: Dockerfile
+    image: ghcr.io/naveenah/zorven-rag-uploader-agent:latest
     container_name: ai-brand-automator-rag-uploader
     environment:
       - UPLOADER_REDIS_URL=redis://redis:6379/7
@@ -1143,6 +1166,7 @@ services:
     build:
       context: ../odoo-mcp-server-svc
       dockerfile: Dockerfile
+    image: ghcr.io/naveenah/zorven-odoo-mcp-server:latest
     container_name: ai-brand-automator-odoo-mcp
     environment:
       - ODOO_MCP_REDIS_URL=redis://redis:6379/9
@@ -1184,6 +1208,7 @@ services:
     build:
       context: ../odoo-worker-agent-svc
       dockerfile: Dockerfile
+    image: ghcr.io/naveenah/zorven-odoo-worker-agent:latest
     container_name: ai-brand-automator-odoo-worker
     environment:
       - ODOO_WORKER_REDIS_URL=redis://redis:6379/10
@@ -1275,6 +1300,7 @@ services:
     build:
       context: ../brand-positioning-agent-svc
       dockerfile: Dockerfile
+    image: ghcr.io/naveenah/zorven-brand-positioning-agent:latest
     container_name: ai-brand-automator-brand-positioning
     environment:
       - BPA_REDIS_URL=redis://redis:6379/16
@@ -1314,6 +1340,7 @@ services:
     build:
       context: ../brand-architecture-agent-svc
       dockerfile: Dockerfile
+    image: ghcr.io/naveenah/zorven-brand-architecture-agent:latest
     container_name: ai-brand-automator-brand-architecture
     environment:
       - BAA_REDIS_URL=redis://redis:6379/17
@@ -1353,6 +1380,7 @@ services:
     build:
       context: ../brand-personality-agent-svc
       dockerfile: Dockerfile
+    image: ghcr.io/naveenah/zorven-brand-personality-agent:latest
     container_name: ai-brand-automator-brand-personality
     environment:
       - BPV_REDIS_URL=redis://redis:6379/18
@@ -1392,6 +1420,7 @@ services:
     build:
       context: ../brand-naming-agent-svc
       dockerfile: Dockerfile
+    image: ghcr.io/naveenah/zorven-brand-naming-agent:latest
     container_name: ai-brand-automator-brand-naming
     environment:
       - NTA_REDIS_URL=redis://redis:6379/19
@@ -1431,6 +1460,7 @@ services:
     build:
       context: ../brand-story-agent-svc
       dockerfile: Dockerfile
+    image: ghcr.io/naveenah/zorven-brand-story-agent:latest
     container_name: ai-brand-automator-brand-story
     environment:
       - BSA_REDIS_URL=redis://redis:6379/20
@@ -1471,6 +1501,7 @@ services:
     build:
       context: ../campaign-architecture-agent-svc
       dockerfile: Dockerfile
+    image: ghcr.io/naveenah/zorven-campaign-architecture-agent:latest
     container_name: ai-brand-automator-campaign-architecture
     environment:
       - CAA_REDIS_URL=redis://redis:6379/21
@@ -1513,6 +1544,7 @@ services:
     build:
       context: ../creative-generation-agent-svc
       dockerfile: Dockerfile
+    image: ghcr.io/naveenah/zorven-creative-generation-agent:latest
     container_name: ai-brand-automator-creative-generation
     environment:
       - CGA_REDIS_URL=redis://redis:6379/22
@@ -1555,6 +1587,7 @@ services:
     build:
       context: ../ad-publishing-agent-svc
       dockerfile: Dockerfile
+    image: ghcr.io/naveenah/zorven-ad-publishing-agent:latest
     container_name: ai-brand-automator-ad-publishing
     environment:
       - ADPUB_REDIS_URL=redis://redis:6379/23
@@ -1592,6 +1625,7 @@ services:
     build:
       context: ../campaign-optimization-agent-svc
       dockerfile: Dockerfile
+    image: ghcr.io/naveenah/zorven-campaign-optimization-agent:latest
     container_name: ai-brand-automator-campaign-optimization
     environment:
       - COA_REDIS_URL=redis://redis:6379/24
@@ -1628,6 +1662,7 @@ services:
     build:
       context: ../intelligence-loop-agent-svc
       dockerfile: Dockerfile
+    image: ghcr.io/naveenah/zorven-intelligence-loop-agent:latest
     container_name: ai-brand-automator-intelligence-loop
     environment:
       - ILA_REDIS_URL=redis://redis:6379/25
@@ -1691,23 +1726,24 @@ services:
     build:
       context: .
       dockerfile: docker/mlflow/Dockerfile
+    image: ghcr.io/naveenah/zorven-mlflow-server:latest
     container_name: ai-brand-automator-mlflow
     environment:
       - MLFLOW_BACKEND_STORE_URI=postgresql://mlflow:${MLFLOW_DB_PASSWORD:-mlflow}@mlflow-db:5432/mlflow
       - MLFLOW_DEFAULT_ARTIFACT_ROOT=/mlflow/artifacts
     ports:
-      - "5000:5000"
+      - "${MLFLOW_HOST_PORT:-5050}:5000"
     volumes:
       - mlflow_artifacts_volume:/mlflow/artifacts
     depends_on:
       mlflow-db:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5000/health"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:5000/health')"]
       interval: 30s
       timeout: 10s
-      retries: 3
-      start_period: 15s
+      retries: 5
+      start_period: 30s
     restart: unless-stopped
     networks:
       - app-network
@@ -1720,6 +1756,7 @@ services:
     build:
       context: ../prompt-optimization-svc
       dockerfile: Dockerfile
+    image: ghcr.io/naveenah/zorven-prompt-optimization:latest
     container_name: ai-brand-automator-prompt-optimization
     environment:
       - POI_REDIS_URL=redis://redis:6379/26
@@ -1761,6 +1798,7 @@ services:
     build:
       context: ../brand-equity-calculator-svc
       dockerfile: Dockerfile
+    image: ghcr.io/naveenah/zorven-brand-equity-calculator:latest
     container_name: ai-brand-automator-brand-equity
     environment:
       - BRAND_EQUITY_REDIS_URL=redis://redis:6379/8

--- a/discovery-agent-svc/.dockerignore
+++ b/discovery-agent-svc/.dockerignore
@@ -1,0 +1,16 @@
+__pycache__
+*.pyc
+*.pyo
+.git
+.gitignore
+.env
+.env.*
+.venv
+venv/
+tests/
+*.md
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.DS_Store
+docker-compose.yml

--- a/intelligence-agent-svc/.dockerignore
+++ b/intelligence-agent-svc/.dockerignore
@@ -1,0 +1,16 @@
+__pycache__
+*.pyc
+*.pyo
+.git
+.gitignore
+.env
+.env.*
+.venv
+venv/
+tests/
+*.md
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.DS_Store
+docker-compose.yml

--- a/intelligence-loop-agent-svc/.dockerignore
+++ b/intelligence-loop-agent-svc/.dockerignore
@@ -1,0 +1,16 @@
+__pycache__
+*.pyc
+*.pyo
+.git
+.gitignore
+.env
+.env.*
+.venv
+venv/
+tests/
+*.md
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.DS_Store
+docker-compose.yml

--- a/market-research-agent-svc/.dockerignore
+++ b/market-research-agent-svc/.dockerignore
@@ -1,0 +1,16 @@
+__pycache__
+*.pyc
+*.pyo
+.git
+.gitignore
+.env
+.env.*
+.venv
+venv/
+tests/
+*.md
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.DS_Store
+docker-compose.yml

--- a/odoo-mcp-server-svc/.dockerignore
+++ b/odoo-mcp-server-svc/.dockerignore
@@ -1,0 +1,16 @@
+__pycache__
+*.pyc
+*.pyo
+.git
+.gitignore
+.env
+.env.*
+.venv
+venv/
+tests/
+*.md
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.DS_Store
+docker-compose.yml

--- a/odoo-worker-agent-svc/.dockerignore
+++ b/odoo-worker-agent-svc/.dockerignore
@@ -1,0 +1,16 @@
+__pycache__
+*.pyc
+*.pyo
+.git
+.gitignore
+.env
+.env.*
+.venv
+venv/
+tests/
+*.md
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.DS_Store
+docker-compose.yml

--- a/pipeline-orchestrator-svc/.dockerignore
+++ b/pipeline-orchestrator-svc/.dockerignore
@@ -1,0 +1,17 @@
+__pycache__
+*.pyc
+*.pyo
+.git
+.gitignore
+.env
+.env.*
+.venv
+venv/
+tests/
+README.md
+CLAUDE.md
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.DS_Store
+docker-compose.yml

--- a/rag-uploader-agent-service/.dockerignore
+++ b/rag-uploader-agent-service/.dockerignore
@@ -1,0 +1,16 @@
+__pycache__
+*.pyc
+*.pyo
+.git
+.gitignore
+.env
+.env.*
+.venv
+venv/
+tests/
+*.md
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.DS_Store
+docker-compose.yml

--- a/social-agent-service/.dockerignore
+++ b/social-agent-service/.dockerignore
@@ -1,0 +1,16 @@
+__pycache__
+*.pyc
+*.pyo
+.git
+.gitignore
+.env
+.env.*
+.venv
+venv/
+tests/
+*.md
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.DS_Store
+docker-compose.yml

--- a/trend-cultural-agent-svc/.dockerignore
+++ b/trend-cultural-agent-svc/.dockerignore
@@ -1,0 +1,16 @@
+__pycache__
+*.pyc
+*.pyo
+.git
+.gitignore
+.env
+.env.*
+.venv
+venv/
+tests/
+*.md
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.DS_Store
+docker-compose.yml

--- a/voc-agent-svc/.dockerignore
+++ b/voc-agent-svc/.dockerignore
@@ -1,0 +1,16 @@
+__pycache__
+*.pyc
+*.pyo
+.git
+.gitignore
+.env
+.env.*
+.venv
+venv/
+tests/
+*.md
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.DS_Store
+docker-compose.yml


### PR DESCRIPTION
## Summary
- **GitHub Actions CI/CD workflow** for automated GHCR image publishing (34 unique images) with per-service change detection via `dorny/paths-filter` and Docker Buildx GHA cache
- **`docker-compose.production.yml`** — standalone pull-only deployment file (no build contexts, just `image:` refs to `ghcr.io/naveenah/zorven-*`)
- **GHCR image references** added to all 38 services in `docker-compose.yml`
- **`.dockerignore`** for all 25 microservices (optimized build contexts, pipeline-orchestrator preserves `skills/*.md`)
- **MLflow port fix** — host port `5000→5050` to avoid macOS AirPlay conflict
- **Production template** updated with Neon prod branch connection string

## How it works
1. Push to `main` triggers CI — only changed services are rebuilt and pushed to GHCR
2. Manual `workflow_dispatch` with `build_all=true` rebuilds everything
3. Images tagged with: `latest`, git SHA, branch name
4. Production deployment: `docker compose -f docker-compose.production.yml pull && up -d`

## All 34 images published to GHCR
All images verified pushed to `ghcr.io/naveenah/zorven-*:latest`

## Test plan
- [x] Built all 36 containers locally — all healthy
- [x] Authenticated to GHCR and pushed all 34 images successfully
- [x] Verified backend connectivity to Neon dev branch database
- [ ] Merge to main to trigger CI workflow and verify automated builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)