### PR TITLE
test: repair two stale backend tests

### DIFF
--- a/ai-brand-automator/ai_services/tests/test_models.py
+++ b/ai-brand-automator/ai_services/tests/test_models.py
@@ -375,7 +375,12 @@ class TestAIGenerationModel:
             prompt="Test",
             response="Response",
         )
-        assert generation.model_used == "gemini-3.5-flash-exp"
+        # Must track AIGeneration.model_used's default, which moved from
+        # "gemini-3.5-flash-exp" to "gemini-3.5-flash" in #509.
+        assert (
+            generation.model_used == AIGeneration._meta.get_field("model_used").default
+        )
+        assert generation.model_used == "gemini-3.5-flash"
 
     def test_processing_time_defaults_to_zero(self, public_tenant):
         """Test processing_time defaults to 0.0"""

--- a/ai-brand-automator/onboarding/tests/test_pipeline_e2e.py
+++ b/ai-brand-automator/onboarding/tests/test_pipeline_e2e.py
@@ -154,8 +154,20 @@ class TestE2ECompanyExport:
     """E2E tests for company RAG export."""
 
     def test_e2e_company_document_structure(self):
-        """Verify company document has correct structure for RAG."""
-        from onboarding.tasks import _build_company_document
+        """Verify company document has correct structure for RAG.
+
+        Company document building moved out of ``onboarding.tasks`` — that
+        module now delegates to ``rag_index.tasks.db_sync_tasks.sync_model_to_rag``,
+        and the document itself is built by ``DbSyncService``. The old
+        ``_build_company_document`` no longer exists anywhere in the backend,
+        so this asserts the current contract:
+
+          * ``company_id`` moved into ``metadata`` and is a string
+          * ``content`` became ``extracted_text``
+          * ``tenant_id``/``source`` are no longer part of the document —
+            tenant is resolved separately via ``get_tenant_id()``
+        """
+        from rag_index.services.db_sync_service import DbSyncService
 
         tenant = create_test_tenant()
         company = Company.objects.create(
@@ -167,21 +179,30 @@ class TestE2ECompanyExport:
             values="Quality, Innovation",
         )
 
-        doc = _build_company_document(company)
+        service = DbSyncService()
+        doc = service.build_document("Company", company)
 
         # Verify required fields for RAG indexing
         assert doc["document_type"] == "company_profile"
-        assert doc["tenant_id"] == str(tenant.id)
-        assert doc["company_id"] == company.id
-        assert doc["source"] == "onboarding_service"
+        assert doc["metadata"]["company_id"] == str(company.id)
 
-        # Metadata should have timestamps
-        assert "metadata" in doc
+        # Tenant routing and upsert identity are resolved by the service
+        assert service.get_tenant_id(company) == str(tenant.id)
+        assert service.get_document_id("Company", company) == f"company-{company.pk}"
+        assert service.should_sync("Company", company) is True
 
-        # Content should be concatenated text
-        content = doc["content"]
-        assert isinstance(content, str)
-        assert len(content) > 0
+        # Metadata should carry the profile fields and timestamps
+        assert doc["metadata"]["name"] == "E2E Company Export"
+        assert doc["metadata"]["industry"] == "Technology"
+        assert "created_at" in doc["metadata"]
+        assert "updated_at" in doc["metadata"]
+
+        # Extracted text should be concatenated content from the company
+        text = doc["extracted_text"]
+        assert isinstance(text, str)
+        assert len(text) > 0
+        assert "E2E Company Export" in text
+        assert "Technology" in text
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Two unrelated tests failing on `main`, found while running the full backend suite.

## 1. `ai_services` — model name drifted

```
assert 'gemini-3.5-flash' == 'gemini-3.5-flash-exp'
```

`AIGeneration.model_used` has defaulted to `gemini-3.5-flash` since #509 migrated the GCP config (`ai_services/models.py:175`), but the test still expected the `-exp` suffix.

The assertion now also pins the value against the field's declared default, so a future rename fails on the field itself rather than on a hardcoded string that drifts silently:

```python
assert generation.model_used == AIGeneration._meta.get_field("model_used").default
assert generation.model_used == "gemini-3.5-flash"
```

## 2. `onboarding` — test imported a function that no longer exists

```
ImportError: cannot import name '_build_company_document' from 'onboarding.tasks'
```

The only references to `_build_company_document` left in the backend were in the test itself, so it failed at import.

Company document building moved to `rag_index`: `onboarding.tasks.export_company_for_rag` now delegates to `rag_index.tasks.db_sync_tasks.sync_model_to_rag`, and the document is built by `DbSyncService._build_company_doc`. The contract changed with the move:

| Old | Current |
|---|---|
| `doc["company_id"]` (int) | `doc["metadata"]["company_id"]` (str) |
| `doc["content"]` | `doc["extracted_text"]` |
| `doc["tenant_id"]` | resolved via `DbSyncService.get_tenant_id()` |
| `doc["source"]` | removed |

`doc["document_type"] == "company_profile"` is unchanged.

**I repointed it rather than deleting it** — verifying the Company RAG document shape is still worth covering, and nothing else tests it. It now asserts the current contract plus the tenant-routing and upsert-identity helpers the sync path depends on (`get_tenant_id`, `get_document_id`, `should_sync`).

If you'd rather this test just be deleted, say so and I'll swap it out — repointing was my call.

## Verification

- Both tests pass
- Both files pass in full: **40 passed**
- `black --check` and `flake8` clean
- Test-only change; no production code touched

## Context

These surfaced during a full-suite run that I have not yet been able to complete — two background runs were killed partway (at 69% and earlier). Everything else observed was `StorageError: Storage not available` from files carrying `pytestmark = [pytest.mark.integration, pytest.mark.gcp]`, which need real GCP credentials per the `gcp` marker and can't pass locally without them. These two were the only genuine code-level failures found so far, so **I can't yet claim the suite is green** — a complete run is still outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)