### PR TITLE
feat(deploy): GCP Cloud Run deployment scripts for full platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,5 +54,10 @@ Thumbs.db
 vendor/odoo/community/**/*.pyc
 vendor/odoo/community/**/__pycache__/
 
+# GCP deployment secrets and generated files
+deployment/gcp/secrets.env
+deployment/gcp/redis-connection.env
+deployment/gcp/service-urls.env
+
 # Claude Code worktrees
 .claude/worktrees/

--- a/deployment/gcp/00-config.sh
+++ b/deployment/gcp/00-config.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Shared configuration for Zorven GCP Cloud Run deployment.
+# Source this file from all other scripts.
+
+set -euo pipefail
+
+# ── GCP Project ──────────────────────────────────────────────
+export GCP_PROJECT_ID="${GCP_PROJECT_ID:-zorven-503517}"
+export GCP_REGION="${GCP_REGION:-us-central1}"
+
+# ── Artifact Registry ───────────────────────────────────────
+export AR_REPO="zorven"
+export AR_HOST="${GCP_REGION}-docker.pkg.dev"
+export AR_PREFIX="${AR_HOST}/${GCP_PROJECT_ID}/${AR_REPO}"
+
+# ── GHCR Source ──────────────────────────────────────────────
+export GHCR_PREFIX="ghcr.io/naveenah"
+
+# ── Networking ───────────────────────────────────────────────
+export VPC_NAME="zorven-vpc"
+export CONNECTOR_NAME="zorven-connector"
+export CONNECTOR_RANGE="10.8.0.0/28"
+
+# ── Redis (Cloud Memorystore) ────────────────────────────────
+export REDIS_INSTANCE="zorven-redis"
+export REDIS_TIER="basic"
+export REDIS_SIZE_GB="1"
+export REDIS_VERSION="REDIS_7_0"
+
+# ── Service Account ─────────────────────────────────────────
+export SA_NAME="zorven-cloudrun"
+export SA_EMAIL="${SA_NAME}@${GCP_PROJECT_ID}.iam.gserviceaccount.com"
+
+# ── Cloud Run Defaults ───────────────────────────────────────
+export CR_MEMORY="512Mi"
+export CR_CPU="1"
+export CR_MAX_INSTANCES="2"
+export CR_TIMEOUT="300"
+
+# ── Database ─────────────────────────────────────────────────
+export DATABASE_URL="postgresql://neondb_owner:npg_ihO4oHanJW8e@ep-small-dawn-aevftgxm-pooler.c-2.us-east-2.aws.neon.tech/neondb?sslmode=require&channel_binding=require"
+
+# ── Unique GHCR images (30) ─────────────────────────────────
+UNIQUE_IMAGES=(
+  zorven-backend
+  zorven-frontend
+  zorven-celery-worker
+  zorven-celery-beat
+  zorven-mlflow-server
+  zorven-orchestrator
+  zorven-discovery-agent
+  zorven-market-research-agent
+  zorven-competitor-intel-agent
+  zorven-audience-persona-agent
+  zorven-trend-cultural-agent
+  zorven-voc-agent
+  zorven-intelligence-agent
+  zorven-brand-positioning-agent
+  zorven-brand-architecture-agent
+  zorven-brand-personality-agent
+  zorven-brand-naming-agent
+  zorven-brand-story-agent
+  zorven-campaign-architecture-agent
+  zorven-creative-generation-agent
+  zorven-ad-publishing-agent
+  zorven-campaign-optimization-agent
+  zorven-intelligence-loop-agent
+  zorven-chat-titling-worker
+  zorven-content-agent
+  zorven-social-agent
+  zorven-rag-uploader-agent
+  zorven-brand-equity-calculator
+  zorven-odoo-mcp-server
+  zorven-odoo-worker-agent
+  zorven-prompt-optimization
+)
+
+# ── All Cloud Run services ───────────────────────────────────
+# Format: SERVICE_NAME:IMAGE_NAME:PORT
+ALL_SERVICES=(
+  # Core
+  "zorven-backend:zorven-backend:8001"
+  "zorven-backend-ws:zorven-backend:8002"
+  "zorven-frontend:zorven-frontend:3000"
+  "zorven-celery-worker:zorven-celery-worker:8080"
+  "zorven-celery-beat:zorven-celery-beat:8080"
+  "zorven-mlflow:zorven-mlflow-server:5000"
+  # Agents
+  "zorven-orchestrator:zorven-orchestrator:8010"
+  "zorven-discovery-agent:zorven-discovery-agent:8020"
+  "zorven-market-research-agent:zorven-market-research-agent:8021"
+  "zorven-competitor-intel-agent:zorven-competitor-intel-agent:8022"
+  "zorven-audience-persona-agent:zorven-audience-persona-agent:8023"
+  "zorven-trend-cultural-agent:zorven-trend-cultural-agent:8024"
+  "zorven-voc-agent:zorven-voc-agent:8025"
+  "zorven-intelligence-agent:zorven-intelligence-agent:8030"
+  "zorven-brand-positioning-agent:zorven-brand-positioning-agent:8031"
+  "zorven-brand-architecture-agent:zorven-brand-architecture-agent:8032"
+  "zorven-brand-personality-agent:zorven-brand-personality-agent:8033"
+  "zorven-brand-naming-agent:zorven-brand-naming-agent:8034"
+  "zorven-brand-story-agent:zorven-brand-story-agent:8035"
+  "zorven-campaign-architecture-agent:zorven-campaign-architecture-agent:8041"
+  "zorven-creative-generation-agent:zorven-creative-generation-agent:8042"
+  "zorven-ad-publishing-agent:zorven-ad-publishing-agent:8043"
+  "zorven-campaign-optimization-agent:zorven-campaign-optimization-agent:8044"
+  "zorven-intelligence-loop-agent:zorven-intelligence-loop-agent:8045"
+  "zorven-chat-titling-worker:zorven-chat-titling-worker:8040"
+  "zorven-content-agent:zorven-content-agent:8050"
+  "zorven-social-agent:zorven-social-agent:8060"
+  "zorven-rag-uploader-agent:zorven-rag-uploader-agent:8070"
+  "zorven-brand-equity-calculator:zorven-brand-equity-calculator:8090"
+  "zorven-odoo-mcp-server:zorven-odoo-mcp-server:8095"
+  "zorven-odoo-worker-agent:zorven-odoo-worker-agent:8100"
+  "zorven-prompt-optimization:zorven-prompt-optimization:8110"
+)
+
+# ── Redis DB mapping (service → DB number) ───────────────────
+# Used to construct per-service REDIS_URL with correct DB number
+declare -A REDIS_DB_MAP=(
+  ["backend"]=0
+  ["celery"]=0
+  ["orchestrator"]=1
+  ["discovery"]=2
+  ["intelligence"]=3
+  ["titling"]=4
+  ["content"]=5
+  ["social"]=6
+  ["rag-uploader"]=7
+  ["brand-equity"]=8
+  ["odoo-mcp"]=9
+  ["odoo-worker"]=10
+  ["market-research"]=11
+  ["competitor-intel"]=12
+  ["audience-persona"]=13
+  ["trend-cultural"]=14
+  ["voc"]=15
+  ["brand-positioning"]=16
+  ["brand-architecture"]=17
+  ["brand-personality"]=18
+  ["brand-naming"]=19
+  ["brand-story"]=20
+  ["campaign-architecture"]=21
+  ["creative-generation"]=22
+  ["ad-publishing"]=23
+  ["campaign-optimization"]=24
+  ["intelligence-loop"]=25
+  ["prompt-optimization"]=26
+)
+
+# ── Helper: get Redis URL for a service DB ───────────────────
+get_redis_url() {
+  local db_num=$1
+  echo "redis://${REDIS_HOST:-localhost}:${REDIS_PORT:-6379}/${db_num}"
+}
+
+# ── Helper: log with timestamp ───────────────────────────────
+log() {
+  echo "[$(date '+%H:%M:%S')] $*"
+}
+
+log_ok() {
+  echo "[$(date '+%H:%M:%S')] ✓ $*"
+}
+
+log_err() {
+  echo "[$(date '+%H:%M:%S')] ✗ $*" >&2
+}

--- a/deployment/gcp/01-setup-project.sh
+++ b/deployment/gcp/01-setup-project.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Enable required GCP APIs and configure IAM for Cloud Run deployment.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/00-config.sh"
+
+log "Setting GCP project to ${GCP_PROJECT_ID}..."
+gcloud config set project "${GCP_PROJECT_ID}"
+
+log "Enabling required APIs..."
+gcloud services enable \
+  run.googleapis.com \
+  artifactregistry.googleapis.com \
+  secretmanager.googleapis.com \
+  redis.googleapis.com \
+  vpcaccess.googleapis.com \
+  compute.googleapis.com \
+  --quiet
+
+log "Creating service account ${SA_NAME}..."
+gcloud iam service-accounts describe "${SA_EMAIL}" >/dev/null 2>&1 || \
+  gcloud iam service-accounts create "${SA_NAME}" \
+    --display-name="Zorven Cloud Run Service Account"
+
+log "Granting IAM roles..."
+ROLES=(
+  roles/run.invoker
+  roles/secretmanager.secretAccessor
+  roles/artifactregistry.reader
+  roles/redis.editor
+  roles/storage.objectAdmin
+  roles/logging.logWriter
+  roles/monitoring.metricWriter
+)
+
+for role in "${ROLES[@]}"; do
+  gcloud projects add-iam-policy-binding "${GCP_PROJECT_ID}" \
+    --member="serviceAccount:${SA_EMAIL}" \
+    --role="${role}" \
+    --quiet >/dev/null 2>&1
+done
+
+log_ok "Project setup complete. APIs enabled, service account ready."

--- a/deployment/gcp/02-setup-networking.sh
+++ b/deployment/gcp/02-setup-networking.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Create VPC and Serverless VPC Access connector for Cloud Memorystore.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/00-config.sh"
+
+log "Creating VPC network ${VPC_NAME}..."
+gcloud compute networks describe "${VPC_NAME}" >/dev/null 2>&1 || \
+  gcloud compute networks create "${VPC_NAME}" \
+    --subnet-mode=auto \
+    --quiet
+
+log "Creating Serverless VPC Access connector ${CONNECTOR_NAME}..."
+gcloud compute networks vpc-access connectors describe "${CONNECTOR_NAME}" \
+  --region="${GCP_REGION}" >/dev/null 2>&1 || \
+  gcloud compute networks vpc-access connectors create "${CONNECTOR_NAME}" \
+    --region="${GCP_REGION}" \
+    --network="${VPC_NAME}" \
+    --range="${CONNECTOR_RANGE}" \
+    --min-instances=2 \
+    --max-instances=3 \
+    --machine-type=e2-micro \
+    --quiet
+
+log_ok "Networking setup complete."

--- a/deployment/gcp/03-setup-redis.sh
+++ b/deployment/gcp/03-setup-redis.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Create Cloud Memorystore Redis instance (27 databases).
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/00-config.sh"
+
+log "Creating Cloud Memorystore Redis instance ${REDIS_INSTANCE}..."
+log "  Tier: ${REDIS_TIER}, Size: ${REDIS_SIZE_GB}GB, Version: ${REDIS_VERSION}"
+log "  This may take 5-10 minutes..."
+
+gcloud redis instances describe "${REDIS_INSTANCE}" \
+  --region="${GCP_REGION}" >/dev/null 2>&1 || \
+  gcloud redis instances create "${REDIS_INSTANCE}" \
+    --size="${REDIS_SIZE_GB}" \
+    --region="${GCP_REGION}" \
+    --tier="${REDIS_TIER}" \
+    --redis-version="${REDIS_VERSION}" \
+    --network="${VPC_NAME}" \
+    --redis-config="maxmemory-policy=allkeys-lru" \
+    --quiet
+
+# Capture Redis connection info
+REDIS_HOST=$(gcloud redis instances describe "${REDIS_INSTANCE}" \
+  --region="${GCP_REGION}" --format='value(host)')
+REDIS_PORT=$(gcloud redis instances describe "${REDIS_INSTANCE}" \
+  --region="${GCP_REGION}" --format='value(port)')
+
+log "Redis host: ${REDIS_HOST}:${REDIS_PORT}"
+
+# Write Redis connection info for other scripts
+cat > "${SCRIPT_DIR}/redis-connection.env" <<EOF
+REDIS_HOST=${REDIS_HOST}
+REDIS_PORT=${REDIS_PORT}
+EOF
+
+log_ok "Redis setup complete. Connection info saved to redis-connection.env"

--- a/deployment/gcp/04-setup-secrets.sh
+++ b/deployment/gcp/04-setup-secrets.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Create Secret Manager secrets from secrets.env file.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/00-config.sh"
+
+SECRETS_FILE="${SCRIPT_DIR}/secrets.env"
+
+if [ ! -f "${SECRETS_FILE}" ]; then
+  log_err "secrets.env not found. Copy secrets.env.template and fill in values."
+  log_err "  cp ${SCRIPT_DIR}/secrets.env.template ${SECRETS_FILE}"
+  exit 1
+fi
+
+log "Creating secrets in Secret Manager..."
+
+while IFS='=' read -r key value; do
+  # Skip comments and empty lines
+  [[ "$key" =~ ^#.*$ ]] && continue
+  [[ -z "$key" ]] && continue
+  # Strip surrounding quotes from value
+  value="${value#\"}"
+  value="${value%\"}"
+  value="${value#\'}"
+  value="${value%\'}"
+
+  if [ -n "$value" ]; then
+    if gcloud secrets describe "$key" --project="${GCP_PROJECT_ID}" >/dev/null 2>&1; then
+      echo -n "$value" | gcloud secrets versions add "$key" --data-file=- --quiet 2>/dev/null
+      log "  Updated: $key"
+    else
+      echo -n "$value" | gcloud secrets create "$key" \
+        --data-file=- \
+        --replication-policy=automatic \
+        --project="${GCP_PROJECT_ID}" \
+        --quiet 2>/dev/null
+      log "  Created: $key"
+    fi
+  fi
+done < "${SECRETS_FILE}"
+
+log_ok "Secrets setup complete."

--- a/deployment/gcp/05-setup-artifact-registry.sh
+++ b/deployment/gcp/05-setup-artifact-registry.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Create Artifact Registry repository for Docker images.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/00-config.sh"
+
+log "Creating Artifact Registry repository ${AR_REPO}..."
+
+gcloud artifacts repositories describe "${AR_REPO}" \
+  --location="${GCP_REGION}" >/dev/null 2>&1 || \
+  gcloud artifacts repositories create "${AR_REPO}" \
+    --repository-format=docker \
+    --location="${GCP_REGION}" \
+    --quiet
+
+# Configure Docker to authenticate with Artifact Registry
+log "Configuring Docker auth for Artifact Registry..."
+gcloud auth configure-docker "${AR_HOST}" --quiet 2>/dev/null
+
+log_ok "Artifact Registry setup complete. Repo: ${AR_PREFIX}"

--- a/deployment/gcp/06-mirror-images.sh
+++ b/deployment/gcp/06-mirror-images.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Mirror all GHCR images to Artifact Registry.
+# This pulls from GHCR and pushes to AR for Cloud Run to consume.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/00-config.sh"
+
+TOTAL=${#UNIQUE_IMAGES[@]}
+COUNT=0
+FAILED=0
+
+log "Mirroring ${TOTAL} images from GHCR to Artifact Registry..."
+log "  Source: ${GHCR_PREFIX}"
+log "  Target: ${AR_PREFIX}"
+
+for img in "${UNIQUE_IMAGES[@]}"; do
+  COUNT=$((COUNT + 1))
+  SRC="${GHCR_PREFIX}/${img}:latest"
+  DST="${AR_PREFIX}/${img}:latest"
+
+  log "  [${COUNT}/${TOTAL}] ${img}..."
+
+  if docker pull "${SRC}" >/dev/null 2>&1; then
+    docker tag "${SRC}" "${DST}"
+    if docker push "${DST}" >/dev/null 2>&1; then
+      log_ok "  [${COUNT}/${TOTAL}] ${img}"
+    else
+      log_err "  [${COUNT}/${TOTAL}] Failed to push ${img}"
+      FAILED=$((FAILED + 1))
+    fi
+  else
+    log_err "  [${COUNT}/${TOTAL}] Failed to pull ${img}"
+    FAILED=$((FAILED + 1))
+  fi
+done
+
+if [ "$FAILED" -gt 0 ]; then
+  log_err "Mirror complete with ${FAILED} failures out of ${TOTAL} images."
+  exit 1
+else
+  log_ok "All ${TOTAL} images mirrored successfully."
+fi

--- a/deployment/gcp/07-run-migrations.sh
+++ b/deployment/gcp/07-run-migrations.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Run Django migrations via a Cloud Run Job.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/00-config.sh"
+
+# Load Redis connection
+if [ -f "${SCRIPT_DIR}/redis-connection.env" ]; then
+  source "${SCRIPT_DIR}/redis-connection.env"
+else
+  log_err "redis-connection.env not found. Run 03-setup-redis.sh first."
+  exit 1
+fi
+
+REDIS_URL_0="redis://${REDIS_HOST}:${REDIS_PORT}/0"
+IMAGE="${AR_PREFIX}/zorven-backend:latest"
+
+log "Creating migration job..."
+
+# Delete existing job if present (idempotent)
+gcloud run jobs delete zorven-migrations \
+  --region="${GCP_REGION}" --quiet 2>/dev/null || true
+
+gcloud run jobs create zorven-migrations \
+  --image="${IMAGE}" \
+  --region="${GCP_REGION}" \
+  --memory=1Gi \
+  --cpu=1 \
+  --max-retries=0 \
+  --task-timeout=600 \
+  --service-account="${SA_EMAIL}" \
+  --vpc-connector="${CONNECTOR_NAME}" \
+  --set-secrets="SECRET_KEY=SECRET_KEY:latest" \
+  --set-env-vars="\
+DATABASE_URL=${DATABASE_URL},\
+REDIS_URL=${REDIS_URL_0},\
+CELERY_BROKER_URL=${REDIS_URL_0},\
+CELERY_RESULT_BACKEND=${REDIS_URL_0},\
+DEBUG=False,\
+ALLOWED_HOSTS=*,\
+KONG_ENABLED=false,\
+GCS_AUTO_PROVISION=false,\
+ORCHESTRATION_KAFKA_ENABLED=false,\
+ONBOARDING_KAFKA_ENABLED=false,\
+ANALYTICS_KAFKA_ENABLED=false,\
+TITLING_KAFKA_ENABLED=false,\
+VERTEX_AI_MOCK_MODE=true,\
+RAG_DB_SYNC_ENABLED=false" \
+  --command="bash" \
+  --args="-c,cd /app && python manage.py migrate_schemas --shared --noinput && python manage.py seed_manifests && python manage.py seed_metrics && echo 'Migrations complete'" \
+  --quiet
+
+log "Running migration job..."
+gcloud run jobs execute zorven-migrations \
+  --region="${GCP_REGION}" \
+  --wait \
+  --quiet
+
+log_ok "Migrations complete."

--- a/deployment/gcp/08-deploy-services.sh
+++ b/deployment/gcp/08-deploy-services.sh
@@ -1,0 +1,467 @@
+#!/usr/bin/env bash
+# Deploy all Cloud Run services (core + agents).
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/00-config.sh"
+
+# Load Redis connection
+if [ -f "${SCRIPT_DIR}/redis-connection.env" ]; then
+  source "${SCRIPT_DIR}/redis-connection.env"
+else
+  log_err "redis-connection.env not found. Run 03-setup-redis.sh first."
+  exit 1
+fi
+
+REDIS_BASE="redis://${REDIS_HOST}:${REDIS_PORT}"
+
+# ── Common flags ─────────────────────────────────────────────
+COMMON_FLAGS=(
+  --region="${GCP_REGION}"
+  --service-account="${SA_EMAIL}"
+  --vpc-connector="${CONNECTOR_NAME}"
+  --allow-unauthenticated
+  --quiet
+)
+
+# ── Helper: deploy a service ─────────────────────────────────
+deploy_service() {
+  local name=$1 image=$2 port=$3
+  shift 3
+  log "  Deploying ${name} (port ${port})..."
+  gcloud run deploy "${name}" \
+    --image="${AR_PREFIX}/${image}:latest" \
+    --port="${port}" \
+    "${COMMON_FLAGS[@]}" \
+    "$@" 2>&1 | tail -1
+}
+
+# ═══════════════════════════════════════════════════════════════
+# CORE SERVICES
+# ═══════════════════════════════════════════════════════════════
+log "Deploying core services..."
+
+# Backend (Django/Gunicorn) — skip startup migrations, run Gunicorn directly
+deploy_service zorven-backend zorven-backend 8001 \
+  --memory=1Gi --cpu=1 \
+  --max-instances="${CR_MAX_INSTANCES}" \
+  --min-instances=0 \
+  --timeout="${CR_TIMEOUT}" \
+  --set-secrets="SECRET_KEY=SECRET_KEY:latest,GOOGLE_API_KEY=GOOGLE_API_KEY:latest,STRIPE_SECRET_KEY=STRIPE_SECRET_KEY:latest,STRIPE_WEBHOOK_SECRET=STRIPE_WEBHOOK_SECRET:latest,ORCHESTRATOR_SERVICE_TOKEN=ORCHESTRATOR_SERVICE_TOKEN:latest,ORCHESTRATOR_CALLBACK_TOKEN=ORCHESTRATOR_CALLBACK_TOKEN:latest,WORKER_TOKEN=WORKER_TOKEN:latest" \
+  --set-env-vars="\
+DATABASE_URL=${DATABASE_URL},\
+REDIS_URL=${REDIS_BASE}/0,\
+CELERY_BROKER_URL=${REDIS_BASE}/0,\
+CELERY_RESULT_BACKEND=${REDIS_BASE}/0,\
+DEBUG=False,\
+KONG_ENABLED=false,\
+PORT=8001,\
+ALLOWED_HOSTS=*,\
+GUNICORN_WORKERS=2,\
+GUNICORN_THREADS=2,\
+GCS_AUTO_PROVISION=false,\
+ORCHESTRATION_KAFKA_ENABLED=false,\
+ONBOARDING_KAFKA_ENABLED=false,\
+ANALYTICS_KAFKA_ENABLED=false,\
+TITLING_KAFKA_ENABLED=false,\
+VERTEX_AI_MOCK_MODE=true,\
+RAG_DB_SYNC_ENABLED=false,\
+ORCHESTRATOR_URL=PLACEHOLDER,\
+BACKEND_URL=PLACEHOLDER,\
+CALLBACK_BASE_URL=PLACEHOLDER" \
+  --command="gunicorn" \
+  --args="brand_automator.wsgi:application,--bind,0.0.0.0:8001,--workers,2,--threads,2,--worker-class,gthread,--timeout,120" &
+
+# Backend WebSocket (Daphne)
+deploy_service zorven-backend-ws zorven-backend 8002 \
+  --memory=512Mi --cpu=1 \
+  --max-instances="${CR_MAX_INSTANCES}" \
+  --min-instances=0 \
+  --session-affinity \
+  --set-secrets="SECRET_KEY=SECRET_KEY:latest" \
+  --set-env-vars="\
+DATABASE_URL=${DATABASE_URL},\
+REDIS_URL=${REDIS_BASE}/0,\
+CHANNELS_REDIS_URL=${REDIS_BASE}/0,\
+CELERY_BROKER_URL=${REDIS_BASE}/0,\
+CELERY_RESULT_BACKEND=${REDIS_BASE}/0,\
+DEBUG=False,\
+KONG_ENABLED=false,\
+PORT=8002,\
+ALLOWED_HOSTS=*" \
+  --command="daphne" \
+  --args="brand_automator.asgi:application,--port,8002,--bind,0.0.0.0" &
+
+# Frontend (Next.js)
+deploy_service zorven-frontend zorven-frontend 3000 \
+  --memory=512Mi --cpu=1 \
+  --max-instances="${CR_MAX_INSTANCES}" \
+  --min-instances=0 \
+  --set-env-vars="\
+NODE_ENV=production,\
+NEXT_PUBLIC_API_URL=PLACEHOLDER,\
+NEXT_PUBLIC_BRAND_EQUITY_API_URL=PLACEHOLDER" &
+
+# MLflow
+deploy_service zorven-mlflow zorven-mlflow-server 5000 \
+  --memory=512Mi --cpu=1 \
+  --max-instances=1 \
+  --min-instances=0 \
+  --set-env-vars="\
+MLFLOW_BACKEND_STORE_URI=${DATABASE_URL}" &
+
+wait
+log_ok "Core services deployed."
+
+# ═══════════════════════════════════════════════════════════════
+# CELERY (always-on)
+# ═══════════════════════════════════════════════════════════════
+log "Deploying Celery services (always-on)..."
+
+# Celery Worker — wrap with health server
+deploy_service zorven-celery-worker zorven-celery-worker 8080 \
+  --memory=1Gi --cpu=1 \
+  --max-instances=1 \
+  --min-instances=1 \
+  --no-cpu-throttling \
+  --set-secrets="SECRET_KEY=SECRET_KEY:latest,GOOGLE_API_KEY=GOOGLE_API_KEY:latest,ORCHESTRATOR_SERVICE_TOKEN=ORCHESTRATOR_SERVICE_TOKEN:latest,ORCHESTRATOR_CALLBACK_TOKEN=ORCHESTRATOR_CALLBACK_TOKEN:latest" \
+  --set-env-vars="\
+DATABASE_URL=${DATABASE_URL},\
+REDIS_URL=${REDIS_BASE}/0,\
+CELERY_BROKER_URL=${REDIS_BASE}/0,\
+CELERY_RESULT_BACKEND=${REDIS_BASE}/0,\
+DEBUG=False,\
+ORCHESTRATION_KAFKA_ENABLED=false,\
+ANALYTICS_KAFKA_ENABLED=false,\
+TITLING_KAFKA_ENABLED=false,\
+VERTEX_AI_MOCK_MODE=true,\
+RAG_DB_SYNC_ENABLED=false,\
+GCS_AUTO_PROVISION=false,\
+ORCHESTRATOR_URL=PLACEHOLDER,\
+BACKEND_URL=PLACEHOLDER,\
+CALLBACK_BASE_URL=PLACEHOLDER" \
+  --command="bash" \
+  --args="-c,python -m http.server \${PORT:-8080} & exec celery -A brand_automator worker --loglevel=info --concurrency=4 -Q celery,high_priority,low_priority,ingestion,curation,orchestration" &
+
+# Celery Beat
+deploy_service zorven-celery-beat zorven-celery-beat 8080 \
+  --memory=256Mi --cpu=1 \
+  --max-instances=1 \
+  --min-instances=1 \
+  --no-cpu-throttling \
+  --set-secrets="SECRET_KEY=SECRET_KEY:latest" \
+  --set-env-vars="\
+DATABASE_URL=${DATABASE_URL},\
+CELERY_BROKER_URL=${REDIS_BASE}/0,\
+CELERY_RESULT_BACKEND=${REDIS_BASE}/0,\
+DEBUG=False,\
+ORCHESTRATION_KAFKA_ENABLED=false,\
+RAG_DB_SYNC_ENABLED=false" \
+  --command="bash" \
+  --args="-c,python -m http.server \${PORT:-8080} & exec celery -A brand_automator beat --loglevel=info" &
+
+wait
+log_ok "Celery services deployed."
+
+# ═══════════════════════════════════════════════════════════════
+# AGENT MICROSERVICES (deploy in parallel batches of 8)
+# ═══════════════════════════════════════════════════════════════
+log "Deploying agent microservices..."
+
+# Common agent env vars
+AGENT_COMMON="\
+ORCHESTRATION_KAFKA_ENABLED=false,\
+KAFKA_BOOTSTRAP_SERVERS="
+
+# ── Batch 1: Orchestrator + WF1 agents ──────────────────────
+deploy_service zorven-orchestrator zorven-orchestrator 8010 \
+  --memory=1Gi --cpu=1 \
+  --max-instances="${CR_MAX_INSTANCES}" \
+  --timeout="${CR_TIMEOUT}" \
+  --set-secrets="GOOGLE_API_KEY=GOOGLE_API_KEY:latest,ORCHESTRATOR_SERVICE_TOKEN=ORCHESTRATOR_SERVICE_TOKEN:latest,ORCHESTRATOR_CALLBACK_TOKEN=ORCHESTRATOR_CALLBACK_TOKEN:latest,TAVILY_API_KEY=TAVILY_API_KEY:latest" \
+  --set-env-vars="\
+ORCHESTRATOR_REDIS_URL=${REDIS_BASE}/1,\
+ORCHESTRATOR_PROMPT_CACHE_REDIS_URL=${REDIS_BASE}/2,\
+ORCHESTRATOR_CALLBACK_BASE_URL=PLACEHOLDER,\
+ORCHESTRATOR_MLFLOW_TRACKING_URI=PLACEHOLDER,\
+ORCHESTRATOR_PROMPT_FALLBACK_ONLY=true,\
+${AGENT_COMMON}" &
+
+deploy_service zorven-discovery-agent zorven-discovery-agent 8020 \
+  --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
+  --max-instances="${CR_MAX_INSTANCES}" \
+  --set-secrets="DISCOVERY_GOOGLE_API_KEY=GOOGLE_API_KEY:latest,DISCOVERY_TAVILY_API_KEY=TAVILY_API_KEY:latest" \
+  --set-env-vars="\
+DISCOVERY_REDIS_URL=${REDIS_BASE}/2,\
+DISCOVERY_PROMPT_CACHE_REDIS_URL=${REDIS_BASE}/2,\
+DISCOVERY_MLFLOW_TRACKING_URI=PLACEHOLDER,\
+DISCOVERY_PROMPT_FALLBACK_ONLY=true,\
+${AGENT_COMMON}" &
+
+deploy_service zorven-market-research-agent zorven-market-research-agent 8021 \
+  --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
+  --max-instances="${CR_MAX_INSTANCES}" \
+  --set-secrets="MRA_ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest,MRA_TAVILY_API_KEY=TAVILY_API_KEY:latest" \
+  --set-env-vars="\
+MRA_REDIS_URL=${REDIS_BASE}/11,\
+MRA_PROMPT_CACHE_REDIS_URL=${REDIS_BASE}/2,\
+MRA_MLFLOW_TRACKING_URI=PLACEHOLDER,\
+MRA_PROMPT_FALLBACK_ONLY=true,\
+${AGENT_COMMON}" &
+
+deploy_service zorven-competitor-intel-agent zorven-competitor-intel-agent 8022 \
+  --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
+  --max-instances="${CR_MAX_INSTANCES}" \
+  --set-secrets="CIA_ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest,CIA_TAVILY_API_KEY=TAVILY_API_KEY:latest" \
+  --set-env-vars="\
+CIA_REDIS_URL=${REDIS_BASE}/12,\
+CIA_PROMPT_CACHE_REDIS_URL=${REDIS_BASE}/2,\
+CIA_MLFLOW_TRACKING_URI=PLACEHOLDER,\
+CIA_PROMPT_FALLBACK_ONLY=true,\
+${AGENT_COMMON}" &
+
+deploy_service zorven-audience-persona-agent zorven-audience-persona-agent 8023 \
+  --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
+  --max-instances="${CR_MAX_INSTANCES}" \
+  --set-secrets="APA_ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest" \
+  --set-env-vars="\
+APA_REDIS_URL=${REDIS_BASE}/13,\
+APA_PROMPT_CACHE_REDIS_URL=${REDIS_BASE}/2,\
+APA_MLFLOW_TRACKING_URI=PLACEHOLDER,\
+APA_PROMPT_FALLBACK_ONLY=true,\
+${AGENT_COMMON}" &
+
+deploy_service zorven-trend-cultural-agent zorven-trend-cultural-agent 8024 \
+  --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
+  --max-instances="${CR_MAX_INSTANCES}" \
+  --set-secrets="TCIA_ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest,TCIA_TAVILY_API_KEY=TAVILY_API_KEY:latest" \
+  --set-env-vars="\
+TCIA_REDIS_URL=${REDIS_BASE}/14,\
+TCIA_PROMPT_CACHE_REDIS_URL=${REDIS_BASE}/2,\
+TCIA_MLFLOW_TRACKING_URI=PLACEHOLDER,\
+TCIA_PROMPT_FALLBACK_ONLY=true,\
+${AGENT_COMMON}" &
+
+deploy_service zorven-voc-agent zorven-voc-agent 8025 \
+  --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
+  --max-instances="${CR_MAX_INSTANCES}" \
+  --set-secrets="VOCA_ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest" \
+  --set-env-vars="\
+VOCA_REDIS_URL=${REDIS_BASE}/15,\
+VOCA_PROMPT_CACHE_REDIS_URL=${REDIS_BASE}/2,\
+VOCA_MLFLOW_TRACKING_URI=PLACEHOLDER,\
+VOCA_PROMPT_FALLBACK_ONLY=true,\
+${AGENT_COMMON}" &
+
+deploy_service zorven-intelligence-agent zorven-intelligence-agent 8030 \
+  --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
+  --max-instances="${CR_MAX_INSTANCES}" \
+  --set-secrets="INTELLIGENCE_GEMINI_API_KEY=GOOGLE_API_KEY:latest" \
+  --set-env-vars="\
+INTELLIGENCE_REDIS_URL=${REDIS_BASE}/3,\
+INTELLIGENCE_PROMPT_CACHE_REDIS_URL=${REDIS_BASE}/2,\
+INTELLIGENCE_MLFLOW_TRACKING_URI=PLACEHOLDER,\
+INTELLIGENCE_PROMPT_FALLBACK_ONLY=true,\
+${AGENT_COMMON}" &
+
+wait
+log "  Batch 1 complete."
+
+# ── Batch 2: WF2 agents ─────────────────────────────────────
+deploy_service zorven-brand-positioning-agent zorven-brand-positioning-agent 8031 \
+  --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
+  --max-instances="${CR_MAX_INSTANCES}" \
+  --set-secrets="BPA_ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest" \
+  --set-env-vars="\
+BPA_REDIS_URL=${REDIS_BASE}/16,\
+BPA_PROMPT_CACHE_REDIS_URL=${REDIS_BASE}/2,\
+BPA_MLFLOW_TRACKING_URI=PLACEHOLDER,\
+BPA_PROMPT_FALLBACK_ONLY=true,\
+${AGENT_COMMON}" &
+
+deploy_service zorven-brand-architecture-agent zorven-brand-architecture-agent 8032 \
+  --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
+  --max-instances="${CR_MAX_INSTANCES}" \
+  --set-secrets="BAA_ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest" \
+  --set-env-vars="\
+BAA_REDIS_URL=${REDIS_BASE}/17,\
+BAA_PROMPT_CACHE_REDIS_URL=${REDIS_BASE}/2,\
+BAA_MLFLOW_TRACKING_URI=PLACEHOLDER,\
+BAA_PROMPT_FALLBACK_ONLY=true,\
+${AGENT_COMMON}" &
+
+deploy_service zorven-brand-personality-agent zorven-brand-personality-agent 8033 \
+  --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
+  --max-instances="${CR_MAX_INSTANCES}" \
+  --set-secrets="BPV_ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest" \
+  --set-env-vars="\
+BPV_REDIS_URL=${REDIS_BASE}/18,\
+BPV_PROMPT_CACHE_REDIS_URL=${REDIS_BASE}/2,\
+BPV_MLFLOW_TRACKING_URI=PLACEHOLDER,\
+BPV_PROMPT_FALLBACK_ONLY=true,\
+${AGENT_COMMON}" &
+
+deploy_service zorven-brand-naming-agent zorven-brand-naming-agent 8034 \
+  --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
+  --max-instances="${CR_MAX_INSTANCES}" \
+  --set-secrets="NTA_ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest" \
+  --set-env-vars="\
+NTA_REDIS_URL=${REDIS_BASE}/19,\
+NTA_PROMPT_CACHE_REDIS_URL=${REDIS_BASE}/2,\
+NTA_MLFLOW_TRACKING_URI=PLACEHOLDER,\
+NTA_PROMPT_FALLBACK_ONLY=true,\
+${AGENT_COMMON}" &
+
+deploy_service zorven-brand-story-agent zorven-brand-story-agent 8035 \
+  --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
+  --max-instances="${CR_MAX_INSTANCES}" \
+  --set-secrets="BSA_ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest" \
+  --set-env-vars="\
+BSA_REDIS_URL=${REDIS_BASE}/20,\
+BSA_PROMPT_CACHE_REDIS_URL=${REDIS_BASE}/2,\
+BSA_MLFLOW_TRACKING_URI=PLACEHOLDER,\
+BSA_PROMPT_FALLBACK_ONLY=true,\
+${AGENT_COMMON}" &
+
+deploy_service zorven-chat-titling-worker zorven-chat-titling-worker 8040 \
+  --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
+  --max-instances="${CR_MAX_INSTANCES}" \
+  --set-secrets="TITLING_GOOGLE_API_KEY=GOOGLE_API_KEY:latest,TITLING_WORKER_TOKEN=WORKER_TOKEN:latest" \
+  --set-env-vars="\
+TITLING_REDIS_URL=${REDIS_BASE}/4,\
+TITLING_PROMPT_CACHE_REDIS_URL=${REDIS_BASE}/2,\
+TITLING_MLFLOW_TRACKING_URI=PLACEHOLDER,\
+TITLING_PROMPT_FALLBACK_ONLY=true,\
+TITLING_CORE_API_URL=PLACEHOLDER,\
+TITLING_KAFKA_ENABLED=false,\
+${AGENT_COMMON}" &
+
+deploy_service zorven-content-agent zorven-content-agent 8050 \
+  --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
+  --max-instances="${CR_MAX_INSTANCES}" \
+  --set-secrets="CONTENT_GOOGLE_API_KEY=GOOGLE_API_KEY:latest,CONTENT_CORE_API_TOKEN=ORCHESTRATOR_SERVICE_TOKEN:latest" \
+  --set-env-vars="\
+CONTENT_REDIS_URL=${REDIS_BASE}/5,\
+CONTENT_PROMPT_CACHE_REDIS_URL=${REDIS_BASE}/2,\
+CONTENT_MLFLOW_TRACKING_URI=PLACEHOLDER,\
+CONTENT_PROMPT_FALLBACK_ONLY=true,\
+CONTENT_CORE_API_URL=PLACEHOLDER,\
+${AGENT_COMMON}" &
+
+deploy_service zorven-social-agent zorven-social-agent 8060 \
+  --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
+  --max-instances="${CR_MAX_INSTANCES}" \
+  --set-secrets="SOCIAL_GOOGLE_API_KEY=GOOGLE_API_KEY:latest,SOCIAL_CORE_API_TOKEN=ORCHESTRATOR_SERVICE_TOKEN:latest" \
+  --set-env-vars="\
+SOCIAL_REDIS_URL=${REDIS_BASE}/6,\
+SOCIAL_PROMPT_CACHE_REDIS_URL=${REDIS_BASE}/2,\
+SOCIAL_MLFLOW_TRACKING_URI=PLACEHOLDER,\
+SOCIAL_PROMPT_FALLBACK_ONLY=true,\
+SOCIAL_CORE_API_URL=PLACEHOLDER,\
+${AGENT_COMMON}" &
+
+wait
+log "  Batch 2 complete."
+
+# ── Batch 3: WF3 + remaining agents ─────────────────────────
+deploy_service zorven-campaign-architecture-agent zorven-campaign-architecture-agent 8041 \
+  --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
+  --max-instances="${CR_MAX_INSTANCES}" \
+  --set-secrets="CAA_ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest" \
+  --set-env-vars="\
+CAA_REDIS_URL=${REDIS_BASE}/21,\
+CAA_PROMPT_CACHE_REDIS_URL=${REDIS_BASE}/2,\
+CAA_MLFLOW_TRACKING_URI=PLACEHOLDER,\
+CAA_PROMPT_FALLBACK_ONLY=true,\
+${AGENT_COMMON}" &
+
+deploy_service zorven-creative-generation-agent zorven-creative-generation-agent 8042 \
+  --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
+  --max-instances="${CR_MAX_INSTANCES}" \
+  --set-secrets="CGA_ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest" \
+  --set-env-vars="\
+CGA_REDIS_URL=${REDIS_BASE}/22,\
+CGA_PROMPT_CACHE_REDIS_URL=${REDIS_BASE}/2,\
+CGA_MLFLOW_TRACKING_URI=PLACEHOLDER,\
+CGA_PROMPT_FALLBACK_ONLY=true,\
+${AGENT_COMMON}" &
+
+deploy_service zorven-ad-publishing-agent zorven-ad-publishing-agent 8043 \
+  --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
+  --max-instances="${CR_MAX_INSTANCES}" \
+  --set-secrets="ADPUB_ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest" \
+  --set-env-vars="\
+ADPUB_REDIS_URL=${REDIS_BASE}/23,\
+ADPUB_PROMPT_CACHE_REDIS_URL=${REDIS_BASE}/2,\
+ADPUB_MLFLOW_TRACKING_URI=PLACEHOLDER,\
+ADPUB_PROMPT_FALLBACK_ONLY=true,\
+${AGENT_COMMON}" &
+
+deploy_service zorven-campaign-optimization-agent zorven-campaign-optimization-agent 8044 \
+  --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
+  --max-instances="${CR_MAX_INSTANCES}" \
+  --set-secrets="COA_ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest" \
+  --set-env-vars="\
+COA_REDIS_URL=${REDIS_BASE}/24,\
+COA_PROMPT_CACHE_REDIS_URL=${REDIS_BASE}/2,\
+COA_MLFLOW_TRACKING_URI=PLACEHOLDER,\
+COA_PROMPT_FALLBACK_ONLY=true,\
+${AGENT_COMMON}" &
+
+deploy_service zorven-intelligence-loop-agent zorven-intelligence-loop-agent 8045 \
+  --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
+  --max-instances="${CR_MAX_INSTANCES}" \
+  --set-secrets="ILA_ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest" \
+  --set-env-vars="\
+ILA_REDIS_URL=${REDIS_BASE}/25,\
+ILA_PROMPT_CACHE_REDIS_URL=${REDIS_BASE}/2,\
+ILA_MLFLOW_TRACKING_URI=PLACEHOLDER,\
+ILA_PROMPT_FALLBACK_ONLY=true,\
+${AGENT_COMMON}" &
+
+deploy_service zorven-rag-uploader-agent zorven-rag-uploader-agent 8070 \
+  --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
+  --max-instances="${CR_MAX_INSTANCES}" \
+  --set-env-vars="\
+RAG_UPLOADER_REDIS_URL=${REDIS_BASE}/7,\
+RAG_UPLOADER_PROMPT_CACHE_REDIS_URL=${REDIS_BASE}/2,\
+RAG_UPLOADER_MLFLOW_TRACKING_URI=PLACEHOLDER,\
+RAG_UPLOADER_PROMPT_FALLBACK_ONLY=true,\
+${AGENT_COMMON}" &
+
+deploy_service zorven-brand-equity-calculator zorven-brand-equity-calculator 8090 \
+  --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
+  --max-instances="${CR_MAX_INSTANCES}" \
+  --set-secrets="BRAND_EQUITY_ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest" \
+  --set-env-vars="\
+BRAND_EQUITY_REDIS_URL=${REDIS_BASE}/8,\
+${AGENT_COMMON}" &
+
+deploy_service zorven-odoo-mcp-server zorven-odoo-mcp-server 8095 \
+  --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
+  --max-instances="${CR_MAX_INSTANCES}" \
+  --set-env-vars="\
+ODOO_MCP_REDIS_URL=${REDIS_BASE}/9,\
+${AGENT_COMMON}" &
+
+deploy_service zorven-odoo-worker-agent zorven-odoo-worker-agent 8100 \
+  --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
+  --max-instances="${CR_MAX_INSTANCES}" \
+  --set-env-vars="\
+ODOO_WORKER_REDIS_URL=${REDIS_BASE}/10,\
+ODOO_WORKER_PROMPT_CACHE_REDIS_URL=${REDIS_BASE}/2,\
+ODOO_WORKER_MLFLOW_TRACKING_URI=PLACEHOLDER,\
+ODOO_WORKER_PROMPT_FALLBACK_ONLY=true,\
+${AGENT_COMMON}" &
+
+deploy_service zorven-prompt-optimization zorven-prompt-optimization 8110 \
+  --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
+  --max-instances="${CR_MAX_INSTANCES}" \
+  --set-secrets="POI_ANTHROPIC_API_KEY=POI_ANTHROPIC_API_KEY:latest" \
+  --set-env-vars="\
+POI_REDIS_URL=${REDIS_BASE}/26,\
+POI_MLFLOW_TRACKING_URI=PLACEHOLDER,\
+POI_DATABASE_URL=${DATABASE_URL},\
+${AGENT_COMMON}" &
+
+wait
+log_ok "All agent microservices deployed."

--- a/deployment/gcp/09-collect-urls.sh
+++ b/deployment/gcp/09-collect-urls.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Collect all Cloud Run service URLs after first-pass deployment.
+# Writes service-urls.env for use by 10-redeploy-with-urls.sh.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/00-config.sh"
+
+OUTPUT="${SCRIPT_DIR}/service-urls.env"
+> "${OUTPUT}"
+
+log "Collecting Cloud Run service URLs..."
+
+for entry in "${ALL_SERVICES[@]}"; do
+  IFS=':' read -r svc_name _image _port <<< "${entry}"
+
+  url=$(gcloud run services describe "${svc_name}" \
+    --region="${GCP_REGION}" \
+    --format='value(status.url)' 2>/dev/null || echo "")
+
+  if [ -z "${url}" ]; then
+    log_err "  ${svc_name}: URL not found (service may not be deployed)"
+    continue
+  fi
+
+  # Convert service name to env-friendly key: zorven-backend → ZORVEN_BACKEND_URL
+  key=$(echo "${svc_name}" | tr '[:lower:]-' '[:upper:]_')_URL
+  echo "${key}=${url}" >> "${OUTPUT}"
+  log "  ${svc_name} → ${url}"
+done
+
+# Count collected URLs
+TOTAL=$(wc -l < "${OUTPUT}" | tr -d ' ')
+log_ok "Collected ${TOTAL} service URLs → ${OUTPUT}"

--- a/deployment/gcp/10-redeploy-with-urls.sh
+++ b/deployment/gcp/10-redeploy-with-urls.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Second-pass deployment: update services with correct inter-service URLs.
+# Resolves the chicken-and-egg problem where services need each other's URLs.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/00-config.sh"
+
+URLS_FILE="${SCRIPT_DIR}/service-urls.env"
+if [ ! -f "${URLS_FILE}" ]; then
+  log_err "service-urls.env not found. Run 09-collect-urls.sh first."
+  exit 1
+fi
+source "${URLS_FILE}"
+
+log "Redeploying services with correct inter-service URLs..."
+
+# ── Helper: update env vars on a service ────────────────────
+update_service() {
+  local name=$1
+  shift
+  log "  Updating ${name}..."
+  gcloud run services update "${name}" \
+    --region="${GCP_REGION}" \
+    --update-env-vars="$*" \
+    --quiet 2>&1 | tail -1
+}
+
+# ═══════════════════════════════════════════════════════════════
+# BACKEND — needs orchestrator URL and its own URL for callbacks
+# ═══════════════════════════════════════════════════════════════
+update_service zorven-backend \
+  "ORCHESTRATOR_URL=${ZORVEN_ORCHESTRATOR_URL},BACKEND_URL=${ZORVEN_BACKEND_URL},CALLBACK_BASE_URL=${ZORVEN_BACKEND_URL}" &
+
+# ═══════════════════════════════════════════════════════════════
+# FRONTEND — needs backend API URL and brand equity URL
+# ═══════════════════════════════════════════════════════════════
+update_service zorven-frontend \
+  "NEXT_PUBLIC_API_URL=${ZORVEN_BACKEND_URL},NEXT_PUBLIC_BRAND_EQUITY_API_URL=${ZORVEN_BRAND_EQUITY_CALCULATOR_URL}" &
+
+# ═══════════════════════════════════════════════════════════════
+# CELERY WORKER — needs orchestrator + backend URLs
+# ═══════════════════════════════════════════════════════════════
+update_service zorven-celery-worker \
+  "ORCHESTRATOR_URL=${ZORVEN_ORCHESTRATOR_URL},BACKEND_URL=${ZORVEN_BACKEND_URL},CALLBACK_BASE_URL=${ZORVEN_BACKEND_URL}" &
+
+wait
+
+# ═══════════════════════════════════════════════════════════════
+# ORCHESTRATOR — needs callback URL + all agent service URLs
+# ═══════════════════════════════════════════════════════════════
+update_service zorven-orchestrator \
+  "ORCHESTRATOR_CALLBACK_BASE_URL=${ZORVEN_BACKEND_URL},\
+ORCHESTRATOR_MLFLOW_TRACKING_URI=${ZORVEN_MLFLOW_URL},\
+ORCHESTRATOR_DISCOVERY_URL=${ZORVEN_DISCOVERY_AGENT_URL},\
+ORCHESTRATOR_MARKET_RESEARCH_URL=${ZORVEN_MARKET_RESEARCH_AGENT_URL},\
+ORCHESTRATOR_COMPETITOR_INTEL_URL=${ZORVEN_COMPETITOR_INTEL_AGENT_URL},\
+ORCHESTRATOR_AUDIENCE_PERSONA_URL=${ZORVEN_AUDIENCE_PERSONA_AGENT_URL},\
+ORCHESTRATOR_TREND_CULTURAL_URL=${ZORVEN_TREND_CULTURAL_AGENT_URL},\
+ORCHESTRATOR_VOC_URL=${ZORVEN_VOC_AGENT_URL},\
+ORCHESTRATOR_INTELLIGENCE_URL=${ZORVEN_INTELLIGENCE_AGENT_URL},\
+ORCHESTRATOR_BRAND_POSITIONING_URL=${ZORVEN_BRAND_POSITIONING_AGENT_URL},\
+ORCHESTRATOR_BRAND_ARCHITECTURE_URL=${ZORVEN_BRAND_ARCHITECTURE_AGENT_URL},\
+ORCHESTRATOR_BRAND_PERSONALITY_URL=${ZORVEN_BRAND_PERSONALITY_AGENT_URL},\
+ORCHESTRATOR_BRAND_NAMING_URL=${ZORVEN_BRAND_NAMING_AGENT_URL},\
+ORCHESTRATOR_BRAND_STORY_URL=${ZORVEN_BRAND_STORY_AGENT_URL},\
+ORCHESTRATOR_CAMPAIGN_ARCHITECTURE_URL=${ZORVEN_CAMPAIGN_ARCHITECTURE_AGENT_URL},\
+ORCHESTRATOR_CREATIVE_GENERATION_URL=${ZORVEN_CREATIVE_GENERATION_AGENT_URL},\
+ORCHESTRATOR_AD_PUBLISHING_URL=${ZORVEN_AD_PUBLISHING_AGENT_URL},\
+ORCHESTRATOR_CAMPAIGN_OPTIMIZATION_URL=${ZORVEN_CAMPAIGN_OPTIMIZATION_AGENT_URL},\
+ORCHESTRATOR_INTELLIGENCE_LOOP_URL=${ZORVEN_INTELLIGENCE_LOOP_AGENT_URL},\
+ORCHESTRATOR_CONTENT_URL=${ZORVEN_CONTENT_AGENT_URL},\
+ORCHESTRATOR_SOCIAL_URL=${ZORVEN_SOCIAL_AGENT_URL},\
+ORCHESTRATOR_RAG_UPLOADER_URL=${ZORVEN_RAG_UPLOADER_AGENT_URL},\
+ORCHESTRATOR_CHAT_TITLING_URL=${ZORVEN_CHAT_TITLING_WORKER_URL},\
+ORCHESTRATOR_ODOO_MCP_URL=${ZORVEN_ODOO_MCP_SERVER_URL},\
+ORCHESTRATOR_ODOO_WORKER_URL=${ZORVEN_ODOO_WORKER_AGENT_URL}" &
+
+# ═══════════════════════════════════════════════════════════════
+# AGENTS that need backend/callback URLs
+# ═══════════════════════════════════════════════════════════════
+
+# Chat titling needs backend API URL
+update_service zorven-chat-titling-worker \
+  "TITLING_CORE_API_URL=${ZORVEN_BACKEND_URL},TITLING_MLFLOW_TRACKING_URI=${ZORVEN_MLFLOW_URL}" &
+
+# Content agent needs backend API URL
+update_service zorven-content-agent \
+  "CONTENT_CORE_API_URL=${ZORVEN_BACKEND_URL},CONTENT_MLFLOW_TRACKING_URI=${ZORVEN_MLFLOW_URL}" &
+
+# Social agent needs backend API URL
+update_service zorven-social-agent \
+  "SOCIAL_CORE_API_URL=${ZORVEN_BACKEND_URL},SOCIAL_MLFLOW_TRACKING_URI=${ZORVEN_MLFLOW_URL}" &
+
+wait
+
+# ═══════════════════════════════════════════════════════════════
+# Remaining agents — just need MLflow URI update
+# ═══════════════════════════════════════════════════════════════
+MLFLOW_AGENTS=(
+  "zorven-discovery-agent:DISCOVERY_MLFLOW_TRACKING_URI"
+  "zorven-market-research-agent:MRA_MLFLOW_TRACKING_URI"
+  "zorven-competitor-intel-agent:CIA_MLFLOW_TRACKING_URI"
+  "zorven-audience-persona-agent:APA_MLFLOW_TRACKING_URI"
+  "zorven-trend-cultural-agent:TCIA_MLFLOW_TRACKING_URI"
+  "zorven-voc-agent:VOCA_MLFLOW_TRACKING_URI"
+  "zorven-intelligence-agent:INTELLIGENCE_MLFLOW_TRACKING_URI"
+  "zorven-brand-positioning-agent:BPA_MLFLOW_TRACKING_URI"
+  "zorven-brand-architecture-agent:BAA_MLFLOW_TRACKING_URI"
+  "zorven-brand-personality-agent:BPV_MLFLOW_TRACKING_URI"
+  "zorven-brand-naming-agent:NTA_MLFLOW_TRACKING_URI"
+  "zorven-brand-story-agent:BSA_MLFLOW_TRACKING_URI"
+  "zorven-campaign-architecture-agent:CAA_MLFLOW_TRACKING_URI"
+  "zorven-creative-generation-agent:CGA_MLFLOW_TRACKING_URI"
+  "zorven-ad-publishing-agent:ADPUB_MLFLOW_TRACKING_URI"
+  "zorven-campaign-optimization-agent:COA_MLFLOW_TRACKING_URI"
+  "zorven-intelligence-loop-agent:ILA_MLFLOW_TRACKING_URI"
+  "zorven-rag-uploader-agent:RAG_UPLOADER_MLFLOW_TRACKING_URI"
+  "zorven-odoo-worker-agent:ODOO_WORKER_MLFLOW_TRACKING_URI"
+  "zorven-prompt-optimization:POI_MLFLOW_TRACKING_URI"
+)
+
+# Deploy in batches of 8
+BATCH=0
+for entry in "${MLFLOW_AGENTS[@]}"; do
+  IFS=':' read -r svc_name env_key <<< "${entry}"
+  update_service "${svc_name}" "${env_key}=${ZORVEN_MLFLOW_URL}" &
+  BATCH=$((BATCH + 1))
+  if [ "$BATCH" -ge 8 ]; then
+    wait
+    BATCH=0
+  fi
+done
+wait
+
+log_ok "All services updated with correct inter-service URLs."

--- a/deployment/gcp/11-verify.sh
+++ b/deployment/gcp/11-verify.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Verify all Cloud Run services are healthy.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/00-config.sh"
+
+URLS_FILE="${SCRIPT_DIR}/service-urls.env"
+if [ ! -f "${URLS_FILE}" ]; then
+  log_err "service-urls.env not found. Run 09-collect-urls.sh first."
+  exit 1
+fi
+source "${URLS_FILE}"
+
+PASSED=0
+FAILED=0
+SKIPPED=0
+TOTAL=${#ALL_SERVICES[@]}
+
+log "Verifying ${TOTAL} services..."
+
+# Health check endpoints per service type
+get_health_path() {
+  local svc_name=$1
+  case "${svc_name}" in
+    zorven-backend|zorven-backend-ws)
+      echo "/health/"
+      ;;
+    zorven-frontend)
+      echo "/"
+      ;;
+    zorven-mlflow)
+      echo "/health"
+      ;;
+    zorven-celery-worker|zorven-celery-beat)
+      echo "/"  # python -m http.server serves directory listing
+      ;;
+    *)
+      echo "/health"  # FastAPI agents all have /health
+      ;;
+  esac
+}
+
+for entry in "${ALL_SERVICES[@]}"; do
+  IFS=':' read -r svc_name _image _port <<< "${entry}"
+
+  # Get URL from env var
+  key=$(echo "${svc_name}" | tr '[:lower:]-' '[:upper:]_')_URL
+  url="${!key:-}"
+
+  if [ -z "${url}" ]; then
+    log_err "  ${svc_name}: No URL found (skipping)"
+    SKIPPED=$((SKIPPED + 1))
+    continue
+  fi
+
+  health_path=$(get_health_path "${svc_name}")
+  full_url="${url}${health_path}"
+
+  # curl with 30s timeout (cold start may take time)
+  http_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 30 "${full_url}" 2>/dev/null || echo "000")
+
+  if [ "${http_code}" -ge 200 ] && [ "${http_code}" -lt 400 ]; then
+    log_ok "  ${svc_name}: ${http_code} ← ${full_url}"
+    PASSED=$((PASSED + 1))
+  else
+    log_err "  ${svc_name}: ${http_code} ← ${full_url}"
+    FAILED=$((FAILED + 1))
+  fi
+done
+
+echo ""
+log "Results: ${PASSED} passed, ${FAILED} failed, ${SKIPPED} skipped (${TOTAL} total)"
+
+if [ "${FAILED}" -gt 0 ]; then
+  log_err "Some services failed health checks. Check logs with:"
+  log_err "  gcloud run services logs read <service-name> --region=${GCP_REGION}"
+  exit 1
+else
+  log_ok "All services healthy!"
+fi

--- a/deployment/gcp/99-teardown.sh
+++ b/deployment/gcp/99-teardown.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Tear down all GCP resources created by the deployment scripts.
+# Use this to avoid ongoing costs when the test environment is not needed.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/00-config.sh"
+
+echo "╔══════════════════════════════════════════════════════════╗"
+echo "║  WARNING: This will delete ALL Zorven GCP resources!    ║"
+echo "║  Project: ${GCP_PROJECT_ID}                             ║"
+echo "║  Region:  ${GCP_REGION}                                 ║"
+echo "╚══════════════════════════════════════════════════════════╝"
+echo ""
+read -rp "Type 'yes' to confirm teardown: " confirm
+if [ "${confirm}" != "yes" ]; then
+  log "Teardown cancelled."
+  exit 0
+fi
+
+# ── Delete Cloud Run services ───────────────────────────────
+log "Deleting Cloud Run services..."
+for entry in "${ALL_SERVICES[@]}"; do
+  IFS=':' read -r svc_name _image _port <<< "${entry}"
+  gcloud run services delete "${svc_name}" \
+    --region="${GCP_REGION}" --quiet 2>/dev/null && \
+    log "  Deleted ${svc_name}" || \
+    log "  ${svc_name} not found (skipping)"
+done
+
+# ── Delete Cloud Run migration job ──────────────────────────
+log "Deleting migration job..."
+gcloud run jobs delete zorven-migrations \
+  --region="${GCP_REGION}" --quiet 2>/dev/null || true
+
+# ── Delete Cloud Memorystore Redis ──────────────────────────
+log "Deleting Redis instance (this may take a few minutes)..."
+gcloud redis instances delete "${REDIS_INSTANCE}" \
+  --region="${GCP_REGION}" --quiet 2>/dev/null || true
+
+# ── Delete VPC Connector ────────────────────────────────────
+log "Deleting VPC connector..."
+gcloud compute networks vpc-access connectors delete "${CONNECTOR_NAME}" \
+  --region="${GCP_REGION}" --quiet 2>/dev/null || true
+
+# ── Delete Secret Manager secrets ───────────────────────────
+log "Deleting secrets..."
+SECRETS=$(gcloud secrets list --format='value(name)' 2>/dev/null || echo "")
+for secret in ${SECRETS}; do
+  gcloud secrets delete "${secret}" --quiet 2>/dev/null && \
+    log "  Deleted secret: ${secret}" || true
+done
+
+# ── Delete Artifact Registry images ─────────────────────────
+log "Deleting Artifact Registry repository..."
+gcloud artifacts repositories delete "${AR_REPO}" \
+  --location="${GCP_REGION}" --quiet 2>/dev/null || true
+
+# ── Delete VPC (if no other resources depend on it) ─────────
+log "Deleting VPC..."
+gcloud compute networks delete "${VPC_NAME}" --quiet 2>/dev/null || \
+  log "  VPC ${VPC_NAME} could not be deleted (may have dependent resources)"
+
+# ── Clean up local env files ────────────────────────────────
+log "Cleaning up local files..."
+rm -f "${SCRIPT_DIR}/redis-connection.env"
+rm -f "${SCRIPT_DIR}/service-urls.env"
+
+log_ok "Teardown complete. All Zorven GCP resources deleted."
+log "Note: The Neon PostgreSQL database was NOT deleted (managed externally)."

--- a/deployment/gcp/deploy-all.sh
+++ b/deployment/gcp/deploy-all.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Master deployment script — runs all steps in sequence.
+# Usage:
+#   ./deploy-all.sh              # Full deployment (steps 01-11)
+#   ./deploy-all.sh --skip-infra # Skip infrastructure (steps 05-11 only)
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+SKIP_INFRA=false
+if [ "${1:-}" = "--skip-infra" ]; then
+  SKIP_INFRA=true
+fi
+
+echo "╔══════════════════════════════════════════════════════════╗"
+echo "║  Zorven Platform — GCP Cloud Run Deployment             ║"
+echo "╚══════════════════════════════════════════════════════════╝"
+echo ""
+
+# Check prerequisites
+if ! command -v gcloud &>/dev/null; then
+  echo "ERROR: gcloud CLI not found. Install: https://cloud.google.com/sdk/docs/install"
+  exit 1
+fi
+
+if ! command -v docker &>/dev/null; then
+  echo "ERROR: Docker not found. Install: https://docs.docker.com/get-docker/"
+  exit 1
+fi
+
+# Check secrets.env exists
+if [ ! -f "${SCRIPT_DIR}/secrets.env" ]; then
+  echo "ERROR: secrets.env not found."
+  echo "  Copy secrets.env.template to secrets.env and fill in values:"
+  echo "  cp ${SCRIPT_DIR}/secrets.env.template ${SCRIPT_DIR}/secrets.env"
+  exit 1
+fi
+
+START_TIME=$(date +%s)
+
+run_step() {
+  local script=$1
+  local desc=$2
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "  ${desc}"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  bash "${SCRIPT_DIR}/${script}"
+}
+
+if [ "${SKIP_INFRA}" = false ]; then
+  run_step "01-setup-project.sh"            "Step 1/11: Project setup (APIs, IAM)"
+  run_step "02-setup-networking.sh"         "Step 2/11: Networking (VPC, connector)"
+  run_step "03-setup-redis.sh"              "Step 3/11: Redis (Cloud Memorystore)"
+  run_step "04-setup-secrets.sh"            "Step 4/11: Secrets (Secret Manager)"
+fi
+
+run_step "05-setup-artifact-registry.sh"  "Step 5/11: Artifact Registry"
+run_step "06-mirror-images.sh"            "Step 6/11: Mirror images (GHCR → AR)"
+run_step "07-run-migrations.sh"           "Step 7/11: Database migrations"
+run_step "08-deploy-services.sh"          "Step 8/11: Deploy services (first pass)"
+run_step "09-collect-urls.sh"             "Step 9/11: Collect service URLs"
+run_step "10-redeploy-with-urls.sh"       "Step 10/11: Redeploy with URLs (second pass)"
+run_step "11-verify.sh"                   "Step 11/11: Health verification"
+
+END_TIME=$(date +%s)
+ELAPSED=$(( END_TIME - START_TIME ))
+MINUTES=$(( ELAPSED / 60 ))
+SECONDS=$(( ELAPSED % 60 ))
+
+echo ""
+echo "╔══════════════════════════════════════════════════════════╗"
+echo "║  Deployment complete! (${MINUTES}m ${SECONDS}s)                        ║"
+echo "╚══════════════════════════════════════════════════════════╝"
+echo ""
+echo "Service URLs saved to: ${SCRIPT_DIR}/service-urls.env"
+echo ""
+echo "To tear down: ./99-teardown.sh"
+echo "To redeploy (skip infra): ./deploy-all.sh --skip-infra"

--- a/deployment/gcp/secrets.env.template
+++ b/deployment/gcp/secrets.env.template
@@ -1,0 +1,39 @@
+# Zorven GCP Cloud Run — Secrets Template
+# Copy to secrets.env and fill in values.
+# This file is used by 04-setup-secrets.sh to populate Secret Manager.
+#
+# IMPORTANT: Never commit secrets.env to git.
+
+# Django
+SECRET_KEY=your-django-secret-key-min-50-chars
+
+# AI Services
+GOOGLE_API_KEY=your-gemini-api-key
+ANTHROPIC_API_KEY=your-anthropic-claude-api-key
+TAVILY_API_KEY=your-tavily-api-key
+GNEWS_API_KEY=your-gnews-api-key
+
+# Stripe
+STRIPE_SECRET_KEY=sk_test_your-key
+STRIPE_PUBLISHABLE_KEY=pk_test_your-key
+STRIPE_WEBHOOK_SECRET=whsec_your-secret
+
+# Email (Mailgun)
+MAILGUN_API_KEY=your-mailgun-key
+MAILGUN_DOMAIN=your-mailgun-domain
+
+# Inter-service authentication tokens
+ORCHESTRATOR_SERVICE_TOKEN=your-service-token
+ORCHESTRATOR_CALLBACK_TOKEN=your-callback-token
+WORKER_TOKEN=your-worker-token
+
+# Social OAuth (optional)
+FACEBOOK_APP_ID=
+FACEBOOK_APP_SECRET=
+LINKEDIN_CLIENT_ID=
+LINKEDIN_CLIENT_SECRET=
+TWITTER_CLIENT_ID=
+TWITTER_CLIENT_SECRET=
+
+# Prompt Optimization
+POI_ANTHROPIC_API_KEY=your-anthropic-key-for-poi


### PR DESCRIPTION
## Summary
- Complete deployment automation for deploying all 32 Zorven services to GCP Cloud Run
- 15 scripts covering infrastructure provisioning (VPC, Memorystore Redis with 27 DBs, Secret Manager, Artifact Registry), GHCR→AR image mirroring, database migrations via Cloud Run Job, two-pass service deployment (resolves inter-service URL dependencies), health verification, and teardown
- Celery worker/beat use HTTP health server wrapper for Cloud Run compatibility; scale-to-zero on all request-driven services; always-on for Celery

## Scripts
| Script | Purpose |
|--------|---------|
| `00-config.sh` | Shared config (project, services, Redis DB map) |
| `01-setup-project.sh` | Enable APIs, create service account + IAM |
| `02-setup-networking.sh` | VPC + Serverless VPC Access connector |
| `03-setup-redis.sh` | Cloud Memorystore Redis (27 databases) |
| `04-setup-secrets.sh` | Secret Manager from `secrets.env` |
| `05-setup-artifact-registry.sh` | Create AR Docker repo |
| `06-mirror-images.sh` | Mirror 30 GHCR images to AR |
| `07-run-migrations.sh` | Cloud Run Job for Django migrations |
| `08-deploy-services.sh` | Deploy all 32 services (parallel batches) |
| `09-collect-urls.sh` | Collect Cloud Run URLs |
| `10-redeploy-with-urls.sh` | Update services with real inter-service URLs |
| `11-verify.sh` | Health check all services |
| `99-teardown.sh` | Delete all GCP resources |
| `deploy-all.sh` | Master script (runs 01-11) |
| `secrets.env.template` | Template for user-provided secrets |

## Test plan
- [ ] Copy `secrets.env.template` to `secrets.env` and fill in values
- [ ] Run `./deploy-all.sh` for full deployment
- [ ] Verify all 32 services pass health checks via `./11-verify.sh`
- [ ] Test frontend login page loads in browser
- [ ] Test backend API: `curl {backend-url}/health/`
- [ ] Run `./99-teardown.sh` to confirm clean deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)