### PR TITLE
feat(ci): enable GHCR image builds on pull requests

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,11 +1,46 @@
 # ==============================================================================
 # Build and publish all Docker images to GitHub Container Registry (GHCR)
-# Triggered on push to main or manual dispatch
+# Triggered on push to main, pull requests, or manual dispatch
+#
+# - PR branches: builds & pushes with branch name + SHA tags (for local testing)
+# - main: builds & pushes with :latest + SHA + branch tags (production)
 # ==============================================================================
 name: Publish Docker Images
 
 on:
   push:
+    branches: [main]
+    paths:
+      - 'ai-brand-automator/**'
+      - 'ai-brand-automator-frontend/**'
+      - 'pipeline-orchestrator-svc/**'
+      - 'discovery-agent-svc/**'
+      - 'intelligence-agent-svc/**'
+      - 'chat-titling-worker/**'
+      - 'content-agent-service/**'
+      - 'social-agent-service/**'
+      - 'rag-uploader-agent-service/**'
+      - 'brand-equity-calculator-svc/**'
+      - 'market-research-agent-svc/**'
+      - 'competitor-intel-agent-svc/**'
+      - 'audience-persona-agent-svc/**'
+      - 'trend-cultural-agent-svc/**'
+      - 'voc-agent-svc/**'
+      - 'brand-positioning-agent-svc/**'
+      - 'brand-architecture-agent-svc/**'
+      - 'brand-personality-agent-svc/**'
+      - 'brand-naming-agent-svc/**'
+      - 'brand-story-agent-svc/**'
+      - 'campaign-architecture-agent-svc/**'
+      - 'creative-generation-agent-svc/**'
+      - 'ad-publishing-agent-svc/**'
+      - 'campaign-optimization-agent-svc/**'
+      - 'intelligence-loop-agent-svc/**'
+      - 'odoo-mcp-server-svc/**'
+      - 'odoo-worker-agent-svc/**'
+      - 'prompt-optimization-svc/**'
+      - 'deployment/docker/**'
+  pull_request:
     branches: [main]
     paths:
       - 'ai-brand-automator/**'
@@ -370,9 +405,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY_PREFIX }}/${{ matrix.image }}
           tags: |
-            type=raw,value=latest
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=sha,prefix=
             type=ref,event=branch
+            type=ref,event=pr
 
       - name: Build and push
         if: matrix.changed == 'true' || needs.changes.outputs.build_all == 'true'


### PR DESCRIPTION
## Summary
- Add `pull_request` trigger to `docker-publish.yml` so images are built and pushed to GHCR when a PR is created/updated
- `:latest` tag only applied on merge to `main` — PR builds get branch name, `pr-<number>`, and commit SHA tags
- Enables pre-merge local testing by pulling PR-tagged images from GHCR

## Developer workflow after this change
```bash
# 1. Push code to feature branch, create PR
# 2. CI builds & pushes images tagged with PR number
# 3. Pull the PR-tagged image locally to test:
docker pull ghcr.io/naveenah/zorven-discovery-agent:pr-123
# 4. If good → merge PR → CI rebuilds with :latest tag
```

## Test plan
- [ ] Create PR with a service change and verify CI builds the image with `pr-<N>` tag
- [ ] Merge to main and verify `:latest` tag is applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)