### PR TITLE
fix(analytics): repair seed_metrics so all 104 MetricDefinitions seed

### DIFF
--- a/ai-brand-automator/analytics/management/commands/seed_metrics.py
+++ b/ai-brand-automator/analytics/management/commands/seed_metrics.py
@@ -1,4 +1,5 @@
 from django.core.management.base import BaseCommand
+from django.db import transaction
 
 from analytics.models import MetricDefinition
 
@@ -379,8 +380,8 @@ METRIC_DEFINITIONS = [
         "display_name": "Architecture Model Score",
         "category": "brand_architecture",
         "unit": "score",
-        "min_value": 0,
-        "max_value": 100,
+        "value_range_min": 0,
+        "value_range_max": 100,
         "higher_is_better": True,
         "chart_color": "#3B82F6",
         "display_order": 200,
@@ -393,8 +394,8 @@ METRIC_DEFINITIONS = [
         "display_name": "Positioning Alignment",
         "category": "brand_architecture",
         "unit": "score",
-        "min_value": 0,
-        "max_value": 25,
+        "value_range_min": 0,
+        "value_range_max": 25,
         "higher_is_better": True,
         "chart_color": "#8B5CF6",
         "display_order": 201,
@@ -406,8 +407,8 @@ METRIC_DEFINITIONS = [
         "display_name": "Audience Fit",
         "category": "brand_architecture",
         "unit": "score",
-        "min_value": 0,
-        "max_value": 25,
+        "value_range_min": 0,
+        "value_range_max": 25,
         "higher_is_better": True,
         "chart_color": "#14B8A6",
         "display_order": 202,
@@ -419,8 +420,8 @@ METRIC_DEFINITIONS = [
         "display_name": "Competitive Differentiation",
         "category": "brand_architecture",
         "unit": "score",
-        "min_value": 0,
-        "max_value": 25,
+        "value_range_min": 0,
+        "value_range_max": 25,
         "higher_is_better": True,
         "chart_color": "#F59E0B",
         "display_order": 203,
@@ -432,8 +433,8 @@ METRIC_DEFINITIONS = [
         "display_name": "Operational Efficiency",
         "category": "brand_architecture",
         "unit": "score",
-        "min_value": 0,
-        "max_value": 25,
+        "value_range_min": 0,
+        "value_range_max": 25,
         "higher_is_better": True,
         "chart_color": "#EC4899",
         "display_order": 204,
@@ -445,8 +446,8 @@ METRIC_DEFINITIONS = [
         "display_name": "Hierarchy Depth",
         "category": "brand_architecture",
         "unit": "count",
-        "min_value": 0,
-        "max_value": 5,
+        "value_range_min": 0,
+        "value_range_max": 5,
         "higher_is_better": False,
         "chart_color": "#6B7280",
         "display_order": 205,
@@ -458,8 +459,8 @@ METRIC_DEFINITIONS = [
         "display_name": "Sub-Brand Count",
         "category": "brand_architecture",
         "unit": "count",
-        "min_value": 0,
-        "max_value": 15,
+        "value_range_min": 0,
+        "value_range_max": 15,
         "higher_is_better": True,
         "chart_color": "#22C55E",
         "display_order": 206,
@@ -471,8 +472,8 @@ METRIC_DEFINITIONS = [
         "display_name": "Naming Consistency",
         "category": "brand_architecture",
         "unit": "score",
-        "min_value": 0,
-        "max_value": 100,
+        "value_range_min": 0,
+        "value_range_max": 100,
         "higher_is_better": True,
         "chart_color": "#00F5FF",
         "display_order": 207,
@@ -484,8 +485,8 @@ METRIC_DEFINITIONS = [
         "display_name": "Growth Phases Planned",
         "category": "brand_architecture",
         "unit": "count",
-        "min_value": 0,
-        "max_value": 10,
+        "value_range_min": 0,
+        "value_range_max": 10,
         "higher_is_better": True,
         "chart_color": "#F59E0B",
         "display_order": 208,
@@ -497,8 +498,8 @@ METRIC_DEFINITIONS = [
         "display_name": "Architecture Confidence",
         "category": "brand_architecture",
         "unit": "score",
-        "min_value": 0,
-        "max_value": 100,
+        "value_range_min": 0,
+        "value_range_max": 100,
         "higher_is_better": True,
         "chart_color": "#10B981",
         "display_order": 209,
@@ -1228,7 +1229,7 @@ METRIC_DEFINITIONS = [
         "unit": "count",
         "value_range_min": 0,
         "value_range_max": 1000,
-        "higher_is_better": None,
+        "higher_is_better": True,
         "chart_color": "#3B82F6",
         "display_order": 1,
         "description": "Number of optimization recommendations generated per tick",
@@ -1254,7 +1255,7 @@ METRIC_DEFINITIONS = [
         "unit": "count",
         "value_range_min": 0,
         "value_range_max": 100,
-        "higher_is_better": None,
+        "higher_is_better": True,
         "chart_color": "#F59E0B",
         "display_order": 3,
         "description": "Number of autonomous optimization actions executed per tick",
@@ -1306,7 +1307,7 @@ METRIC_DEFINITIONS = [
         "unit": "currency",
         "value_range_min": 0,
         "value_range_max": 100000,
-        "higher_is_better": None,
+        "higher_is_better": False,
         "chart_color": "#EC4899",
         "display_order": 7,
         "description": "Campaign spend for the current day in USD",
@@ -1375,7 +1376,7 @@ METRIC_DEFINITIONS = [
         "unit": "count",
         "value_range_min": 0,
         "value_range_max": 1000,
-        "higher_is_better": None,
+        "higher_is_better": False,
         "chart_color": "#F59E0B",
         "display_order": 4,
         "description": (
@@ -1423,7 +1424,12 @@ METRIC_DEFINITIONS = [
 class Command(BaseCommand):
     help = "Seed MetricDefinition rows for workflow analytics"
 
+    @transaction.atomic
     def handle(self, *args, **options):
+        # Atomic so a bad record cannot leave a partial registry behind. A
+        # field-name mismatch in the brand-architecture block (record 27 of
+        # 104) previously raised FieldError mid-loop, committing the first 26
+        # rows and silently skipping the remaining 78 in production.
         created = 0
         updated = 0
 

--- a/ai-brand-automator/analytics/tests/test_seed_metrics.py
+++ b/ai-brand-automator/analytics/tests/test_seed_metrics.py
@@ -1,0 +1,104 @@
+"""
+Tests for the seed_metrics management command.
+
+Regression coverage for a field-name mismatch that broke the command in
+production: 10 brand-architecture records used "min_value"/"max_value" while
+MetricDefinition defines "value_range_min"/"value_range_max". The 27th of 104
+records raised FieldError mid-loop, so the first 26 rows committed and the
+remaining 78 never seeded — and the failure was invisible because the Cloud
+Run migration job wraps the call in
+`|| echo 'seed_metrics failed - non-critical'`.
+"""
+
+import pytest
+
+from django.core.management import call_command
+
+from analytics.management.commands.seed_metrics import METRIC_DEFINITIONS
+from analytics.models import MetricDefinition
+
+
+def _model_field_names():
+    return {f.name for f in MetricDefinition._meta.get_fields()}
+
+
+@pytest.mark.unit
+def test_every_definition_uses_only_real_model_fields():
+    """Guards against the FieldError class of bug for all future records.
+
+    A key that is not a MetricDefinition field makes update_or_create raise,
+    so this must hold for every record — not just the ones we fixed.
+    """
+    valid = _model_field_names()
+    offenders = {}
+
+    for defn in METRIC_DEFINITIONS:
+        unknown = sorted(k for k in defn if k not in valid)
+        if unknown:
+            offenders[defn.get("metric_name", "<unnamed>")] = unknown
+
+    assert not offenders, f"definitions reference unknown model fields: {offenders}"
+
+
+@pytest.mark.unit
+def test_legacy_range_key_names_are_gone():
+    """The exact keys that caused the production failure."""
+    for defn in METRIC_DEFINITIONS:
+        assert "min_value" not in defn, defn["metric_name"]
+        assert "max_value" not in defn, defn["metric_name"]
+
+
+@pytest.mark.unit
+def test_no_definition_passes_none_to_a_not_null_column():
+    """Second bug found by this suite: four optimization metrics set
+    "higher_is_better": None to mean "neutral", but the column is NOT NULL,
+    so seeding died with IntegrityError even after the field names were fixed.
+    """
+    not_null = {
+        f.name
+        for f in MetricDefinition._meta.get_fields()
+        if hasattr(f, "null") and not f.null and not f.auto_created
+    }
+    offenders = {}
+
+    for defn in METRIC_DEFINITIONS:
+        nulls = sorted(k for k, v in defn.items() if v is None and k in not_null)
+        if nulls:
+            offenders[defn["metric_name"]] = nulls
+
+    assert not offenders, f"None passed to NOT NULL columns: {offenders}"
+
+
+@pytest.mark.unit
+def test_definitions_have_unique_metric_names():
+    """update_or_create keys on metric_name, so duplicates silently collapse."""
+    names = [d["metric_name"] for d in METRIC_DEFINITIONS]
+    dupes = {n for n in names if names.count(n) > 1}
+    assert not dupes, f"duplicate metric_name values: {sorted(dupes)}"
+
+
+@pytest.mark.django_db
+def test_seed_metrics_creates_every_definition():
+    """End-to-end: the command seeds all records, not a partial prefix."""
+    call_command("seed_metrics")
+
+    assert MetricDefinition.objects.count() == len(METRIC_DEFINITIONS)
+
+    # The brand-architecture block is where seeding used to abort.
+    architecture = MetricDefinition.objects.filter(category="brand_architecture")
+    assert architecture.exists(), "brand_architecture metrics were not seeded"
+
+    model_score = MetricDefinition.objects.get(metric_name="architecture_model_score")
+    assert model_score.value_range_min == 0
+    assert model_score.value_range_max == 100
+
+
+@pytest.mark.django_db
+def test_seed_metrics_is_idempotent():
+    """Seeding twice updates in place rather than duplicating."""
+    call_command("seed_metrics")
+    first_count = MetricDefinition.objects.count()
+
+    call_command("seed_metrics")
+
+    assert MetricDefinition.objects.count() == first_count


### PR DESCRIPTION
`seed_metrics` has **never completed successfully in production**. Found while reading the repaired migration job's logs — the Cloud Run job hides it behind `|| echo 'seed_metrics failed - non-critical'`, so it failed silently on every deploy.

Two independent defects, the second only discoverable after fixing the first.

## Defect 1 — field-name mismatch

Ten brand-architecture records used `min_value` / `max_value`; `MetricDefinition` defines `value_range_min` / `value_range_max`:

```
FieldError: Invalid field name(s) for model MetricDefinition: 'max_value', 'min_value'
```

It aborted on **record 27 of 104**. `handle()` was not atomic, so the first 26 rows committed and the remaining 78 were skipped — **production currently has a partially seeded registry**, which is why `/api/v1/analytics/` has been missing metric definitions.

Affected: `architecture_model_score`, `architecture_positioning_alignment`, `architecture_audience_fit`, `architecture_competitive_diff`, `architecture_operational_efficiency`, `hierarchy_depth`, `sub_brand_count`, `naming_consistency_score`, `growth_phases_planned`, `architecture_confidence`.

Pure key rename — structure and semantics matched the 94 correct records.

## Defect 2 — `None` on a NOT NULL column

Surfaced by the new tests once the names were fixed:

```
IntegrityError: null value in column "higher_is_better" violates not-null constraint
```

Four optimization metrics set `"higher_is_better": None` to mean "neutral", but the field is `BooleanField(default=True)` and not nullable. "Neutral" isn't representable without a cross-stack change — `KpiScorecard.tsx:60-61` renders it as a binary good/bad arrow, and both the serializer and the TS type are non-nullable.

Assigned per-metric directions rather than expanding scope into a migration:

| Metric | `higher_is_better` | Rationale |
|---|---|---|
| `recommendations_generated` | `True` | more recommendations is better |
| `auto_actions_executed` | `True` | more automation is better |
| `campaign_spend_today` | `False` | lower spend is better |
| `auto_reruns_triggered` | `False` | reruns signal failures |

These encode product semantics that show up in UI tooltips — flagging explicitly in case you'd read any of them differently. Making the field nullable to support genuine "neutral" is the alternative; it needs a migration plus serializer, TS type, and `KpiScorecard` changes, so I left it out.

## Hardening

`handle()` is now wrapped in `transaction.atomic` so a bad record can no longer leave a partial registry behind — that partial-commit behavior is exactly what made defect 1 hard to spot.

## Tests

There was **no coverage for this command at all**. Adds `analytics/tests/test_seed_metrics.py`:

| Test | Marker | Catches |
|---|---|---|
| `test_every_definition_uses_only_real_model_fields` | unit | any unknown key, for all future records |
| `test_legacy_range_key_names_are_gone` | unit | defect 1 specifically |
| `test_no_definition_passes_none_to_a_not_null_column` | unit | defect 2 specifically |
| `test_definitions_have_unique_metric_names` | unit | duplicates silently collapsing under `update_or_create` |
| `test_seed_metrics_creates_every_definition` | db | all 104 rows seed, not a partial prefix |
| `test_seed_metrics_is_idempotent` | db | re-seeding updates in place |

The four unit tests catch both defects in ~14s without a database, so this can't regress silently again.

## Verification

- 6/6 new tests pass; **76/76 analytics tests pass** (full app suite)
- `black --check` and `flake8` clean on both files
- All 104 records validated against the live model: no unknown keys, no `None` on NOT NULL columns
- No model or schema change, so **no migration required**

## Follow-up worth considering

The migration job's `|| echo 'seed_metrics failed - non-critical'` is what let this hide for so long. Same pattern as the migration-failure mask fixed in #520 — worth removing now that the command actually works, so future breakage is visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)