### PR TITLE
fix(deploy): raise the Cloud Run request timeout for zorven-backend-ws (300s → 3600s)

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -341,9 +341,23 @@ jobs:
           IFS=',' read -ra SERVICES <<< "${{ matrix.cloud_run_services }}"
           for svc in "${SERVICES[@]}"; do
             echo "Deploying ${svc}..."
+
+            # Services that hold WebSockets open need the request timeout
+            # raised. On Cloud Run a WebSocket is one long-lived request, so
+            # the 300s default severs the connection after five minutes with
+            # no close frame (measured at 301.9s by spike A-02). Applied on
+            # every deploy so the setting cannot silently drift back.
+            EXTRA_FLAGS=()
+            case "${svc}" in
+              zorven-backend-ws)
+                EXTRA_FLAGS+=(--timeout=3600)
+                ;;
+            esac
+
             gcloud run services update "${svc}" \
               --region="${{ env.GCP_REGION }}" \
               --image="${{ env.AR_PREFIX }}/${{ matrix.image }}:latest" \
+              "${EXTRA_FLAGS[@]}" \
               --quiet
             echo "Deployed ${svc} successfully"
           done

--- a/deployment/gcp/00-config.sh
+++ b/deployment/gcp/00-config.sh
@@ -36,6 +36,15 @@ export CR_MEMORY="512Mi"
 export CR_CPU="1"
 export CR_TIMEOUT="300"
 
+# Request timeout for services that hold WebSockets open.
+#
+# On Cloud Run a WebSocket is a single long-lived request, so the service's
+# request timeout caps the connection outright — it is not an idle timeout.
+# At the CR_TIMEOUT default of 300s a socket is severed after five minutes
+# with no close frame, which spike A-02 measured at 301.9s
+# (docs/spikes/A-02-gateway-websocket-note.md). 3600s is the platform maximum.
+export CR_WS_TIMEOUT="3600"
+
 # Max instances for user-facing services (backend, frontend, orchestrator).
 # These absorb interactive traffic and keep burst headroom.
 export CR_MAX_INSTANCES="2"

--- a/deployment/gcp/08-deploy-services.sh
+++ b/deployment/gcp/08-deploy-services.sh
@@ -99,6 +99,7 @@ deploy_service zorven-backend-ws zorven-backend 8002 \
   --max-instances="${CR_MAX_INSTANCES}" \
   --min-instances=0 \
   --session-affinity \
+  --timeout="${CR_WS_TIMEOUT}" \
   --set-secrets="SECRET_KEY=SECRET_KEY:latest" \
   --set-env-vars="\
 DATABASE_URL=${DATABASE_URL},\


### PR DESCRIPTION
## The bug

`zorven-backend-ws` is deployed with **no `--timeout` flag**, so it inherits Cloud Run's 300s default (`deployment/gcp/08-deploy-services.sh:97`, compare `zorven-backend` on line 65 which does pass `--timeout`).

On Cloud Run a WebSocket is a **single long-lived request**. The service request timeout therefore caps the connection outright — it is not an idle timeout, and a heartbeat does not reset it. Every Django Channels socket in production is severed after five minutes: that is the workspace real-time progress feed (`ws://…/ws/workspace/<tenant_id>/`) dropping mid-session.

## The evidence

Found while running spike A-02 (#528), which measured the same mechanism on a throwaway service:

| Configuration | Result |
|---|---|
| `--timeout=300` (the default) | **severed at 301.9 s** — `no close frame received or sent` |
| `--timeout=3600` | **held 45 minutes** (2700.7 s, 134,800 frames) |

Raw measurements: `spike-ws-gateway/results/cloudrun-soak-300.jsonl` and `cloudrun-soak-3600.jsonl`. Analysis: `docs/spikes/A-02-gateway-websocket-note.md`.

## The fix — two changes, because either alone is insufficient

1. **`08-deploy-services.sh`** passes `--timeout="${CR_WS_TIMEOUT}"` (new variable in `00-config.sh`, set to 3600 — the platform maximum). This makes *re-provisioning* correct.
2. **`deploy-gcp.yml`** applies `--timeout=3600` to `zorven-backend-ws` on every deploy.

Change 2 is the one that actually fixes production. The provisioning script is one-time and is not run by CI, and CI's `gcloud run services update --image=...` preserves whatever configuration the service already carries — so with only change 1 the live service would keep its 300s setting indefinitely. Applying the flag on every deploy also prevents it drifting back, which this fleet has form for (CLAUDE.md notes the celery-worker service having drifted from the backend service).

The `case` statement is deliberately an explicit service list rather than a `*-ws` glob, so a future WebSocket service has to opt in consciously rather than inherit it by naming accident.

## Applying it to the running service

The next backend deploy applies it automatically. To fix it immediately without waiting:

```bash
gcloud run services update zorven-backend-ws --region=us-central1 --timeout=3600
```

**I have not run this** — it is a production change and yours to make.

## Verification

- `bash -n` clean on both shell scripts; the workflow YAML parses.
- The flag logic was dry-run: only `zorven-backend-ws` receives `--timeout=3600`; `zorven-backend` and every other service expand to no extra flags.
- **Confirmed on the live service**: `zorven-backend-ws` currently reports `timeoutSeconds: 300`. Every other Cloud Run service reads 300 too, which is correct for them — they serve ordinary HTTP requests, and only the WebSocket service is harmed by that value.

## Note

This touches `.github/workflows/deploy-gcp.yml`. That file is not on CLAUDE.md's do-not-modify list (only `ci-cd.yml` is), but it is CI — if you would rather keep the workflow untouched, drop change 2 and run the one-time command above instead. The trade-off is that the setting can then drift back unnoticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
