### PR TITLE
spike(oia): A-01 STT v2 streaming latency and diarization

### DIFF
--- a/spike-stt-v2/README.md
+++ b/spike-stt-v2/README.md
@@ -1,0 +1,62 @@
+# spike-stt-v2 — A-01: STT v2 Streaming Latency Spike
+
+Timeboxed 2-day spike measuring Google Cloud Speech-to-Text v2 streaming latency and diarization quality. Answers four questions before LIVE mode implementation begins (F-05, F-06).
+
+## Prerequisites
+
+1. **Enable Speech-to-Text API**:
+   ```bash
+   gcloud services enable speech.googleapis.com
+   ```
+
+2. **Set environment variables**:
+   ```bash
+   export OIA_SPIKE_PROJECT_ID=your-gcp-project-id
+   # Optional: export OIA_SPIKE_CREDENTIALS_JSON='{"type":"service_account",...}'
+   # Optional: export OIA_SPIKE_CREDENTIALS_PATH=/path/to/sa.json
+   # Default: uses Application Default Credentials (gcloud auth application-default login)
+   ```
+
+3. **Create recognizer resources** (one-time):
+   ```bash
+   pip install -r requirements.txt
+   python create_recognizers.py
+   ```
+
+## Run the Spike Relay
+
+```bash
+pip install -r requirements.txt
+uvicorn main:app --host 0.0.0.0 --port 8120
+```
+
+Open http://localhost:8120 in Chrome. Select a recognizer, click **Start Session**, and speak. The page shows real-time latency measurements.
+
+## Run Tests
+
+```bash
+# Unit + property tests (no GCP required)
+cd spike-stt-v2
+pytest tests/test_measurement.py tests/test_stt_client.py -v
+
+# Integration tests (requires GCP credentials + recognizer resources)
+pytest tests/test_stt_integration.py tests/test_e2e_relay.py -v -m integration
+
+# All tests
+pytest tests/ -v
+```
+
+## Acceptance Criteria
+
+| AC | Question | Metric |
+|----|----------|--------|
+| AC-1 | Streaming latency ≤ 2s? | p95 of utterance-onset → first-partial |
+| AC-2 | Diarization works? Labels survive reconnect? | Misattribution rate, label stability |
+| AC-3 | Cost per 60-min meeting? | $/hour (streaming + diarization + backfill) |
+| AC-4 | Fixed vs auto language? | Latency/cost delta between recognizers |
+
+## Deliverables
+
+- `docs/spikes/A-01-stt-v2-measurement-note.md` — measurement report
+- `docs/decisions/OD-002-stt-language-mode.md` — language mode ADR
+- `tests/fixtures/two_speaker_onboarding_sample.wav` — audio fixture for F-05 tests

--- a/spike-stt-v2/create_recognizers.py
+++ b/spike-stt-v2/create_recognizers.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""One-time script to create STT v2 recognizer resources for the A-01 spike.
+
+Usage:
+    export OIA_SPIKE_PROJECT_ID=your-gcp-project-id
+    python create_recognizers.py [--location us-central1]
+
+Creates two recognizers:
+  1. oia-spike-en-us  — fixed English, diarization enabled
+  2. oia-spike-auto   — multi-language, diarization enabled
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+from stt_client import STTConfig, create_recognizer
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Create STT v2 recognizer resources")
+    parser.add_argument(
+        "--location",
+        default="us-central1",
+        help="GCP location for recognizers (default: us-central1)",
+    )
+    parser.add_argument(
+        "--project-id",
+        default=os.environ.get("OIA_SPIKE_PROJECT_ID", ""),
+        help="GCP project ID (or set OIA_SPIKE_PROJECT_ID env var)",
+    )
+    parser.add_argument(
+        "--credentials-json",
+        default=os.environ.get("OIA_SPIKE_CREDENTIALS_JSON", ""),
+        help="Service account JSON string (optional)",
+    )
+    args = parser.parse_args()
+
+    if not args.project_id:
+        logger.error(
+            "Project ID required. Set OIA_SPIKE_PROJECT_ID or pass --project-id"
+        )
+        sys.exit(1)
+
+    config = STTConfig(
+        project_id=args.project_id,
+        location=args.location,
+        credentials_json=args.credentials_json,
+    )
+
+    # 1. Fixed English recognizer
+    logger.info("Creating fixed-language recognizer (en-US)...")
+    name_en = create_recognizer(
+        config=config,
+        recognizer_id="oia-spike-en-us",
+        language_codes=["en-US"],
+        enable_diarization=True,
+    )
+    logger.info("  -> %s", name_en)
+
+    # 2. Multi-language recognizer
+    logger.info("Creating multi-language recognizer...")
+    name_auto = create_recognizer(
+        config=config,
+        recognizer_id="oia-spike-auto",
+        language_codes=["en-US", "es-US", "fr-FR", "de-DE"],
+        enable_diarization=True,
+    )
+    logger.info("  -> %s", name_auto)
+
+    print()
+    print("=" * 60)
+    print("Recognizers ready. Use these in the spike relay:")
+    print(f"  Fixed:  ?recognizer=oia-spike-en-us")
+    print(f"  Auto:   ?recognizer=oia-spike-auto")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/spike-stt-v2/index.html
+++ b/spike-stt-v2/index.html
@@ -1,0 +1,375 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>A-01 — STT v2 Spike</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #1a1a2e; color: #e0e0e0; padding: 24px;
+    }
+    h1 { color: #00d4ff; margin-bottom: 8px; }
+    h2 { color: #8888cc; margin: 16px 0 8px; font-size: 1.1em; }
+    .controls { display: flex; gap: 12px; margin: 16px 0; flex-wrap: wrap; }
+    button {
+      padding: 10px 20px; border: none; border-radius: 6px;
+      font-size: 14px; cursor: pointer; font-weight: 600;
+    }
+    button:disabled { opacity: 0.4; cursor: not-allowed; }
+    .btn-start { background: #00c853; color: #000; }
+    .btn-stop { background: #ff1744; color: #fff; }
+    .btn-reconnect { background: #ff9100; color: #000; }
+    .btn-record { background: #651fff; color: #fff; }
+    .btn-stats { background: #2979ff; color: #fff; }
+    .status {
+      padding: 8px 16px; border-radius: 4px; margin: 8px 0;
+      font-family: monospace; font-size: 13px;
+    }
+    .status-ok { background: #1b5e20; }
+    .status-err { background: #b71c1c; }
+    .status-idle { background: #333; }
+    .config { margin: 12px 0; }
+    .config label { margin-right: 8px; }
+    .config select, .config input {
+      background: #2a2a4a; color: #e0e0e0; border: 1px solid #444;
+      padding: 6px 10px; border-radius: 4px;
+    }
+    #transcript {
+      background: #0d0d1a; border: 1px solid #333; border-radius: 6px;
+      padding: 12px; min-height: 120px; max-height: 300px; overflow-y: auto;
+      font-family: monospace; font-size: 13px; margin: 12px 0;
+      white-space: pre-wrap;
+    }
+    table {
+      width: 100%; border-collapse: collapse; margin: 12px 0;
+      font-size: 13px;
+    }
+    th { background: #2a2a4a; padding: 8px; text-align: left; }
+    td { padding: 6px 8px; border-bottom: 1px solid #222; }
+    .pass { color: #00c853; font-weight: bold; }
+    .marginal { color: #ff9100; font-weight: bold; }
+    .fail { color: #ff1744; font-weight: bold; }
+    #stats-summary {
+      background: #1a1a3a; border: 1px solid #444; border-radius: 6px;
+      padding: 16px; margin: 12px 0; font-family: monospace;
+    }
+    .counter { font-size: 1.2em; color: #00d4ff; margin: 8px 0; }
+  </style>
+</head>
+<body>
+  <h1>A-01 — STT v2 Streaming Latency Spike</h1>
+  <p>Measures end-to-end latency from utterance onset to first partial transcript.</p>
+
+  <div class="config">
+    <label for="recognizer">Recognizer:</label>
+    <select id="recognizer">
+      <option value="oia-spike-en-us">Fixed English (oia-spike-en-us)</option>
+      <option value="oia-spike-auto">Multi-language (oia-spike-auto)</option>
+    </select>
+  </div>
+
+  <div class="controls">
+    <button class="btn-start" id="btnStart" onclick="startSession()">Start Session</button>
+    <button class="btn-stop" id="btnStop" onclick="stopSession()" disabled>Stop</button>
+    <button class="btn-reconnect" id="btnReconnect" onclick="testReconnect()" disabled>Test Reconnect</button>
+    <button class="btn-record" id="btnRecord" onclick="toggleFixtureRecording()">Record Fixture</button>
+    <button class="btn-stats" onclick="showStats()">Show Stats</button>
+  </div>
+
+  <div id="status" class="status status-idle">Idle — click Start to begin</div>
+  <div class="counter">Utterances measured: <span id="utteranceCount">0</span></div>
+
+  <h2>Live Transcript</h2>
+  <div id="transcript"></div>
+
+  <h2>Latency Measurements</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>#</th>
+        <th>Latency (ms)</th>
+        <th>Speaker</th>
+        <th>Text</th>
+        <th>Stream</th>
+      </tr>
+    </thead>
+    <tbody id="measurementTable"></tbody>
+  </table>
+
+  <div id="stats-summary" style="display:none"></div>
+
+  <script>
+    let ws = null;
+    let audioCtx = null;
+    let workletNode = null;
+    let mediaStream = null;
+    let currentOnsetTs = 0;
+    let utteranceCount = 0;
+    let measurements = [];
+    let fixtureChunks = [];
+    let recordingFixture = false;
+
+    function setStatus(msg, type) {
+      const el = document.getElementById('status');
+      el.textContent = msg;
+      el.className = 'status status-' + type;
+    }
+
+    async function startSession() {
+      const recognizer = document.getElementById('recognizer').value;
+      setStatus('Connecting...', 'idle');
+
+      // Open WebSocket
+      const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+      const wsUrl = `${proto}//${location.host}/ws/stt-spike?recognizer=${recognizer}`;
+      ws = new WebSocket(wsUrl);
+
+      ws.onopen = async () => {
+        setStatus('Connected — starting microphone...', 'ok');
+        await startAudio();
+        document.getElementById('btnStart').disabled = true;
+        document.getElementById('btnStop').disabled = false;
+        document.getElementById('btnReconnect').disabled = false;
+      };
+
+      ws.onmessage = (event) => {
+        const msg = JSON.parse(event.data);
+        handleServerMessage(msg);
+      };
+
+      ws.onclose = () => {
+        setStatus('Disconnected', 'idle');
+        stopAudio();
+        document.getElementById('btnStart').disabled = false;
+        document.getElementById('btnStop').disabled = true;
+        document.getElementById('btnReconnect').disabled = true;
+      };
+
+      ws.onerror = () => {
+        setStatus('WebSocket error', 'err');
+      };
+    }
+
+    async function startAudio() {
+      try {
+        mediaStream = await navigator.mediaDevices.getUserMedia({
+          audio: {
+            sampleRate: 16000,
+            channelCount: 1,
+            echoCancellation: true,
+            noiseSuppression: true,
+          }
+        });
+
+        audioCtx = new AudioContext({ sampleRate: mediaStream.getAudioTracks()[0].getSettings().sampleRate || 48000 });
+        await audioCtx.audioWorklet.addModule('/worklet.js');
+
+        const source = audioCtx.createMediaStreamSource(mediaStream);
+        workletNode = new AudioWorkletNode(audioCtx, 'stt-worklet-processor');
+
+        // Configure the worklet with the actual sample rate
+        workletNode.port.postMessage({
+          type: 'configure',
+          sampleRate: audioCtx.sampleRate,
+        });
+
+        workletNode.port.onmessage = (event) => {
+          const msg = event.data;
+
+          if (msg.type === 'onset') {
+            currentOnsetTs = msg.performanceNow;
+          } else if (msg.type === 'silence') {
+            // Reset onset for next utterance
+          } else if (msg.type === 'audio') {
+            if (ws && ws.readyState === WebSocket.OPEN) {
+              // Prepend onset timestamp (8 bytes float64)
+              const tsBuf = new ArrayBuffer(8);
+              new Float64Array(tsBuf)[0] = currentOnsetTs || 0;
+              const combined = new Uint8Array(8 + msg.data.length);
+              combined.set(new Uint8Array(tsBuf), 0);
+              combined.set(msg.data, 8);
+              ws.send(combined.buffer);
+            }
+            if (recordingFixture) {
+              fixtureChunks.push(new Uint8Array(msg.data));
+            }
+          }
+        };
+
+        source.connect(workletNode);
+        workletNode.connect(audioCtx.destination);
+        setStatus(`Streaming — sample rate: ${audioCtx.sampleRate}Hz, recognizer: ${document.getElementById('recognizer').value}`, 'ok');
+
+      } catch (err) {
+        setStatus('Microphone error: ' + err.message, 'err');
+      }
+    }
+
+    function stopAudio() {
+      if (workletNode) { workletNode.disconnect(); workletNode = null; }
+      if (audioCtx) { audioCtx.close(); audioCtx = null; }
+      if (mediaStream) { mediaStream.getTracks().forEach(t => t.stop()); mediaStream = null; }
+    }
+
+    function stopSession() {
+      stopAudio();
+      if (ws) { ws.close(); ws = null; }
+      setStatus('Session ended', 'idle');
+    }
+
+    function testReconnect() {
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ action: 'reconnect' }));
+        setStatus('Reconnect requested...', 'idle');
+      }
+    }
+
+    function handleServerMessage(msg) {
+      const transcript = document.getElementById('transcript');
+
+      if (msg.type === 'transcript.partial') {
+        transcript.textContent = transcript.textContent.replace(/\[partial\].*$/, '') +
+          `[partial] ${msg.text}\n`;
+      } else if (msg.type === 'transcript.final') {
+        transcript.textContent = transcript.textContent.replace(/\[partial\].*$/, '') +
+          `[S${msg.speaker_tag}] ${msg.text}\n`;
+      } else if (msg.type === 'reconnected') {
+        setStatus(`Reconnected — new stream: ${msg.stream_id.substring(0, 8)}`, 'ok');
+        return;
+      }
+
+      // Log latency measurement for partials
+      if (msg.type === 'transcript.partial' && msg.latency_ms > 0) {
+        utteranceCount++;
+        document.getElementById('utteranceCount').textContent = utteranceCount;
+
+        measurements.push({
+          id: utteranceCount,
+          latency_ms: msg.latency_ms,
+          speaker_tag: msg.speaker_tag,
+          text: msg.text.substring(0, 60),
+          stream_id: msg.stream_id ? msg.stream_id.substring(0, 8) : '',
+        });
+
+        // Add to table
+        const row = document.createElement('tr');
+        const cls = msg.latency_ms <= 2000 ? 'pass' : msg.latency_ms <= 3000 ? 'marginal' : 'fail';
+        row.innerHTML = `
+          <td>${utteranceCount}</td>
+          <td class="${cls}">${msg.latency_ms.toFixed(0)}</td>
+          <td>S${msg.speaker_tag}</td>
+          <td>${msg.text.substring(0, 60)}</td>
+          <td>${msg.stream_id ? msg.stream_id.substring(0, 8) : ''}</td>
+        `;
+        document.getElementById('measurementTable').prepend(row);
+      }
+
+      // Auto-scroll transcript
+      transcript.scrollTop = transcript.scrollHeight;
+    }
+
+    function showStats() {
+      if (measurements.length === 0) {
+        alert('No measurements yet. Start a session and speak first.');
+        return;
+      }
+
+      const latencies = measurements.map(m => m.latency_ms).sort((a, b) => a - b);
+      const n = latencies.length;
+      const p50 = latencies[Math.floor(n * 0.5)];
+      const p95 = latencies[Math.floor(n * 0.95)];
+      const min = latencies[0];
+      const max = latencies[n - 1];
+      const mean = latencies.reduce((a, b) => a + b, 0) / n;
+
+      let verdict = 'PASS';
+      if (p95 > 2000 && p50 <= 2000) verdict = 'MARGINAL';
+      if (p50 > 2000) verdict = 'FAIL';
+
+      const el = document.getElementById('stats-summary');
+      el.style.display = 'block';
+      el.innerHTML = `
+        <h2>Statistics Summary</h2>
+        <p>Samples: ${n}</p>
+        <p>p50: ${p50.toFixed(0)}ms | p95: ${p95.toFixed(0)}ms</p>
+        <p>Min: ${min.toFixed(0)}ms | Max: ${max.toFixed(0)}ms | Mean: ${mean.toFixed(0)}ms</p>
+        <p>Verdict: <span class="${verdict.toLowerCase()}">${verdict}</span> (budget: 2000ms)</p>
+      `;
+    }
+
+    function toggleFixtureRecording() {
+      const btn = document.getElementById('btnRecord');
+      if (!recordingFixture) {
+        fixtureChunks = [];
+        recordingFixture = true;
+        btn.textContent = 'Stop Recording Fixture';
+        btn.style.background = '#ff1744';
+      } else {
+        recordingFixture = false;
+        btn.textContent = 'Record Fixture';
+        btn.style.background = '#651fff';
+        downloadFixture();
+      }
+    }
+
+    function downloadFixture() {
+      if (fixtureChunks.length === 0) {
+        alert('No audio recorded');
+        return;
+      }
+
+      // Concatenate all INT16 PCM chunks
+      const totalLen = fixtureChunks.reduce((sum, c) => sum + c.length, 0);
+      const pcm = new Uint8Array(totalLen);
+      let offset = 0;
+      for (const chunk of fixtureChunks) {
+        pcm.set(chunk, offset);
+        offset += chunk.length;
+      }
+
+      // Build WAV header (16kHz, 16-bit, mono)
+      const sampleRate = 16000;
+      const bitsPerSample = 16;
+      const channels = 1;
+      const dataSize = pcm.length;
+      const header = new ArrayBuffer(44);
+      const view = new DataView(header);
+
+      // RIFF header
+      writeString(view, 0, 'RIFF');
+      view.setUint32(4, 36 + dataSize, true);
+      writeString(view, 8, 'WAVE');
+
+      // fmt chunk
+      writeString(view, 12, 'fmt ');
+      view.setUint32(16, 16, true); // chunk size
+      view.setUint16(20, 1, true);  // PCM format
+      view.setUint16(22, channels, true);
+      view.setUint32(24, sampleRate, true);
+      view.setUint32(28, sampleRate * channels * bitsPerSample / 8, true);
+      view.setUint16(32, channels * bitsPerSample / 8, true);
+      view.setUint16(34, bitsPerSample, true);
+
+      // data chunk
+      writeString(view, 36, 'data');
+      view.setUint32(40, dataSize, true);
+
+      const wav = new Blob([header, pcm], { type: 'audio/wav' });
+      const url = URL.createObjectURL(wav);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'two_speaker_onboarding_sample.wav';
+      a.click();
+      URL.revokeObjectURL(url);
+    }
+
+    function writeString(view, offset, str) {
+      for (let i = 0; i < str.length; i++) {
+        view.setUint8(offset + i, str.charCodeAt(i));
+      }
+    }
+  </script>
+</body>
+</html>

--- a/spike-stt-v2/main.py
+++ b/spike-stt-v2/main.py
@@ -1,0 +1,227 @@
+"""FastAPI spike relay for A-01: STT v2 streaming latency measurement.
+
+Serves a browser page that captures microphone audio via AudioWorklet,
+streams it to Google Cloud STT v2, and measures end-to-end latency.
+
+Usage:
+    export OIA_SPIKE_PROJECT_ID=your-gcp-project-id
+    uvicorn main:app --host 0.0.0.0 --port 8120
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import struct
+import time
+from pathlib import Path
+
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect, Query
+from fastapi.responses import FileResponse, HTMLResponse
+from fastapi.staticfiles import StaticFiles
+
+from measurement import (
+    Measurement,
+    create_jsonl_path,
+    write_measurement,
+)
+from stt_client import STTConfig, STTStreamingSession
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+app = FastAPI(title="STT v2 Spike — A-01")
+
+STATIC_DIR = Path(__file__).parent
+
+
+# ---------------------------------------------------------------------------
+# Configuration from environment
+# ---------------------------------------------------------------------------
+
+
+def _get_config(recognizer_id: str = "oia-spike-en-us") -> STTConfig:
+    project_id = os.environ.get("OIA_SPIKE_PROJECT_ID", "")
+    if not project_id:
+        raise ValueError(
+            "OIA_SPIKE_PROJECT_ID environment variable must be set. "
+            "This is your GCP project ID."
+        )
+    return STTConfig(
+        project_id=project_id,
+        location=os.environ.get("OIA_SPIKE_LOCATION", "us-central1"),
+        recognizer_id=recognizer_id,
+        credentials_json=os.environ.get("OIA_SPIKE_CREDENTIALS_JSON", ""),
+        credentials_path=os.environ.get("OIA_SPIKE_CREDENTIALS_PATH", ""),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Static file routes
+# ---------------------------------------------------------------------------
+
+
+@app.get("/", response_class=HTMLResponse)
+async def serve_index():
+    """Serve the spike measurement page."""
+    return FileResponse(STATIC_DIR / "index.html")
+
+
+@app.get("/worklet.js")
+async def serve_worklet():
+    """Serve the AudioWorklet processor."""
+    return FileResponse(
+        STATIC_DIR / "worklet.js",
+        media_type="application/javascript",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Health check
+# ---------------------------------------------------------------------------
+
+
+@app.get("/health")
+async def health():
+    project_id = os.environ.get("OIA_SPIKE_PROJECT_ID", "")
+    return {
+        "status": "ok" if project_id else "unconfigured",
+        "project_id": project_id[:8] + "..." if len(project_id) > 8 else project_id,
+    }
+
+
+# ---------------------------------------------------------------------------
+# WebSocket relay
+# ---------------------------------------------------------------------------
+
+
+@app.websocket("/ws/stt-spike")
+async def stt_relay(
+    websocket: WebSocket,
+    recognizer: str = Query(default="oia-spike-en-us"),
+):
+    """WebSocket endpoint that relays browser audio to STT v2.
+
+    Binary frames from the browser:
+        [8-byte float64 onset_ts_ms][PCM bytes]
+
+    JSON frames to the browser:
+        {type, text, is_final, speaker_tag, confidence, latency_ms, seq, ...}
+
+    Control frames from the browser (JSON):
+        {"action": "reconnect"} — force reconnect for label stability test
+    """
+    await websocket.accept()
+    logger.info("WebSocket connected, recognizer=%s", recognizer)
+
+    config = _get_config(recognizer_id=recognizer)
+    session = STTStreamingSession(config)
+    loop = asyncio.get_running_loop()
+
+    jsonl_path = create_jsonl_path(output_dir=str(STATIC_DIR))
+    logger.info("Measurements will be written to %s", jsonl_path)
+
+    utterance_counter = 0
+    current_onset_ts: float = 0.0
+    seq = 0
+
+    session.start(loop)
+
+    async def consume_results():
+        """Forward STT results back to the browser and log measurements."""
+        nonlocal utterance_counter, current_onset_ts, seq
+
+        async for result in session.results():
+            now_ms = time.time() * 1000
+            seq += 1
+
+            # Compute latency if we have an onset timestamp
+            latency_ms = 0.0
+            if current_onset_ts > 0:
+                latency_ms = now_ms - current_onset_ts
+
+            frame = {
+                "type": "transcript.final" if result.is_final else "transcript.partial",
+                "seq": seq,
+                "text": result.text,
+                "is_final": result.is_final,
+                "speaker_tag": result.speaker_tag,
+                "confidence": round(result.confidence, 3),
+                "latency_ms": round(latency_ms, 1),
+                "stream_id": session.stream_id,
+            }
+
+            try:
+                await websocket.send_json(frame)
+            except Exception:
+                break
+
+            # Log the first partial for each utterance
+            if not result.is_final and latency_ms > 0:
+                utterance_counter += 1
+                m = Measurement(
+                    utterance_id=utterance_counter,
+                    onset_ts_ms=current_onset_ts,
+                    first_partial_ts_ms=now_ms,
+                    latency_ms=latency_ms,
+                    text=result.text,
+                    is_final=False,
+                    speaker_tag=result.speaker_tag,
+                    recognizer=recognizer,
+                )
+                write_measurement(jsonl_path, m)
+                # Reset onset for next utterance
+                current_onset_ts = 0.0
+
+    result_task = asyncio.create_task(consume_results())
+
+    try:
+        while True:
+            data = await websocket.receive()
+
+            if "bytes" in data and data["bytes"]:
+                raw = data["bytes"]
+                if len(raw) > 8:
+                    # Extract onset timestamp from first 8 bytes
+                    onset_ts = struct.unpack("<d", raw[:8])[0]
+                    pcm = raw[8:]
+
+                    if onset_ts > 0 and current_onset_ts == 0:
+                        current_onset_ts = onset_ts
+
+                    session.feed_audio(pcm)
+
+            elif "text" in data and data["text"]:
+                try:
+                    msg = json.loads(data["text"])
+                    if msg.get("action") == "reconnect":
+                        logger.info("Reconnect requested by client")
+                        session.reconnect()
+                        await websocket.send_json({
+                            "type": "reconnected",
+                            "seq": seq + 1,
+                            "stream_id": session.stream_id,
+                        })
+                        seq += 1
+                except json.JSONDecodeError:
+                    pass
+
+    except WebSocketDisconnect:
+        logger.info("WebSocket disconnected")
+    finally:
+        session.close()
+        result_task.cancel()
+        try:
+            await result_task
+        except asyncio.CancelledError:
+            pass
+        logger.info(
+            "Session ended. %d utterances measured. Data: %s",
+            utterance_counter,
+            jsonl_path,
+        )

--- a/spike-stt-v2/measurement.py
+++ b/spike-stt-v2/measurement.py
@@ -1,0 +1,379 @@
+"""Latency, diarization and cost measurement for STT v2 spike.
+
+Collects per-utterance measurements as JSONL, computes statistics,
+and generates the markdown report for A-01.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Measurement:
+    """A single utterance latency measurement."""
+
+    utterance_id: int
+    onset_ts_ms: float
+    first_partial_ts_ms: float
+    latency_ms: float
+    text: str
+    is_final: bool
+    speaker_tag: int
+    recognizer: str
+
+
+@dataclass
+class LatencyStats:
+    """Aggregated latency statistics for a recognizer configuration."""
+
+    recognizer: str
+    sample_count: int
+    p50_ms: float
+    p95_ms: float
+    min_ms: float
+    max_ms: float
+    mean_ms: float
+    verdict: str  # PASS | MARGINAL | FAIL
+
+
+@dataclass
+class DiarizationResult:
+    """Diarization accuracy results."""
+
+    total_segments: int
+    correct_segments: int
+    misattributed_segments: int
+    misattribution_rate: float
+    reconnect_labels_stable: bool | None = None
+
+
+@dataclass
+class CostEstimate:
+    """Per-hour cost estimate."""
+
+    streaming_cost_per_hour: float
+    diarization_increment: float
+    batch_backfill_cost: float
+    total_per_hour: float
+    price_per_15s: float
+    price_source: str  # "billing" or "published"
+
+
+LATENCY_BUDGET_MS = 2000
+
+
+# ---------------------------------------------------------------------------
+# JSONL I/O
+# ---------------------------------------------------------------------------
+
+
+def create_jsonl_path(output_dir: str = ".") -> Path:
+    """Create a timestamped JSONL file path."""
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    return Path(output_dir) / f"measurements_{ts}.jsonl"
+
+
+def write_measurement(path: Path, m: Measurement) -> None:
+    """Append a single measurement to a JSONL file."""
+    with open(path, "a") as f:
+        f.write(json.dumps(asdict(m)) + "\n")
+
+
+def read_measurements(path: Path) -> list[Measurement]:
+    """Read all measurements from a JSONL file."""
+    measurements: list[Measurement] = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            data = json.loads(line)
+            measurements.append(Measurement(**data))
+    return measurements
+
+
+# ---------------------------------------------------------------------------
+# Statistics
+# ---------------------------------------------------------------------------
+
+
+def compute_stats(
+    measurements: list[Measurement],
+    recognizer: str | None = None,
+) -> LatencyStats:
+    """Compute latency percentiles and verdict for a set of measurements.
+
+    Args:
+        measurements: List of measurements to analyse.
+        recognizer: If provided, filter to this recognizer only.
+
+    Returns:
+        LatencyStats with p50, p95, min, max, mean, and verdict.
+
+    Raises:
+        ValueError: If no measurements match the filter.
+    """
+    if recognizer:
+        measurements = [m for m in measurements if m.recognizer == recognizer]
+
+    if not measurements:
+        raise ValueError(
+            f"No measurements found"
+            + (f" for recognizer '{recognizer}'" if recognizer else "")
+        )
+
+    latencies = np.array([m.latency_ms for m in measurements], dtype=np.float64)
+    p50 = float(np.percentile(latencies, 50))
+    p95 = float(np.percentile(latencies, 95))
+    min_ms = float(np.min(latencies))
+    max_ms = float(np.max(latencies))
+    mean_ms = float(np.mean(latencies))
+
+    verdict = _compute_verdict(p50, p95)
+
+    return LatencyStats(
+        recognizer=recognizer or "all",
+        sample_count=len(measurements),
+        p50_ms=round(p50, 1),
+        p95_ms=round(p95, 1),
+        min_ms=round(min_ms, 1),
+        max_ms=round(max_ms, 1),
+        mean_ms=round(mean_ms, 1),
+        verdict=verdict,
+    )
+
+
+def _compute_verdict(p50: float, p95: float) -> str:
+    """Determine PASS/MARGINAL/FAIL against the 2-second budget.
+
+    PASS:     p95 <= 2000ms
+    MARGINAL: p50 <= 2000ms < p95
+    FAIL:     p50 > 2000ms
+    """
+    if p95 <= LATENCY_BUDGET_MS:
+        return "PASS"
+    elif p50 <= LATENCY_BUDGET_MS:
+        return "MARGINAL"
+    else:
+        return "FAIL"
+
+
+# ---------------------------------------------------------------------------
+# Diarization accuracy
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SegmentLabel:
+    """A segment with predicted and ground-truth speaker labels."""
+
+    segment_id: int
+    predicted_speaker: int
+    actual_speaker: int
+
+
+def compute_diarization_accuracy(
+    segments: list[SegmentLabel],
+    reconnect_labels_stable: bool | None = None,
+) -> DiarizationResult:
+    """Compute diarization misattribution rate.
+
+    Args:
+        segments: List of segments with predicted and actual speaker labels.
+        reconnect_labels_stable: Whether labels remained stable across a
+            mid-stream reconnect (None if not tested).
+
+    Returns:
+        DiarizationResult with misattribution rate.
+
+    Raises:
+        ValueError: If segments list is empty.
+    """
+    if not segments:
+        raise ValueError("No segments provided for diarization accuracy")
+
+    correct = sum(1 for s in segments if s.predicted_speaker == s.actual_speaker)
+    misattributed = len(segments) - correct
+    rate = misattributed / len(segments)
+
+    return DiarizationResult(
+        total_segments=len(segments),
+        correct_segments=correct,
+        misattributed_segments=misattributed,
+        misattribution_rate=round(rate, 4),
+        reconnect_labels_stable=reconnect_labels_stable,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cost calculation
+# ---------------------------------------------------------------------------
+
+
+def compute_cost(
+    duration_s: float,
+    price_per_15s: float,
+    diarization_surcharge_per_15s: float = 0.0,
+    reconnect_loss_fraction: float = 0.05,
+    batch_price_per_15s: float | None = None,
+    price_source: str = "published",
+) -> CostEstimate:
+    """Calculate per-hour cost for STT v2 streaming.
+
+    Args:
+        duration_s: Duration to calculate for (typically 3600 for one hour).
+        price_per_15s: Base streaming price per 15-second increment.
+        diarization_surcharge_per_15s: Extra charge for diarization (if any).
+        reconnect_loss_fraction: Fraction of audio lost to reconnects (batch backfill).
+        batch_price_per_15s: Batch recognition price per 15s (for backfill).
+            If None, uses price_per_15s * 0.667 as estimate.
+        price_source: "billing" or "published".
+
+    Returns:
+        CostEstimate with itemised costs.
+    """
+    intervals = math.ceil(duration_s / 15)
+    streaming_cost = intervals * price_per_15s
+    diarization_cost = intervals * diarization_surcharge_per_15s
+
+    if batch_price_per_15s is None:
+        batch_price_per_15s = price_per_15s * 0.667
+
+    backfill_duration = duration_s * reconnect_loss_fraction
+    backfill_intervals = math.ceil(backfill_duration / 15)
+    backfill_cost = backfill_intervals * batch_price_per_15s
+
+    total = streaming_cost + diarization_cost + backfill_cost
+
+    return CostEstimate(
+        streaming_cost_per_hour=round(streaming_cost, 4),
+        diarization_increment=round(diarization_cost, 4),
+        batch_backfill_cost=round(backfill_cost, 4),
+        total_per_hour=round(total, 4),
+        price_per_15s=price_per_15s,
+        price_source=price_source,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Report generation
+# ---------------------------------------------------------------------------
+
+
+def generate_report(
+    stats_fixed: LatencyStats,
+    stats_auto: LatencyStats | None,
+    diarization: DiarizationResult | None,
+    cost: CostEstimate,
+    environment: dict[str, str] | None = None,
+) -> str:
+    """Generate the A-01 measurement note as markdown.
+
+    Args:
+        stats_fixed: Latency stats for the fixed-language recognizer.
+        stats_auto: Latency stats for the multi-language recognizer (optional).
+        diarization: Diarization accuracy results (optional).
+        cost: Cost estimate.
+        environment: Optional dict of environment details (os, browser, etc.).
+
+    Returns:
+        Markdown string for docs/spikes/A-01-stt-v2-measurement-note.md.
+    """
+    lines: list[str] = []
+    lines.append("# A-01 — STT v2 Streaming Latency Measurement Note")
+    lines.append("")
+    lines.append(f"**Date**: {datetime.now(timezone.utc).strftime('%Y-%m-%d')}")
+    lines.append(f"**Spike**: A-01 — Google STT v2 streaming latency and diarization")
+    lines.append("")
+
+    # Environment
+    if environment:
+        lines.append("## Environment")
+        lines.append("")
+        for key, value in environment.items():
+            lines.append(f"- **{key}**: {value}")
+        lines.append("")
+
+    # Latency
+    lines.append("## Latency Results")
+    lines.append("")
+    lines.append(
+        "| Recognizer | Samples | p50 (ms) | p95 (ms) | Min (ms) | Max (ms) "
+        "| Mean (ms) | Verdict |"
+    )
+    lines.append("|---|---|---|---|---|---|---|---|")
+    for s in [stats_fixed] + ([stats_auto] if stats_auto else []):
+        lines.append(
+            f"| {s.recognizer} | {s.sample_count} | {s.p50_ms} | {s.p95_ms} "
+            f"| {s.min_ms} | {s.max_ms} | {s.mean_ms} | **{s.verdict}** |"
+        )
+    lines.append("")
+    lines.append(f"Budget: {LATENCY_BUDGET_MS}ms. ")
+    lines.append("Verdict rules: PASS = p95 ≤ budget, MARGINAL = p50 ≤ budget < p95, "
+                  "FAIL = p50 > budget.")
+    lines.append("")
+
+    # Diarization
+    if diarization:
+        lines.append("## Diarization Results")
+        lines.append("")
+        lines.append(f"- **Total segments**: {diarization.total_segments}")
+        lines.append(f"- **Correct**: {diarization.correct_segments}")
+        lines.append(f"- **Misattributed**: {diarization.misattributed_segments}")
+        lines.append(
+            f"- **Misattribution rate**: {diarization.misattribution_rate:.2%}"
+        )
+        if diarization.reconnect_labels_stable is not None:
+            stability = (
+                "Stable" if diarization.reconnect_labels_stable else "Unstable"
+            )
+            lines.append(f"- **Reconnect label stability**: {stability}")
+        lines.append("")
+
+    # Cost
+    lines.append("## Cost Estimate")
+    lines.append("")
+    lines.append(f"- **Price per 15s**: ${cost.price_per_15s:.4f} "
+                  f"(source: {cost.price_source})")
+    lines.append(
+        f"- **Streaming cost per hour**: ${cost.streaming_cost_per_hour:.2f}"
+    )
+    lines.append(f"- **Diarization increment**: ${cost.diarization_increment:.2f}")
+    lines.append(f"- **Batch backfill cost (5%)**: ${cost.batch_backfill_cost:.2f}")
+    lines.append(f"- **Total per meeting hour**: **${cost.total_per_hour:.2f}**")
+    lines.append("")
+
+    # Language comparison
+    if stats_auto:
+        lines.append("## Language Mode Comparison")
+        lines.append("")
+        delta_p50 = stats_auto.p50_ms - stats_fixed.p50_ms
+        delta_p95 = stats_auto.p95_ms - stats_fixed.p95_ms
+        lines.append(f"- **p50 delta** (auto − fixed): {delta_p50:+.1f}ms")
+        lines.append(f"- **p95 delta** (auto − fixed): {delta_p95:+.1f}ms")
+        lines.append("")
+
+    # Recommendations
+    lines.append("## Recommendations")
+    lines.append("")
+    lines.append("- See `docs/decisions/OD-002-stt-language-mode.md` for the "
+                  "language mode decision.")
+    lines.append("- F-05 and F-06 should reference this note for latency budgets "
+                  "and cost projections.")
+    lines.append("")
+
+    return "\n".join(lines)

--- a/spike-stt-v2/pyproject.toml
+++ b/spike-stt-v2/pyproject.toml
@@ -1,0 +1,9 @@
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+markers = [
+    "integration: requires real Google Cloud STT v2 credentials",
+]
+
+[tool.black]
+line-length = 88
+target-version = ["py312"]

--- a/spike-stt-v2/requirements.txt
+++ b/spike-stt-v2/requirements.txt
@@ -1,0 +1,9 @@
+google-cloud-speech>=2.28.0
+fastapi==0.129.1
+uvicorn[standard]==0.41.0
+websockets>=13.0
+numpy>=1.26.0
+hypothesis>=6.100.0
+pytest>=8.0.0
+pytest-asyncio>=0.24.0
+httpx>=0.28.0

--- a/spike-stt-v2/stt_client.py
+++ b/spike-stt-v2/stt_client.py
@@ -1,0 +1,302 @@
+"""Google Cloud Speech-to-Text v2 streaming client for the A-01 spike.
+
+Wraps the synchronous gRPC client and bridges to asyncio via a
+background thread, following the fleet pattern used in
+creative-generation-agent-svc/app/services/gcs_client.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import queue
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from typing import AsyncIterator, Iterator
+
+from google.cloud.speech_v2 import SpeechClient
+from google.cloud.speech_v2.types import cloud_speech
+from google.oauth2 import service_account
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TranscriptResult:
+    """A single transcript result from STT v2."""
+
+    text: str
+    is_final: bool
+    confidence: float
+    speaker_tag: int
+    stability: float
+    result_end_offset_ms: float
+
+
+@dataclass
+class STTConfig:
+    """Configuration for the STT v2 streaming session."""
+
+    project_id: str
+    location: str = "us-central1"
+    recognizer_id: str = "oia-spike-en-us"
+    credentials_json: str = ""
+    credentials_path: str = ""
+
+
+# Sentinel to signal end of audio stream
+_STOP = object()
+
+
+def _build_client(config: STTConfig) -> SpeechClient:
+    """Build a SpeechClient using the 3-tier credential pattern."""
+    if config.credentials_json:
+        info = json.loads(config.credentials_json)
+        credentials = service_account.Credentials.from_service_account_info(info)
+        return SpeechClient(credentials=credentials)
+    elif config.credentials_path:
+        return SpeechClient.from_service_account_file(config.credentials_path)
+    else:
+        # ADC fallback
+        return SpeechClient()
+
+
+def _recognizer_name(config: STTConfig) -> str:
+    """Build the full recognizer resource name."""
+    return (
+        f"projects/{config.project_id}"
+        f"/locations/{config.location}"
+        f"/recognizers/{config.recognizer_id}"
+    )
+
+
+class STTStreamingSession:
+    """A single STT v2 bidirectional streaming session.
+
+    Runs the synchronous gRPC stream in a background thread and
+    exposes results via an async iterator.
+    """
+
+    def __init__(self, config: STTConfig) -> None:
+        self.config = config
+        self._client = _build_client(config)
+        self._recognizer = _recognizer_name(config)
+        self._audio_queue: queue.Queue = queue.Queue(maxsize=500)
+        self._result_queue: asyncio.Queue[TranscriptResult | None] = asyncio.Queue()
+        self._stream_thread: threading.Thread | None = None
+        self._running = False
+        self._stream_id = str(uuid.uuid4())
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    @property
+    def stream_id(self) -> str:
+        """Unique identifier for the current gRPC stream."""
+        return self._stream_id
+
+    def start(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Start the background streaming thread."""
+        self._loop = loop
+        self._running = True
+        self._stream_thread = threading.Thread(
+            target=self._run_stream,
+            daemon=True,
+            name=f"stt-stream-{self._stream_id[:8]}",
+        )
+        self._stream_thread.start()
+        logger.info("STT stream started: %s", self._stream_id)
+
+    def feed_audio(self, pcm_bytes: bytes) -> None:
+        """Feed a chunk of LINEAR16 PCM audio into the stream."""
+        if self._running:
+            try:
+                self._audio_queue.put_nowait(pcm_bytes)
+            except queue.Full:
+                logger.warning("Audio queue full, dropping chunk")
+
+    async def results(self) -> AsyncIterator[TranscriptResult]:
+        """Async iterator over transcript results."""
+        while True:
+            result = await self._result_queue.get()
+            if result is None:
+                break
+            yield result
+
+    def reconnect(self) -> None:
+        """Force-close the current stream and open a new one.
+
+        Used to test speaker label stability across reconnects (AC-2).
+        """
+        logger.info("Reconnect requested for stream %s", self._stream_id)
+        self._running = False
+        # Drain the audio queue
+        while not self._audio_queue.empty():
+            try:
+                self._audio_queue.get_nowait()
+            except queue.Empty:
+                break
+        self._audio_queue.put(_STOP)
+
+        if self._stream_thread:
+            self._stream_thread.join(timeout=5.0)
+
+        # Reset for new stream
+        self._audio_queue = queue.Queue(maxsize=500)
+        self._stream_id = str(uuid.uuid4())
+        self._running = True
+        self._stream_thread = threading.Thread(
+            target=self._run_stream,
+            daemon=True,
+            name=f"stt-stream-{self._stream_id[:8]}",
+        )
+        self._stream_thread.start()
+        logger.info("STT stream reconnected: %s", self._stream_id)
+
+    def close(self) -> None:
+        """Stop the streaming session and drain queues."""
+        self._running = False
+        # Signal the audio generator to stop
+        try:
+            self._audio_queue.put_nowait(_STOP)
+        except queue.Full:
+            pass
+
+        if self._stream_thread:
+            self._stream_thread.join(timeout=5.0)
+
+        # Signal the result consumer to stop
+        if self._loop and self._loop.is_running():
+            self._loop.call_soon_threadsafe(self._result_queue.put_nowait, None)
+
+        logger.info("STT stream closed: %s", self._stream_id)
+
+    def _audio_generator(self) -> Iterator[cloud_speech.StreamingRecognizeRequest]:
+        """Generate streaming requests: config first, then audio chunks."""
+        # First request carries the streaming config
+        streaming_config = cloud_speech.StreamingRecognitionConfig(
+            config=cloud_speech.RecognitionConfig(
+                auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
+                features=cloud_speech.RecognitionFeatures(
+                    enable_automatic_punctuation=True,
+                    diarization_config=cloud_speech.SpeakerDiarizationConfig(
+                        min_speaker_count=2,
+                        max_speaker_count=2,
+                    ),
+                ),
+            ),
+            streaming_features=cloud_speech.StreamingRecognitionFeatures(
+                interim_results=True,
+            ),
+        )
+
+        yield cloud_speech.StreamingRecognizeRequest(
+            recognizer=self._recognizer,
+            streaming_config=streaming_config,
+        )
+
+        # Subsequent requests carry audio content
+        while self._running:
+            try:
+                chunk = self._audio_queue.get(timeout=0.1)
+            except queue.Empty:
+                continue
+            if chunk is _STOP:
+                break
+            yield cloud_speech.StreamingRecognizeRequest(audio=chunk)
+
+    def _run_stream(self) -> None:
+        """Run the synchronous gRPC streaming call in a background thread."""
+        try:
+            responses = self._client.streaming_recognize(
+                requests=self._audio_generator()
+            )
+            for response in responses:
+                if not self._running:
+                    break
+                for result in response.results:
+                    if not result.alternatives:
+                        continue
+                    alt = result.alternatives[0]
+
+                    # Extract speaker tag from word-level info if available
+                    speaker_tag = 0
+                    if alt.words:
+                        speaker_tag = alt.words[-1].speaker_tag
+
+                    tr = TranscriptResult(
+                        text=alt.transcript,
+                        is_final=result.is_final,
+                        confidence=alt.confidence,
+                        speaker_tag=speaker_tag,
+                        stability=result.stability,
+                        result_end_offset_ms=(
+                            result.result_end_offset.total_seconds() * 1000
+                            if result.result_end_offset
+                            else 0.0
+                        ),
+                    )
+
+                    if self._loop and self._loop.is_running():
+                        self._loop.call_soon_threadsafe(
+                            self._result_queue.put_nowait, tr
+                        )
+
+        except Exception as e:
+            logger.error("STT stream error: %s", e)
+        finally:
+            if self._loop and self._loop.is_running():
+                self._loop.call_soon_threadsafe(
+                    self._result_queue.put_nowait, None
+                )
+
+
+def create_recognizer(
+    config: STTConfig,
+    recognizer_id: str,
+    language_codes: list[str],
+    enable_diarization: bool = True,
+) -> str:
+    """Create a recognizer resource (idempotent).
+
+    Returns the full recognizer name.
+    """
+    client = _build_client(config)
+    parent = f"projects/{config.project_id}/locations/{config.location}"
+    name = f"{parent}/recognizers/{recognizer_id}"
+
+    # Check if it already exists
+    try:
+        existing = client.get_recognizer(name=name)
+        logger.info("Recognizer already exists: %s", name)
+        return existing.name
+    except Exception:
+        pass
+
+    features = cloud_speech.RecognitionFeatures(
+        enable_automatic_punctuation=True,
+    )
+    if enable_diarization:
+        features.diarization_config = cloud_speech.SpeakerDiarizationConfig(
+            min_speaker_count=2,
+            max_speaker_count=2,
+        )
+
+    request = cloud_speech.CreateRecognizerRequest(
+        parent=parent,
+        recognizer_id=recognizer_id,
+        recognizer=cloud_speech.Recognizer(
+            language_codes=language_codes,
+            model="long",
+            default_recognition_config=cloud_speech.RecognitionConfig(
+                features=features,
+            ),
+        ),
+    )
+
+    operation = client.create_recognizer(request=request)
+    recognizer = operation.result(timeout=60)
+    logger.info("Created recognizer: %s", recognizer.name)
+    return recognizer.name

--- a/spike-stt-v2/tests/conftest.py
+++ b/spike-stt-v2/tests/conftest.py
@@ -1,0 +1,145 @@
+"""Shared fixtures for spike-stt-v2 tests."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from measurement import (
+    CostEstimate,
+    DiarizationResult,
+    LatencyStats,
+    Measurement,
+    SegmentLabel,
+    write_measurement,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — Measurement data
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sample_measurements() -> list[Measurement]:
+    """A list of 10 measurements with known latency values."""
+    return [
+        Measurement(
+            utterance_id=i + 1,
+            onset_ts_ms=1000.0 * i,
+            first_partial_ts_ms=1000.0 * i + latency,
+            latency_ms=latency,
+            text=f"utterance {i + 1}",
+            is_final=False,
+            speaker_tag=1 if i % 2 == 0 else 2,
+            recognizer="oia-spike-en-us",
+        )
+        for i, latency in enumerate(
+            [800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1600, 1700]
+        )
+    ]
+
+
+@pytest.fixture
+def passing_measurements() -> list[Measurement]:
+    """Measurements that should produce a PASS verdict (p95 <= 2000)."""
+    return [
+        Measurement(
+            utterance_id=i + 1,
+            onset_ts_ms=1000.0 * i,
+            first_partial_ts_ms=1000.0 * i + latency,
+            latency_ms=latency,
+            text=f"utterance {i + 1}",
+            is_final=False,
+            speaker_tag=1,
+            recognizer="oia-spike-en-us",
+        )
+        for i, latency in enumerate([500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400])
+    ]
+
+
+@pytest.fixture
+def marginal_measurements() -> list[Measurement]:
+    """Measurements that should produce a MARGINAL verdict (p50 <= 2000 < p95)."""
+    return [
+        Measurement(
+            utterance_id=i + 1,
+            onset_ts_ms=1000.0 * i,
+            first_partial_ts_ms=1000.0 * i + latency,
+            latency_ms=latency,
+            text=f"utterance {i + 1}",
+            is_final=False,
+            speaker_tag=1,
+            recognizer="oia-spike-en-us",
+        )
+        for i, latency in enumerate(
+            [500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 5000]
+        )
+    ]
+
+
+@pytest.fixture
+def failing_measurements() -> list[Measurement]:
+    """Measurements that should produce a FAIL verdict (p50 > 2000)."""
+    return [
+        Measurement(
+            utterance_id=i + 1,
+            onset_ts_ms=1000.0 * i,
+            first_partial_ts_ms=1000.0 * i + latency,
+            latency_ms=latency,
+            text=f"utterance {i + 1}",
+            is_final=False,
+            speaker_tag=1,
+            recognizer="oia-spike-en-us",
+        )
+        for i, latency in enumerate(
+            [2100, 2200, 2300, 2400, 2500, 2600, 2700, 2800, 2900, 3000]
+        )
+    ]
+
+
+@pytest.fixture
+def jsonl_file(sample_measurements: list[Measurement], tmp_path: Path) -> Path:
+    """Write sample measurements to a temporary JSONL file."""
+    path = tmp_path / "test_measurements.jsonl"
+    for m in sample_measurements:
+        write_measurement(path, m)
+    return path
+
+
+@pytest.fixture
+def perfect_segments() -> list[SegmentLabel]:
+    """Segments where all predictions match ground truth."""
+    return [
+        SegmentLabel(segment_id=i, predicted_speaker=s, actual_speaker=s)
+        for i, s in enumerate([1, 2, 1, 2, 1, 2, 1, 2, 1, 2])
+    ]
+
+
+@pytest.fixture
+def imperfect_segments() -> list[SegmentLabel]:
+    """Segments with 3 out of 10 misattributed."""
+    predicted = [1, 2, 1, 2, 1, 2, 1, 2, 1, 2]
+    actual = [1, 2, 2, 2, 1, 1, 1, 2, 2, 2]  # 3 wrong: idx 2, 5, 8
+    return [
+        SegmentLabel(segment_id=i, predicted_speaker=p, actual_speaker=a)
+        for i, (p, a) in enumerate(zip(predicted, actual))
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — STT config
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def gcp_project_id() -> str:
+    """GCP project ID from environment, skip if not set."""
+    project_id = os.environ.get("OIA_SPIKE_PROJECT_ID", "")
+    if not project_id:
+        pytest.skip("OIA_SPIKE_PROJECT_ID not set — skipping integration test")
+    return project_id

--- a/spike-stt-v2/tests/test_e2e_relay.py
+++ b/spike-stt-v2/tests/test_e2e_relay.py
@@ -1,0 +1,181 @@
+"""End-to-end tests for the FastAPI WebSocket relay.
+
+Require real Google Cloud credentials. Marked with @pytest.mark.integration.
+
+Run with: pytest tests/test_e2e_relay.py -v -m integration
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import struct
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+pytestmark = pytest.mark.integration
+
+FIXTURE_DIR = Path(__file__).parent.parent.parent / "tests" / "fixtures"
+
+
+def _load_fixture_pcm() -> bytes | None:
+    """Load the WAV fixture and return raw PCM bytes (skip header)."""
+    wav_path = FIXTURE_DIR / "two_speaker_onboarding_sample.wav"
+    if not wav_path.exists():
+        return None
+    with open(wav_path, "rb") as f:
+        data = f.read()
+    return data[44:]
+
+
+@pytest.fixture
+def require_gcp():
+    if not os.environ.get("OIA_SPIKE_PROJECT_ID"):
+        pytest.skip("OIA_SPIKE_PROJECT_ID not set")
+
+
+class TestHealthEndpoint:
+    async def test_health_returns_status(self):
+        from main import app
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/health")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert "status" in data
+
+
+class TestWebSocketRelay:
+    async def test_websocket_accepts_connection(self, require_gcp):
+        from main import app
+        from starlette.testclient import TestClient
+
+        client = TestClient(app)
+        with client.websocket_connect("/ws/stt-spike?recognizer=oia-spike-en-us") as ws:
+            # Connection accepted — just close cleanly
+            pass
+
+    async def test_audio_through_relay_produces_transcript(self, require_gcp):
+        """Send audio fixture chunks through the WebSocket and expect transcripts."""
+        pcm = _load_fixture_pcm()
+        if pcm is None:
+            pytest.skip("Audio fixture not found")
+
+        from main import app
+        from starlette.testclient import TestClient
+
+        client = TestClient(app)
+        received = []
+
+        with client.websocket_connect("/ws/stt-spike?recognizer=oia-spike-en-us") as ws:
+            chunk_size = 3200
+            onset_ts = 1000.0  # Fake onset timestamp
+
+            for i in range(0, min(len(pcm), chunk_size * 30), chunk_size):
+                chunk = pcm[i : i + chunk_size]
+                # Prepend 8-byte onset timestamp
+                ts_buf = struct.pack("<d", onset_ts)
+                ws.send_bytes(ts_buf + chunk)
+                # Small delay for real-time pacing
+                import time
+
+                time.sleep(0.05)
+
+            # Wait for results
+            import time
+
+            time.sleep(3.0)
+
+            # Try to receive messages (non-blocking)
+            try:
+                while True:
+                    data = ws.receive_json(mode="text")
+                    received.append(data)
+            except Exception:
+                pass
+
+        # We should have received at least one transcript
+        assert len(received) > 0
+        assert any("text" in msg for msg in received)
+
+    async def test_reconnect_via_control_frame(self, require_gcp):
+        """Sending reconnect action should succeed without dropping WebSocket."""
+        from main import app
+        from starlette.testclient import TestClient
+
+        client = TestClient(app)
+
+        with client.websocket_connect("/ws/stt-spike?recognizer=oia-spike-en-us") as ws:
+            # Send some audio first
+            pcm = _load_fixture_pcm()
+            if pcm:
+                ts_buf = struct.pack("<d", 1000.0)
+                ws.send_bytes(ts_buf + pcm[:3200])
+                import time
+
+                time.sleep(0.5)
+
+            # Send reconnect control frame
+            ws.send_json({"action": "reconnect"})
+
+            # Should receive a reconnected message
+            import time
+
+            time.sleep(1.0)
+
+            try:
+                data = ws.receive_json(mode="text")
+                if data.get("type") == "reconnected":
+                    assert "stream_id" in data
+            except Exception:
+                # Connection may have produced other messages first
+                pass
+
+    async def test_measurement_jsonl_written(self, require_gcp, tmp_path):
+        """After a relay session, JSONL measurements should be written."""
+        pcm = _load_fixture_pcm()
+        if pcm is None:
+            pytest.skip("Audio fixture not found")
+
+        # Check that measurement files get created in the spike dir
+        from main import app, STATIC_DIR
+
+        jsonl_files_before = set(STATIC_DIR.glob("measurements_*.jsonl"))
+
+        from starlette.testclient import TestClient
+
+        client = TestClient(app)
+
+        with client.websocket_connect("/ws/stt-spike?recognizer=oia-spike-en-us") as ws:
+            chunk_size = 3200
+            ts_buf = struct.pack("<d", 1000.0)
+            for i in range(0, min(len(pcm), chunk_size * 20), chunk_size):
+                ws.send_bytes(ts_buf + pcm[i : i + chunk_size])
+                import time
+
+                time.sleep(0.05)
+
+            import time
+
+            time.sleep(3.0)
+
+        jsonl_files_after = set(STATIC_DIR.glob("measurements_*.jsonl"))
+        new_files = jsonl_files_after - jsonl_files_before
+
+        assert len(new_files) >= 1, "Expected at least one new JSONL measurement file"
+
+        # Verify the file has valid JSON lines
+        for f in new_files:
+            with open(f) as fh:
+                for line in fh:
+                    line = line.strip()
+                    if line:
+                        data = json.loads(line)
+                        assert "utterance_id" in data
+                        assert "latency_ms" in data
+                        assert "speaker_tag" in data
+                        assert "recognizer" in data

--- a/spike-stt-v2/tests/test_measurement.py
+++ b/spike-stt-v2/tests/test_measurement.py
@@ -1,0 +1,327 @@
+"""Unit and property tests for measurement.py.
+
+No Google Cloud credentials required.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from measurement import (
+    LATENCY_BUDGET_MS,
+    CostEstimate,
+    DiarizationResult,
+    LatencyStats,
+    Measurement,
+    SegmentLabel,
+    compute_cost,
+    compute_diarization_accuracy,
+    compute_stats,
+    generate_report,
+    read_measurements,
+    write_measurement,
+    _compute_verdict,
+)
+
+
+# ===================================================================
+# Unit tests — compute_stats
+# ===================================================================
+
+
+class TestComputeStatsVerdict:
+    def test_pass_verdict(self, passing_measurements: list[Measurement]):
+        stats = compute_stats(passing_measurements)
+        assert stats.verdict == "PASS"
+        assert stats.p95_ms <= LATENCY_BUDGET_MS
+
+    def test_marginal_verdict(self, marginal_measurements: list[Measurement]):
+        stats = compute_stats(marginal_measurements)
+        assert stats.verdict == "MARGINAL"
+        assert stats.p50_ms <= LATENCY_BUDGET_MS
+        assert stats.p95_ms > LATENCY_BUDGET_MS
+
+    def test_fail_verdict(self, failing_measurements: list[Measurement]):
+        stats = compute_stats(failing_measurements)
+        assert stats.verdict == "FAIL"
+        assert stats.p50_ms > LATENCY_BUDGET_MS
+
+    def test_empty_data_raises(self):
+        with pytest.raises(ValueError, match="No measurements found"):
+            compute_stats([])
+
+    def test_single_measurement(self):
+        m = Measurement(
+            utterance_id=1,
+            onset_ts_ms=0,
+            first_partial_ts_ms=1500,
+            latency_ms=1500,
+            text="hello",
+            is_final=False,
+            speaker_tag=1,
+            recognizer="oia-spike-en-us",
+        )
+        stats = compute_stats([m])
+        assert stats.p50_ms == 1500.0
+        assert stats.p95_ms == 1500.0
+        assert stats.sample_count == 1
+        assert stats.verdict == "PASS"
+
+    def test_filter_by_recognizer(self, sample_measurements: list[Measurement]):
+        # Add a measurement with a different recognizer
+        extra = Measurement(
+            utterance_id=99,
+            onset_ts_ms=0,
+            first_partial_ts_ms=5000,
+            latency_ms=5000,
+            text="other",
+            is_final=False,
+            speaker_tag=1,
+            recognizer="oia-spike-auto",
+        )
+        all_m = sample_measurements + [extra]
+        stats = compute_stats(all_m, recognizer="oia-spike-en-us")
+        assert stats.sample_count == len(sample_measurements)
+        assert stats.recognizer == "oia-spike-en-us"
+
+    def test_filter_by_missing_recognizer_raises(self, sample_measurements):
+        with pytest.raises(ValueError, match="No measurements found"):
+            compute_stats(sample_measurements, recognizer="nonexistent")
+
+
+# ===================================================================
+# Unit tests — diarization accuracy
+# ===================================================================
+
+
+class TestDiarizationAccuracy:
+    def test_perfect_accuracy(self, perfect_segments: list[SegmentLabel]):
+        result = compute_diarization_accuracy(perfect_segments)
+        assert result.misattribution_rate == 0.0
+        assert result.correct_segments == 10
+        assert result.misattributed_segments == 0
+
+    def test_with_errors(self, imperfect_segments: list[SegmentLabel]):
+        result = compute_diarization_accuracy(imperfect_segments)
+        assert result.misattributed_segments == 3
+        assert result.misattribution_rate == 0.3
+
+    def test_empty_segments_raises(self):
+        with pytest.raises(ValueError, match="No segments provided"):
+            compute_diarization_accuracy([])
+
+    def test_reconnect_stability_flag(self, perfect_segments):
+        result = compute_diarization_accuracy(perfect_segments, reconnect_labels_stable=True)
+        assert result.reconnect_labels_stable is True
+
+
+# ===================================================================
+# Unit tests — cost calculation
+# ===================================================================
+
+
+class TestComputeCost:
+    def test_one_hour(self):
+        cost = compute_cost(
+            duration_s=3600,
+            price_per_15s=0.006,
+        )
+        # 3600/15 = 240 intervals
+        assert cost.streaming_cost_per_hour == 240 * 0.006
+        assert cost.price_source == "published"
+
+    def test_with_diarization_surcharge(self):
+        cost = compute_cost(
+            duration_s=3600,
+            price_per_15s=0.006,
+            diarization_surcharge_per_15s=0.001,
+        )
+        assert cost.diarization_increment == 240 * 0.001
+
+    def test_with_batch_backfill(self):
+        cost = compute_cost(
+            duration_s=3600,
+            price_per_15s=0.006,
+            reconnect_loss_fraction=0.05,
+            batch_price_per_15s=0.004,
+        )
+        # Backfill: 3600 * 0.05 = 180s, ceil(180/15) = 12 intervals
+        assert cost.batch_backfill_cost == 12 * 0.004
+
+
+# ===================================================================
+# Unit tests — JSONL roundtrip
+# ===================================================================
+
+
+class TestJsonlRoundtrip:
+    def test_write_read_roundtrip(
+        self, sample_measurements: list[Measurement], tmp_path: Path
+    ):
+        path = tmp_path / "roundtrip.jsonl"
+        for m in sample_measurements:
+            write_measurement(path, m)
+
+        loaded = read_measurements(path)
+        assert len(loaded) == len(sample_measurements)
+        for orig, loaded_m in zip(sample_measurements, loaded):
+            assert orig.utterance_id == loaded_m.utterance_id
+            assert orig.latency_ms == loaded_m.latency_ms
+            assert orig.text == loaded_m.text
+            assert orig.recognizer == loaded_m.recognizer
+
+
+# ===================================================================
+# Unit tests — report generation
+# ===================================================================
+
+
+class TestGenerateReport:
+    def test_contains_all_sections(self, passing_measurements, perfect_segments):
+        stats = compute_stats(passing_measurements)
+        diarization = compute_diarization_accuracy(perfect_segments)
+        cost = compute_cost(3600, 0.006)
+
+        report = generate_report(
+            stats_fixed=stats,
+            stats_auto=None,
+            diarization=diarization,
+            cost=cost,
+            environment={"OS": "macOS", "Browser": "Chrome"},
+        )
+
+        assert "# A-01" in report
+        assert "## Latency Results" in report
+        assert "## Diarization Results" in report
+        assert "## Cost Estimate" in report
+        assert "## Recommendations" in report
+        assert "## Environment" in report
+        assert "macOS" in report
+
+    def test_with_auto_recognizer(self, passing_measurements):
+        stats_fixed = compute_stats(passing_measurements)
+        # Create auto measurements with different latencies
+        auto_measurements = [
+            Measurement(
+                utterance_id=m.utterance_id,
+                onset_ts_ms=m.onset_ts_ms,
+                first_partial_ts_ms=m.first_partial_ts_ms + 100,
+                latency_ms=m.latency_ms + 100,
+                text=m.text,
+                is_final=False,
+                speaker_tag=m.speaker_tag,
+                recognizer="oia-spike-auto",
+            )
+            for m in passing_measurements
+        ]
+        stats_auto = compute_stats(auto_measurements)
+        cost = compute_cost(3600, 0.006)
+
+        report = generate_report(
+            stats_fixed=stats_fixed,
+            stats_auto=stats_auto,
+            diarization=None,
+            cost=cost,
+        )
+
+        assert "## Language Mode Comparison" in report
+        assert "p50 delta" in report
+
+
+# ===================================================================
+# Property tests (Hypothesis)
+# ===================================================================
+
+positive_floats = st.floats(min_value=1.0, max_value=100000.0, allow_nan=False)
+
+
+class TestPropertyStats:
+    @given(st.lists(positive_floats, min_size=1, max_size=200))
+    @settings(max_examples=50)
+    def test_p50_between_min_and_max(self, latencies: list[float]):
+        measurements = [
+            Measurement(
+                utterance_id=i,
+                onset_ts_ms=0,
+                first_partial_ts_ms=lat,
+                latency_ms=lat,
+                text="t",
+                is_final=False,
+                speaker_tag=1,
+                recognizer="test",
+            )
+            for i, lat in enumerate(latencies)
+        ]
+        stats = compute_stats(measurements)
+        assert stats.min_ms <= stats.p50_ms <= stats.max_ms
+
+    @given(st.lists(positive_floats, min_size=1, max_size=200))
+    @settings(max_examples=50)
+    def test_p95_gte_p50(self, latencies: list[float]):
+        measurements = [
+            Measurement(
+                utterance_id=i,
+                onset_ts_ms=0,
+                first_partial_ts_ms=lat,
+                latency_ms=lat,
+                text="t",
+                is_final=False,
+                speaker_tag=1,
+                recognizer="test",
+            )
+            for i, lat in enumerate(latencies)
+        ]
+        stats = compute_stats(measurements)
+        assert stats.p95_ms >= stats.p50_ms
+
+    @given(
+        p50=st.floats(min_value=0, max_value=10000, allow_nan=False),
+        p95=st.floats(min_value=0, max_value=10000, allow_nan=False),
+    )
+    @settings(max_examples=100)
+    def test_verdict_consistent_with_thresholds(self, p50: float, p95: float):
+        # Ensure p95 >= p50 as would be in real data
+        if p95 < p50:
+            p50, p95 = p95, p50
+
+        verdict = _compute_verdict(p50, p95)
+
+        if p95 <= LATENCY_BUDGET_MS:
+            assert verdict == "PASS"
+        elif p50 <= LATENCY_BUDGET_MS:
+            assert verdict == "MARGINAL"
+        else:
+            assert verdict == "FAIL"
+
+    @given(
+        st.lists(
+            st.tuples(st.integers(0, 5), st.integers(0, 5)),
+            min_size=1,
+            max_size=50,
+        )
+    )
+    @settings(max_examples=50)
+    def test_misattribution_rate_bounded_0_1(self, speaker_pairs):
+        segments = [
+            SegmentLabel(segment_id=i, predicted_speaker=p, actual_speaker=a)
+            for i, (p, a) in enumerate(speaker_pairs)
+        ]
+        result = compute_diarization_accuracy(segments)
+        assert 0.0 <= result.misattribution_rate <= 1.0
+
+    @given(
+        duration=st.floats(min_value=1.0, max_value=36000.0, allow_nan=False),
+        price=st.floats(min_value=0.0001, max_value=1.0, allow_nan=False),
+    )
+    @settings(max_examples=50)
+    def test_cost_scales_with_duration(self, duration: float, price: float):
+        cost1 = compute_cost(duration, price, reconnect_loss_fraction=0.0, diarization_surcharge_per_15s=0.0)
+        cost2 = compute_cost(duration * 2, price, reconnect_loss_fraction=0.0, diarization_surcharge_per_15s=0.0)
+        # Due to ceiling, cost2 may be slightly less than 2x cost1 but never more
+        assert cost2.streaming_cost_per_hour >= cost1.streaming_cost_per_hour

--- a/spike-stt-v2/tests/test_stt_client.py
+++ b/spike-stt-v2/tests/test_stt_client.py
@@ -1,0 +1,144 @@
+"""Unit tests for stt_client.py.
+
+No Google Cloud credentials required — tests only exercise local logic.
+"""
+
+from __future__ import annotations
+
+import queue
+import uuid
+
+import pytest
+
+from stt_client import (
+    STTConfig,
+    STTStreamingSession,
+    _recognizer_name,
+)
+
+
+class TestRecognizerName:
+    def test_format(self):
+        config = STTConfig(
+            project_id="my-project",
+            location="us-central1",
+            recognizer_id="oia-spike-en-us",
+        )
+        name = _recognizer_name(config)
+        assert name == "projects/my-project/locations/us-central1/recognizers/oia-spike-en-us"
+
+    def test_different_location(self):
+        config = STTConfig(
+            project_id="proj-x",
+            location="europe-west1",
+            recognizer_id="custom-rec",
+        )
+        name = _recognizer_name(config)
+        assert "locations/europe-west1" in name
+        assert "recognizers/custom-rec" in name
+
+
+class TestSTTStreamingSession:
+    def _make_session(self) -> STTStreamingSession:
+        """Create a session without connecting to GCP."""
+        config = STTConfig(
+            project_id="test-project",
+            location="us-central1",
+            recognizer_id="oia-spike-en-us",
+        )
+        # We can't actually build a client without credentials,
+        # so we test the session's local state management
+        session = STTStreamingSession.__new__(STTStreamingSession)
+        session.config = config
+        session._recognizer = _recognizer_name(config)
+        session._audio_queue = queue.Queue(maxsize=500)
+        session._running = False
+        session._stream_id = str(uuid.uuid4())
+        session._stream_thread = None
+        session._loop = None
+        return session
+
+    def test_stream_id_is_uuid(self):
+        session = self._make_session()
+        # Validate it's a valid UUID
+        parsed = uuid.UUID(session.stream_id)
+        assert str(parsed) == session.stream_id
+
+    def test_reconnect_changes_stream_id(self):
+        session = self._make_session()
+        old_id = session.stream_id
+
+        # Simulate reconnect state changes (without actual gRPC)
+        session._stream_id = str(uuid.uuid4())
+        session._audio_queue = queue.Queue(maxsize=500)
+
+        assert session.stream_id != old_id
+
+    def test_audio_queue_drains_on_close(self):
+        session = self._make_session()
+        session._running = True
+
+        # Put some items in the queue
+        for i in range(5):
+            session._audio_queue.put(b"chunk")
+
+        assert session._audio_queue.qsize() == 5
+
+        # close() signals stop
+        session._running = False
+        # Drain manually (close() does this via _STOP sentinel)
+        while not session._audio_queue.empty():
+            session._audio_queue.get_nowait()
+
+        assert session._audio_queue.empty()
+
+    def test_feed_audio_drops_when_not_running(self):
+        session = self._make_session()
+        session._running = False
+        session.feed_audio(b"should be dropped")
+        assert session._audio_queue.empty()
+
+    def test_feed_audio_queues_when_running(self):
+        session = self._make_session()
+        session._running = True
+        session.feed_audio(b"chunk1")
+        session.feed_audio(b"chunk2")
+        assert session._audio_queue.qsize() == 2
+
+
+class TestSTTConfig:
+    def test_defaults(self):
+        config = STTConfig(project_id="test")
+        assert config.location == "us-central1"
+        assert config.recognizer_id == "oia-spike-en-us"
+        assert config.credentials_json == ""
+        assert config.credentials_path == ""
+
+    def test_streaming_config_values(self):
+        """Verify the streaming config constants used in _audio_generator."""
+        from google.cloud.speech_v2.types import cloud_speech
+
+        # Build the streaming config the same way stt_client.py does
+        streaming_config = cloud_speech.StreamingRecognitionConfig(
+            config=cloud_speech.RecognitionConfig(
+                auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
+                features=cloud_speech.RecognitionFeatures(
+                    enable_automatic_punctuation=True,
+                    diarization_config=cloud_speech.SpeakerDiarizationConfig(
+                        min_speaker_count=2,
+                        max_speaker_count=2,
+                    ),
+                ),
+            ),
+            streaming_features=cloud_speech.StreamingRecognitionFeatures(
+                interim_results=True,
+            ),
+        )
+
+        # Verify interim results enabled
+        assert streaming_config.streaming_features.interim_results is True
+
+        # Verify diarization config
+        diar = streaming_config.config.features.diarization_config
+        assert diar.min_speaker_count == 2
+        assert diar.max_speaker_count == 2

--- a/spike-stt-v2/tests/test_stt_integration.py
+++ b/spike-stt-v2/tests/test_stt_integration.py
@@ -1,0 +1,239 @@
+"""Integration tests for STT v2 — require real Google Cloud credentials.
+
+Run with: pytest tests/test_stt_integration.py -v -m integration
+
+Requires:
+    - OIA_SPIKE_PROJECT_ID environment variable set
+    - Valid GCP credentials (ADC or OIA_SPIKE_CREDENTIALS_JSON)
+    - Recognizer resources created via create_recognizers.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import struct
+import time
+from pathlib import Path
+
+import pytest
+
+from stt_client import STTConfig, STTStreamingSession, _build_client, _recognizer_name
+
+pytestmark = pytest.mark.integration
+
+FIXTURE_DIR = Path(__file__).parent.parent.parent / "tests" / "fixtures"
+
+
+def _get_config(recognizer_id: str = "oia-spike-en-us") -> STTConfig:
+    return STTConfig(
+        project_id=os.environ.get("OIA_SPIKE_PROJECT_ID", ""),
+        location=os.environ.get("OIA_SPIKE_LOCATION", "us-central1"),
+        recognizer_id=recognizer_id,
+        credentials_json=os.environ.get("OIA_SPIKE_CREDENTIALS_JSON", ""),
+        credentials_path=os.environ.get("OIA_SPIKE_CREDENTIALS_PATH", ""),
+    )
+
+
+def _load_fixture_pcm() -> bytes | None:
+    """Load the WAV fixture and return raw PCM bytes (skip header)."""
+    wav_path = FIXTURE_DIR / "two_speaker_onboarding_sample.wav"
+    if not wav_path.exists():
+        return None
+    with open(wav_path, "rb") as f:
+        data = f.read()
+    # Skip 44-byte WAV header
+    return data[44:]
+
+
+class TestRecognizerExists:
+    def test_en_us_recognizer_reachable(self, gcp_project_id: str):
+        config = _get_config("oia-spike-en-us")
+        client = _build_client(config)
+        name = _recognizer_name(config)
+        recognizer = client.get_recognizer(name=name)
+        assert recognizer.name == name
+
+    def test_auto_recognizer_reachable(self, gcp_project_id: str):
+        config = _get_config("oia-spike-auto")
+        client = _build_client(config)
+        name = _recognizer_name(config)
+        recognizer = client.get_recognizer(name=name)
+        assert recognizer.name == name
+
+
+class TestStreamingRecognize:
+    def test_streaming_fixture_produces_results(self, gcp_project_id: str):
+        """Stream the audio fixture and verify we get transcript results."""
+        pcm = _load_fixture_pcm()
+        if pcm is None:
+            pytest.skip("Audio fixture not found — record it first")
+
+        config = _get_config("oia-spike-en-us")
+        session = STTStreamingSession(config)
+        loop = asyncio.new_event_loop()
+
+        results = []
+
+        async def run():
+            session.start(loop)
+
+            # Feed audio in 100ms chunks (3200 bytes = 1600 samples * 2 bytes at 16kHz)
+            chunk_size = 3200
+            for i in range(0, min(len(pcm), chunk_size * 50), chunk_size):
+                chunk = pcm[i : i + chunk_size]
+                session.feed_audio(chunk)
+                await asyncio.sleep(0.1)  # Real-time pacing
+
+            # Wait for results
+            await asyncio.sleep(2.0)
+            session.close()
+
+            async for result in session.results():
+                results.append(result)
+
+        loop.run_until_complete(run())
+        loop.close()
+
+        assert len(results) > 0, "Expected at least one transcript result"
+
+    def test_streaming_diarization_returns_speaker_tags(self, gcp_project_id: str):
+        """Verify that streaming results include speaker_tag values."""
+        pcm = _load_fixture_pcm()
+        if pcm is None:
+            pytest.skip("Audio fixture not found — record it first")
+
+        config = _get_config("oia-spike-en-us")
+        session = STTStreamingSession(config)
+        loop = asyncio.new_event_loop()
+
+        results = []
+
+        async def run():
+            session.start(loop)
+
+            chunk_size = 3200
+            for i in range(0, min(len(pcm), chunk_size * 50), chunk_size):
+                session.feed_audio(pcm[i : i + chunk_size])
+                await asyncio.sleep(0.1)
+
+            await asyncio.sleep(2.0)
+            session.close()
+
+            async for result in session.results():
+                results.append(result)
+
+        loop.run_until_complete(run())
+        loop.close()
+
+        # At least some results should have non-zero speaker tags
+        speaker_tags = {r.speaker_tag for r in results if r.is_final}
+        # Diarization may not always produce tags for short clips,
+        # but the field should exist
+        assert all(hasattr(r, "speaker_tag") for r in results)
+
+    def test_streaming_interim_results_arrive(self, gcp_project_id: str):
+        """Verify that interim (non-final) results arrive before final results."""
+        pcm = _load_fixture_pcm()
+        if pcm is None:
+            pytest.skip("Audio fixture not found — record it first")
+
+        config = _get_config("oia-spike-en-us")
+        session = STTStreamingSession(config)
+        loop = asyncio.new_event_loop()
+
+        results = []
+
+        async def run():
+            session.start(loop)
+
+            chunk_size = 3200
+            for i in range(0, min(len(pcm), chunk_size * 100), chunk_size):
+                session.feed_audio(pcm[i : i + chunk_size])
+                await asyncio.sleep(0.1)
+
+            await asyncio.sleep(3.0)
+            session.close()
+
+            async for result in session.results():
+                results.append(result)
+
+        loop.run_until_complete(run())
+        loop.close()
+
+        interim = [r for r in results if not r.is_final]
+        assert len(interim) > 0, "Expected interim results with interim_results=True"
+
+    def test_multi_language_recognizer_on_english_audio(self, gcp_project_id: str):
+        """Verify oia-spike-auto correctly transcribes English audio."""
+        pcm = _load_fixture_pcm()
+        if pcm is None:
+            pytest.skip("Audio fixture not found — record it first")
+
+        config = _get_config("oia-spike-auto")
+        session = STTStreamingSession(config)
+        loop = asyncio.new_event_loop()
+
+        results = []
+
+        async def run():
+            session.start(loop)
+
+            chunk_size = 3200
+            for i in range(0, min(len(pcm), chunk_size * 50), chunk_size):
+                session.feed_audio(pcm[i : i + chunk_size])
+                await asyncio.sleep(0.1)
+
+            await asyncio.sleep(2.0)
+            session.close()
+
+            async for result in session.results():
+                results.append(result)
+
+        loop.run_until_complete(run())
+        loop.close()
+
+        assert len(results) > 0
+
+    def test_reconnect_produces_valid_results(self, gcp_project_id: str):
+        """After forced reconnect, subsequent audio still transcribes."""
+        pcm = _load_fixture_pcm()
+        if pcm is None:
+            pytest.skip("Audio fixture not found — record it first")
+
+        config = _get_config("oia-spike-en-us")
+        session = STTStreamingSession(config)
+        loop = asyncio.new_event_loop()
+
+        stream_ids = []
+
+        async def run():
+            session.start(loop)
+            stream_ids.append(session.stream_id)
+
+            chunk_size = 3200
+            # Send first batch
+            for i in range(0, min(len(pcm), chunk_size * 20), chunk_size):
+                session.feed_audio(pcm[i : i + chunk_size])
+                await asyncio.sleep(0.1)
+
+            await asyncio.sleep(1.0)
+
+            # Reconnect
+            session.reconnect()
+            stream_ids.append(session.stream_id)
+
+            # Send second batch
+            offset = chunk_size * 20
+            for i in range(offset, min(len(pcm), offset + chunk_size * 20), chunk_size):
+                session.feed_audio(pcm[i : i + chunk_size])
+                await asyncio.sleep(0.1)
+
+            await asyncio.sleep(2.0)
+            session.close()
+
+        loop.run_until_complete(run())
+        loop.close()
+
+        assert len(stream_ids) == 2
+        assert stream_ids[0] != stream_ids[1], "Reconnect should produce a new stream ID"

--- a/spike-stt-v2/worklet.js
+++ b/spike-stt-v2/worklet.js
@@ -1,0 +1,113 @@
+/**
+ * AudioWorklet processor for STT v2 spike (A-01).
+ *
+ * Responsibilities:
+ * - Detect utterance onset (first frame above noise floor after silence)
+ * - Chunk audio into ~100ms LINEAR16 PCM frames at 16kHz
+ * - Handle sample rate mismatch (48kHz → 16kHz decimation)
+ * - Post onset timestamps and audio chunks to the main thread
+ */
+class STTWorkletProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+
+    // Onset detection state
+    this._silenceFrames = 0;
+    this._silenceThresholdFrames = 10; // ~200ms at 128 samples/frame, ~48kHz
+    this._noiseFloorDb = -40;
+    this._inUtterance = false;
+
+    // Audio buffering
+    this._buffer = [];
+    this._bufferSamples = 0;
+    this._targetSamplesPerChunk = 1600; // 100ms at 16kHz
+
+    // Sample rate handling — AudioWorklet always runs at AudioContext.sampleRate
+    // We need 16kHz output; if the context is 48kHz, we decimate by 3
+    this._decimationFactor = 1; // Set by main thread via message
+    this._inputSampleRate = 48000; // Default assumption
+
+    this.port.onmessage = (event) => {
+      if (event.data.type === 'configure') {
+        this._inputSampleRate = event.data.sampleRate || 48000;
+        this._decimationFactor = Math.round(this._inputSampleRate / 16000);
+        if (this._decimationFactor < 1) this._decimationFactor = 1;
+
+        // Recalculate silence threshold based on actual sample rate
+        // 200ms of silence = 200ms / (128 samples / sampleRate)
+        const samplesPerFrame = 128;
+        const msPerFrame = (samplesPerFrame / this._inputSampleRate) * 1000;
+        this._silenceThresholdFrames = Math.ceil(200 / msPerFrame);
+      }
+    };
+  }
+
+  process(inputs, outputs, parameters) {
+    const input = inputs[0];
+    if (!input || !input[0] || input[0].length === 0) {
+      return true;
+    }
+
+    const samples = input[0]; // Float32, mono
+
+    // Compute RMS for onset detection
+    let sumSq = 0;
+    for (let i = 0; i < samples.length; i++) {
+      sumSq += samples[i] * samples[i];
+    }
+    const rms = Math.sqrt(sumSq / samples.length);
+    const rmsDb = rms > 0 ? 20 * Math.log10(rms) : -100;
+
+    const aboveFloor = rmsDb > this._noiseFloorDb;
+
+    if (aboveFloor) {
+      this._silenceFrames = 0;
+
+      if (!this._inUtterance) {
+        // Utterance onset detected
+        this._inUtterance = true;
+        this.port.postMessage({
+          type: 'onset',
+          timestamp: currentTime * 1000, // AudioContext currentTime in ms
+          performanceNow: Date.now(),     // Wall-clock for correlation
+        });
+      }
+    } else {
+      this._silenceFrames++;
+      if (this._silenceFrames >= this._silenceThresholdFrames && this._inUtterance) {
+        this._inUtterance = false;
+        this.port.postMessage({ type: 'silence' });
+      }
+    }
+
+    // Decimate to 16kHz and convert to LINEAR16 PCM
+    const decimated = [];
+    for (let i = 0; i < samples.length; i += this._decimationFactor) {
+      // Clamp and convert float32 [-1, 1] to int16 [-32768, 32767]
+      const s = Math.max(-1, Math.min(1, samples[i]));
+      decimated.push(Math.round(s * 32767));
+    }
+
+    // Accumulate into buffer
+    for (const s of decimated) {
+      this._buffer.push(s);
+    }
+    this._bufferSamples += decimated.length;
+
+    // Flush when we have ~100ms worth of 16kHz audio
+    if (this._bufferSamples >= this._targetSamplesPerChunk) {
+      const pcm = new Int16Array(this._buffer);
+      const bytes = new Uint8Array(pcm.buffer);
+      this.port.postMessage(
+        { type: 'audio', data: bytes },
+        [bytes.buffer] // Transfer ownership for zero-copy
+      );
+      this._buffer = [];
+      this._bufferSamples = 0;
+    }
+
+    return true;
+  }
+}
+
+registerProcessor('stt-worklet-processor', STTWorkletProcessor);


### PR DESCRIPTION
## Summary

- Implements the spike relay for measuring Google Cloud STT v2 streaming latency and two-speaker diarization quality (story A-01)
- FastAPI WebSocket relay server, AudioWorklet browser capture with onset detection, measurement statistics module with PASS/MARGINAL/FAIL verdicts
- Comprehensive test suite: 31 unit/property tests (all passing) + 12 integration tests (require GCP credentials)

## What's included

| File | Purpose |
|------|---------|
| `main.py` | FastAPI WebSocket relay (`/ws/stt-spike`) |
| `stt_client.py` | Google STT v2 streaming wrapper with reconnect support |
| `measurement.py` | Latency stats, diarization accuracy, cost calculation, report generation |
| `create_recognizers.py` | One-time recognizer resource setup script |
| `index.html` + `worklet.js` | Browser UI with AudioWorklet mic capture |
| `tests/` | 43 total tests (31 unit/property + 12 integration) |

## Pending

- [ ] GCP setup (enable Speech API, create recognizers)
- [ ] Live measurements (latency AC-1, diarization AC-2, cost AC-3, language AC-4)
- [ ] Record audio fixture (`two_speaker_onboarding_sample.wav`)
- [ ] Write measurement note (`docs/spikes/A-01-stt-v2-measurement-note.md`)
- [ ] Write language mode ADR (`docs/decisions/OD-002-stt-language-mode.md`)

## Test plan

- [x] Unit tests pass: `pytest tests/test_measurement.py tests/test_stt_client.py -v` (31/31 green)
- [ ] Integration tests: `pytest tests/ -m integration -v` (requires GCP credentials)
- [ ] Live spike session with real microphone input

🤖 Generated with [Claude Code](https://claude.com/claude-code)