### PR TITLE
fix: apply Black formatting to files/services.py

### DIFF
--- a/ai-brand-automator/files/services.py
+++ b/ai-brand-automator/files/services.py
@@ -329,12 +329,9 @@ class GCSService:
                 import google.auth.transport.requests
 
                 if not self._credentials.token or (
-                    hasattr(self._credentials, "expired")
-                    and self._credentials.expired
+                    hasattr(self._credentials, "expired") and self._credentials.expired
                 ):
-                    self._credentials.refresh(
-                        google.auth.transport.requests.Request()
-                    )
+                    self._credentials.refresh(google.auth.transport.requests.Request())
 
                 sa_email = getattr(
                     settings,


### PR DESCRIPTION
## Summary

- Apply Black formatting to `files/services.py` to fix CI lint failure

## Test plan

- [ ] `black --check .` passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)