### PR TITLE
docs: OIA Redis allocation errata + refresh CLAUDE.md/AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Project Guidelines
 
-- Monorepo: Django core API (`ai-brand-automator/`), Next.js frontend (`ai-brand-automator-frontend/`), 22 FastAPI microservices, and an Odoo Community submodule (`vendor/odoo/community/`).
-- Read first: `ARCHITECTURE.md`, `.github/copilot-instructions.md`, `CLAUDE.md`, and service-local `CLAUDE.md` before edits.
+- Monorepo: Django core API (`ai-brand-automator/`), Next.js frontend (`ai-brand-automator-frontend/`), 26 FastAPI microservices, and an Odoo Community submodule (`vendor/odoo/community/`).
+- Read first: `ARCHITECTURE.md`, `CLAUDE.md`, and service-local `CLAUDE.md` before edits. (`.github/copilot-instructions.md` is no longer maintained — do not treat it as authoritative.)
 - Prefer the closest instruction file to your target code (service-local guidance wins).
 - Do not modify without explicit request: `docs/LICENSE.md`, `credentials/`, `deployment/config/kong/`, `.github/workflows/ci-cd.yml`, `ai-brand-automator/db.sqlite3`, `vendor/`.
 
@@ -24,7 +24,7 @@
 - `brand-equity-calculator-svc` (port 8090) is **public/unauthenticated** and uses Anthropic Claude (not Gemini).
 - `odoo-mcp-server-svc` (port 8095) bridges Odoo ERP via MCP protocol — RBAC engine with 16 YAML role definitions, 101 tools across 14 categories.
 - Onboarding is a 5-step wizard: Company Info → Brand Voice → Target Audience → Asset Upload → Review. On completion, a PDF of all onboarding data is generated via `fpdf2` and fed into the RAG pipeline.
-- Redis DB allocation: 0=Django/Celery, 1=Orchestrator, 2=Discovery, 3=Intelligence, 4=Titling, 5=Content, 6=Social, 7=RAG Uploader, 8=Brand Equity, 9=Odoo MCP, 10=Odoo Worker, 11=Market Research, 12=Competitor Intel, 13=Audience Persona, 14=Trend Cultural, 15=VoC Agent, 16=Brand Positioning, 17=Brand Architecture, 18=Brand Personality, 19=Brand Naming, 20=Brand Story, 21=Campaign Architecture, 22=Creative Generation, 23=Ad Publishing (requires `databases 24` in redis.conf).
+- Redis DB allocation: 0=Django/Celery, 1=Orchestrator, 2=Discovery **+ shared prompt cache** (key-prefix isolated), 3=Intelligence, 4=Titling, 5=Content, 6=Social, 7=RAG Uploader, 8=Brand Equity, 9=Odoo MCP, 10=Odoo Worker, 11=Market Research, 12=Competitor Intel, 13=Audience Persona, 14=Trend Cultural, 15=VoC Agent, 16=Brand Positioning, 17=Brand Architecture, 18=Brand Personality, 19=Brand Naming, 20=Brand Story, 21=Campaign Architecture, 22=Creative Generation, 23=Ad Publishing, 24=Campaign Optimization, 25=Intelligence Loop, 26=Prompt Optimization (requires `databases 27` in redis.conf and `--databases 27` in docker-compose; `ERR DB index is out of range` means bump it).
 
 ## Build and Test
 
@@ -38,7 +38,8 @@
 - Integration tests: `cd tests/integration && pytest -v`
 - Migrations: `cd ai-brand-automator && python manage.py makemigrations && python manage.py migrate_schemas --shared --noinput`
 - Seed data: `python manage.py seed_manifests` (pipeline manifests), `python manage.py seed_subscription_plans` (Stripe plans)
-- Full stack: `cd deployment && docker compose up --build`
+- Full stack: `cd deployment && docker compose up --build` (optional profiles: `with-kafka`, `with-db`, `with-odoo`, `with-nginx`)
+- Branching: feature branch → PR into `development_main` (dev tier, auto-deployed via GHCR `:development_main` + Watchtower) → merge into `main` (production, GCP Cloud Run). Never commit directly to `main`.
 
 ## Project Conventions
 
@@ -58,7 +59,7 @@
 - `X-Callback-Token`: Orchestrator -> Django callbacks.
 - `X-Worker-Token`: chat-titling worker -> Django.
 - `X-Tenant-ID`: Content/Social Agent and Orchestrator -> Django/Odoo MCP for tenant routing.
-- Kafka topics: `pipeline-trigger-topic`, `pipeline-result-topic`, `agent-trace-topic`, `data-ingestion-topic`, `media-curation-topic`, `chat-titling-topic`, `odoo-mcp-audit-topic`, `odoo-tenant-events-topic`, `tenant-provisioning-topic`.
+- Kafka topics (core set — see the full table in `CLAUDE.md`; each agent service also has its own `*-audit-topic`/`*-events-topic`): `pipeline-trigger-topic`, `pipeline-result-topic`, `agent-trace-topic`, `data-ingestion-topic`, `media-curation-topic`, `chat-titling-topic`, `odoo-mcp-audit-topic`, `odoo-tenant-events-topic`, `tenant-provisioning-topic`.
 - Key files: `ai-brand-automator/orchestration/views.py`, `ai-brand-automator/orchestration/services.py`, `pipeline-orchestrator-svc/app/services/job_executor.py`, `pipeline-orchestrator-svc/app/factory/node_registry.py`, `pipeline-orchestrator-svc/app/skills/`, `odoo-mcp-server-svc/app/tools/registry.py`, `odoo-mcp-server-svc/app/rbac/engine.py`, `ai-brand-automator-frontend/src/hooks/usePollingJob.ts`, `ai-brand-automator-frontend/src/lib/api.ts`.
 
 ## Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-AI Brand Automator is a **multi-tenant SaaS platform** for AI-powered brand building. Django REST Framework backend + Next.js 15 frontend + 26 Python FastAPI microservices, connected via Kafka event streaming and HTTP callbacks. AI powered by Google Gemini 2.0 Flash and Anthropic Claude. ~5,900 test functions across all components (excluding the vendored Odoo submodule).
+AI Brand Automator is a **multi-tenant SaaS platform** for AI-powered brand building. Django REST Framework backend + Next.js 15 frontend + 26 Python FastAPI microservices, connected via Kafka event streaming and HTTP callbacks. AI powered by Google Gemini (default `gemini-3.5-flash`, set in `ai_services/services.py`) and Anthropic Claude. ~8,470 test functions across all components (excluding the vendored Odoo submodule).
 
 ## Monorepo Layout
 
@@ -58,7 +58,7 @@ cd ai-brand-automator && source ../.venv/bin/activate
 python manage.py runserver 0.0.0.0:8001
 
 # Tests
-pytest -v                                    # All ~2450 tests
+pytest -v                                    # All ~2470 tests
 pytest automation/tests/ -v                  # Single app
 pytest media_curation/tests/test_views.py -v # Single file
 pytest -k "test_my_function" -v              # Single test by name
@@ -142,8 +142,12 @@ cd deployment
 docker compose up --build                                     # Core services
 docker compose --profile with-kafka up --build                # + Kafka streaming
 docker compose --profile with-kafka --profile with-db up      # + Local PostgreSQL
+docker compose --profile with-odoo up --build                 # + Odoo CE + its PostgreSQL
+docker compose --profile with-nginx up --build                # + Nginx reverse proxy
 docker compose down -v                                        # Tear down
 ```
+
+Four profiles gate optional stacks: `with-kafka` (Zookeeper, Kafka, Kafka UI, and the three pipeline consumers), `with-db` (local PostgreSQL on host 5433 instead of Neon), `with-odoo` (Odoo CE on 8069/8072 + `odoo-db` on host 5434), `with-nginx`. Everything else — all 26 agent services, Redis, MLflow — starts unprofiled. `spike-stt-v2` is **not** in Compose; run it standalone with uvicorn.
 
 **Service ports**: Kong 8000, Backend 8001 (internal only in Docker), Kong Admin 8001 (Docker only), Frontend 3000, MLflow 5000, MLflow DB 5435 (host), Orchestrator 8010, Discovery 8020, Market Research 8021, Competitor Intel 8022, Audience Persona 8023, Trend Cultural 8024, VoC Agent 8025, Intelligence 8030, Brand Positioning 8031, Brand Architecture 8032, Brand Personality 8033, Brand Naming 8034, Brand Story 8035, Titling 8040, Campaign Architecture 8041, Creative Generation 8042, Ad Publishing 8043, Campaign Optimization 8044, Content 8050, Social 8060, RAG Uploader 8070, MCP 8085, Kafka UI 8080, Brand Equity 8090, Odoo MCP 8095, Odoo Worker 8100, Prompt Optimization 8110, Intelligence Loop 8045, STT Spike 8120
 
@@ -562,6 +566,9 @@ ORCHESTRATOR_CALLBACK_TOKEN=<callback-token> # Auth for callbacks (orchestrator 
 BACKEND_URL=http://localhost:8001            # Used to build callback URL
 WORKER_TOKEN=<worker-token>                  # Auth for chat-titling-worker callbacks
 ORCHESTRATION_KAFKA_ENABLED=false            # true for Kafka-based dispatch (vs HTTP)
+GS_BUCKET_NAME=zorven-raw-assets             # Raw uploads (also RAW_GCP_BUCKET_NAME/GCP_BUCKET_NAME)
+VERTEX_AI_DATA_STORE_ID=zorven-rag-dev       # Vertex AI Search data store for RAG
+CURATION_AI_MODEL=gemini-3.5-flash
 
 # Frontend (.env.local)
 NEXT_PUBLIC_API_URL=http://localhost:8000     # Auto-detected via env.ts in browser
@@ -573,6 +580,8 @@ Each microservice uses its own env-var prefix (e.g., `DISCOVERY_REDIS_URL`, `CON
 ## CI/CD
 
 **Tests** (`.github/workflows/ci-cd.yml`) — 10 jobs: backend-tests, test-media-curation, orchestrator-tests, discovery-agent-tests, intelligence-agent-tests, odoo-mcp-server-tests, odoo-worker-tests, frontend-tests, integration-tests, build-images. Backend CI runs `black --check .`, `flake8 .`, `pytest --cov`, and MCP server tests.
+
+**Two-tier branching.** Feature branch → PR into `development_main` (dev tier) → PR/sync merge into `main` (production tier). `ci-cd.yml` runs on pushes and PRs to `main`, `develop`, `development_main` (plus pushes to `bugfixes/**`). `docker-publish.yml` builds on pushes to `main` **and** `development_main` and on PRs — PR builds get branch+SHA tags for pre-merge testing. Only `main` triggers the GCP deploy; `development_main` images are tagged `:development_main` and picked up by a **Watchtower** container (5-minute poll) running alongside `deployment/docker-compose.production.yml` on the dev host, which auto-pulls and recreates changed containers.
 
 **Production deploy — GCP Cloud Run** (primary). Chain on `main`: `docker-publish.yml` builds/pushes images to GHCR (`ghcr.io/zorvenai`) → `deploy-gcp.yml` triggers on that workflow's success, mirrors only *changed* images to Artifact Registry (`us-central1-docker.pkg.dev/zorven-503517/zorven`), runs the `zorven-migrations` Cloud Run job when the backend changed, then `gcloud run services update`s each service and health-checks it. Cloud Run services are named `zorven-<service>`; the backend image feeds `zorven-backend` + `zorven-backend-ws`, with `zorven-celery-worker` and `zorven-celery-beat` as separate services keyed off the same backend change filter.
 

--- a/docs/Onboarding_Intelligence/ERRATA-01-redis-allocation.md
+++ b/docs/Onboarding_Intelligence/ERRATA-01-redis-allocation.md
@@ -1,0 +1,108 @@
+# ERRATA-01 — Redis allocation for OIA
+
+**Status:** Accepted correction. Read this before implementing anything that touches Redis.
+**Date:** 2026-07-30
+**Supersedes:** Backlog v2.0 story **A-04**; Design v2.1 **§4.2** and **§14** (Redis DB assignment only)
+**Unchanged:** everything else in both documents
+
+The source documents are binaries (`.pdf` / `.docx`) and cannot be edited in place, so corrections live here. Where this file and the PDFs disagree about Redis, **this file wins**.
+
+---
+
+## 1. The correction in one line
+
+> OIA uses **Redis DB 2** with the `oia:v1:` key prefix. **Not DB 27.**
+
+| | Design v2.1 says | Correct value |
+|---|---|---|
+| OIA session / live state | DB **27** (owned outright) | DB **2**, isolated by the `oia:v1:` prefix |
+| Prompt cache (read-only) | DB 2, `poi:` prefix | unchanged — DB 2, `poi:` prefix |
+| `config` → `redis_db:` | `27` | `2` |
+| `app/cache/redis_manager.py` | "DB 27 pool" | DB 2 pool |
+| Prerequisite | raise `databases` 27 → 28, restart Redis | **none** — no config change, no restart |
+
+Both OIA's own state and the prompt cache it reads now live in the same database. Isolation is by key prefix, not by database index.
+
+---
+
+## 2. Why — DB 27 cannot exist in production
+
+Production Redis is **Memorystore for Redis** (`zorven-redis`, BASIC tier, REDIS_7_0). Memorystore does **not** expose `databases` as a tunable `redisConfig`; the instance is fixed at **16 databases (0–15)**. There is no `redis.conf` to edit and no restart that changes it. DBs 16–26 do not exist there either — the fleet's documented 0–26 allocation was only ever valid under docker-compose, which starts Redis with `--databases 27`.
+
+**The backlog predicted this exactly.** A-04's Technical Notes read:
+
+> "If Redis is managed (Railway plugin, Redis Cloud) rather than self-hosted from a `redis.conf`, `databases` may not be operator-settable. Confirm this on day one of week 1. If it is not settable, the fallback is a key-prefix namespace on an existing DB rather than a dedicated DB — which changes every key pattern in Design §14 and makes `tests/test_redis_key_isolation.py` more important, not less. **Escalate immediately; do not silently pick DB 26.**"
+
+That fallback branch is now the live path. The escalation happened, and this errata is its outcome.
+
+### It was already breaking eleven services
+
+This was not theoretical. Eleven services allocated DBs 16–26 had been failing in production with `ERR DB index is out of range` since at least **2026-07-25**:
+
+`brand-positioning` (16), `brand-architecture` (17), `brand-personality` (18), `brand-naming` (19), `brand-story` (20), `campaign-architecture` (21), `creative-generation` (22), `ad-publishing` (23), `campaign-optimization` (24), `intelligence-loop` (25), `prompt-optimization` (26)
+
+A-04 assumed `SELECT 27` would fail loudly at connection time and stop the service from starting. In practice the agent `RedisManager`s **fail open** — they log a warning and continue with no cache. So all eleven ran cacheless and silently for days. Anything OIA builds on Redis must not assume a bad DB index will announce itself.
+
+Fixed in **PR #522** (script) and applied to the running services on 2026-07-30: all eleven remapped to DB 2 with prefix isolation. The root `CLAUDE.md` Redis allocation table now records the constraint — which also discharges A-04's final note ("update the monorepo CLAUDE.md Redis allocation table so the next service does not repeat this discovery").
+
+---
+
+## 3. What changes in the backlog
+
+**A-04 · "Raise Redis `databases` to 28 across the shared instance" — drop it.** No `redis.conf` edit, no instance restart, no staging/production rollout window, no rollback plan. Its 2 points come out of Epic A.
+
+Consequences:
+
+- **A-05 is no longer blocked by A-04.** A-04 blocked "A-05, and transitively every story touching Redis" — that edge is gone, so Epic A shortens and every Redis-touching story is unblocked from week 1.
+- **`tests/test_redis_key_isolation.py` becomes more important, not less** — exactly as A-04's notes warned. It is now the *only* mechanism keeping OIA's keys from colliding with ten other services sharing DB 2. It should assert that every key OIA writes begins with `oia:v1:`, and that OIA writes nothing under any other prefix.
+- Anything asserting `CONFIG GET databases == 28` or a successful `SELECT 27` must be deleted rather than adapted.
+
+---
+
+## 4. What changes in Design §14
+
+The key patterns in §14 are **already correctly prefixed** with `oia:v1:` and carry over unchanged — the table is sound, only the database index it sits in was wrong.
+
+One exception. This key does not start with the service prefix:
+
+```
+tenant:{id}:oia:config        →  oia:v1:{tenant}:config
+```
+
+On a dedicated DB the generic `tenant:` prefix was harmless. On shared DB 2 it breaks the single-prefix invariant that `test_redis_key_isolation.py` enforces, and `tenant:`-rooted keys are used by other services on the same instance. Normalize it so **every** OIA key starts with `oia:v1:`.
+
+Two properties of §14 that matter more now that the DB is shared:
+
+- Every key must carry a TTL. §14 already assigns one to everything except `tenant:{id}:oia:config`; give the renamed key an explicit TTL or an explicit documented exemption. Memorystore applies `maxmemory-policy allkeys-lru` **instance-wide**, so an untrimmed OIA key can cause eviction pressure on other services' data.
+- `oia:v1:circuit:{dep}` is deliberately not tenant-scoped. That stays correct — it just needs the `oia:v1:` prefix it already has, since circuit state for another service's dependency must not be readable as OIA's.
+
+---
+
+## 5. Local development is unaffected
+
+`deployment/docker-compose.yml` still starts Redis with `--databases 27`, and the 0–26 allocation remains valid locally. Production and local therefore diverge, and the divergence is carried by environment variables (`OIA_REDIS_URL`), not by code defaults.
+
+Set the service's default to the production-safe value so a missing env var fails safe:
+
+```python
+REDIS_URL: str = "redis://localhost:6379/2"    # not /27
+```
+
+---
+
+## 6. Port 8120 — no longer a concern
+
+Earlier notes flagged a collision with `spike-stt-v2`. That was overstated. `spike-stt-v2` is the **completed A-01 spike** (timeboxed, delivered in #495/#496). It is not in `docker-compose.yml`, not in CI, and not deployed to Cloud Run — 8120 is bound only when someone runs its `uvicorn` command by hand. OIA can take **8120** as designed; retiring the spike directory when OIA lands is tidy-up, not a prerequisite.
+
+---
+
+## 7. Checklist for the implementer
+
+- [ ] `OIA_REDIS_URL` default is `redis://localhost:6379/2`
+- [ ] `app/cache/redis_manager.py` opens a **DB 2** pool
+- [ ] Every key written begins with `oia:v1:` — including the renamed `oia:v1:{tenant}:config`
+- [ ] `tests/test_redis_key_isolation.py` asserts the prefix structurally, for every writer
+- [ ] Every key has a TTL, or a documented reason it does not
+- [ ] Prompt cache reads stay read-only against `poi:` in DB 2
+- [ ] A-04 removed from Epic A; A-05's dependency edge on it deleted
+- [ ] No test asserts `databases == 28` or `SELECT 27`


### PR DESCRIPTION
## Summary

Two documentation commits, ahead of OIA service implementation:

1. **`fed271f4`** — errata correcting the OIA Redis allocation from DB 27 to DB 2 (shared with Discovery, key-prefix isolated).
2. **`18227cac`** — refresh of `CLAUDE.md` and `AGENTS.md` against the current codebase.

## Corrections (verified against code)

- Gemini default is `gemini-3.5-flash` (`ai_services/services.py:25`, `settings.py:822`), not "Gemini 2.0 Flash".
- Test counts: ~8,470 repo-wide excluding `vendor/` (was ~5,900); backend ~2,470.
- `AGENTS.md`: 22 → 26 microservices; Redis allocation extended from DB 23 to DB 26 (Campaign Optimization 24, Intelligence Loop 25, Prompt Optimization 26) and `databases 24` → `databases 27`, matching `deployment/docker-compose.yml:320`.

## Additions

- Compose profiles `with-odoo` (Odoo CE 8069/8072 + odoo-db on 5434) and `with-nginx`, which were undocumented; noted that `spike-stt-v2` is not in Compose despite being listed with port 8120.
- **Two-tier branching**: feature branch → `development_main` (GHCR `:development_main` tags, Watchtower 5-min poll auto-recreating containers on the dev host) → `main` (GCP Cloud Run). This tier was entirely absent from the docs.
- GCP resource defaults after the `brandsol-project` migration: `zorven-raw-assets` bucket, `zorven-rag-dev` Vertex AI data store.

## Note on Copilot instructions

`.github/copilot-instructions.md` is no longer maintained, so it is dropped from the `AGENTS.md` read-first list and marked non-authoritative rather than updated — it still carries the stale service count and model name.

Docs only; no code or config changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)