### PR TITLE
fix: convert all shell-form HEALTHCHECK CMD to exec form

### DIFF
--- a/ad-publishing-agent-svc/Dockerfile
+++ b/ad-publishing-agent-svc/Dockerfile
@@ -17,6 +17,6 @@ EXPOSE 8043
 ENV PORT=8043
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
-    CMD curl -f http://localhost:${PORT:-8043}/health || exit 1
+    CMD ["sh", "-c", "curl -f http://localhost:${PORT:-8043}/health || exit 1"]
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8043"]

--- a/audience-persona-agent-svc/Dockerfile
+++ b/audience-persona-agent-svc/Dockerfile
@@ -18,6 +18,6 @@ COPY app/ app/
 EXPOSE 8023
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
-    CMD curl -f http://localhost:8023/health || exit 1
+    CMD ["sh", "-c", "curl -f http://localhost:8023/health || exit 1"]
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8023"]

--- a/brand-architecture-agent-svc/Dockerfile
+++ b/brand-architecture-agent-svc/Dockerfile
@@ -15,6 +15,6 @@ COPY app/ app/
 EXPOSE 8032
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
-    CMD curl -f http://localhost:${PORT:-8032}/health || exit 1
+    CMD ["sh", "-c", "curl -f http://localhost:${PORT:-8032}/health || exit 1"]
 
 CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8032}"]

--- a/brand-naming-agent-svc/Dockerfile
+++ b/brand-naming-agent-svc/Dockerfile
@@ -15,6 +15,6 @@ COPY app/ app/
 EXPOSE 8034
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
-    CMD curl -f http://localhost:${PORT:-8034}/health || exit 1
+    CMD ["sh", "-c", "curl -f http://localhost:${PORT:-8034}/health || exit 1"]
 
 CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8034}"]

--- a/brand-personality-agent-svc/Dockerfile
+++ b/brand-personality-agent-svc/Dockerfile
@@ -15,6 +15,6 @@ COPY app/ app/
 EXPOSE 8033
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
-    CMD curl -f http://localhost:${PORT:-8033}/health || exit 1
+    CMD ["sh", "-c", "curl -f http://localhost:${PORT:-8033}/health || exit 1"]
 
 CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8033}"]

--- a/brand-positioning-agent-svc/Dockerfile
+++ b/brand-positioning-agent-svc/Dockerfile
@@ -15,6 +15,6 @@ COPY app/ app/
 EXPOSE 8031
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
-    CMD curl -f http://localhost:${PORT:-8031}/health || exit 1
+    CMD ["sh", "-c", "curl -f http://localhost:${PORT:-8031}/health || exit 1"]
 
 CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8031}"]

--- a/brand-story-agent-svc/Dockerfile
+++ b/brand-story-agent-svc/Dockerfile
@@ -15,6 +15,6 @@ COPY app/ app/
 EXPOSE 8035
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
-    CMD curl -f http://localhost:${PORT:-8035}/health || exit 1
+    CMD ["sh", "-c", "curl -f http://localhost:${PORT:-8035}/health || exit 1"]
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8035"]

--- a/campaign-architecture-agent-svc/Dockerfile
+++ b/campaign-architecture-agent-svc/Dockerfile
@@ -15,6 +15,6 @@ COPY app/ app/
 EXPOSE 8041
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
-    CMD curl -f http://localhost:${PORT:-8041}/health || exit 1
+    CMD ["sh", "-c", "curl -f http://localhost:${PORT:-8041}/health || exit 1"]
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8041"]

--- a/campaign-optimization-agent-svc/Dockerfile
+++ b/campaign-optimization-agent-svc/Dockerfile
@@ -21,7 +21,7 @@ EXPOSE 8044
 ENV PORT=8044
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
-    CMD curl -f http://localhost:${PORT:-8044}/health || exit 1
+    CMD ["sh", "-c", "curl -f http://localhost:${PORT:-8044}/health || exit 1"]
 
 # tini as PID 1 → forwards SIGTERM to entrypoint → entrypoint traps and
 # kills all child processes cleanly.

--- a/creative-generation-agent-svc/Dockerfile
+++ b/creative-generation-agent-svc/Dockerfile
@@ -15,6 +15,6 @@ COPY app/ app/
 EXPOSE 8042
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
-    CMD curl -f http://localhost:${PORT:-8042}/health || exit 1
+    CMD ["sh", "-c", "curl -f http://localhost:${PORT:-8042}/health || exit 1"]
 
 CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8042}"]

--- a/deployment/docker/backend/Dockerfile
+++ b/deployment/docker/backend/Dockerfile
@@ -71,7 +71,7 @@ USER appuser
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:${PORT}/health/ || exit 1
+    CMD ["sh", "-c", "curl -f http://localhost:${PORT}/health/ || exit 1"]
 
 # Expose port
 EXPOSE ${PORT}

--- a/deployment/docker/celery-worker/Dockerfile
+++ b/deployment/docker/celery-worker/Dockerfile
@@ -57,6 +57,6 @@ USER appuser
 
 # Health check - verify Celery worker is responding
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
-    CMD celery -A brand_automator inspect ping -d celery@$HOSTNAME || exit 1
+    CMD ["sh", "-c", "celery -A brand_automator inspect ping -d celery@$HOSTNAME || exit 1"]
 
 CMD ["bash", "/app/start.sh"]

--- a/deployment/docker/kong/Dockerfile
+++ b/deployment/docker/kong/Dockerfile
@@ -41,7 +41,7 @@ EXPOSE 8000 8443 8001 8444
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
-    CMD kong health || exit 1
+    CMD ["sh", "-c", "kong health || exit 1"]
 
 # Run custom entrypoint which processes env vars then calls Kong's entrypoint
 USER root

--- a/deployment/docker/mlflow/Dockerfile
+++ b/deployment/docker/mlflow/Dockerfile
@@ -5,10 +5,4 @@ RUN pip install --no-cache-dir psycopg2-binary alembic
 
 EXPOSE 5000
 
-# Shell form to allow environment variable expansion
-CMD mlflow server \
-    --host 0.0.0.0 \
-    --port ${PORT:-5000} \
-    --backend-store-uri "${MLFLOW_BACKEND_STORE_URI}" \
-    --default-artifact-root "${MLFLOW_DEFAULT_ARTIFACT_ROOT:-/mlflow/artifacts}" \
-    --allowed-hosts "*"
+CMD ["sh", "-c", "mlflow server --host 0.0.0.0 --port ${PORT:-5000} --backend-store-uri \"${MLFLOW_BACKEND_STORE_URI}\" --default-artifact-root \"${MLFLOW_DEFAULT_ARTIFACT_ROOT:-/mlflow/artifacts}\" --allowed-hosts \"*\""]

--- a/deployment/docker/nginx/Dockerfile
+++ b/deployment/docker/nginx/Dockerfile
@@ -13,7 +13,7 @@ COPY deployment/docker/nginx/nginx.conf /etc/nginx/nginx.conf
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost/health || exit 1
+    CMD ["sh", "-c", "wget --no-verbose --tries=1 --spider http://localhost/health || exit 1"]
 
 EXPOSE 80 443
 

--- a/intelligence-loop-agent-svc/Dockerfile
+++ b/intelligence-loop-agent-svc/Dockerfile
@@ -16,6 +16,6 @@ EXPOSE 8045
 ENV PORT=8045
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
-    CMD curl -f http://localhost:${PORT:-8045}/health || exit 1
+    CMD ["sh", "-c", "curl -f http://localhost:${PORT:-8045}/health || exit 1"]
 
 CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8045}"]

--- a/odoo-mcp-server-svc/Dockerfile
+++ b/odoo-mcp-server-svc/Dockerfile
@@ -24,6 +24,6 @@ USER appuser
 EXPOSE 8095
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
-    CMD curl -f http://localhost:8095/health || exit 1
+    CMD ["sh", "-c", "curl -f http://localhost:8095/health || exit 1"]
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8095"]

--- a/voc-agent-svc/Dockerfile
+++ b/voc-agent-svc/Dockerfile
@@ -18,6 +18,6 @@ COPY app/ app/
 EXPOSE 8025
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
-    CMD curl -f http://localhost:8025/health || exit 1
+    CMD ["sh", "-c", "curl -f http://localhost:8025/health || exit 1"]
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8025"]


### PR DESCRIPTION
## Summary
Fixes `JSONArgsRecommended` linter warnings across all remaining Dockerfiles by converting shell-form `HEALTHCHECK CMD` and `CMD` instructions to JSON exec form (`["sh", "-c", "..."]`).

## Files changed (18 Dockerfiles)
- `ad-publishing-agent-svc/Dockerfile`
- `audience-persona-agent-svc/Dockerfile`
- `brand-architecture-agent-svc/Dockerfile`
- `brand-naming-agent-svc/Dockerfile`
- `brand-personality-agent-svc/Dockerfile`
- `brand-positioning-agent-svc/Dockerfile`
- `brand-story-agent-svc/Dockerfile`
- `campaign-architecture-agent-svc/Dockerfile`
- `campaign-optimization-agent-svc/Dockerfile`
- `creative-generation-agent-svc/Dockerfile`
- `intelligence-loop-agent-svc/Dockerfile`
- `odoo-mcp-server-svc/Dockerfile`
- `voc-agent-svc/Dockerfile`
- `deployment/docker/backend/Dockerfile`
- `deployment/docker/celery-worker/Dockerfile`
- `deployment/docker/kong/Dockerfile`
- `deployment/docker/mlflow/Dockerfile`
- `deployment/docker/nginx/Dockerfile`

## Test plan
- [ ] Verify no `JSONArgsRecommended` warnings remain in any Dockerfile
- [ ] Verify all containers start and health checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)