### PR TITLE
fix(ci): update GHCR prefix to ZorvenAI organization

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -82,7 +82,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  REGISTRY_PREFIX: ghcr.io/naveenah
+  REGISTRY_PREFIX: ghcr.io/zorvenai
 
 permissions:
   contents: read

--- a/deployment/gcp/00-config.sh
+++ b/deployment/gcp/00-config.sh
@@ -14,7 +14,7 @@ export AR_HOST="${GCP_REGION}-docker.pkg.dev"
 export AR_PREFIX="${AR_HOST}/${GCP_PROJECT_ID}/${AR_REPO}"
 
 # ── GHCR Source ──────────────────────────────────────────────
-export GHCR_PREFIX="ghcr.io/naveenah"
+export GHCR_PREFIX="ghcr.io/zorvenai"
 
 # ── Networking ───────────────────────────────────────────────
 export VPC_NAME="zorven-vpc"


### PR DESCRIPTION
## Summary
- Repository moved from `naveenah` to `ZorvenAI` org
- Update GHCR registry prefix from `ghcr.io/naveenah` to `ghcr.io/zorvenai` in CI workflow and deployment config

## Test plan
- [ ] Merge and trigger `workflow_dispatch` with `build_all=true`
- [ ] Verify images published to `ghcr.io/zorvenai/zorven-*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)