### PR TITLE
fix(ci): resolve parent commit for paths-filter in deploy-gcp workflow

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -74,10 +74,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 2
+      - name: Resolve base commit
+        id: base
+        run: echo "sha=$(git rev-parse HEAD~1)" >> "$GITHUB_OUTPUT"
       - uses: dorny/paths-filter@v3
         id: filter
         with:
-          base: ${{ github.event.workflow_run.head_sha }}~1
+          base: ${{ steps.base.outputs.sha }}
           ref: ${{ github.event.workflow_run.head_sha }}
           filters: |
             backend:


### PR DESCRIPTION
## Summary

- Fix GCP Cloud Run auto-deploy workflow failing with `fatal: invalid refspec` error
- `dorny/paths-filter` doesn't support git `~1` suffix in the `base` parameter — `git fetch` treats it as an invalid refspec
- Resolve the parent commit SHA explicitly via `git rev-parse HEAD~1` before passing to paths-filter

## Test plan

- [ ] Deploy workflow triggers successfully after Docker publish completes
- [ ] Changed services are correctly detected and deployed to Cloud Run

🤖 Generated with [Claude Code](https://claude.com/claude-code)