### PR TITLE
fix(deploy): serialize Cloud Run rollouts, cut agent max-instances, gate migration failures

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -155,7 +155,21 @@ jobs:
     needs: changes
     strategy:
       fail-fast: false
-      max-parallel: 8
+      # QUOTA: us-central1 allows 20 vCPU total (CpuAllocPerProjectRegion =
+      # 20000 milli vCPU). Rolling a revision needs headroom for the old and
+      # new revision to be live simultaneously, so N parallel rollouts can
+      # transiently demand ~2N vCPU on top of whatever is already serving.
+      # At max-parallel: 8 that spike exhausted the quota mid-deploy and
+      # failed 4 services (backend/-ws, intelligence-loop, odoo-mcp,
+      # prompt-optimization) with "Quota exceeded for total allowable CPU".
+      #
+      # Evidence that the spike — not the steady-state total — was the cause:
+      # 28 services deployed fine while potential allocation was already
+      # 61 vCPU, so the quota is enforced against concurrent CPU in use.
+      #
+      # 3 keeps the transient draw near ~6 vCPU. Raise this once the
+      # CpuAllocPerProjectRegion quota increase is granted.
+      max-parallel: 3
       matrix:
         include:
           # Backend (image used by backend + backend-ws)

--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -303,10 +303,22 @@ jobs:
         if: matrix.changed == 'true' && matrix.image == 'zorven-backend'
         run: |
           echo "Running database migrations..."
-          gcloud run jobs execute zorven-migrations \
+          # NOTE: this step must fail the deploy on migration failure. It
+          # previously ended in `|| echo "Warning: ..."`, which meant a broken
+          # migration job passed silently and services rolled forward onto an
+          # unmigrated schema. A real failure went unnoticed this way: the
+          # zorven-migrations job was pinned to a decommissioned Neon endpoint
+          # and had been exiting 1 on every deploy.
+          if ! gcloud run jobs execute zorven-migrations \
             --region="${{ env.GCP_REGION }}" \
             --wait \
-            --quiet || echo "Warning: Migration job failed or not found"
+            --quiet; then
+            echo "::error::Migration job 'zorven-migrations' failed. Aborting deploy."
+            echo "Inspect the failing execution with:"
+            echo "  gcloud run jobs executions list --job=zorven-migrations --region=${{ env.GCP_REGION }}"
+            echo "  gcloud logging read 'resource.type=\"cloud_run_job\" resource.labels.job_name=\"zorven-migrations\"' --limit=50"
+            exit 1
+          fi
 
       # Update Cloud Run services with new image
       - name: Deploy to Cloud Run

--- a/deployment/gcp/00-config.sh
+++ b/deployment/gcp/00-config.sh
@@ -34,8 +34,25 @@ export SA_EMAIL="${SA_NAME}@${GCP_PROJECT_ID}.iam.gserviceaccount.com"
 # ── Cloud Run Defaults ───────────────────────────────────────
 export CR_MEMORY="512Mi"
 export CR_CPU="1"
-export CR_MAX_INSTANCES="2"
 export CR_TIMEOUT="300"
+
+# Max instances for user-facing services (backend, frontend, orchestrator).
+# These absorb interactive traffic and keep burst headroom.
+export CR_MAX_INSTANCES="2"
+
+# Max instances for agent microservices.
+#
+# QUOTA: us-central1 allows 20 vCPU total (CpuAllocPerProjectRegion =
+# 20000 milli vCPU). At cpu=1 each, the ~29 CR_MAX_INSTANCES services could
+# request 58 vCPU on their own, which blew the ceiling and failed 4 services
+# mid-rollout. Agents are invoked per-pipeline-node and rarely need to scale
+# out, so they are pinned to 1 instance to cut rollout pressure roughly in
+# half (61 -> 36 vCPU potential).
+#
+# NOTE: 32 services x 1 instance = 32 vCPU still exceeds the 20 vCPU quota.
+# This reduces pressure but does NOT by itself make the ceiling safe — the
+# quota increase is still required.
+export CR_MAX_INSTANCES_AGENT="1"
 
 # ── Database ─────────────────────────────────────────────────
 # SECURITY: DATABASE_URL carries credentials and MUST NOT be hardcoded here.

--- a/deployment/gcp/08-deploy-services.sh
+++ b/deployment/gcp/08-deploy-services.sh
@@ -198,7 +198,7 @@ ${AGENT_COMMON}" &
 
 deploy_service zorven-discovery-agent zorven-discovery-agent 8020 \
   --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
-  --max-instances="${CR_MAX_INSTANCES}" \
+  --max-instances="${CR_MAX_INSTANCES_AGENT}" \
   --set-secrets="DISCOVERY_GOOGLE_API_KEY=GOOGLE_API_KEY:latest,DISCOVERY_TAVILY_API_KEY=TAVILY_API_KEY:latest" \
   --set-env-vars="\
 DISCOVERY_REDIS_URL=${REDIS_BASE}/2,\
@@ -209,7 +209,7 @@ ${AGENT_COMMON}" &
 
 deploy_service zorven-market-research-agent zorven-market-research-agent 8021 \
   --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
-  --max-instances="${CR_MAX_INSTANCES}" \
+  --max-instances="${CR_MAX_INSTANCES_AGENT}" \
   --set-secrets="MRA_ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest,MRA_TAVILY_API_KEY=TAVILY_API_KEY:latest" \
   --set-env-vars="\
 MRA_REDIS_URL=${REDIS_BASE}/11,\
@@ -220,7 +220,7 @@ ${AGENT_COMMON}" &
 
 deploy_service zorven-competitor-intel-agent zorven-competitor-intel-agent 8022 \
   --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
-  --max-instances="${CR_MAX_INSTANCES}" \
+  --max-instances="${CR_MAX_INSTANCES_AGENT}" \
   --set-secrets="CIA_ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest,CIA_TAVILY_API_KEY=TAVILY_API_KEY:latest" \
   --set-env-vars="\
 CIA_REDIS_URL=${REDIS_BASE}/12,\
@@ -231,7 +231,7 @@ ${AGENT_COMMON}" &
 
 deploy_service zorven-audience-persona-agent zorven-audience-persona-agent 8023 \
   --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
-  --max-instances="${CR_MAX_INSTANCES}" \
+  --max-instances="${CR_MAX_INSTANCES_AGENT}" \
   --set-secrets="APA_ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest" \
   --set-env-vars="\
 APA_REDIS_URL=${REDIS_BASE}/13,\
@@ -242,7 +242,7 @@ ${AGENT_COMMON}" &
 
 deploy_service zorven-trend-cultural-agent zorven-trend-cultural-agent 8024 \
   --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
-  --max-instances="${CR_MAX_INSTANCES}" \
+  --max-instances="${CR_MAX_INSTANCES_AGENT}" \
   --set-secrets="TCIA_ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest,TCIA_TAVILY_API_KEY=TAVILY_API_KEY:latest" \
   --set-env-vars="\
 TCIA_REDIS_URL=${REDIS_BASE}/14,\
@@ -253,7 +253,7 @@ ${AGENT_COMMON}" &
 
 deploy_service zorven-voc-agent zorven-voc-agent 8025 \
   --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
-  --max-instances="${CR_MAX_INSTANCES}" \
+  --max-instances="${CR_MAX_INSTANCES_AGENT}" \
   --set-secrets="VOCA_ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest" \
   --set-env-vars="\
 VOCA_REDIS_URL=${REDIS_BASE}/15,\
@@ -264,7 +264,7 @@ ${AGENT_COMMON}" &
 
 deploy_service zorven-intelligence-agent zorven-intelligence-agent 8030 \
   --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
-  --max-instances="${CR_MAX_INSTANCES}" \
+  --max-instances="${CR_MAX_INSTANCES_AGENT}" \
   --set-secrets="INTELLIGENCE_GEMINI_API_KEY=GOOGLE_API_KEY:latest" \
   --set-env-vars="\
 INTELLIGENCE_REDIS_URL=${REDIS_BASE}/3,\
@@ -279,7 +279,7 @@ log "  Batch 1 complete."
 # ── Batch 2: WF2 agents ─────────────────────────────────────
 deploy_service zorven-brand-positioning-agent zorven-brand-positioning-agent 8031 \
   --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
-  --max-instances="${CR_MAX_INSTANCES}" \
+  --max-instances="${CR_MAX_INSTANCES_AGENT}" \
   --set-secrets="BPA_ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest" \
   --set-env-vars="\
 BPA_REDIS_URL=${REDIS_BASE}/16,\
@@ -290,7 +290,7 @@ ${AGENT_COMMON}" &
 
 deploy_service zorven-brand-architecture-agent zorven-brand-architecture-agent 8032 \
   --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
-  --max-instances="${CR_MAX_INSTANCES}" \
+  --max-instances="${CR_MAX_INSTANCES_AGENT}" \
   --set-secrets="BAA_ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest" \
   --set-env-vars="\
 BAA_REDIS_URL=${REDIS_BASE}/17,\
@@ -301,7 +301,7 @@ ${AGENT_COMMON}" &
 
 deploy_service zorven-brand-personality-agent zorven-brand-personality-agent 8033 \
   --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
-  --max-instances="${CR_MAX_INSTANCES}" \
+  --max-instances="${CR_MAX_INSTANCES_AGENT}" \
   --set-secrets="BPV_ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest" \
   --set-env-vars="\
 BPV_REDIS_URL=${REDIS_BASE}/18,\
@@ -312,7 +312,7 @@ ${AGENT_COMMON}" &
 
 deploy_service zorven-brand-naming-agent zorven-brand-naming-agent 8034 \
   --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
-  --max-instances="${CR_MAX_INSTANCES}" \
+  --max-instances="${CR_MAX_INSTANCES_AGENT}" \
   --set-secrets="NTA_ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest" \
   --set-env-vars="\
 NTA_REDIS_URL=${REDIS_BASE}/19,\
@@ -323,7 +323,7 @@ ${AGENT_COMMON}" &
 
 deploy_service zorven-brand-story-agent zorven-brand-story-agent 8035 \
   --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
-  --max-instances="${CR_MAX_INSTANCES}" \
+  --max-instances="${CR_MAX_INSTANCES_AGENT}" \
   --set-secrets="BSA_ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest" \
   --set-env-vars="\
 BSA_REDIS_URL=${REDIS_BASE}/20,\
@@ -334,7 +334,7 @@ ${AGENT_COMMON}" &
 
 deploy_service zorven-chat-titling-worker zorven-chat-titling-worker 8040 \
   --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
-  --max-instances="${CR_MAX_INSTANCES}" \
+  --max-instances="${CR_MAX_INSTANCES_AGENT}" \
   --set-secrets="TITLING_GOOGLE_API_KEY=GOOGLE_API_KEY:latest,TITLING_WORKER_TOKEN=WORKER_TOKEN:latest" \
   --set-env-vars="\
 TITLING_REDIS_URL=${REDIS_BASE}/4,\
@@ -347,7 +347,7 @@ ${AGENT_COMMON}" &
 
 deploy_service zorven-content-agent zorven-content-agent 8050 \
   --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
-  --max-instances="${CR_MAX_INSTANCES}" \
+  --max-instances="${CR_MAX_INSTANCES_AGENT}" \
   --set-secrets="CONTENT_GOOGLE_API_KEY=GOOGLE_API_KEY:latest,CONTENT_CORE_API_TOKEN=ORCHESTRATOR_SERVICE_TOKEN:latest" \
   --set-env-vars="\
 CONTENT_REDIS_URL=${REDIS_BASE}/5,\
@@ -359,7 +359,7 @@ ${AGENT_COMMON}" &
 
 deploy_service zorven-social-agent zorven-social-agent 8060 \
   --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
-  --max-instances="${CR_MAX_INSTANCES}" \
+  --max-instances="${CR_MAX_INSTANCES_AGENT}" \
   --set-secrets="SOCIAL_GOOGLE_API_KEY=GOOGLE_API_KEY:latest,SOCIAL_CORE_API_TOKEN=ORCHESTRATOR_SERVICE_TOKEN:latest" \
   --set-env-vars="\
 SOCIAL_REDIS_URL=${REDIS_BASE}/6,\
@@ -375,7 +375,7 @@ log "  Batch 2 complete."
 # ── Batch 3: WF3 + remaining agents ─────────────────────────
 deploy_service zorven-campaign-architecture-agent zorven-campaign-architecture-agent 8041 \
   --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
-  --max-instances="${CR_MAX_INSTANCES}" \
+  --max-instances="${CR_MAX_INSTANCES_AGENT}" \
   --set-secrets="CAA_ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest" \
   --set-env-vars="\
 CAA_REDIS_URL=${REDIS_BASE}/21,\
@@ -386,7 +386,7 @@ ${AGENT_COMMON}" &
 
 deploy_service zorven-creative-generation-agent zorven-creative-generation-agent 8042 \
   --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
-  --max-instances="${CR_MAX_INSTANCES}" \
+  --max-instances="${CR_MAX_INSTANCES_AGENT}" \
   --set-secrets="CGA_ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest" \
   --set-env-vars="\
 CGA_REDIS_URL=${REDIS_BASE}/22,\
@@ -397,7 +397,7 @@ ${AGENT_COMMON}" &
 
 deploy_service zorven-ad-publishing-agent zorven-ad-publishing-agent 8043 \
   --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
-  --max-instances="${CR_MAX_INSTANCES}" \
+  --max-instances="${CR_MAX_INSTANCES_AGENT}" \
   --set-secrets="ADPUB_ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest" \
   --set-env-vars="\
 ADPUB_REDIS_URL=${REDIS_BASE}/23,\
@@ -408,7 +408,7 @@ ${AGENT_COMMON}" &
 
 deploy_service zorven-campaign-optimization-agent zorven-campaign-optimization-agent 8044 \
   --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
-  --max-instances="${CR_MAX_INSTANCES}" \
+  --max-instances="${CR_MAX_INSTANCES_AGENT}" \
   --set-secrets="COA_ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest" \
   --set-env-vars="\
 COA_REDIS_URL=${REDIS_BASE}/24,\
@@ -419,7 +419,7 @@ ${AGENT_COMMON}" &
 
 deploy_service zorven-intelligence-loop-agent zorven-intelligence-loop-agent 8045 \
   --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
-  --max-instances="${CR_MAX_INSTANCES}" \
+  --max-instances="${CR_MAX_INSTANCES_AGENT}" \
   --set-secrets="ILA_ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest" \
   --set-env-vars="\
 ILA_REDIS_URL=${REDIS_BASE}/25,\
@@ -430,7 +430,7 @@ ${AGENT_COMMON}" &
 
 deploy_service zorven-rag-uploader-agent zorven-rag-uploader-agent 8070 \
   --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
-  --max-instances="${CR_MAX_INSTANCES}" \
+  --max-instances="${CR_MAX_INSTANCES_AGENT}" \
   --set-env-vars="\
 RAG_UPLOADER_REDIS_URL=${REDIS_BASE}/7,\
 RAG_UPLOADER_PROMPT_CACHE_REDIS_URL=${REDIS_BASE}/2,\
@@ -440,7 +440,7 @@ ${AGENT_COMMON}" &
 
 deploy_service zorven-brand-equity-calculator zorven-brand-equity-calculator 8090 \
   --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
-  --max-instances="${CR_MAX_INSTANCES}" \
+  --max-instances="${CR_MAX_INSTANCES_AGENT}" \
   --set-secrets="BRAND_EQUITY_ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest" \
   --set-env-vars="\
 BRAND_EQUITY_REDIS_URL=${REDIS_BASE}/8,\
@@ -448,14 +448,14 @@ ${AGENT_COMMON}" &
 
 deploy_service zorven-odoo-mcp-server zorven-odoo-mcp-server 8095 \
   --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
-  --max-instances="${CR_MAX_INSTANCES}" \
+  --max-instances="${CR_MAX_INSTANCES_AGENT}" \
   --set-env-vars="\
 ODOO_MCP_REDIS_URL=${REDIS_BASE}/9,\
 ${AGENT_COMMON}" &
 
 deploy_service zorven-odoo-worker-agent zorven-odoo-worker-agent 8100 \
   --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
-  --max-instances="${CR_MAX_INSTANCES}" \
+  --max-instances="${CR_MAX_INSTANCES_AGENT}" \
   --set-env-vars="\
 ODOO_WORKER_REDIS_URL=${REDIS_BASE}/10,\
 ODOO_WORKER_PROMPT_CACHE_REDIS_URL=${REDIS_BASE}/2,\
@@ -465,7 +465,7 @@ ${AGENT_COMMON}" &
 
 deploy_service zorven-prompt-optimization zorven-prompt-optimization 8110 \
   --memory="${CR_MEMORY}" --cpu="${CR_CPU}" \
-  --max-instances="${CR_MAX_INSTANCES}" \
+  --max-instances="${CR_MAX_INSTANCES_AGENT}" \
   --set-secrets="POI_ANTHROPIC_API_KEY=POI_ANTHROPIC_API_KEY:latest" \
   --set-env-vars="\
 POI_REDIS_URL=${REDIS_BASE}/26,\


### PR DESCRIPTION
Fixes the 4 Cloud Run deploy failures from the 2026-07-28 push, plus a silent migration failure found while diagnosing them.

## The failure

4 of 32 services failed — `zorven-backend` (+`-ws`), `zorven-intelligence-loop-agent`, `zorven-odoo-mcp-server`, `zorven-prompt-optimization` — all with:

```
Quota exceeded for total allowable CPU per project per region.
```

`us-central1` allows **20 vCPU** (`CpuAllocPerProjectRegion` = 20000 milli vCPU).

## Fix 1 (primary) — `max-parallel: 8 → 3`

**28 of 32 services deployed successfully while potential allocation was already 61 vCPU** against a 20 vCPU ceiling. That rules out steady-state total as the cause: the quota is enforced against *concurrent CPU in use*. The failure was a **transient spike**.

Rolling a revision keeps old and new live simultaneously, so N parallel rollouts transiently demand ~2N vCPU on top of what's already serving. At `max-parallel: 8` that exceeded the ceiling mid-deploy; the 4 unlucky services were simply last.

`max-parallel: 3` keeps the transient draw near ~6 vCPU.

**Trade-off:** 31 services roll out in ~11 batches instead of ~4, so a full-platform deploy takes proportionally longer. Raise it once the quota increase lands.

## Fix 2 (secondary) — max-instances tiering

| Tier | Value | Services |
|---|---|---|
| `CR_MAX_INSTANCES` | 2 | 4 user-facing: backend, backend-ws, frontend, orchestrator |
| `CR_MAX_INSTANCES_AGENT` | 1 | 25 agent microservices (per-pipeline-node, rarely scale out) |
| unchanged | 1 | 3 already pinned: mlflow, celery-worker, celery-beat |

Potential allocation 61 → 36 vCPU. This reduces steady-state pressure but, per the evidence above, targets the secondary factor — I initially had this backwards and ranked it as the main fix.

Note it does **not** clear the 20 vCPU ceiling on its own (32 × 1 = 32 vCPU), and it only affects **future provisioning** — `deploy-gcp.yml` sets no resource flags, so live values don't change on merge. To apply to running services:

```bash
for svc in $(gcloud run services list --region=us-central1 --format='value(metadata.name)' \
  | grep -vE 'zorven-(backend|backend-ws|frontend|orchestrator|mlflow|celery-worker|celery-beat)$'); do
  gcloud run services update "$svc" --region=us-central1 --max-instances=1 --quiet
done
```

## Fix 3 — migration failures no longer silent

```bash
--quiet || echo "Warning: Migration job failed or not found"
```

That `||` let a failing migration pass while services rolled forward onto a potentially unmigrated schema — and it was masking a real break: `zorven-migrations` was pinned to a decommissioned Neon endpoint (`ep-small-dawn-aevftgxm`) while every service used `ep-delicate-unit-aes0pu6a`, exiting 1 with `password authentication failed` on every deploy since **Jul 26** (last success Jul 25).

The step now fails the job and prints inspection commands.

### That break is already repaired — this PR is safe to merge

Fixed out-of-band before merging, so Fix 3 will not block deploys:

- `deployment/gcp/secrets.env` repointed to `ep-delicate-unit-aes0pu6a` (host swap only; password untouched)
- live `zorven-migrations` job repointed via `gcloud run jobs update`
- executed green as `zorven-migrations-kgbxh`, applying the one-migration backlog: `onboarding.0012_alter_brandasset_gcs_bucket`

## Quota status

A programmatic increase request to 80 vCPU was **auto-denied** — still granted 20000. Needs the console form or a support case. Fix 1 is intended to make deploys succeed *without* waiting on that.

## Verification

- `deploy-gcp.yml` parses as valid YAML: `max-parallel: 3`, `fail-fast: false`, 31 matrix entries, all 8 deploy steps intact
- `bash -n` clean on `00-config.sh` and `08-deploy-services.sh`
- Tier counts parsed from the script: 4 + 25 + 3 = 32 services
- Migration job verified green against the correct endpoint (above)
- No change to any service's image, env, secrets, or ports
- **Not verified:** a full green deploy run — that happens on merge

## Out of scope (found while diagnosing, filed separately)

- **`seed_metrics` has never worked in production.** `FieldError: Invalid field name(s) for MetricDefinition: 'max_value', 'min_value'` — the model defines `value_range_min`/`value_range_max`. Swallowed by `|| echo 'seed_metrics failed - non-critical'` in the job args, so the analytics metric registry behind `/api/v1/analytics/` is empty. Predates this work (last touched in #294).
- **The live production DB password is in `development_main`'s git history** and needs rotating. `DATABASE_URL` is a plain env var, not a Secret Manager ref, so rotation currently means six touchpoints — worth moving it to `--set-secrets` like `SECRET_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)