### PR TITLE
feat(deployment): add Watchtower for automatic Docker image updates

### DIFF
--- a/deployment/docker-compose.production.yml
+++ b/deployment/docker-compose.production.yml
@@ -864,6 +864,24 @@ services:
     networks:
       - app-network
 
+  # --- Auto-Update (Watchtower) ---
+  # Monitors GHCR for new image digests and restarts containers automatically.
+  # When a new :development_main image is pushed, Watchtower pulls it and recreates the container.
+  watchtower:
+    image: containrrr/watchtower:latest
+    container_name: zorven-watchtower
+    environment:
+      - WATCHTOWER_CLEANUP=true
+      - WATCHTOWER_POLL_INTERVAL=300
+      - WATCHTOWER_LABEL_ENABLE=false
+      - WATCHTOWER_INCLUDE_STOPPED=false
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ~/.docker/config.json:/config.json:ro
+    restart: unless-stopped
+    networks:
+      - app-network
+
 volumes:
   redis_volume:
   mlflow_postgres_volume:


### PR DESCRIPTION
## Summary
- Adds Watchtower service to `docker-compose.production.yml` for automatic container updates
- Watchtower polls GHCR every 5 minutes for new `:development_main` image digests
- When new images are detected, containers are automatically pulled, recreated, and old images cleaned up

## Configuration
- `WATCHTOWER_POLL_INTERVAL=300` — checks every 5 minutes
- `WATCHTOWER_CLEANUP=true` — removes old images after update
- Mounts `~/.docker/config.json` for GHCR authentication

## Test plan
- [ ] Start containers with `docker compose -f docker-compose.production.yml up -d`
- [ ] Verify Watchtower is running: `docker logs zorven-watchtower`
- [ ] Push a code change to `development_main` and verify containers auto-update within 5 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)