### PR TITLE
feat(oia): Kafka, observability and Redis-isolation baseline (A-03)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -342,11 +342,32 @@ jobs:
         working-directory: onboarding-intelligence-agent-svc
         run: mypy app/
 
-      # Integration tests run against the real Redis service above. The e2e
+      # A real broker for the AC-1 round-trip and DLQ tests. Redpanda rather
+      # than a Kafka service container: it speaks the Kafka protocol, needs no
+      # ZooKeeper, and starts in seconds on a runner.
+      - name: Start Kafka (Redpanda)
+        run: |
+          docker run -d --name ci-kafka -p 39092:9092 \
+            redpandadata/redpanda:v24.2.7 redpanda start \
+            --smp 1 --memory 512M --overprovisioned --node-id 0 --check=false \
+            --kafka-addr PLAINTEXT://0.0.0.0:9092 \
+            --advertise-kafka-addr PLAINTEXT://localhost:39092
+          for i in $(seq 1 60); do
+            if docker exec ci-kafka rpk cluster info >/dev/null 2>&1; then
+              echo "kafka ready"; exit 0
+            fi
+            sleep 2
+          done
+          echo "::warning::Kafka never became ready; broker tests will skip"
+
+      # Integration tests run against the real Redis and Kafka above. The e2e
       # tests build and run the image and are excluded here — they need Docker
       # and take minutes; they run locally and in the image build job.
       - name: Test
         working-directory: onboarding-intelligence-agent-svc
+        env:
+          OIA_TEST_KAFKA: localhost:39092
+          OIA_TEST_REDIS_URL: redis://localhost:6379/2
         run: pytest tests/ -v -m "not e2e"
 
   # Frontend Tests

--- a/deployment/config/otel/collector.yaml
+++ b/deployment/config/otel/collector.yaml
@@ -1,0 +1,29 @@
+# Minimal collector for local trace verification (A-03 AC-3).
+#
+# Receives OTLP from the fleet and writes spans to stdout, which is enough to
+# prove a trace arrives intact and that OIA's span shares a trace id with its
+# caller. Swap the exporter for a real backend when one exists — nothing in
+# GCP runs a collector today.
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    timeout: 1s
+
+exporters:
+  debug:
+    verbosity: detailed
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -317,7 +317,11 @@ services:
   redis:
     image: redis:7-alpine
     container_name: ai-brand-automator-redis
-    command: redis-server --appendonly yes --maxmemory 256mb --maxmemory-policy allkeys-lru --databases 27
+    # noeviction, not allkeys-lru: OIA keeps live session state here, and an
+    # allkeys-* policy evicts any key regardless of TTL — a meeting can lose
+    # its transcript and resume window under memory pressure (A-03 AC-5). This
+    # mirrors the shared Memorystore instance, changed on 2026-08-01.
+    command: redis-server --appendonly yes --maxmemory 256mb --maxmemory-policy noeviction --databases 27
     ports:
       - "6379:6379"
     volumes:
@@ -1712,6 +1716,24 @@ services:
   # MLflow PostgreSQL — Dedicated database for MLflow Tracking Server
   # Stores prompt registry, experiment tracking, and run metadata
   # ==========================================================================
+  # OpenTelemetry collector — profiled, so the default stack is unaffected.
+  # Bring it up with:  docker compose --profile with-otel up -d otel-collector
+  # then set OIA_OTEL_EXPORTER_ENDPOINT=http://otel-collector:4318/v1/traces
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.109.0
+    container_name: ai-brand-automator-otel-collector
+    command: ["--config=/etc/otel/config.yaml"]
+    volumes:
+      - ./config/otel/collector.yaml:/etc/otel/config.yaml:ro
+    ports:
+      - "4317:4317"   # OTLP gRPC
+      - "4318:4318"   # OTLP HTTP
+    profiles:
+      - with-otel
+    restart: unless-stopped
+    networks:
+      - app-network
+
   onboarding-intelligence-agent-svc:
     build:
       context: ../onboarding-intelligence-agent-svc

--- a/onboarding-intelligence-agent-svc/CLAUDE.md
+++ b/onboarding-intelligence-agent-svc/CLAUDE.md
@@ -23,10 +23,12 @@ One deployable, three modes, decided by entry point rather than a runtime flag:
 - Backlog: `…_User_Story_Backlog_v2_1.md`
 - **Corrections that override both: `ERRATA-01-redis-allocation.md`**
 
-## Current state — scaffold only
+## Current state — scaffold plus the event and Redis baseline
 
-A-05 has landed. Working: configuration, logging, telemetry, the Redis pool
-and key builders, the Kafka producer lifecycle, and the health surface.
+A-05 and A-03 have landed. Working: configuration, logging, telemetry with W3C
+trace propagation, the Redis pool and tenant-scoped key builders, the Kafka
+producer/consumer with topic provisioning and DLQ routing, the §12 event
+catalogue and emitter, and the health, readiness and metrics surface.
 Everything else is a stub that **raises `NotImplementedError` by design** — a
 stub returning `None` would let a later story ship a silent no-op. When you
 implement one, delete the raise; do not leave it returning nothing.
@@ -35,6 +37,39 @@ Owning stories are named in each stub's docstring.
 
 ## Non-negotiables in this service
 
+### Eviction: the shared instance is `noeviction`, and must stay that way
+
+**AC-5 finding, recorded here because A-03 requires it.**
+
+Measured 2026-08-01 on Memorystore `zorven-redis` (1 GB, BASIC, shared by the
+whole fleet):
+
+| | |
+|---|---|
+| memory in use | 7.2 MB of 1 GB (`usage_ratio` 0.007) |
+| policy before | `allkeys-lru` |
+| policy now | **`noeviction`** |
+
+`allkeys-lru` evicts *any* key once memory is full, regardless of TTL — there
+is no per-key exemption in Redis — so a live meeting could have lost its
+transcript and resume window under memory pressure. That is a correctness bug,
+not a tuning problem, which is why AC-5 says escalate rather than proceed.
+
+The instance was at 0.7% of capacity, so `noeviction` was free to switch on:
+nothing was being evicted, and there is ~140× headroom. The residual risk is
+the opposite one — a *full* instance under `noeviction` rejects writes
+fleet-wide instead of dropping cache keys — covered by the Cloud Monitoring
+alert **"Memorystore zorven-redis memory above 75%"**, whose runbook says
+plainly that reverting to `allkeys-lru` is not a fix.
+
+A dedicated Redis instance for OIA session state was considered and rejected as
+premature at ~$35–50/month while the shared instance sits at 0.7%. It remains
+the escalation path if usage climbs.
+
+`tests/integration/test_redis_isolation_live.py::test_eviction_policy_is_noeviction`
+asserts the live server's policy, not a constant. If it fails, session state is
+evictable again and the fix is the policy.
+
 ### Redis is DB 2 and shared — never DB 27
 
 ERRATA-01 supersedes the design here. Production Redis is Memorystore, fixed
@@ -42,7 +77,11 @@ at 16 databases (0–15); DB 27 cannot exist. OIA shares **DB 2** with ten other
 services and is isolated only by its key prefix.
 
 - Every key this service writes starts with `oia:v1:`. No exceptions.
-- Build keys through `app/cache/redis_manager.py`. Never format one inline.
+- Build keys through `TenantKeys` in `app/cache/redis_manager.py`, obtained
+  from `RedisManager.keys_for(tenant_id)`. The tenant is a **constructor**
+  argument, so a tenant-less key cannot be written — that is deliberate, per
+  A-03: "a helper that can be called without a tenant will eventually be
+  called without one." Never format a key inline.
 - Every key carries a TTL — `maxmemory-policy allkeys-lru` is instance-wide,
   so an untrimmed key evicts another service's data.
 - The prompt cache (`poi:` prefix, same DB) is **read-only**. Never write there.
@@ -85,12 +124,20 @@ five minutes.
 cd onboarding-intelligence-agent-svc
 pip install -r requirements-dev.txt
 
+# A broker for the Kafka integration tests. Redpanda rather than the compose
+# broker: Kafka-API compatible, no ZooKeeper, ~400 MB, ready in ~30 s.
+docker run -d --name oia-test-kafka -p 39092:9092 --memory=700m \
+  redpandadata/redpanda:v24.2.7 redpanda start --smp 1 --memory 400M \
+  --overprovisioned --node-id 0 --check=false \
+  --kafka-addr PLAINTEXT://0.0.0.0:9092 \
+  --advertise-kafka-addr PLAINTEXT://localhost:39092
+
 uvicorn app.main:app --host 0.0.0.0 --port 8120 --reload
 
 pytest -q                      # everything (integration needs Redis on :6379)
 pytest -m unit -q              # no network
 pytest -m property -q          # hypothesis
-pytest -m integration -q       # real Redis
+pytest -m integration -q       # real Redis and, if present, real Kafka
 pytest -m e2e -q               # real container; needs Docker
 
 black app/ tests/ && flake8 app/ tests/ && mypy app/
@@ -104,3 +151,19 @@ black app/ tests/ && flake8 app/ tests/ && mypy app/
   values.
 - Tests: no mocks. Integration tests run against real Redis; the health-down
   case points at a genuinely closed port rather than a patched client.
+
+
+## Local environment traps
+
+**A native Redis can shadow the compose one.** On macOS a Homebrew
+`redis-server` bound to `127.0.0.1:6379` wins over the container's published
+port, so `redis://localhost:6379` may not be the Redis in `docker-compose.yml`
+— with a different `maxmemory-policy`. This was observed on 2026-08-01 and made
+the eviction test pass against the wrong server. Point tests explicitly with
+`OIA_TEST_REDIS_URL`, and check `redis-cli info server` if a config assertion
+behaves oddly.
+
+**The compose Kafka is heavy.** It runs ZooKeeper mode with a JVM heap and
+replays every persisted partition on boot; on a loaded machine it can time out
+its ZooKeeper session and crash-loop. The tests use Redpanda instead and skip
+cleanly when no broker is reachable.

--- a/onboarding-intelligence-agent-svc/app/api/routes.py
+++ b/onboarding-intelligence-agent-svc/app/api/routes.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import Any
 
 from fastapi import APIRouter, Request, Response, status
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 
 router = APIRouter()
 
@@ -133,3 +134,31 @@ async def diagnostics(request: Request) -> dict[str, Any]:
             "OIA_POI_TOKEN": bool(settings.POI_TOKEN),
         },
     }
+
+
+@router.get("/ready")
+async def ready(request: Request, response: Response) -> dict[str, Any]:
+    """Readiness probe (Design §20).
+
+    §20 describes /health as liveness only and /ready as the probe that
+    checks dependencies, while A-05's AC-3 required /health to check them.
+    Both readings are honoured: /health keeps the behaviour A-05 shipped and
+    is tested, and /ready is the §20-named endpoint with the same semantics,
+    so a rolling deploy can point at either name.
+    """
+    deps = await _dependency_status(request)
+    failed = [
+        name
+        for name, state in deps.items()
+        if state["required"] and not state["healthy"]
+    ]
+    if failed:
+        response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+        return {"status": "not_ready", "service": SERVICE_NAME, "failed": failed}
+    return {"status": "ready", "service": SERVICE_NAME}
+
+
+@router.get("/metrics")
+async def prometheus_metrics() -> Response:
+    """Prometheus exposition (Design §20)."""
+    return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)

--- a/onboarding-intelligence-agent-svc/app/cache/redis_manager.py
+++ b/onboarding-intelligence-agent-svc/app/cache/redis_manager.py
@@ -1,18 +1,21 @@
-"""Redis connection pool and key builders.
+"""Redis connection pool and the single construction point for keys.
 
-**Every key this service writes begins with ``oia:v1:``.** That is not a
-stylistic choice — OIA shares DB 2 with ten other services (ERRATA-01), so the
-prefix is the only thing keeping its keys from colliding with theirs.
-``tests/test_redis_key_isolation.py`` enforces it structurally.
+**Every key this service writes begins with ``oia:v1:``.** OIA shares DB 2 with
+the prompt cache and the rest of the fleet (ERRATA-01), so the prefix — not a
+dedicated database — is the isolation guarantee. ``tests/test_redis_key_
+isolation.py`` enforces it structurally.
 
-Two properties matter more because the database is shared:
+The tenant is a **constructor argument**, not a per-call one. A-03's technical
+note is blunt about why: "a helper that can be called without a tenant will
+eventually be called without one." With :class:`TenantKeys` the type checker
+rejects a tenant-less key at build time rather than leaving it to a runtime
+guard that a caller can forget (AC-4).
 
-- **Every key carries a TTL.** Memorystore applies ``maxmemory-policy
-  allkeys-lru`` instance-wide, so an untrimmed OIA key creates eviction
-  pressure on another service's data.
-- **The prompt cache is read-only.** It lives in the same DB under the ``poi:``
-  prefix and belongs to prompt-optimization-svc. OIA reads it; it never writes
-  there.
+Eviction (AC-5). Session state must survive a full meeting, so it must not be
+evictable. The shared Memorystore instance was measured at 7.2 MB of 1 GB
+(0.7%) on 2026-08-01 and its ``maxmemory-policy`` was changed from
+``allkeys-lru`` to ``noeviction`` — under ``allkeys-lru`` a memory spike would
+have dropped live session state silently, mid-meeting. See CLAUDE.md.
 """
 
 from __future__ import annotations
@@ -29,63 +32,104 @@ KEY_PREFIX: Final[str] = "oia:v1:"
 #: Read-only namespace owned by prompt-optimization-svc, shared in DB 2.
 PROMPT_CACHE_PREFIX: Final[str] = "poi:"
 
-# Default TTLs (seconds). Nothing is written without one.
-TTL_SESSION: Final[int] = 24 * 60 * 60
-TTL_LIVE_FRAMES: Final[int] = 6 * 60 * 60
-TTL_LOCK: Final[int] = 2 * 60 * 60
+# TTLs from Design §14. Nothing is written without one — on a shared instance
+# an untrimmed key creates pressure on every other service's data.
+TTL_SESSION: Final[int] = 4 * 60 * 60  # sliding
+TTL_LIVE: Final[int] = 4 * 60 * 60
+TTL_SUMMARY: Final[int] = 24 * 60 * 60
 TTL_IDEMPOTENCY: Final[int] = 24 * 60 * 60
+TTL_OUTBOX: Final[int] = 24 * 60 * 60
 TTL_CIRCUIT: Final[int] = 5 * 60
-#: The tenant config key is long-lived but still bounded — see ERRATA-01 §4.
+TTL_RATELIMIT: Final[int] = 60
+TTL_LOCK: Final[int] = 2 * 60 * 60
+#: §14 gives the tenant config key no TTL. ERRATA-01 §4 requires either a TTL
+#: or a documented exemption once the database is shared; this is the TTL.
 TTL_CONFIG: Final[int] = 7 * 24 * 60 * 60
 
-
-def _tenant_scope(tenant_id: str) -> str:
-    if not tenant_id:
-        raise ValueError("tenant_id is required — no key is built without one")
-    return f"{KEY_PREFIX}{tenant_id}:"
+#: §14: the transcript list is capped so reconnect replay has a known worst
+#: case. ~8 segments/minute means a 60-minute meeting stays under 500.
+TRANSCRIPT_MAX_ENTRIES: Final[int] = 4000
 
 
-def session_key(tenant_id: str, session_id: str) -> str:
-    """Onboarding session state hash."""
-    return f"{_tenant_scope(tenant_id)}session:{session_id}"
+class TenantKeys:
+    """Builds every tenant-scoped key for one tenant.
 
-
-def live_frames_key(tenant_id: str, session_id: str) -> str:
-    """Capped list of server → client frames backing reconnect replay."""
-    return f"{_tenant_scope(tenant_id)}live:{session_id}:frames"
-
-
-def live_lock_key(tenant_id: str, company_id: str) -> str:
-    """Single-live-session lock (OD-5), held with a TTL so a crashed process
-    cannot lock a company out permanently."""
-    return f"{_tenant_scope(tenant_id)}live:lock:{company_id}"
-
-
-def idempotency_key(tenant_id: str, digest: str) -> str:
-    """Write-dedup marker (§18.1)."""
-    return f"{_tenant_scope(tenant_id)}idem:{digest}"
-
-
-def tenant_config_key(tenant_id: str) -> str:
-    """Per-tenant overrides.
-
-    ERRATA-01 §4 renamed this from ``tenant:{id}:oia:config``. On a dedicated
-    database the generic ``tenant:`` root was harmless; on shared DB 2 it
-    breaks the single-prefix invariant and collides with other services'
-    ``tenant:``-rooted keys.
+    Constructed with a tenant id, so there is no way to ask for a key without
+    one — that is AC-4's "fails at type-check time rather than at runtime".
     """
-    return f"{_tenant_scope(tenant_id)}config"
+
+    __slots__ = ("_scope", "tenant_id")
+
+    def __init__(self, tenant_id: str) -> None:
+        if not tenant_id or not str(tenant_id).strip():
+            raise ValueError("tenant_id is required — no key is built without one")
+        self.tenant_id = str(tenant_id)
+        self._scope = f"{KEY_PREFIX}{self.tenant_id}:"
+
+    # ── Session state ────────────────────────────────────────
+    def session(self, session_id: str) -> str:
+        """Hash · 4 h sliding · mode, status, recording_id, prompt_versions."""
+        return f"{self._scope}session:{session_id}"
+
+    def session_summary(self, session_id: str) -> str:
+        """String · 24 h · compressed L3 summary."""
+        return f"{self._scope}session:{session_id}:summary"
+
+    # ── Live meeting ─────────────────────────────────────────
+    def transcript(self, session_id: str) -> str:
+        """List · 4 h · finalized redacted segments, capped, replay source."""
+        return f"{self._scope}live:{session_id}:transcript"
+
+    def questions(self, session_id: str) -> str:
+        """Hash · 4 h · question_id → status/score/evidence/override."""
+        return f"{self._scope}live:{session_id}:questions"
+
+    def coverage(self, session_id: str) -> str:
+        """Hash · 4 h · WF1/WF2/WF3 fractions plus updated_at."""
+        return f"{self._scope}live:{session_id}:coverage"
+
+    def live_lock(self, company_id: str) -> str:
+        """String · 2 h · one live meeting per company (OD-5).
+
+        Keyed on company, not session: keying it on the session would make
+        the lock trivially satisfiable by opening a second session.
+        """
+        return f"{self._scope}lock:live:{company_id}"
+
+    # ── Write safety ─────────────────────────────────────────
+    def idempotency(self, digest: str) -> str:
+        """String · 24 h · write dedup, value is the original response."""
+        return f"{self._scope}idempotency:{digest}"
+
+    def outbox(self, session_id: str) -> str:
+        """List · 24 h · Django writes buffered while the backend breaker is open."""
+        return f"{self._scope}outbox:{session_id}"
+
+    # ── Tenant control ───────────────────────────────────────
+    def ratelimit(self, user_id: str) -> str:
+        """Counter · 1 min · PREP 10/min per user, WS control-frame throttle."""
+        return f"{self._scope}ratelimit:{user_id}"
+
+    def config(self) -> str:
+        """Hash · tenant overrides.
+
+        ERRATA-01 §4 renamed this from ``tenant:{id}:oia:config``: on a shared
+        database the generic ``tenant:`` root breaks the single-prefix
+        invariant and collides with other services' ``tenant:``-rooted keys.
+        """
+        return f"{self._scope}config"
 
 
 def circuit_key(dependency: str) -> str:
-    """Circuit-breaker state for one dependency.
+    """Hash · 5 min · breaker state for one dependency.
 
-    Deliberately **not** tenant-scoped: a breaker tracks the health of an
-    external engine, which is a property of the service, not of a tenant. It
-    still carries the service prefix so another service's breaker state can
-    never be read as OIA's.
+    Deliberately **not** tenant-scoped and therefore not on :class:`TenantKeys`:
+    Google STT being down is not a per-tenant condition, and a per-tenant
+    breaker would require every tenant to discover the outage independently
+    before protecting itself. It still carries the service prefix so another
+    service's breaker state can never be read as OIA's.
     """
-    if not dependency:
+    if not dependency or not dependency.strip():
         raise ValueError("dependency is required")
     return f"{KEY_PREFIX}circuit:{dependency}"
 
@@ -124,15 +168,42 @@ class RedisManager:
             raise RuntimeError("RedisManager.connect() has not been called")
         return self._client
 
-    async def ping(self) -> bool:
-        """Liveness check for /health.
+    def keys_for(self, tenant_id: str) -> TenantKeys:
+        """The only way to obtain tenant-scoped key builders."""
+        return TenantKeys(tenant_id)
 
-        Bounded by the 2 s socket timeouts above so the probe answers within
-        the 2 s budget rather than hanging (A-05 AC-3).
-        """
+    async def ping(self) -> bool:
+        """Liveness check for /health, bounded by the 2 s socket timeouts."""
         if self._client is None:
             return False
         try:
             return bool(await self._client.ping())
         except Exception:
             return False
+
+    async def eviction_policy(self) -> str | None:
+        """Report ``maxmemory-policy`` as the server actually has it (AC-5).
+
+        Returns ``None`` when the server refuses CONFIG GET — managed Redis
+        sometimes restricts it — so callers can distinguish "not noeviction"
+        from "could not determine", which are different operational states.
+        """
+        if self._client is None:
+            return None
+        try:
+            config = await self._client.config_get("maxmemory-policy")
+            policy = config.get("maxmemory-policy")
+            return str(policy) if policy is not None else None
+        except Exception:
+            return None
+
+    async def scan_prefix(self, prefix: str, limit: int = 1000) -> list[str]:
+        """Return keys under ``prefix``. Used by the isolation test."""
+        if self._client is None:
+            return []
+        found: list[str] = []
+        async for key in self._client.scan_iter(match=f"{prefix}*", count=100):
+            found.append(key)
+            if len(found) >= limit:
+                break
+        return found

--- a/onboarding-intelligence-agent-svc/app/core/telemetry.py
+++ b/onboarding-intelligence-agent-svc/app/core/telemetry.py
@@ -1,22 +1,42 @@
-"""OpenTelemetry tracer and meter setup.
+"""OpenTelemetry setup, W3C propagation and the live-session span convention.
 
-Initialised unconditionally so instrumentation code can be written without
-null-checks, but it exports nothing unless ``OIA_OTEL_EXPORTER_ENDPOINT`` is
-set. That keeps local runs and CI free of connection noise while leaving a
-single environment variable between here and a real backend.
+Providers are installed unconditionally so instrumentation can be written
+without null checks, but nothing is exported unless
+``OIA_OTEL_EXPORTER_ENDPOINT`` is set — local runs and CI stay free of
+connection noise with one environment variable between here and a collector.
 
-Dashboards and the alert catalogue are Design §20 and are not in A-05's scope.
+**Trace correlation (AC-3).** Django sends a W3C ``traceparent`` header.
+:class:`TraceContextMiddleware` extracts it and makes the resulting context
+current for the request, so a span opened here — and any event emitted, since
+:class:`~app.events.emitter.EventEmitter` reads ``trace_id`` from the active
+span — lands in the caller's trace rather than starting a new one.
+
+**Live sessions (A-03 technical note).** One span covers a whole meeting and
+child spans cover each analysis batch. A 45-minute span cannot accumulate
+nested children per audio frame without becoming unreadable, so per-frame
+detail is recorded with ``set_attribute`` and span events on the session span
+instead. :class:`LiveSessionSpan` encodes that convention.
 """
 
 from __future__ import annotations
 
+from types import TracebackType
+from typing import Any, Awaitable, Callable
+
 from opentelemetry import metrics, trace
+from opentelemetry.propagate import extract, inject
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.trace import Span, Status, StatusCode
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
 
 _SERVICE = "onboarding-intelligence-agent"
+
+TRACEPARENT_HEADER = "traceparent"
 
 
 def configure_telemetry(exporter_endpoint: str = "") -> None:
@@ -46,3 +66,99 @@ def get_tracer() -> trace.Tracer:
 
 def get_meter() -> metrics.Meter:
     return metrics.get_meter(_SERVICE)
+
+
+def current_trace_id() -> str:
+    """Hex trace id of the active span, or 32 zeros when there is none."""
+    return format(trace.get_current_span().get_span_context().trace_id, "032x")
+
+
+def current_span_id() -> str:
+    return format(trace.get_current_span().get_span_context().span_id, "016x")
+
+
+def outbound_headers() -> dict[str, str]:
+    """Headers that propagate the current trace to a downstream call."""
+    carrier: dict[str, str] = {}
+    inject(carrier)
+    return carrier
+
+
+class TraceContextMiddleware(BaseHTTPMiddleware):
+    """Continues an inbound W3C trace and opens a server span for the request.
+
+    Without this the service would start a fresh trace per request and the
+    Django span and the OIA span would sit in two unrelated trees — which is
+    precisely the failure AC-3 is written to prevent.
+    """
+
+    async def dispatch(
+        self, request: Request, call_next: Callable[[Request], Awaitable[Response]]
+    ) -> Response:
+        context = extract(dict(request.headers))
+        tracer = get_tracer()
+        with tracer.start_as_current_span(
+            f"{request.method} {request.url.path}",
+            context=context,
+            kind=trace.SpanKind.SERVER,
+        ) as span:
+            span.set_attribute("http.method", request.method)
+            span.set_attribute("http.route", request.url.path)
+            response = await call_next(request)
+            span.set_attribute("http.status_code", response.status_code)
+            if response.status_code >= 500:
+                span.set_status(Status(StatusCode.ERROR))
+            # Handy for correlating a user-reported request with a trace.
+            response.headers["X-Trace-Id"] = current_trace_id()
+            return response
+
+
+class LiveSessionSpan:
+    """One span for a whole live meeting, per the A-03 technical note.
+
+    Batches get child spans via :meth:`batch`; per-frame facts are folded into
+    counters on the session span with :meth:`record_frame` rather than becoming
+    thousands of children.
+    """
+
+    def __init__(self, session_id: str, tenant_id: str) -> None:
+        self._tracer = get_tracer()
+        self._span: Span | None = None
+        self._session_id = session_id
+        self._tenant_id = tenant_id
+        self._frames = 0
+        self._batches = 0
+
+    def __enter__(self) -> "LiveSessionSpan":
+        self._span = self._tracer.start_span("oia.live_session")
+        self._span.set_attribute("oia.session_id", self._session_id)
+        self._span.set_attribute("oia.tenant_id", self._tenant_id)
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        if self._span is None:
+            return
+        self._span.set_attribute("oia.frames_total", self._frames)
+        self._span.set_attribute("oia.batches_total", self._batches)
+        if exc is not None:
+            self._span.set_status(Status(StatusCode.ERROR, str(exc)))
+        self._span.end()
+        self._span = None
+
+    def record_frame(self, **attributes: Any) -> None:
+        """Fold one frame into the session span without nesting a child."""
+        self._frames += 1
+        if self._span is not None and attributes:
+            for key, value in attributes.items():
+                self._span.set_attribute(f"oia.{key}", value)
+
+    def batch(self, name: str = "oia.analysis_batch") -> Any:
+        """A child span for one analysis batch."""
+        self._batches += 1
+        context = trace.set_span_in_context(self._span) if self._span else None
+        return self._tracer.start_as_current_span(name, context=context)

--- a/onboarding-intelligence-agent-svc/app/events/catalog.py
+++ b/onboarding-intelligence-agent-svc/app/events/catalog.py
@@ -180,6 +180,26 @@ class AgentEvent(BaseModel):
             )
         return v
 
+    @field_validator("trace_id", "span_id")
+    @classmethod
+    def _must_not_be_the_invalid_context(cls, v: str) -> str:
+        """Reject OpenTelemetry's all-zero ids.
+
+        Emitting outside an active span yields the invalid context, whose ids
+        are all zeros. Such an event validates structurally but can never be
+        joined to anything, so the audit stream would fill with events that
+        look correlated and are not. The emitter starts a span rather than
+        letting this happen; this is the guard for any other caller.
+        """
+        if set(v) == {"0"}:
+            raise ValueError(
+                "is OpenTelemetry's invalid context (all zeros) — the event "
+                "was built outside an active span and would be "
+                "uncorrelatable. Start a span, or use EventEmitter, which "
+                "does it for you."
+            )
+        return v
+
     @property
     def event_ref(self) -> str:
         """The §12 ID this event realises, e.g. ``EVT-103``."""

--- a/onboarding-intelligence-agent-svc/app/events/catalog.py
+++ b/onboarding-intelligence-agent-svc/app/events/catalog.py
@@ -1,19 +1,186 @@
-"""Event type enum and emitter.
+"""Event type catalogue and envelope (Design §12).
 
-Design §12 · implemented by story A-03.
+The enum is populated with the **full** EVT-001…012 and EVT-101…110 set now,
+even though most are unused until later epics. A-03's technical note explains
+why: a complete enum makes the later stories one-line additions, and it makes
+``tests/test_events_no_pii.py`` meaningful from week 2 rather than week 9.
 
-Scaffolded by A-05. The body raises NotImplementedError deliberately: a
-stub that silently returns None would let a later story ship a no-op
-that passes its tests.
+Note on counting. §12 lists 22 event **IDs**, but two of them name a pair —
+EVT-011 is ``agent.circuit.opened`` / ``.closed`` and EVT-102 is
+``onboarding.recording.started`` / ``.stopped``. The enum is keyed by
+``event_type`` string, so it has 24 members covering 22 IDs. Both counts are
+asserted in the tests so neither can drift.
+
+The event stream is a **lower-trust surface than the transcript store** — it
+fans out to observability tooling under a different access model. EVT-103
+therefore carries entity *types* and never entity values or segment text.
+:func:`assert_no_pii` enforces that structurally.
 """
 
 from __future__ import annotations
 
-_NOT_YET = "app.events.catalog — implemented by A-03"
+import uuid
+from datetime import datetime, timezone
+from enum import StrEnum
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+AGENT_ID = "onboarding-intelligence"
+SCHEMA_VERSION = "1.0"
 
 
-class EventType:
-    """Not yet implemented."""
+class EventType(StrEnum):
+    """Every event this service can emit (Design §12.1 and §12.2)."""
 
-    def __init__(self, *args: object, **kwargs: object) -> None:
-        raise NotImplementedError(_NOT_YET)
+    # ── §12.1 Mandatory fleet events ─────────────────────────
+    AGENT_INVOKED = "agent.invoked"  # EVT-001
+    AGENT_PLAN_CREATED = "agent.plan.created"  # EVT-002
+    AGENT_SKILL_INVOKED = "agent.skill.invoked"  # EVT-003
+    AGENT_GUARDRAIL_TRIGGERED = "agent.guardrail.triggered"  # EVT-004
+    AGENT_TOOL_CALLED = "agent.tool.called"  # EVT-005
+    AGENT_MEMORY_WRITTEN = "agent.memory.written"  # EVT-006
+    AGENT_ESCALATED = "agent.escalated"  # EVT-007
+    AGENT_COMPLETED = "agent.completed"  # EVT-008
+    AGENT_FAILED = "agent.failed"  # EVT-009
+    AGENT_RETRIED = "agent.retried"  # EVT-010
+    AGENT_CIRCUIT_OPENED = "agent.circuit.opened"  # EVT-011
+    AGENT_CIRCUIT_CLOSED = "agent.circuit.closed"  # EVT-011
+    AGENT_RATE_LIMITED = "agent.rate_limited"  # EVT-012
+
+    # ── §12.2 Domain events ──────────────────────────────────
+    CONSENT_VERIFIED = "onboarding.consent.verified"  # EVT-101
+    RECORDING_STARTED = "onboarding.recording.started"  # EVT-102
+    RECORDING_STOPPED = "onboarding.recording.stopped"  # EVT-102
+    TRANSCRIPT_SEGMENT_FINALIZED = "onboarding.transcript.segment.finalized"  # 103
+    SUFFICIENCY_SIGNAL = "onboarding.sufficiency.signal"  # EVT-104
+    FOLLOWUP_SUGGESTED = "onboarding.followup.suggested"  # EVT-105
+    MEDIA_CAPTURED_ANALYZED = "onboarding.media.captured.analyzed"  # EVT-106
+    COVERAGE_UPDATED = "onboarding.coverage.updated"  # EVT-107
+    PROCESSING_COMPLETED = "onboarding.processing.completed"  # EVT-108
+    PROVENANCE_REVIEWED = "onboarding.provenance.reviewed"  # EVT-109
+    GOLDEN_CANDIDATE_RECORDED = "onboarding.golden.candidate.recorded"  # EVT-110
+
+
+#: event_type → the §12 ID it realises. Two IDs map from two members each.
+EVENT_IDS: dict[EventType, str] = {
+    EventType.AGENT_INVOKED: "EVT-001",
+    EventType.AGENT_PLAN_CREATED: "EVT-002",
+    EventType.AGENT_SKILL_INVOKED: "EVT-003",
+    EventType.AGENT_GUARDRAIL_TRIGGERED: "EVT-004",
+    EventType.AGENT_TOOL_CALLED: "EVT-005",
+    EventType.AGENT_MEMORY_WRITTEN: "EVT-006",
+    EventType.AGENT_ESCALATED: "EVT-007",
+    EventType.AGENT_COMPLETED: "EVT-008",
+    EventType.AGENT_FAILED: "EVT-009",
+    EventType.AGENT_RETRIED: "EVT-010",
+    EventType.AGENT_CIRCUIT_OPENED: "EVT-011",
+    EventType.AGENT_CIRCUIT_CLOSED: "EVT-011",
+    EventType.AGENT_RATE_LIMITED: "EVT-012",
+    EventType.CONSENT_VERIFIED: "EVT-101",
+    EventType.RECORDING_STARTED: "EVT-102",
+    EventType.RECORDING_STOPPED: "EVT-102",
+    EventType.TRANSCRIPT_SEGMENT_FINALIZED: "EVT-103",
+    EventType.SUFFICIENCY_SIGNAL: "EVT-104",
+    EventType.FOLLOWUP_SUGGESTED: "EVT-105",
+    EventType.MEDIA_CAPTURED_ANALYZED: "EVT-106",
+    EventType.COVERAGE_UPDATED: "EVT-107",
+    EventType.PROCESSING_COMPLETED: "EVT-108",
+    EventType.PROVENANCE_REVIEWED: "EVT-109",
+    EventType.GOLDEN_CANDIDATE_RECORDED: "EVT-110",
+}
+
+Outcome = Literal["SUCCESS", "FAILURE", "BLOCKED", "DEGRADED"]
+
+#: Payload keys that must never appear on the event stream. The stream reaches
+#: observability tooling under a different access model than the tenant-scoped
+#: transcript store, so text and entity values stay out of it entirely.
+FORBIDDEN_PAYLOAD_KEYS: frozenset[str] = frozenset(
+    {
+        "text",
+        "transcript",
+        "segment",
+        "segment_text",
+        "content",
+        "entity_values",
+        "entities",
+        "raw",
+        "audio",
+        "email",
+        "phone",
+        "phone_number",
+        "address",
+        "full_name",
+        "subject_name",
+        "value",
+        "extracted_value",
+        "admin_final_value",
+    }
+)
+
+
+class PIILeakError(ValueError):
+    """Raised when a payload carries a field the event stream must not see."""
+
+
+def assert_no_pii(event_type: EventType, payload: dict[str, Any]) -> None:
+    """Reject payload shapes that would put PII on the event stream.
+
+    Structural, not semantic: it catches a caller reaching for ``text`` or
+    ``entity_values``. Semantic redaction of free text is SKL-OIA-16's job in
+    F-05 — this is the guard that stops an unredacted field being attached to
+    an event in the first place.
+    """
+    offending = sorted(FORBIDDEN_PAYLOAD_KEYS.intersection(payload))
+    if offending:
+        raise PIILeakError(
+            f"{event_type.value} payload carries forbidden key(s) {offending}. "
+            "The event stream records that redaction fired and on what — "
+            "entity types, counts, ids — never values or text (Design §12.2)."
+        )
+
+
+class AgentEvent(BaseModel):
+    """The fleet-standard envelope (Design §12).
+
+    Note on naming: A-03 AC-2 lists the field as ``occurred_at`` while §12's
+    model calls it ``timestamp``. AC-2 defers to "the AgentEvent Pydantic
+    envelope specified in Design §12", so ``timestamp`` is authoritative and
+    ``occurred_at`` is accepted as an alias.
+    """
+
+    model_config = {"populate_by_name": True}
+
+    event_id: uuid.UUID = Field(default_factory=uuid.uuid4)
+    event_type: EventType
+    schema_version: str = SCHEMA_VERSION
+    timestamp: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc), alias="occurred_at"
+    )
+    trace_id: str
+    span_id: str
+    correlation_id: str
+    tenant_id: uuid.UUID
+    agent_id: str = AGENT_ID
+    session_id: uuid.UUID | None = None
+    user_id: uuid.UUID | None = None
+    role: str | None = None
+    skill_id: str | None = None
+    payload: dict[str, Any] = Field(default_factory=dict)
+    duration_ms: int | None = None
+    outcome: Outcome = "SUCCESS"
+
+    @field_validator("trace_id", "span_id", "correlation_id")
+    @classmethod
+    def _must_not_be_blank(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError(
+                "must not be empty — an event without correlation cannot be "
+                "joined to the request that caused it"
+            )
+        return v
+
+    @property
+    def event_ref(self) -> str:
+        """The §12 ID this event realises, e.g. ``EVT-103``."""
+        return EVENT_IDS[self.event_type]

--- a/onboarding-intelligence-agent-svc/app/events/emitter.py
+++ b/onboarding-intelligence-agent-svc/app/events/emitter.py
@@ -29,6 +29,7 @@ from typing import Any
 from opentelemetry import trace
 
 from app.core.logging import get_logger
+from app.core.telemetry import get_tracer
 from app.events.catalog import AgentEvent, EventType, Outcome, assert_no_pii
 from app.messaging.producer import KafkaProducer
 from app.messaging.topics import events_topic, message_key
@@ -82,13 +83,12 @@ class EventEmitter:
         body = payload or {}
         assert_no_pii(event_type, body)
 
-        span = trace.get_current_span()
-        context = span.get_span_context()
+        trace_id, span_id = self._trace_ids(event_type)
 
         return AgentEvent(
             event_type=event_type,
-            trace_id=format(context.trace_id, "032x"),
-            span_id=format(context.span_id, "016x"),
+            trace_id=trace_id,
+            span_id=span_id,
             correlation_id=correlation_id,
             tenant_id=uuid.UUID(str(tenant_id)),
             session_id=uuid.UUID(str(session_id)) if session_id else None,
@@ -99,6 +99,41 @@ class EventEmitter:
             duration_ms=duration_ms,
             outcome=outcome,
         )
+
+    @staticmethod
+    def _trace_ids(event_type: EventType) -> tuple[str, str]:
+        """Correlation ids for an event, guaranteed to be real.
+
+        Outside an active span — a Kafka consumer callback, a background
+        task, a Celery-style worker — OpenTelemetry returns the invalid
+        context, whose ids are all zeros. An event carrying 000… is
+        uncorrelatable and quietly poisons the audit stream, so a span is
+        started for it instead. The event then has a trace of its own that a
+        backend can join, rather than a placeholder.
+        """
+        context = trace.get_current_span().get_span_context()
+        if context.is_valid:
+            return format(context.trace_id, "032x"), format(context.span_id, "016x")
+
+        with get_tracer().start_as_current_span(
+            f"oia.event.{event_type.value}"
+        ) as span:
+            fresh = span.get_span_context()
+            if fresh.is_valid:
+                return format(fresh.trace_id, "032x"), format(fresh.span_id, "016x")
+
+        # No SDK tracer provider is installed, so even a started span is
+        # non-recording and its context is still all zeros. The service always
+        # installs one (app.main calls configure_telemetry at import), so this
+        # is the library-used-standalone case — a test, a script, a future
+        # worker entry point that forgot to configure telemetry.
+        #
+        # Synthesised ids rather than zeros: unique per event, so the audit
+        # stream stays groupable and an operator can still follow one event,
+        # and they can never collide with a real trace. Emission degrades; it
+        # does not crash, and it does not lie by reusing 000….
+        logger.debug("event_trace_synthesised", event_type=event_type.value)
+        return uuid.uuid4().hex, uuid.uuid4().hex[:16]
 
     async def emit(
         self, event_type: EventType, *, tenant_id: uuid.UUID | str, **kwargs: Any

--- a/onboarding-intelligence-agent-svc/app/events/emitter.py
+++ b/onboarding-intelligence-agent-svc/app/events/emitter.py
@@ -1,0 +1,172 @@
+"""EventEmitter — the single way this service emits a §12 event.
+
+Three properties are load-bearing:
+
+**Validation raises, it does not warn.** AC-2: "a payload that fails validation
+raises rather than silently emitting a malformed event." A malformed event that
+reaches the stream is worse than no event, because downstream consumers and the
+audit trail both treat the stream as authoritative.
+
+**Emission never fails the caller.** A meeting must not drop because Kafka is
+unreachable. Publication is fire-and-forget onto a bounded queue; the envelope
+is always recorded as a span event and a structured log line, both of which
+survive Kafka being absent entirely — which in production it is, since no
+`deployment/gcp` script provisions a broker.
+
+**The trace comes from the active span.** ``trace_id`` and ``span_id`` are read
+from the current OpenTelemetry context rather than passed in, so an event
+emitted while handling a request carrying a W3C ``traceparent`` is joined to
+the caller's trace automatically (AC-3).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from typing import Any
+
+from opentelemetry import trace
+
+from app.core.logging import get_logger
+from app.events.catalog import AgentEvent, EventType, Outcome, assert_no_pii
+from app.messaging.producer import KafkaProducer
+from app.messaging.topics import events_topic, message_key
+
+logger = get_logger(__name__)
+
+#: Bounded so a Kafka outage costs memory in a known, small amount rather than
+#: growing until the process dies.
+MAX_QUEUED_EVENTS = 1000
+
+
+class EventEmitter:
+    """Builds, validates and publishes §12 events."""
+
+    def __init__(self, producer: KafkaProducer) -> None:
+        self._producer = producer
+        self._queue: asyncio.Queue[tuple[str, str, bytes]] = asyncio.Queue(
+            maxsize=MAX_QUEUED_EVENTS
+        )
+        self._worker: asyncio.Task[None] | None = None
+        self.dropped = 0
+
+    async def start(self) -> None:
+        if self._worker is None:
+            self._worker = asyncio.create_task(self._drain())
+
+    async def stop(self) -> None:
+        if self._worker is not None:
+            self._worker.cancel()
+            try:
+                await self._worker
+            except asyncio.CancelledError:
+                pass
+            self._worker = None
+
+    def build(
+        self,
+        event_type: EventType,
+        *,
+        tenant_id: uuid.UUID | str,
+        correlation_id: str,
+        session_id: uuid.UUID | str | None = None,
+        user_id: uuid.UUID | str | None = None,
+        role: str | None = None,
+        skill_id: str | None = None,
+        payload: dict[str, Any] | None = None,
+        duration_ms: int | None = None,
+        outcome: Outcome = "SUCCESS",
+    ) -> AgentEvent:
+        """Construct and validate an envelope. Raises on anything malformed."""
+        body = payload or {}
+        assert_no_pii(event_type, body)
+
+        span = trace.get_current_span()
+        context = span.get_span_context()
+
+        return AgentEvent(
+            event_type=event_type,
+            trace_id=format(context.trace_id, "032x"),
+            span_id=format(context.span_id, "016x"),
+            correlation_id=correlation_id,
+            tenant_id=uuid.UUID(str(tenant_id)),
+            session_id=uuid.UUID(str(session_id)) if session_id else None,
+            user_id=uuid.UUID(str(user_id)) if user_id else None,
+            role=role,
+            skill_id=skill_id,
+            payload=body,
+            duration_ms=duration_ms,
+            outcome=outcome,
+        )
+
+    async def emit(
+        self, event_type: EventType, *, tenant_id: uuid.UUID | str, **kwargs: Any
+    ) -> AgentEvent:
+        """Build, record and enqueue one event.
+
+        Returns the validated envelope so callers can assert on it. Raises if
+        the event is malformed; never raises because publication failed.
+        """
+        event = self.build(event_type, tenant_id=tenant_id, **kwargs)
+
+        # Always recorded, even with no broker: the span event and the log line
+        # are what make events observable in production today.
+        trace.get_current_span().add_event(
+            event.event_type.value,
+            attributes={
+                "event.id": str(event.event_id),
+                "event.ref": event.event_ref,
+                "event.outcome": event.outcome,
+                "tenant.id": str(event.tenant_id),
+            },
+        )
+        logger.info(
+            "agent_event",
+            event_type=event.event_type.value,
+            event_ref=event.event_ref,
+            event_id=str(event.event_id),
+            tenant_id=str(event.tenant_id),
+            session_id=str(event.session_id) if event.session_id else None,
+            trace_id=event.trace_id,
+            outcome=event.outcome,
+        )
+
+        self._enqueue(event)
+        return event
+
+    def _enqueue(self, event: AgentEvent) -> None:
+        payload = json.dumps(event.model_dump(mode="json")).encode()
+        item = (
+            events_topic(str(event.tenant_id)),
+            message_key(str(event.tenant_id), str(event.session_id or "")),
+            payload,
+        )
+        try:
+            self._queue.put_nowait(item)
+        except asyncio.QueueFull:
+            # Losing an event is bad; losing the meeting is worse.
+            self.dropped += 1
+            logger.warning(
+                "event_queue_full",
+                dropped_total=self.dropped,
+                event_type=event.event_type.value,
+            )
+
+    async def _drain(self) -> None:
+        while True:
+            topic, key, payload = await self._queue.get()
+            try:
+                await self._producer.send(topic, key=key, value=payload)
+            except Exception as exc:  # noqa: BLE001 — never kills the worker
+                logger.warning("event_publish_failed", topic=topic, error=str(exc))
+            finally:
+                self._queue.task_done()
+
+    async def flush(self, timeout: float = 5.0) -> bool:
+        """Wait for the queue to drain. Used by tests and graceful shutdown."""
+        try:
+            await asyncio.wait_for(self._queue.join(), timeout=timeout)
+            return True
+        except asyncio.TimeoutError:
+            return False

--- a/onboarding-intelligence-agent-svc/app/main.py
+++ b/onboarding-intelligence-agent-svc/app/main.py
@@ -47,17 +47,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     except Exception as exc:  # noqa: BLE001 — reported via /health
         logger.warning("kafka_start_failed", error=str(exc))
 
-    app.state.events = EventEmitter(app.state.kafka)
-    await app.state.events.start()
-
-    app.state.commands = CommandConsumer(settings, app.state.kafka)
-    try:
-        await app.state.commands.start()
-    except Exception as exc:  # noqa: BLE001 — reported via /health
-        logger.warning("command_consumer_start_failed", error=str(exc))
-
-    # AC-1: provision the fleet topics and prove they are reachable. Skipped
-    # entirely where no broker is configured, which is production today.
+    # AC-1: provision the fleet topics and prove they are reachable. This runs
+    # BEFORE the consumer subscribes and before the emitter can publish:
+    # either would trigger Kafka's auto-create first, and an auto-created
+    # topic takes the broker's default retention rather than the §13.1 value.
+    # Skipped entirely where no broker is configured, which is production.
     if settings.kafka_enabled:
         try:
             report = await provision(settings.KAFKA_BOOTSTRAP_SERVERS)
@@ -66,11 +60,21 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                 "kafka_topics_ready",
                 created=report.created,
                 existing=report.existing,
+                reconciled=report.reconciled,
                 reachable=reachable,
                 missing=missing,
             )
         except Exception as exc:  # noqa: BLE001 — reported via /health
             logger.warning("kafka_topic_provisioning_failed", error=str(exc))
+
+    app.state.events = EventEmitter(app.state.kafka)
+    await app.state.events.start()
+
+    app.state.commands = CommandConsumer(settings, app.state.kafka)
+    try:
+        await app.state.commands.start()
+    except Exception as exc:  # noqa: BLE001 — reported via /health
+        logger.warning("command_consumer_start_failed", error=str(exc))
 
     # AC-5: session state must not be evictable. Reported rather than fatal —
     # refusing to start would take the service down for a condition an

--- a/onboarding-intelligence-agent-svc/app/main.py
+++ b/onboarding-intelligence-agent-svc/app/main.py
@@ -17,8 +17,11 @@ from app.api.routes import router
 from app.cache.redis_manager import RedisManager
 from app.core.config import get_settings
 from app.core.logging import configure_logging, get_logger
-from app.core.telemetry import configure_telemetry
+from app.core.telemetry import TraceContextMiddleware, configure_telemetry
+from app.events.emitter import EventEmitter
+from app.messaging.consumer import CommandConsumer
 from app.messaging.producer import KafkaProducer
+from app.messaging.provision import provision, verify
 
 settings = get_settings()
 configure_logging(settings.LOG_LEVEL)
@@ -44,16 +47,61 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     except Exception as exc:  # noqa: BLE001 — reported via /health
         logger.warning("kafka_start_failed", error=str(exc))
 
+    app.state.events = EventEmitter(app.state.kafka)
+    await app.state.events.start()
+
+    app.state.commands = CommandConsumer(settings, app.state.kafka)
+    try:
+        await app.state.commands.start()
+    except Exception as exc:  # noqa: BLE001 — reported via /health
+        logger.warning("command_consumer_start_failed", error=str(exc))
+
+    # AC-1: provision the fleet topics and prove they are reachable. Skipped
+    # entirely where no broker is configured, which is production today.
+    if settings.kafka_enabled:
+        try:
+            report = await provision(settings.KAFKA_BOOTSTRAP_SERVERS)
+            reachable, missing = await verify(settings.KAFKA_BOOTSTRAP_SERVERS)
+            logger.info(
+                "kafka_topics_ready",
+                created=report.created,
+                existing=report.existing,
+                reachable=reachable,
+                missing=missing,
+            )
+        except Exception as exc:  # noqa: BLE001 — reported via /health
+            logger.warning("kafka_topic_provisioning_failed", error=str(exc))
+
+    # AC-5: session state must not be evictable. Reported rather than fatal —
+    # refusing to start would take the service down for a condition an
+    # operator has to fix on the shared instance anyway.
+    policy = await app.state.redis.eviction_policy()
+    app.state.eviction_policy = policy
+    if policy is None:
+        logger.warning("redis_eviction_policy_unknown", detail="CONFIG GET refused")
+    elif policy != "noeviction":
+        logger.warning(
+            "redis_eviction_policy_unsafe",
+            policy=policy,
+            detail=(
+                "live session state can be evicted mid-meeting; "
+                "expected noeviction (A-03 AC-5)"
+            ),
+        )
+
     logger.info(
         "service_started",
         service="onboarding-intelligence-agent",
         port=settings.PORT,
         redis_db=settings.REDIS_DB,
         kafka_configured=settings.kafka_enabled,
+        eviction_policy=policy,
     )
 
     yield
 
+    await app.state.commands.stop()
+    await app.state.events.stop()
     await app.state.kafka.stop()
     await app.state.redis.close()
     logger.info("service_stopped")
@@ -69,4 +117,5 @@ app = FastAPI(
     version="0.1.0",
     lifespan=lifespan,
 )
+app.add_middleware(TraceContextMiddleware)
 app.include_router(router)

--- a/onboarding-intelligence-agent-svc/app/messaging/consumer.py
+++ b/onboarding-intelligence-agent-svc/app/messaging/consumer.py
@@ -1,19 +1,172 @@
-"""agent.commands consumer.
+"""agent.commands consumer with dead-letter routing (Design §13, §20).
 
-Design §13 · implemented by story A-03.
+A-03 delivers the transport: consume, validate, hand to a handler, retry with
+backoff, and dead-letter on exhaustion. The PROCESS handler itself is J-01's.
 
-Scaffolded by A-05. The body raises NotImplementedError deliberately: a
-stub that silently returns None would let a later story ship a no-op
-that passes its tests.
+Dead-lettering is the point. §20 says the DLQ is reviewed daily and the replay
+tool re-publishes with the same ``idempotency_key``, "so replay is safe by
+construction" — which only holds if the key survives into the dead letter, so
+:class:`DeadLetter` carries it.
 """
 
 from __future__ import annotations
 
-_NOT_YET = "app.messaging.consumer — implemented by A-03"
+import asyncio
+import json
+from typing import Any, Awaitable, Callable
+
+from aiokafka import AIOKafkaConsumer
+
+from app.core.config import Settings
+from app.core.logging import get_logger
+from app.messaging.producer import KafkaProducer
+from app.messaging.schemas import DeadLetter, ProcessCommand
+from app.messaging.topics import COMMANDS, DLQ
+
+logger = get_logger(__name__)
+
+CommandHandler = Callable[[ProcessCommand], Awaitable[None]]
+
+DEFAULT_MAX_ATTEMPTS = 3
+DEFAULT_BACKOFF_S = 0.5
 
 
 class CommandConsumer:
-    """Not yet implemented."""
+    """Consumes ``agent.commands.onboarding-intelligence``."""
 
-    def __init__(self, *args: object, **kwargs: object) -> None:
-        raise NotImplementedError(_NOT_YET)
+    def __init__(
+        self,
+        settings: Settings,
+        producer: KafkaProducer,
+        handler: CommandHandler | None = None,
+        *,
+        max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+        backoff_s: float = DEFAULT_BACKOFF_S,
+    ) -> None:
+        self._settings = settings
+        self._producer = producer
+        self._handler = handler
+        self._max_attempts = max_attempts
+        self._backoff_s = backoff_s
+        self._consumer: AIOKafkaConsumer | None = None
+        self._task: asyncio.Task[None] | None = None
+        self.dead_lettered = 0
+        self.processed = 0
+
+    @property
+    def configured(self) -> bool:
+        return self._settings.kafka_enabled
+
+    async def start(self) -> None:
+        if not self.configured:
+            logger.info("kafka_not_configured", detail="command consumer disabled")
+            return
+        self._consumer = AIOKafkaConsumer(
+            COMMANDS.name,
+            bootstrap_servers=self._settings.KAFKA_BOOTSTRAP_SERVERS,
+            group_id=f"{COMMANDS.name}.consumers",
+            enable_auto_commit=True,
+            auto_offset_reset="latest",
+        )
+        await self._consumer.start()
+        self._task = asyncio.create_task(self._run())
+        logger.info("command_consumer_started", topic=COMMANDS.name)
+
+    async def stop(self) -> None:
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+        if self._consumer is not None:
+            await self._consumer.stop()
+            self._consumer = None
+
+    async def _run(self) -> None:
+        assert self._consumer is not None
+        async for message in self._consumer:
+            await self.handle_raw(
+                message.value,
+                key=message.key.decode() if message.key else None,
+            )
+
+    async def handle_raw(self, raw: bytes, *, key: str | None = None) -> bool:
+        """Process one message. Returns True when it was handled.
+
+        Kept separate from the consume loop so the retry and dead-letter
+        behaviour can be tested against a real broker without waiting on a
+        subscription.
+        """
+        try:
+            body: dict[str, Any] = json.loads(raw)
+            command = ProcessCommand.model_validate(body)
+        except Exception as exc:  # noqa: BLE001 — malformed input is a dead letter
+            await self._dead_letter(
+                raw, key, "ERR-MSG-01", f"unparseable command: {exc}", attempts=1
+            )
+            return False
+
+        for attempt in range(1, self._max_attempts + 1):
+            try:
+                if self._handler is not None:
+                    await self._handler(command)
+                self.processed += 1
+                return True
+            except Exception as exc:  # noqa: BLE001 — retried, then dead-lettered
+                logger.warning(
+                    "command_handler_failed",
+                    attempt=attempt,
+                    job_id=command.job_id,
+                    error=str(exc),
+                )
+                if attempt >= self._max_attempts:
+                    await self._dead_letter(
+                        raw,
+                        key,
+                        "ERR-CMD-01",
+                        str(exc),
+                        attempts=attempt,
+                        idempotency_key=command.idempotency_key,
+                    )
+                    return False
+                await asyncio.sleep(self._backoff_s * attempt)
+        return False
+
+    async def _dead_letter(
+        self,
+        raw: bytes,
+        key: str | None,
+        error_code: str,
+        error_message: str,
+        *,
+        attempts: int,
+        idempotency_key: str | None = None,
+    ) -> None:
+        try:
+            payload = json.loads(raw)
+        except Exception:  # noqa: BLE001 — keep what we can for triage
+            payload = {"unparseable": raw[:512].decode(errors="replace")}
+
+        letter = DeadLetter(
+            original_topic=COMMANDS.name,
+            original_key=key,
+            payload=payload,
+            error_code=error_code,
+            error_message=error_message[:500],
+            attempts=attempts,
+            idempotency_key=idempotency_key,
+        )
+        self.dead_lettered += 1
+        logger.error(
+            "command_dead_lettered",
+            error_code=error_code,
+            attempts=attempts,
+            dlq_topic=DLQ.name,
+        )
+        await self._producer.send(
+            DLQ.name,
+            key=key,
+            value=json.dumps(letter.model_dump(mode="json")).encode(),
+        )

--- a/onboarding-intelligence-agent-svc/app/messaging/consumer.py
+++ b/onboarding-intelligence-agent-svc/app/messaging/consumer.py
@@ -65,7 +65,12 @@ class CommandConsumer:
             COMMANDS.name,
             bootstrap_servers=self._settings.KAFKA_BOOTSTRAP_SERVERS,
             group_id=f"{COMMANDS.name}.consumers",
-            enable_auto_commit=True,
+            # Offsets are committed explicitly, after handle_raw has either
+            # succeeded or dead-lettered. On a timer, auto-commit can advance
+            # past a message this process never finished handling, and the
+            # message is simply lost on restart — retries and the DLQ only
+            # help if the offset has not already moved.
+            enable_auto_commit=False,
             auto_offset_reset="latest",
         )
         await self._consumer.start()
@@ -91,6 +96,10 @@ class CommandConsumer:
                 message.value,
                 key=message.key.decode() if message.key else None,
             )
+            # Committed regardless of outcome: a failure has already been
+            # retried and dead-lettered inside handle_raw, so replaying it
+            # would duplicate the dead letter rather than recover anything.
+            await self._consumer.commit()
 
     async def handle_raw(self, raw: bytes, *, key: str | None = None) -> bool:
         """Process one message. Returns True when it was handled.

--- a/onboarding-intelligence-agent-svc/app/messaging/producer.py
+++ b/onboarding-intelligence-agent-svc/app/messaging/producer.py
@@ -46,7 +46,11 @@ class KafkaProducer:
             return
         self._producer = AIOKafkaProducer(
             bootstrap_servers=self._settings.KAFKA_BOOTSTRAP_SERVERS,
-            request_timeout_ms=2000,
+            # Bounded, but not so tight that ordinary cloud latency or a
+            # busy broker turns a healthy publish into a dropped event. The
+            # health probe does not depend on this — is_live() reads cluster
+            # metadata rather than producing.
+            request_timeout_ms=10000,
         )
         await self._producer.start()
         self._started = True
@@ -60,6 +64,22 @@ class KafkaProducer:
             await self._producer.stop()
             self._producer = None
         self._started = False
+
+    async def send(
+        self, topic: str, *, key: str | None = None, value: bytes = b""
+    ) -> bool:
+        """Publish one message. Returns False when there is no broker.
+
+        Never raises for an absent broker: production has none, and an event
+        that cannot be published must not fail the request that produced it.
+        A genuine publish error still propagates so the caller can log it.
+        """
+        if not self.configured or self._producer is None or not self._started:
+            return False
+        await self._producer.send_and_wait(
+            topic, value=value, key=key.encode() if key else None
+        )
+        return True
 
     async def is_live(self) -> bool:
         """Whether a configured broker is actually reachable.

--- a/onboarding-intelligence-agent-svc/app/messaging/provision.py
+++ b/onboarding-intelligence-agent-svc/app/messaging/provision.py
@@ -1,0 +1,100 @@
+"""Idempotent topic provisioning (AC-1).
+
+Stands in for the Terraform module AC-1 assumes. There is no Terraform in this
+monorepo, and Kafka's ``auto.create.topics.enable`` produces topics with
+default retention rather than the values Design §13.1 specifies — a topic that
+exists but keeps escalations for 7 days instead of 30 is a silent compliance
+gap, not a working topic.
+
+Idempotent by construction: creating a topic that already exists is treated as
+success, and existing topics have their retention reconciled to the catalogue.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from aiokafka.admin import AIOKafkaAdminClient, NewTopic
+from aiokafka.errors import KafkaError, TopicAlreadyExistsError
+
+from app.messaging.topics import FLEET_TOPICS, TopicSpec
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ProvisionReport:
+    """What provisioning actually did, for the startup log and the tests."""
+
+    created: list[str]
+    existing: list[str]
+    reconciled: list[str]
+    failed: dict[str, str]
+
+    @property
+    def ok(self) -> bool:
+        return not self.failed
+
+    @property
+    def all_present(self) -> list[str]:
+        return sorted(self.created + self.existing + self.reconciled)
+
+
+async def provision(
+    bootstrap_servers: str, specs: tuple[TopicSpec, ...] = FLEET_TOPICS
+) -> ProvisionReport:
+    """Create every topic in ``specs``, reconciling retention where it exists."""
+    report = ProvisionReport([], [], [], {})
+    admin = AIOKafkaAdminClient(bootstrap_servers=bootstrap_servers)
+    await admin.start()
+    try:
+        existing = set(await admin.list_topics())
+
+        to_create = [
+            NewTopic(
+                name=spec.name,
+                num_partitions=spec.partitions,
+                replication_factor=spec.replication_factor,
+                topic_configs=spec.config,
+            )
+            for spec in specs
+            if spec.name not in existing
+        ]
+
+        if to_create:
+            try:
+                await admin.create_topics(to_create)
+                report.created.extend(t.name for t in to_create)
+            except TopicAlreadyExistsError:
+                # Another instance won the race. That is success, not failure.
+                report.existing.extend(t.name for t in to_create)
+            except KafkaError as exc:
+                for topic in to_create:
+                    report.failed[topic.name] = str(exc)
+
+        for spec in specs:
+            if spec.name in existing:
+                report.existing.append(spec.name)
+
+        logger.info(
+            "kafka topics provisioned: created=%s existing=%s failed=%s",
+            report.created,
+            report.existing,
+            list(report.failed),
+        )
+        return report
+    finally:
+        await admin.close()
+
+
+async def verify(bootstrap_servers: str) -> tuple[bool, list[str]]:
+    """Report which fleet topics are missing. Used by the startup smoke check."""
+    admin = AIOKafkaAdminClient(bootstrap_servers=bootstrap_servers)
+    await admin.start()
+    try:
+        existing = set(await admin.list_topics())
+        missing = sorted(s.name for s in FLEET_TOPICS if s.name not in existing)
+        return (not missing), missing
+    finally:
+        await admin.close()

--- a/onboarding-intelligence-agent-svc/app/messaging/provision.py
+++ b/onboarding-intelligence-agent-svc/app/messaging/provision.py
@@ -16,6 +16,7 @@ import logging
 from dataclasses import dataclass
 
 from aiokafka.admin import AIOKafkaAdminClient, NewTopic
+from aiokafka.admin.config_resource import ConfigResource, ConfigResourceType
 from aiokafka.errors import KafkaError, TopicAlreadyExistsError
 
 from app.messaging.topics import FLEET_TOPICS, TopicSpec
@@ -73,17 +74,73 @@ async def provision(
                 for topic in to_create:
                     report.failed[topic.name] = str(exc)
 
+        # Reconcile retention on topics that already exist. This is the whole
+        # reason the provisioner exists rather than relying on Kafka's
+        # auto-create: an auto-created topic gets the broker default, so
+        # agent.escalations would silently keep 7 days instead of 30 — a
+        # compliance gap that looks like a working topic.
         for spec in specs:
-            if spec.name in existing:
+            if spec.name not in existing:
+                continue
+            try:
+                changed = await _reconcile_retention(admin, spec)
+            except KafkaError as exc:
+                report.failed[spec.name] = f"retention reconcile failed: {exc}"
+                continue
+            if changed:
+                report.reconciled.append(spec.name)
+            else:
                 report.existing.append(spec.name)
 
         logger.info(
-            "kafka topics provisioned: created=%s existing=%s failed=%s",
+            "kafka topics provisioned: created=%s existing=%s reconciled=%s "
+            "failed=%s",
             report.created,
             report.existing,
+            report.reconciled,
             list(report.failed),
         )
         return report
+    finally:
+        await admin.close()
+
+
+async def _current_retention(admin: AIOKafkaAdminClient, topic: str) -> str | None:
+    """Read ``retention.ms`` as the broker currently has it."""
+    resource = ConfigResource(ConfigResourceType.TOPIC, topic)
+    responses = await admin.describe_configs([resource])
+    for response in responses:
+        for described in response.resources:
+            # The resource tuple's arity varies with the DescribeConfigs API
+            # version (5 fields here, 6 in later ones); the config entries are
+            # always last, and each entry starts (name, value, ...).
+            entries = described[-1]
+            for entry in entries:
+                if entry[0] == "retention.ms":
+                    return str(entry[1])
+    return None
+
+
+async def _reconcile_retention(admin: AIOKafkaAdminClient, spec: TopicSpec) -> bool:
+    """Set ``retention.ms`` to the catalogue value. True when it changed."""
+    current = await _current_retention(admin, spec.name)
+    desired = str(spec.retention_ms)
+    if current == desired:
+        return False
+
+    await admin.alter_configs(
+        [ConfigResource(ConfigResourceType.TOPIC, spec.name, configs=spec.config)]
+    )
+    logger.info("topic retention reconciled: %s %s -> %s", spec.name, current, desired)
+    return True
+
+
+async def retention_of(bootstrap_servers: str, topic: str) -> str | None:
+    """Public read of a topic's retention, for tests and diagnostics."""
+    admin = AIOKafkaAdminClient(bootstrap_servers=bootstrap_servers)
+    await admin.start()
+    try:
+        return await _current_retention(admin, topic)
     finally:
         await admin.close()
 

--- a/onboarding-intelligence-agent-svc/app/messaging/schemas.py
+++ b/onboarding-intelligence-agent-svc/app/messaging/schemas.py
@@ -1,19 +1,132 @@
-"""Kafka payload models.
+"""Kafka payload models (Design §13.2).
 
-Design §13.2 · implemented by story A-03.
+The envelope is shared across every topic; only ``payload`` varies. Models are
+Pydantic so a malformed message fails at the boundary rather than three calls
+deep inside a handler.
 
-Scaffolded by A-05. The body raises NotImplementedError deliberately: a
-stub that silently returns None would let a later story ship a no-op
-that passes its tests.
+``GoldenCandidate`` is defined here because §13.2 defines it, but its topic is
+**not** provisioned by A-03 — that is L-02's, and an empty topic nobody
+consumes is worse than no topic.
 """
 
 from __future__ import annotations
 
-_NOT_YET = "app.messaging.schemas — implemented by A-03"
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+SOURCE_AGENT = "onboarding-intelligence"
+SCHEMA_VERSION = "1.0"
 
 
-class AgentEvent:
-    """Not yet implemented."""
+class MessageEnvelope(BaseModel):
+    """Shared envelope for every Kafka message this service sends."""
 
-    def __init__(self, *args: object, **kwargs: object) -> None:
-        raise NotImplementedError(_NOT_YET)
+    schema_version: str = SCHEMA_VERSION
+    message_id: uuid.UUID = Field(default_factory=uuid.uuid4)
+    correlation_id: str
+    source_agent: str = SOURCE_AGENT
+    tenant_id: uuid.UUID
+    session_id: uuid.UUID | None = None
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    payload: dict[str, Any] = Field(default_factory=dict)
+
+
+class EvidenceManifest(BaseModel):
+    """What a PROCESS run is being asked to read.
+
+    The manifest hash is half of the idempotency key, so re-running over
+    unchanged evidence returns the original job rather than writing twice.
+    """
+
+    recording_ids: list[str] = Field(default_factory=list)
+    media_ids: list[str] = Field(default_factory=list)
+    document_ids: list[str] = Field(default_factory=list)
+    manifest_hash: str
+
+
+class ProcessOptions(BaseModel):
+    force_rerun: bool = False
+    language: str | None = None
+
+
+class ProcessCommand(BaseModel):
+    job_id: str
+    session_id: uuid.UUID
+    evidence_manifest: EvidenceManifest
+    options: ProcessOptions = Field(default_factory=ProcessOptions)
+    idempotency_key: str
+
+
+class ProcessSummary(BaseModel):
+    fields_written: int = 0
+    key_count: int = 0
+    secondary_count: int = 0
+    dropped_ungrounded: int = 0
+    conflicts: int = 0
+
+
+class ErrorDetail(BaseModel):
+    """Errors carry a code from the §18.4 taxonomy, not a free-text message."""
+
+    error_code: str
+    message: str
+    recoverable: bool = False
+
+
+class ProcessResult(BaseModel):
+    job_id: str
+    status: Literal["SUCCEEDED", "FAILED", "PARTIAL"]
+    summary: ProcessSummary | None = None
+    error: ErrorDetail | None = None
+    prompt_versions: dict[str, str] = Field(default_factory=dict)
+    duration_ms: int = 0
+
+
+class EscalationMessage(BaseModel):
+    """SKL-OIA-14 output — a conflict or low-confidence case for a human."""
+
+    escalation_id: uuid.UUID = Field(default_factory=uuid.uuid4)
+    tenant_id: uuid.UUID
+    session_id: uuid.UUID | None = None
+    reason_code: str
+    field_name: str | None = None
+    confidence: float | None = None
+    requires_role: str = "Admin"
+
+
+class GoldenCandidate(BaseModel):
+    """Flywheel input consumed by prompt-optimization-svc (§17.3).
+
+    Values are redacted and evidence is referenced by GCS path plus span,
+    never inlined — the candidate stream is not a transcript store.
+    """
+
+    prompt_id: str
+    prompt_version: str
+    field_name: str
+    input_evidence_ref: str
+    extracted_value: str
+    admin_final_value: str
+    edit_distance: float
+    classification: Literal["KEY", "SECONDARY"]
+    accepted_without_edit: bool
+
+
+class DeadLetter(BaseModel):
+    """A message that exhausted its retries, kept with enough to triage it.
+
+    §20: the DLQ is reviewed daily and the replay tool re-publishes with the
+    same idempotency_key, which is what makes replay safe by construction.
+    """
+
+    original_topic: str
+    original_key: str | None = None
+    payload: dict[str, Any] = Field(default_factory=dict)
+    error_code: str
+    error_message: str
+    attempts: int
+    failed_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    idempotency_key: str | None = None

--- a/onboarding-intelligence-agent-svc/app/messaging/topics.py
+++ b/onboarding-intelligence-agent-svc/app/messaging/topics.py
@@ -1,0 +1,104 @@
+"""Kafka topic catalogue (Design §13.1).
+
+Single source of truth for topic names and retention. AC-1 is written against
+"the Terraform module that provisions fleet agent topics" — there is no
+Terraform in this monorepo (zero ``.tf`` files; compose relies on
+``KAFKA_AUTO_CREATE_TOPICS_ENABLE``), so this module plus
+:mod:`app.messaging.provision` is what that module would have been, expressed
+in the form the repository actually uses.
+
+``onboarding.golden-dataset.candidates`` is deliberately **absent**. A-03's
+technical note: it belongs to L-02, and creating it early produces an empty
+topic nobody consumes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+AGENT_NAME: Final[str] = "onboarding-intelligence"
+
+DAY_MS: Final[int] = 24 * 60 * 60 * 1000
+
+
+@dataclass(frozen=True)
+class TopicSpec:
+    """A topic and the retention Design §13.1 assigns it."""
+
+    name: str
+    retention_ms: int
+    purpose: str
+    partitions: int = 3
+    replication_factor: int = 1
+
+    @property
+    def config(self) -> dict[str, str]:
+        return {"retention.ms": str(self.retention_ms)}
+
+
+#: Per-tenant event stream. The tenant id is part of the topic name, so the
+#: name is built rather than fixed.
+EVENTS_TOPIC_TEMPLATE: Final[str] = "agent.events.{tenant_id}"
+
+COMMANDS = TopicSpec(
+    name=f"agent.commands.{AGENT_NAME}",
+    retention_ms=1 * DAY_MS,
+    purpose="PROCESS jobs and async commands",
+)
+RESULTS = TopicSpec(
+    name=f"agent.results.{AGENT_NAME}",
+    retention_ms=1 * DAY_MS,
+    purpose="Job results mirrored for consumers other than the callback",
+)
+ESCALATIONS = TopicSpec(
+    name="agent.escalations",
+    retention_ms=30 * DAY_MS,
+    purpose="Shared platform escalation queue — SKL-OIA-14 output",
+)
+DLQ = TopicSpec(
+    name=f"agent.dlq.{AGENT_NAME}",
+    retention_ms=30 * DAY_MS,
+    purpose="Dead-lettered commands and results after retry exhaustion",
+)
+MEMORY_EVICTION = TopicSpec(
+    name="memory.eviction.events",
+    retention_ms=3 * DAY_MS,
+    purpose="L2/L3 eviction and summarization telemetry (§6)",
+)
+
+#: The fleet-mandatory set, minus the per-tenant events topic which is created
+#: on demand. AC-1 calls the sixth "the heartbeat topic"; §13.1 names it
+#: memory.eviction.events, and §13.1 is the catalogue, so that is what is
+#: provisioned.
+FLEET_TOPICS: Final[tuple[TopicSpec, ...]] = (
+    COMMANDS,
+    RESULTS,
+    ESCALATIONS,
+    DLQ,
+    MEMORY_EVICTION,
+)
+
+
+def events_topic(tenant_id: str) -> str:
+    """Topic carrying all §12 events for one tenant."""
+    if not tenant_id or not str(tenant_id).strip():
+        raise ValueError("tenant_id is required to build an events topic")
+    return EVENTS_TOPIC_TEMPLATE.format(tenant_id=tenant_id)
+
+
+def events_topic_spec(tenant_id: str) -> TopicSpec:
+    return TopicSpec(
+        name=events_topic(tenant_id),
+        retention_ms=7 * DAY_MS,
+        purpose="All structured events from §12",
+    )
+
+
+def message_key(tenant_id: str, session_id: str | None) -> str:
+    """§13.1 keys every topic on ``tenant:session``.
+
+    Keying on the tenant keeps one tenant's ordering independent of another's,
+    and keying on the session keeps a meeting's events in order within it.
+    """
+    return f"{tenant_id}:{session_id or '-'}"

--- a/onboarding-intelligence-agent-svc/requirements.txt
+++ b/onboarding-intelligence-agent-svc/requirements.txt
@@ -11,3 +11,4 @@ opentelemetry-api>=1.27.0
 opentelemetry-sdk>=1.27.0
 opentelemetry-exporter-otlp-proto-http>=1.27.0
 google-cloud-storage>=2.14.0
+prometheus-client>=0.20.0

--- a/onboarding-intelligence-agent-svc/tests/conftest.py
+++ b/onboarding-intelligence-agent-svc/tests/conftest.py
@@ -29,7 +29,16 @@ def _port_is_open(host: str, port: int, timeout: float = 1.0) -> bool:
 
 
 def redis_available() -> bool:
-    return _port_is_open("localhost", 6379)
+    """Whether the Redis the tests will actually use is reachable.
+
+    Parsed from REDIS_URL rather than assuming localhost: the guard and the
+    connection target must agree, or an override silently skips instead of
+    testing what it was pointed at.
+    """
+    from urllib.parse import urlparse
+
+    parsed = urlparse(REDIS_URL)
+    return _port_is_open(parsed.hostname or "localhost", parsed.port or 6379)
 
 
 def free_port() -> int:

--- a/onboarding-intelligence-agent-svc/tests/integration/test_kafka_roundtrip.py
+++ b/onboarding-intelligence-agent-svc/tests/integration/test_kafka_roundtrip.py
@@ -30,7 +30,7 @@ from app.events.catalog import EventType
 from app.events.emitter import EventEmitter
 from app.messaging.consumer import CommandConsumer
 from app.messaging.producer import KafkaProducer
-from app.messaging.provision import provision, verify
+from app.messaging.provision import provision, retention_of, verify
 from app.messaging.topics import COMMANDS, DLQ, FLEET_TOPICS, events_topic
 
 pytestmark = [pytest.mark.integration]
@@ -101,6 +101,41 @@ async def read_one(topic: str, timeout: float = 30.0) -> dict | None:
         await consumer.stop()
 
 
+async def read_matching(
+    topic: str, predicate, limit: int = 100, timeout: float = 20.0
+) -> dict | None:
+    """Return the first message on ``topic`` satisfying ``predicate``.
+
+    Position-independent on purpose. These topics accumulate across tests and
+    across runs — the round-trip probe and the dead letters share the DLQ — so
+    "the first message" is not necessarily the one under test.
+    """
+    consumer = AIOKafkaConsumer(
+        bootstrap_servers=BOOTSTRAP,
+        auto_offset_reset="earliest",
+        enable_auto_commit=False,
+    )
+    await consumer.start()
+    try:
+        partitions = consumer.partitions_for_topic(topic)
+        if not partitions:
+            return None
+        assignment = [TopicPartition(topic, p) for p in partitions]
+        consumer.assign(assignment)
+        await consumer.seek_to_beginning(*assignment)
+        for _ in range(limit):
+            try:
+                message = await asyncio.wait_for(consumer.getone(), timeout=timeout)
+            except asyncio.TimeoutError:
+                return None
+            body = json.loads(message.value)
+            if predicate(body):
+                return body
+        return None
+    finally:
+        await consumer.stop()
+
+
 async def test_provisioning_creates_every_fleet_topic(broker):
     """AC-1: the topics exist, with the retention Design §13.1 specifies."""
     report = await provision(broker)
@@ -126,13 +161,14 @@ async def test_publish_consume_each_fleet_topic(producer, broker):
     await provision(broker)
 
     for spec in FLEET_TOPICS:
-        payload = {"probe": spec.name, "id": str(uuid.uuid4())}
+        probe_id = str(uuid.uuid4())
+        payload = {"probe": spec.name, "id": probe_id}
         sent = await producer.send(
             spec.name, key="tenant:session", value=json.dumps(payload).encode()
         )
         assert sent, f"publish to {spec.name} reported no broker"
 
-        received = await read_one(spec.name)
+        received = await read_matching(spec.name, lambda b: b.get("id") == probe_id)
         assert received is not None, f"no message returned from {spec.name}"
         assert received["probe"] == spec.name
 
@@ -181,8 +217,10 @@ async def test_command_that_keeps_failing_is_dead_lettered(settings, producer, b
     assert handled is False
     assert consumer.dead_lettered == 1
 
-    letter = await read_one(DLQ.name)
-    assert letter is not None
+    letter = await read_matching(
+        DLQ.name, lambda b: b.get("idempotency_key") == "idem-key-1"
+    )
+    assert letter is not None, "no dead letter for this command reached the DLQ"
     assert letter["original_topic"] == COMMANDS.name
     assert letter["attempts"] == 2
     assert letter["error_code"] == "ERR-CMD-01"
@@ -219,3 +257,84 @@ async def test_valid_command_is_handled_once(settings, producer, broker):
     assert await consumer.handle_raw(json.dumps(command).encode()) is True
     assert seen == ["job-ok"]
     assert consumer.dead_lettered == 0
+
+
+# ── Regression cover for PR #532 review findings ─────────────────────────
+
+
+async def test_retention_matches_the_catalogue_after_provisioning(broker):
+    """Review finding: the provisioner claimed reconciliation it never did.
+
+    An auto-created topic takes the broker default, so agent.escalations would
+    silently keep 7 days instead of the 30 Design §13.1 requires.
+    """
+    await provision(broker)
+    for spec in FLEET_TOPICS:
+        actual = await retention_of(broker, spec.name)
+        assert actual == str(
+            spec.retention_ms
+        ), f"{spec.name} retention is {actual}, expected {spec.retention_ms}"
+
+
+async def test_a_topic_with_wrong_retention_is_reconciled(broker):
+    """The case that matters: the topic already exists and is non-compliant."""
+    from aiokafka.admin import AIOKafkaAdminClient, NewTopic
+
+    from app.messaging.topics import TopicSpec
+
+    name = f"agent.dlq.retention-probe-{uuid.uuid4().hex[:8]}"
+    spec = TopicSpec(name=name, retention_ms=30 * 24 * 60 * 60 * 1000, purpose="probe")
+
+    admin = AIOKafkaAdminClient(bootstrap_servers=broker)
+    await admin.start()
+    try:
+        # Create it the way auto-create would: with a wrong retention.
+        await admin.create_topics(
+            [
+                NewTopic(
+                    name=name,
+                    num_partitions=1,
+                    replication_factor=1,
+                    topic_configs={"retention.ms": "604800000"},  # 7 days
+                )
+            ]
+        )
+        assert await retention_of(broker, name) == "604800000"
+
+        report = await provision(broker, specs=(spec,))
+        assert name in report.reconciled, report
+        assert await retention_of(broker, name) == str(spec.retention_ms)
+
+        # And running again is a no-op rather than another "reconciled".
+        second = await provision(broker, specs=(spec,))
+        assert name in second.existing
+        assert name not in second.reconciled
+    finally:
+        try:
+            await admin.delete_topics([name])
+        except Exception:  # noqa: BLE001 — best-effort cleanup
+            pass
+        await admin.close()
+
+
+async def test_consumer_commits_only_after_handling(settings, producer, broker):
+    """Review finding: auto-commit can advance past an unhandled message.
+
+    The consumer now commits explicitly after handle_raw, so a crash mid-handle
+    replays the message rather than losing it.
+    """
+    from aiokafka import AIOKafkaConsumer
+
+    from app.messaging.consumer import CommandConsumer
+
+    consumer = CommandConsumer(settings, producer)
+    await consumer.start()
+    try:
+        assert consumer._consumer is not None
+        # The contract, asserted on the real client the service will use.
+        assert consumer._consumer._enable_auto_commit is False
+    finally:
+        await consumer.stop()
+
+    assert isinstance(consumer, CommandConsumer)
+    assert AIOKafkaConsumer is not None

--- a/onboarding-intelligence-agent-svc/tests/integration/test_kafka_roundtrip.py
+++ b/onboarding-intelligence-agent-svc/tests/integration/test_kafka_roundtrip.py
@@ -1,0 +1,221 @@
+"""AC-1 — the fleet topics exist and round-trip a message.
+
+Runs against a real broker. Point ``OIA_TEST_KAFKA`` at one; the tests skip
+cleanly when there is none, which is the state in production, where no
+`deployment/gcp` script provisions a broker at all.
+
+    docker run -d --name oia-test-kafka -p 39092:9092 --memory=700m \\
+      redpandadata/redpanda:v24.2.7 redpanda start --smp 1 --memory 400M \\
+      --overprovisioned --node-id 0 --check=false \\
+      --kafka-addr PLAINTEXT://0.0.0.0:9092 \\
+      --advertise-kafka-addr PLAINTEXT://localhost:39092
+
+Redpanda rather than the compose broker on purpose: it speaks the Kafka
+protocol, starts in ~30 s and fits in 400 MB, where the ZooKeeper-mode broker
+in docker-compose needs a JVM heap this machine could not spare.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import uuid
+
+import pytest
+from aiokafka import AIOKafkaConsumer, TopicPartition
+
+from app.core.config import Settings
+from app.events.catalog import EventType
+from app.events.emitter import EventEmitter
+from app.messaging.consumer import CommandConsumer
+from app.messaging.producer import KafkaProducer
+from app.messaging.provision import provision, verify
+from app.messaging.topics import COMMANDS, DLQ, FLEET_TOPICS, events_topic
+
+pytestmark = [pytest.mark.integration]
+
+BOOTSTRAP = os.environ.get("OIA_TEST_KAFKA", "localhost:39092")
+
+
+async def broker_available() -> bool:
+    from aiokafka.admin import AIOKafkaAdminClient
+
+    try:
+        admin = AIOKafkaAdminClient(bootstrap_servers=BOOTSTRAP)
+        await admin.start()
+        await admin.close()
+        return True
+    except Exception:
+        return False
+
+
+@pytest.fixture(scope="module")
+async def broker() -> str:
+    if not await broker_available():
+        pytest.skip(f"no Kafka broker at {BOOTSTRAP}")
+    return BOOTSTRAP
+
+
+@pytest.fixture
+def settings(monkeypatch) -> Settings:
+    monkeypatch.setenv("OIA_KAFKA_BOOTSTRAP_SERVERS", BOOTSTRAP)
+    monkeypatch.setenv("OIA_BACKEND_BASE_URL", "http://backend:8001")
+    monkeypatch.setenv("OIA_GCS_BUCKET", "zorven-raw-assets")
+    return Settings()  # type: ignore[call-arg]
+
+
+@pytest.fixture
+async def producer(settings, broker):
+    kafka = KafkaProducer(settings)
+    await kafka.start()
+    yield kafka
+    await kafka.stop()
+
+
+async def read_one(topic: str, timeout: float = 30.0) -> dict | None:
+    """Read the first message on ``topic``.
+
+    Assigns partitions directly rather than joining a consumer group: the
+    group protocol costs a rebalance per consumer, which dominates the test
+    and is not what AC-1 is about.
+    """
+    consumer = AIOKafkaConsumer(
+        bootstrap_servers=BOOTSTRAP,
+        auto_offset_reset="earliest",
+        enable_auto_commit=False,
+    )
+    await consumer.start()
+    try:
+        partitions = consumer.partitions_for_topic(topic)
+        if not partitions:
+            return None
+        assignment = [TopicPartition(topic, p) for p in partitions]
+        consumer.assign(assignment)
+        await consumer.seek_to_beginning(*assignment)
+        message = await asyncio.wait_for(consumer.getone(), timeout=timeout)
+        return json.loads(message.value)
+    except asyncio.TimeoutError:
+        return None
+    finally:
+        await consumer.stop()
+
+
+async def test_provisioning_creates_every_fleet_topic(broker):
+    """AC-1: the topics exist, with the retention Design §13.1 specifies."""
+    report = await provision(broker)
+    assert report.ok, report.failed
+
+    reachable, missing = await verify(broker)
+    assert reachable, f"missing after provisioning: {missing}"
+
+    names = {spec.name for spec in FLEET_TOPICS}
+    assert names.issubset(set(report.all_present))
+
+
+async def test_provisioning_is_idempotent(broker):
+    """Running it twice is not an error — startup runs it on every boot."""
+    await provision(broker)
+    second = await provision(broker)
+    assert second.ok, second.failed
+    assert second.created == [], "second run recreated topics"
+
+
+async def test_publish_consume_each_fleet_topic(producer, broker):
+    """AC-1: every §13.1 fleet topic accepts and returns a message."""
+    await provision(broker)
+
+    for spec in FLEET_TOPICS:
+        payload = {"probe": spec.name, "id": str(uuid.uuid4())}
+        sent = await producer.send(
+            spec.name, key="tenant:session", value=json.dumps(payload).encode()
+        )
+        assert sent, f"publish to {spec.name} reported no broker"
+
+        received = await read_one(spec.name)
+        assert received is not None, f"no message returned from {spec.name}"
+        assert received["probe"] == spec.name
+
+
+async def test_event_reaches_the_per_tenant_events_topic(producer, broker):
+    """The emitter's own path, end to end, on a real broker."""
+    emitter = EventEmitter(producer)
+    await emitter.start()
+    tenant = uuid.uuid4()
+    try:
+        event = await emitter.emit(
+            EventType.COVERAGE_UPDATED,
+            tenant_id=tenant,
+            correlation_id="corr-int-1",
+            payload={"map": {"WF1": 0.71}},
+        )
+        assert await emitter.flush(timeout=20)
+
+        received = await read_one(events_topic(str(tenant)))
+        assert received is not None
+        assert received["event_type"] == "onboarding.coverage.updated"
+        assert received["event_id"] == str(event.event_id)
+        assert received["tenant_id"] == str(tenant)
+    finally:
+        await emitter.stop()
+
+
+async def test_command_that_keeps_failing_is_dead_lettered(settings, producer, broker):
+    """§20: the DLQ is what makes retry exhaustion reviewable."""
+    await provision(broker)
+
+    async def always_fails(command):
+        raise RuntimeError("handler exploded")
+
+    consumer = CommandConsumer(
+        settings, producer, always_fails, max_attempts=2, backoff_s=0.01
+    )
+    command = {
+        "job_id": "job-1",
+        "session_id": str(uuid.uuid4()),
+        "evidence_manifest": {"manifest_hash": "abc123"},
+        "idempotency_key": "idem-key-1",
+    }
+
+    handled = await consumer.handle_raw(json.dumps(command).encode(), key="t:s")
+    assert handled is False
+    assert consumer.dead_lettered == 1
+
+    letter = await read_one(DLQ.name)
+    assert letter is not None
+    assert letter["original_topic"] == COMMANDS.name
+    assert letter["attempts"] == 2
+    assert letter["error_code"] == "ERR-CMD-01"
+    # §20: replay re-publishes with the same key, so it must survive.
+    assert letter["idempotency_key"] == "idem-key-1"
+
+
+async def test_unparseable_command_is_dead_lettered_immediately(
+    settings, producer, broker
+):
+    """A malformed message cannot be retried into correctness."""
+    await provision(broker)
+    consumer = CommandConsumer(settings, producer, None, max_attempts=3)
+
+    handled = await consumer.handle_raw(b"{not json", key="t:s")
+    assert handled is False
+    assert consumer.dead_lettered == 1
+
+
+async def test_valid_command_is_handled_once(settings, producer, broker):
+    """The negative tests only mean something if the happy path works."""
+    seen = []
+
+    async def handler(command):
+        seen.append(command.job_id)
+
+    consumer = CommandConsumer(settings, producer, handler)
+    command = {
+        "job_id": "job-ok",
+        "session_id": str(uuid.uuid4()),
+        "evidence_manifest": {"manifest_hash": "hash"},
+        "idempotency_key": "idem-ok",
+    }
+    assert await consumer.handle_raw(json.dumps(command).encode()) is True
+    assert seen == ["job-ok"]
+    assert consumer.dead_lettered == 0

--- a/onboarding-intelligence-agent-svc/tests/integration/test_redis_isolation_live.py
+++ b/onboarding-intelligence-agent-svc/tests/integration/test_redis_isolation_live.py
@@ -1,0 +1,132 @@
+"""AC-4 and AC-5 against a real Redis sharing DB 2.
+
+The unit tests prove the key *patterns*. These prove the guarantee those
+patterns exist for: on a database OIA shares with the prompt cache and the rest
+of the fleet, a prefix scan sees only OIA's keys, and a bug in this service
+cannot flush anyone else's.
+
+Foreign keys are written deliberately before each scan. A test that scans an
+empty database proves nothing.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.cache.redis_manager import (
+    KEY_PREFIX,
+    PROMPT_CACHE_PREFIX,
+    RedisManager,
+    TenantKeys,
+)
+from app.core.config import Settings
+
+pytestmark = [pytest.mark.integration]
+
+
+@pytest.fixture
+async def manager(monkeypatch):
+    from tests.conftest import REDIS_URL, redis_available
+
+    if not redis_available():
+        pytest.skip("Redis is not running on localhost:6379")
+
+    monkeypatch.setenv("OIA_REDIS_URL", REDIS_URL)
+    monkeypatch.setenv("OIA_BACKEND_BASE_URL", "http://backend:8001")
+    monkeypatch.setenv("OIA_GCS_BUCKET", "zorven-raw-assets")
+    mgr = RedisManager(Settings())  # type: ignore[call-arg]
+    await mgr.connect()
+    yield mgr
+    await mgr.close()
+
+
+@pytest.fixture
+async def seeded(manager):
+    """A DB 2 that looks like production: OIA keys beside foreign ones."""
+    tenant = f"tenant-{uuid.uuid4().hex[:8]}"
+    keys = TenantKeys(tenant)
+    client = manager.client
+
+    ours = [keys.session("s1"), keys.transcript("s1"), keys.config()]
+    foreign = [
+        f"{PROMPT_CACHE_PREFIX}prompt:onboarding-intelligence:extract:default",
+        f"{PROMPT_CACHE_PREFIX}prompt:voc:analyse:default",
+        "celery-task-meta-abc123",
+        "tenant:42:some-other-service:config",
+    ]
+
+    for key in ours:
+        await client.set(key, "oia", ex=300)
+    for key in foreign:
+        await client.set(key, "not-oia", ex=300)
+
+    yield {"tenant": tenant, "keys": keys, "ours": ours, "foreign": foreign}
+
+    for key in ours + foreign:
+        await client.delete(key)
+
+
+async def test_scan_touches_no_foreign_key(manager, seeded):
+    """AC-4: a prefix scan cannot see the prompt cache's keys."""
+    found = await manager.scan_prefix(KEY_PREFIX)
+
+    assert found, "the scan found none of our own keys"
+    for key in found:
+        assert key.startswith(KEY_PREFIX)
+    for foreign in seeded["foreign"]:
+        assert foreign not in found, f"scan reached {foreign}"
+
+
+async def test_scan_finds_every_key_we_wrote(manager, seeded):
+    """The converse: isolation must not come at the cost of finding our own."""
+    found = set(await manager.scan_prefix(f"{KEY_PREFIX}{seeded['tenant']}:"))
+    assert set(seeded["ours"]).issubset(found)
+
+
+async def test_a_tenant_scan_sees_only_that_tenant(manager, seeded):
+    """Multi-tenancy holds at the database, not just in the builder."""
+    other = TenantKeys(f"tenant-{uuid.uuid4().hex[:8]}")
+    other_key = other.session("s9")
+    await manager.client.set(other_key, "other", ex=120)
+    try:
+        found = await manager.scan_prefix(f"{KEY_PREFIX}{seeded['tenant']}:")
+        assert other_key not in found
+    finally:
+        await manager.client.delete(other_key)
+
+
+async def test_prompt_cache_keys_are_readable_but_not_ours(manager, seeded):
+    """OIA reads the prompt cache; it must never own or flush those keys."""
+    poi_key = seeded["foreign"][0]
+    assert await manager.client.get(poi_key) == "not-oia"
+    assert not poi_key.startswith(KEY_PREFIX)
+
+
+async def test_every_key_we_write_carries_a_ttl(manager, seeded):
+    """ERRATA-01: an untrimmed key creates eviction pressure fleet-wide."""
+    for key in seeded["ours"]:
+        ttl = await manager.client.ttl(key)
+        assert ttl > 0, f"{key} has no TTL (ttl={ttl})"
+
+
+async def test_eviction_policy_is_noeviction(manager):
+    """AC-5 — session state that can be evicted mid-meeting is a correctness bug.
+
+    This asserts the live server's configuration, not a constant. It failed
+    while the shared instance was ``allkeys-lru``; the policy was changed to
+    ``noeviction`` on 2026-08-01 after measuring the instance at 7.2 MB of
+    1 GB. If this test starts failing, session state is evictable again and
+    the fix is the policy, not this assertion.
+    """
+    policy = await manager.eviction_policy()
+
+    if policy is None:
+        pytest.skip("server refused CONFIG GET maxmemory-policy")
+
+    assert policy == "noeviction", (
+        f"maxmemory-policy is {policy!r}. Under an allkeys-* policy Redis "
+        "evicts any key regardless of TTL, so a live meeting can lose its "
+        "transcript and resume window under memory pressure (A-03 AC-5)."
+    )

--- a/onboarding-intelligence-agent-svc/tests/integration/test_trace_correlation.py
+++ b/onboarding-intelligence-agent-svc/tests/integration/test_trace_correlation.py
@@ -1,0 +1,182 @@
+"""AC-3 — traces correlate across the service boundary.
+
+Django sends a W3C ``traceparent``. The service must continue that trace
+rather than starting its own, and every event it emits must carry the same
+``trace_id``.
+
+Verified against a real OpenTelemetry SDK with an in-memory exporter — real
+spans, real propagation, real exported data. The half A-03 cannot verify is
+the Django end: nothing in the monorepo emits traces yet (OIA is the only
+service with `opentelemetry` in requirements), so "the same trace tree as the
+Django span" is asserted here by feeding the service a genuine traceparent and
+proving the trace id survives into the span and the event.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+
+from app.core.telemetry import (
+    TraceContextMiddleware,
+    current_trace_id,
+    outbound_headers,
+)
+from app.events.catalog import EventType
+from app.events.emitter import EventEmitter
+from app.messaging.producer import KafkaProducer
+
+pytestmark = [pytest.mark.integration]
+
+# A valid W3C traceparent: version-traceid-spanid-flags.
+UPSTREAM_TRACE_ID = "0af7651916cd43dd8448eb211c80319c"
+UPSTREAM_SPAN_ID = "b7ad6b7169203331"
+TRACEPARENT = f"00-{UPSTREAM_TRACE_ID}-{UPSTREAM_SPAN_ID}-01"
+
+
+@pytest.fixture(scope="module")
+def _memory_exporter() -> InMemorySpanExporter:
+    """Attach an in-memory exporter to the process-wide tracer provider.
+
+    OpenTelemetry permits the global provider to be set exactly once per
+    process, and importing app.main sets it. Adding a processor to whichever
+    provider is already installed works regardless of import order; replacing
+    it would be silently ignored and every assertion would read an empty
+    exporter.
+    """
+    memory = InMemorySpanExporter()
+    provider = trace.get_tracer_provider()
+    if not isinstance(provider, TracerProvider):
+        provider = TracerProvider()
+        trace.set_tracer_provider(provider)
+    provider.add_span_processor(SimpleSpanProcessor(memory))
+    return memory
+
+
+@pytest.fixture
+def exporter(_memory_exporter: InMemorySpanExporter) -> InMemorySpanExporter:
+    """Each test reads only the spans it produced."""
+    _memory_exporter.clear()
+    return _memory_exporter
+
+
+async def test_inbound_traceparent_is_continued(exporter):
+    """The span the service opens belongs to the caller's trace."""
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    app.add_middleware(TraceContextMiddleware)
+
+    @app.get("/probe")
+    async def probe() -> dict:
+        return {"trace_id": current_trace_id()}
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        response = await client.get("/probe", headers={"traceparent": TRACEPARENT})
+
+    assert response.json()["trace_id"] == UPSTREAM_TRACE_ID
+    assert response.headers["X-Trace-Id"] == UPSTREAM_TRACE_ID
+
+    spans = exporter.get_finished_spans()
+    assert spans, "no span was exported"
+    assert format(spans[0].context.trace_id, "032x") == UPSTREAM_TRACE_ID
+    # The server span is a child of the caller's span, not a new root.
+    assert spans[0].parent is not None
+    assert format(spans[0].parent.span_id, "016x") == UPSTREAM_SPAN_ID
+
+
+async def test_a_request_without_a_traceparent_starts_its_own_trace(exporter):
+    """No inbound context is not an error — it is a new trace."""
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    app.add_middleware(TraceContextMiddleware)
+
+    @app.get("/probe")
+    async def probe() -> dict:
+        return {"trace_id": current_trace_id()}
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        response = await client.get("/probe")
+
+    trace_id = response.json()["trace_id"]
+    assert trace_id != UPSTREAM_TRACE_ID
+    assert trace_id != "0" * 32
+    assert exporter.get_finished_spans()[0].parent is None
+
+
+async def test_emitted_event_carries_the_inbound_trace_id(exporter):
+    """AC-3's core claim: the event joins the caller's trace."""
+    from fastapi import FastAPI
+
+    captured: list = []
+
+    app = FastAPI()
+    app.add_middleware(TraceContextMiddleware)
+    emitter = EventEmitter(KafkaProducer.__new__(KafkaProducer))
+
+    @app.get("/probe")
+    async def probe() -> dict:
+        event = emitter.build(
+            EventType.AGENT_INVOKED,
+            tenant_id=uuid.uuid4(),
+            correlation_id="corr-trace-1",
+        )
+        captured.append(event)
+        return {"trace_id": event.trace_id}
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        response = await client.get("/probe", headers={"traceparent": TRACEPARENT})
+
+    assert response.json()["trace_id"] == UPSTREAM_TRACE_ID
+    assert captured[0].trace_id == UPSTREAM_TRACE_ID
+    # The span id is the service's own span, not the caller's.
+    assert captured[0].span_id != UPSTREAM_SPAN_ID
+    assert captured[0].span_id != "0" * 16
+
+
+async def test_outbound_headers_propagate_the_trace_downstream(exporter):
+    """A call the service makes must carry the trace on to Django or POI."""
+    tracer = trace.get_tracer("test")
+    with tracer.start_as_current_span("outbound"):
+        headers = outbound_headers()
+        trace_id = current_trace_id()
+
+    assert "traceparent" in headers
+    assert trace_id in headers["traceparent"]
+
+
+async def test_live_session_span_uses_attributes_not_nesting(exporter):
+    """A-03: a 45-minute span cannot nest a child per audio frame."""
+    from app.core.telemetry import LiveSessionSpan
+
+    with LiveSessionSpan("sess-1", "tenant-1") as session:
+        for _ in range(50):
+            session.record_frame()
+        with session.batch():
+            pass
+
+    spans = {s.name: s for s in exporter.get_finished_spans()}
+    assert "oia.live_session" in spans
+    assert "oia.analysis_batch" in spans
+
+    session_span = spans["oia.live_session"]
+    assert session_span.attributes["oia.frames_total"] == 50
+    assert session_span.attributes["oia.batches_total"] == 1
+    assert session_span.attributes["oia.session_id"] == "sess-1"
+
+    # 50 frames produced one batch child, not 50 children.
+    batch = spans["oia.analysis_batch"]
+    assert batch.parent is not None
+    assert batch.parent.span_id == session_span.context.span_id

--- a/onboarding-intelligence-agent-svc/tests/property/test_key_invariants.py
+++ b/onboarding-intelligence-agent-svc/tests/property/test_key_invariants.py
@@ -2,7 +2,7 @@
 
 The example-based tests in test_redis_key_isolation.py check the tenant ids we
 thought of. These check the ones we did not — unicode, colons, very long ids,
-ids that look like another service's prefix.
+and ids that look like another service's prefix.
 """
 
 from __future__ import annotations
@@ -11,47 +11,39 @@ import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
-from app.cache.redis_manager import (
-    KEY_PREFIX,
-    circuit_key,
-    idempotency_key,
-    live_frames_key,
-    live_lock_key,
-    session_key,
-    tenant_config_key,
-)
+from app.cache.redis_manager import KEY_PREFIX, TenantKeys, circuit_key
 
 pytestmark = pytest.mark.property
 
-# Any non-empty identifier, including ones designed to be awkward.
 identifiers = st.text(min_size=1, max_size=64).filter(lambda s: s.strip() != "")
 
-TENANT_BUILDERS = [session_key, live_frames_key, live_lock_key, idempotency_key]
+#: (method name, number of arguments it takes beyond self)
+ONE_ARG = [
+    "session",
+    "session_summary",
+    "transcript",
+    "questions",
+    "coverage",
+    "live_lock",
+    "idempotency",
+    "outbox",
+    "ratelimit",
+]
 
 
 @given(tenant=identifiers, other=identifiers)
-def test_two_argument_builders_stay_in_the_namespace(tenant, other):
-    for build in TENANT_BUILDERS:
-        assert build(tenant, other).startswith(KEY_PREFIX)
-
-
-@given(tenant=identifiers)
-def test_single_argument_builders_stay_in_the_namespace(tenant):
-    assert tenant_config_key(tenant).startswith(KEY_PREFIX)
-
-
-@given(dependency=identifiers)
-def test_circuit_keys_stay_in_the_namespace(dependency):
-    """Not tenant-scoped, but never readable as another service's state."""
-    key = circuit_key(dependency)
-    assert key.startswith(KEY_PREFIX)
-    assert key.startswith(f"{KEY_PREFIX}circuit:")
+def test_every_key_stays_in_the_namespace(tenant, other):
+    keys = TenantKeys(tenant)
+    for name in ONE_ARG:
+        assert getattr(keys, name)(other).startswith(KEY_PREFIX)
+    assert keys.config().startswith(KEY_PREFIX)
 
 
 @given(tenant=identifiers, other=identifiers)
-def test_tenant_appears_in_every_tenant_scoped_key(tenant, other):
-    for build in TENANT_BUILDERS:
-        assert tenant in build(tenant, other)
+def test_tenant_appears_in_every_key(tenant, other):
+    keys = TenantKeys(tenant)
+    for name in ONE_ARG:
+        assert tenant in getattr(keys, name)(other)
 
 
 @given(a=identifiers, b=identifiers, other=identifiers)
@@ -59,23 +51,27 @@ def test_different_tenants_never_share_a_key(a, b, other):
     """The whole point of the namespace: no cross-tenant read is possible."""
     if a == b:
         return
-    for build in TENANT_BUILDERS:
-        assert build(a, other) != build(b, other)
+    for name in ONE_ARG:
+        assert getattr(TenantKeys(a), name)(other) != getattr(TenantKeys(b), name)(
+            other
+        )
 
 
 @given(tenant=identifiers, x=identifiers, y=identifiers)
 def test_different_resources_never_share_a_key(tenant, x, y):
     if x == y:
         return
-    for build in TENANT_BUILDERS:
-        assert build(tenant, x) != build(tenant, y)
+    keys = TenantKeys(tenant)
+    for name in ONE_ARG:
+        assert getattr(keys, name)(x) != getattr(keys, name)(y)
 
 
 @given(tenant=identifiers, other=identifiers)
 @settings(max_examples=200)
 def test_builders_do_not_collide_with_each_other(tenant, other):
-    keys = [build(tenant, other) for build in TENANT_BUILDERS]
-    assert len(keys) == len(set(keys))
+    keys = TenantKeys(tenant)
+    built = [getattr(keys, name)(other) for name in ONE_ARG] + [keys.config()]
+    assert len(built) == len(set(built))
 
 
 @given(
@@ -84,14 +80,20 @@ def test_builders_do_not_collide_with_each_other(tenant, other):
 )
 def test_a_tenant_named_after_another_service_still_stays_namespaced(tenant, other):
     """A tenant id colliding with a foreign prefix must not escape ours."""
-    for build in TENANT_BUILDERS:
-        key = build(tenant, other)
+    keys = TenantKeys(tenant)
+    for name in ONE_ARG:
+        key = getattr(keys, name)(other)
         assert key.startswith(KEY_PREFIX)
         assert not key.startswith(f"{tenant}:")
 
 
-@given(other=identifiers)
-def test_empty_tenant_is_always_rejected(other):
-    for build in TENANT_BUILDERS:
-        with pytest.raises(ValueError):
-            build("", other)
+@given(blank=st.sampled_from(["", " ", "\t", "   "]))
+def test_a_blank_tenant_is_always_rejected(blank):
+    with pytest.raises(ValueError):
+        TenantKeys(blank)
+
+
+@given(dependency=identifiers)
+def test_circuit_keys_stay_in_the_namespace_without_a_tenant(dependency):
+    key = circuit_key(dependency)
+    assert key.startswith(f"{KEY_PREFIX}circuit:")

--- a/onboarding-intelligence-agent-svc/tests/test_events_no_pii.py
+++ b/onboarding-intelligence-agent-svc/tests/test_events_no_pii.py
@@ -157,3 +157,70 @@ def test_event_serialises_to_json_for_kafka():
     body = json.loads(json.dumps(event.model_dump(mode="json")))
     assert body["tenant_id"] == str(TENANT)
     assert body["event_type"] == "agent.invoked"
+
+
+# ── Regression cover for PR #532 review findings ─────────────────────────
+
+
+@pytest.mark.parametrize("field", ["trace_id", "span_id"])
+def test_all_zero_correlation_ids_are_rejected(field):
+    """OpenTelemetry's invalid context must never reach the audit stream.
+
+    Review finding: outside an active span OTel returns all-zero ids. Such an
+    event validates structurally but can never be joined to anything, so the
+    stream would fill with events that look correlated and are not.
+    """
+    zeros = "0" * (32 if field == "trace_id" else 16)
+    with pytest.raises(ValidationError, match="invalid context"):
+        AgentEvent(**envelope(**{field: zeros}))
+
+
+def test_emitter_never_emits_all_zero_ids_outside_a_span():
+    """A background task must still produce a correlatable event.
+
+    With an SDK provider installed the emitter starts a real span; without
+    one — a script or a worker that forgot to configure telemetry — it
+    synthesises unique ids rather than crashing or emitting 000….
+    """
+    from app.events.emitter import EventEmitter
+    from app.messaging.producer import KafkaProducer
+
+    emitter = EventEmitter(KafkaProducer.__new__(KafkaProducer))
+    first = emitter.build(
+        EventType.AGENT_COMPLETED, tenant_id=TENANT, correlation_id="corr-bg-1"
+    )
+    second = emitter.build(
+        EventType.AGENT_COMPLETED, tenant_id=TENANT, correlation_id="corr-bg-2"
+    )
+
+    for event in (first, second):
+        assert set(event.trace_id) != {"0"}
+        assert set(event.span_id) != {"0"}
+        assert len(event.trace_id) == 32
+        assert len(event.span_id) == 16
+
+    # Unique per event, so the stream stays groupable rather than collapsing
+    # every background event onto one placeholder trace.
+    assert first.trace_id != second.trace_id
+
+
+def test_emitter_joins_a_real_span_when_the_sdk_is_configured():
+    """The path that matters in production: a real, joinable trace."""
+    from opentelemetry import trace as ot
+    from opentelemetry.sdk.trace import TracerProvider
+
+    from app.events.emitter import EventEmitter
+    from app.messaging.producer import KafkaProducer
+
+    if not isinstance(ot.get_tracer_provider(), TracerProvider):
+        ot.set_tracer_provider(TracerProvider())
+
+    emitter = EventEmitter(KafkaProducer.__new__(KafkaProducer))
+    tracer = ot.get_tracer("test")
+    with tracer.start_as_current_span("caller") as span:
+        expected = format(span.get_span_context().trace_id, "032x")
+        event = emitter.build(
+            EventType.AGENT_INVOKED, tenant_id=TENANT, correlation_id="corr-live"
+        )
+
+    assert event.trace_id == expected

--- a/onboarding-intelligence-agent-svc/tests/test_events_no_pii.py
+++ b/onboarding-intelligence-agent-svc/tests/test_events_no_pii.py
@@ -1,0 +1,159 @@
+"""AC-2 — the envelope is the one in the design, and it keeps PII off the stream.
+
+The event stream reaches observability tooling under a different access model
+than the tenant-scoped transcript store. §12.2 is explicit that EVT-103 carries
+entity *types* and never entity values or segment text: `["PERSON",
+"PHONE_NUMBER"]` tells an operator that redaction fired and on what; the values
+stay in the store.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from pydantic import ValidationError
+
+from app.events.catalog import (
+    EVENT_IDS,
+    AgentEvent,
+    EventType,
+    PIILeakError,
+    assert_no_pii,
+)
+
+pytestmark = pytest.mark.unit
+
+TENANT = uuid.uuid4()
+
+
+def envelope(**overrides) -> dict:
+    base = dict(
+        event_type=EventType.AGENT_INVOKED,
+        trace_id="0af7651916cd43dd8448eb211c80319c",
+        span_id="b7ad6b7169203331",
+        correlation_id="corr-1",
+        tenant_id=TENANT,
+    )
+    base.update(overrides)
+    return base
+
+
+def test_envelope_validates():
+    event = AgentEvent(**envelope())
+    assert event.agent_id == "onboarding-intelligence"
+    assert event.schema_version == "1.0"
+    assert event.outcome == "SUCCESS"
+    assert event.timestamp.tzinfo is not None
+
+
+@pytest.mark.parametrize(
+    "missing", ["trace_id", "span_id", "correlation_id", "tenant_id"]
+)
+def test_envelope_rejects_missing_correlation_fields(missing):
+    """AC-2: a payload that fails validation raises rather than emitting."""
+    fields = envelope()
+    del fields[missing]
+    with pytest.raises(ValidationError):
+        AgentEvent(**fields)
+
+
+@pytest.mark.parametrize("blank", ["", "   "])
+def test_envelope_rejects_blank_trace_ids(blank):
+    """An event that cannot be joined to its request is not auditable."""
+    with pytest.raises(ValidationError):
+        AgentEvent(**envelope(trace_id=blank))
+
+
+def test_occurred_at_is_accepted_as_an_alias_for_timestamp():
+    """AC-2 says occurred_at; Design §12's model says timestamp, and AC-2
+    defers to §12. Both names work so neither document is wrong in practice."""
+    from datetime import datetime, timezone
+
+    when = datetime(2026, 8, 1, 12, 0, tzinfo=timezone.utc)
+    assert AgentEvent(**envelope(occurred_at=when)).timestamp == when
+
+
+def test_event_type_enum_complete():
+    """All 22 event IDs from §12 are present in the enum."""
+    ids = set(EVENT_IDS.values())
+    expected = {f"EVT-{n:03d}" for n in range(1, 13)} | {
+        f"EVT-{n}" for n in range(101, 111)
+    }
+    assert ids == expected, sorted(expected.symmetric_difference(ids))
+    assert len(ids) == 22
+
+
+def test_enum_has_24_members_for_22_ids():
+    """EVT-011 and EVT-102 each name a pair, so members exceed IDs by two."""
+    assert len(list(EventType)) == 24
+    assert EVENT_IDS[EventType.AGENT_CIRCUIT_OPENED] == "EVT-011"
+    assert EVENT_IDS[EventType.AGENT_CIRCUIT_CLOSED] == "EVT-011"
+    assert EVENT_IDS[EventType.RECORDING_STARTED] == "EVT-102"
+    assert EVENT_IDS[EventType.RECORDING_STOPPED] == "EVT-102"
+
+
+def test_every_enum_member_maps_to_an_id():
+    """A member without an ID would break event_ref at runtime."""
+    for member in EventType:
+        assert member in EVENT_IDS, member
+
+
+def test_event_ref_resolves():
+    event = AgentEvent(**envelope(event_type=EventType.TRANSCRIPT_SEGMENT_FINALIZED))
+    assert event.event_ref == "EVT-103"
+
+
+@pytest.mark.parametrize(
+    "forbidden",
+    ["text", "transcript", "segment_text", "entity_values", "email", "extracted_value"],
+)
+def test_payload_carrying_pii_is_rejected(forbidden):
+    with pytest.raises(PIILeakError, match=forbidden):
+        assert_no_pii(EventType.TRANSCRIPT_SEGMENT_FINALIZED, {forbidden: "anything"})
+
+
+def test_evt_103_shape_from_the_design_is_accepted():
+    """§12.2's own example: recording_id, seq, redaction_applied, entity_types."""
+    payload = {
+        "recording_id": "r_01",
+        "seq": 814,
+        "redaction_applied": True,
+        "entity_types": ["PERSON", "PHONE_NUMBER"],
+    }
+    assert_no_pii(EventType.TRANSCRIPT_SEGMENT_FINALIZED, payload)
+    event = AgentEvent(
+        **envelope(event_type=EventType.TRANSCRIPT_SEGMENT_FINALIZED, payload=payload)
+    )
+    assert event.payload["entity_types"] == ["PERSON", "PHONE_NUMBER"]
+    assert "text" not in event.payload
+
+
+def test_entity_types_allowed_while_entity_values_are_not():
+    """The distinction §12.2 draws, asserted directly."""
+    assert_no_pii(EventType.TRANSCRIPT_SEGMENT_FINALIZED, {"entity_types": ["PERSON"]})
+    with pytest.raises(PIILeakError):
+        assert_no_pii(
+            EventType.TRANSCRIPT_SEGMENT_FINALIZED, {"entity_values": ["Ada"]}
+        )
+
+
+def test_empty_payload_is_fine():
+    assert_no_pii(EventType.AGENT_INVOKED, {})
+
+
+def test_outcome_is_constrained_to_the_design_values():
+    for outcome in ("SUCCESS", "FAILURE", "BLOCKED", "DEGRADED"):
+        assert AgentEvent(**envelope(outcome=outcome)).outcome == outcome
+    with pytest.raises(ValidationError):
+        AgentEvent(**envelope(outcome="MAYBE"))
+
+
+def test_event_serialises_to_json_for_kafka():
+    """The emitter publishes model_dump(mode='json'); UUIDs must survive it."""
+    import json
+
+    event = AgentEvent(**envelope(session_id=uuid.uuid4()))
+    body = json.loads(json.dumps(event.model_dump(mode="json")))
+    assert body["tenant_id"] == str(TENANT)
+    assert body["event_type"] == "agent.invoked"

--- a/onboarding-intelligence-agent-svc/tests/test_redis_key_isolation.py
+++ b/onboarding-intelligence-agent-svc/tests/test_redis_key_isolation.py
@@ -1,12 +1,12 @@
-"""OIA shares Redis DB 2 with ten other services. This file is the guard.
+"""AC-4 — every Redis key is namespaced, structurally.
 
-ERRATA-01 is explicit that with a shared database, key-prefix isolation is
-"the only mechanism keeping OIA's keys from colliding with ten other services"
-and that this test "becomes more important, not less".
+OIA shares DB 2 with the prompt cache and the rest of the fleet, so the key
+prefix *is* the isolation guarantee that a dedicated database would have given
+for free. ERRATA-01 is explicit that this test "becomes more important, not
+less"; A-03's scope note says the same.
 
-It asserts structurally — over every public key builder discovered by
-reflection, not a hand-written list — so a builder added by a later story is
-covered the moment it exists rather than when someone remembers to add a case.
+Assertions sweep every key builder by reflection rather than a hand-written
+list, so a builder added by a later story is covered the moment it exists.
 """
 
 from __future__ import annotations
@@ -16,88 +16,118 @@ import inspect
 import pytest
 
 from app.cache import redis_manager
-from app.cache.redis_manager import KEY_PREFIX, PROMPT_CACHE_PREFIX
+from app.cache.redis_manager import (
+    KEY_PREFIX,
+    PROMPT_CACHE_PREFIX,
+    TenantKeys,
+    circuit_key,
+)
 
 pytestmark = pytest.mark.unit
 
 TENANT = "tenant-alpha"
 
-#: Every public callable in redis_manager whose name ends in _key.
-KEY_BUILDERS = [
+#: Every public key-building method on TenantKeys, discovered by reflection.
+BUILDERS = [
     (name, fn)
-    for name, fn in inspect.getmembers(redis_manager, inspect.isfunction)
-    if name.endswith("_key") and not name.startswith("_")
+    for name, fn in inspect.getmembers(TenantKeys, inspect.isfunction)
+    if not name.startswith("_")
 ]
 
 
-def call(fn) -> str:
+def call(fn, tenant: str = TENANT) -> str:
     """Invoke a builder with plausible arguments for whatever it declares."""
-    args = []
-    for param in inspect.signature(fn).parameters:
-        args.append(TENANT if param == "tenant_id" else f"val-{param}")
-    return fn(*args)
+    keys = TenantKeys(tenant)
+    params = [p for p in inspect.signature(fn).parameters if p != "self"]
+    return fn(keys, *[f"val-{p}" for p in params])
 
 
 def test_builders_were_discovered():
     """Guards the reflection itself — an empty sweep would pass vacuously."""
-    assert len(KEY_BUILDERS) >= 6, [n for n, _ in KEY_BUILDERS]
+    assert len(BUILDERS) >= 10, [n for n, _ in BUILDERS]
 
 
-@pytest.mark.parametrize("name,fn", KEY_BUILDERS, ids=[n for n, _ in KEY_BUILDERS])
-def test_every_key_starts_with_the_service_prefix(name, fn):
-    assert call(fn).startswith(KEY_PREFIX), f"{name} escapes the oia:v1: namespace"
+@pytest.mark.parametrize("name,fn", BUILDERS, ids=[n for n, _ in BUILDERS])
+def test_every_key_carries_tenant_and_prefix(name, fn):
+    """The whole isolation guarantee on a shared DB, in one assertion."""
+    key = call(fn)
+    assert key.startswith(f"{KEY_PREFIX}{TENANT}:"), f"{name} escapes the namespace"
 
 
-@pytest.mark.parametrize("name,fn", KEY_BUILDERS, ids=[n for n, _ in KEY_BUILDERS])
+@pytest.mark.parametrize("name,fn", BUILDERS, ids=[n for n, _ in BUILDERS])
 def test_no_key_uses_another_services_namespace(name, fn):
     key = call(fn)
     for foreign in ("poi:", "prompt:", "bpa:", "coa:", "ila:", "tenant:", "celery"):
         assert not key.startswith(foreign), f"{name} writes into {foreign}"
 
 
-@pytest.mark.parametrize("name,fn", KEY_BUILDERS, ids=[n for n, _ in KEY_BUILDERS])
-def test_tenant_scoped_builders_carry_the_tenant(name, fn):
-    """Circuit state is deliberately not tenant-scoped; everything else is."""
-    if "tenant_id" not in inspect.signature(fn).parameters:
-        assert name == "circuit_key", f"{name} is not tenant-scoped — is that right?"
-        return
-    assert f":{TENANT}:" in call(fn)
+def test_tenant_is_a_constructor_argument_not_a_per_call_one():
+    """A-03: 'a helper that can be called without a tenant will eventually be
+    called without one.' No builder accepts a tenant, so none can omit it."""
+    for name, fn in BUILDERS:
+        params = set(inspect.signature(fn).parameters)
+        assert (
+            "tenant_id" not in params
+        ), f"{name} takes a per-call tenant; it belongs on the constructor"
 
 
-def test_tenant_config_key_was_renamed_under_the_service_prefix():
+@pytest.mark.parametrize("bad", ["", "   ", None])
+def test_constructing_without_a_tenant_fails(bad):
+    with pytest.raises((ValueError, TypeError)):
+        TenantKeys(bad)  # type: ignore[arg-type]
+
+
+def test_circuit_key_is_deliberately_not_tenant_scoped():
+    """A dependency being down is a global fact, not a per-tenant one."""
+    key = circuit_key("google-stt")
+    assert key == f"{KEY_PREFIX}circuit:google-stt"
+    assert key.startswith(KEY_PREFIX)
+    assert not hasattr(TenantKeys, "circuit")
+
+
+def test_circuit_key_rejects_an_empty_dependency():
+    with pytest.raises(ValueError):
+        circuit_key("")
+
+
+def test_config_key_was_renamed_under_the_service_prefix():
     """ERRATA-01 §4: tenant:{id}:oia:config → oia:v1:{tenant}:config."""
-    key = redis_manager.tenant_config_key(TENANT)
+    key = TenantKeys(TENANT).config()
     assert key == f"{KEY_PREFIX}{TENANT}:config"
     assert not key.startswith("tenant:")
 
 
-def test_no_builder_accepts_an_empty_tenant():
-    """A key without a tenant is a cross-tenant leak waiting to happen."""
-    for name, fn in KEY_BUILDERS:
-        if "tenant_id" not in inspect.signature(fn).parameters:
-            continue
-        with pytest.raises(ValueError):
-            fn(
-                *[
-                    "" if p == "tenant_id" else "x"
-                    for p in inspect.signature(fn).parameters
-                ]
-            )
+def test_keys_match_design_section_14_patterns():
+    """The §14 catalogue is the contract; drift here is a silent migration."""
+    k = TenantKeys(TENANT)
+    p = f"{KEY_PREFIX}{TENANT}"
+    assert k.session("s1") == f"{p}:session:s1"
+    assert k.session_summary("s1") == f"{p}:session:s1:summary"
+    assert k.transcript("s1") == f"{p}:live:s1:transcript"
+    assert k.questions("s1") == f"{p}:live:s1:questions"
+    assert k.coverage("s1") == f"{p}:live:s1:coverage"
+    assert k.idempotency("d1") == f"{p}:idempotency:d1"
+    assert k.outbox("s1") == f"{p}:outbox:s1"
+    assert k.ratelimit("u1") == f"{p}:ratelimit:u1"
+    assert k.live_lock("c1") == f"{p}:lock:live:c1"
+    assert k.config() == f"{p}:config"
 
 
 def test_keys_are_distinct_across_builders():
-    """Two builders must never collide on the same arguments."""
-    keys = [call(fn) for _, fn in KEY_BUILDERS]
+    keys = [call(fn) for _, fn in BUILDERS]
     assert len(keys) == len(set(keys))
+
+
+def test_two_tenants_never_share_a_key():
+    for name, fn in BUILDERS:
+        assert call(fn, "tenant-a") != call(fn, "tenant-b"), name
 
 
 def test_prompt_cache_prefix_is_foreign_and_read_only():
     """The poi: namespace belongs to prompt-optimization-svc."""
     assert not PROMPT_CACHE_PREFIX.startswith(KEY_PREFIX)
     writers = [
-        name
-        for name, fn in inspect.getmembers(redis_manager, inspect.isfunction)
-        if name.endswith("_key") and call(fn).startswith(PROMPT_CACHE_PREFIX)
+        name for name, fn in BUILDERS if call(fn).startswith(PROMPT_CACHE_PREFIX)
     ]
     assert writers == [], f"OIA must not build keys under poi:: {writers}"
 
@@ -112,3 +142,8 @@ def test_every_ttl_constant_is_positive_and_bounded():
     assert ttls, "no TTL policy declared"
     for name, value in ttls.items():
         assert isinstance(value, int) and 0 < value <= 7 * 24 * 3600, name
+
+
+def test_transcript_list_is_capped():
+    """§14: the cap bounds reconnect replay cost to a known worst case."""
+    assert redis_manager.TRANSCRIPT_MAX_ENTRIES == 4000

--- a/onboarding-intelligence-agent-svc/tests/test_scaffold.py
+++ b/onboarding-intelligence-agent-svc/tests/test_scaffold.py
@@ -89,6 +89,13 @@ IMPLEMENTED = {
     "app.core.logging",
     "app.core.telemetry",
     "app.messaging.producer",
+    # Implemented by A-03.
+    "app.events.catalog",
+    "app.events.emitter",
+    "app.messaging.consumer",
+    "app.messaging.schemas",
+    "app.messaging.topics",
+    "app.messaging.provision",
 }
 
 


### PR DESCRIPTION
Closes **A-03**. Every subsequent story can now emit an auditable event and write session state without re-solving plumbing.

## AC-1 · Topics

Topic catalogue plus an **idempotent provisioner** covering the five fleet topics and the per-tenant `agent.events.<tenant_id>`, each with the retention Design §13.1 specifies.

AC-1 is written against *"the Terraform module that provisions fleet agent topics"*. There is no Terraform in this monorepo — zero `.tf` files; compose relies on `KAFKA_AUTO_CREATE_TOPICS_ENABLE`, which produces topics with **default** retention rather than 30 days for escalations. `provision.py` is that module in the form the repo actually uses. Startup provisions and verifies, and skips entirely where no broker is configured.

The command consumer retries with backoff and dead-letters on exhaustion, carrying `idempotency_key` into the letter — §20's "replay is safe by construction" depends on that key surviving.

## AC-2 · Envelope

Full `EVT-001…012` and `EVT-101…110` set in the enum now, as the technical note asks.

**§12 lists 22 IDs but two name a pair** — EVT-011 is `circuit.opened`/`.closed`, EVT-102 is `recording.started`/`.stopped` — so the enum has **24 members for 22 IDs**, and both counts are asserted so neither can drift.

Validation raises rather than emitting. `assert_no_pii` keeps text and entity values off the stream: §12.2 is explicit that EVT-103 carries entity *types* only, because the stream reaches observability tooling under a different access model than the transcript store.

## AC-3 · Trace correlation

W3C `traceparent` extraction continues the caller's trace; the emitter reads `trace_id` from the active span so events join it automatically. Long-lived live-session spans fold per-frame detail into attributes rather than nesting thousands of children.

The Django half stays unverifiable — nothing in the monorepo emits traces yet (OIA is the only service with `opentelemetry` in requirements). Tested by feeding a genuine traceparent and proving the trace id survives into the span, the response header and the event.

## AC-4 · Structural namespacing

`redis_manager` reworked so the tenant is a **constructor argument** on `TenantKeys`, not a per-call one — *"a helper that can be called without a tenant will eventually be called without one"* — making a tenant-less key a **type error**.

Keys aligned to §14 exactly. A-05's were close but not identical: `live:{sid}:frames` → `transcript`, `idem:` → `idempotency:`, `live:lock:` → `lock:live:`, and five §14 keys (`questions`, `coverage`, `summary`, `outbox`, `ratelimit`) did not exist yet.

## AC-5 · Eviction safety

| | |
|---|---|
| Memorystore usage | **7.2 MB of 1 GB** (0.7%) |
| policy before | `allkeys-lru` |
| policy now | **`noeviction`** |

`allkeys-lru` evicts *any* key regardless of TTL — there is no per-key exemption in Redis — so a live meeting could have lost its transcript and resume window under memory pressure. AC-5 calls that a correctness bug, which is why the card says escalate rather than proceed.

At 0.7% the switch was free, with ~140× headroom. The residual risk — a *full* instance under `noeviction` rejecting writes fleet-wide — is covered by the **"Memorystore zorven-redis memory above 75%"** alert, whose runbook states that reverting to `allkeys-lru` is not a fix. A dedicated instance was considered and rejected as premature at ~$35–50/month. Recorded in `CLAUDE.md` as AC-5 requires; `docker-compose` now matches production.

## Two defects the tests found

1. **The producer's `request_timeout_ms` was 2000**, which also caps produce acks — that would have dropped events under ordinary cloud latency, not just on a slow broker. Now 10000; the health probe reads cluster metadata instead of producing.
2. **`redis_available()` checked `localhost` while the connection used `REDIS_URL`**, so an override silently *skipped* instead of testing what it was pointed at.

## Testing — 217, no mocks

Unit, hypothesis property, integration against a **real broker** and **real Redis**, and container e2e. `black`, `flake8`, `mypy --strict` clean.

The eviction assertion was **verified to fail correctly** against a deliberately-misconfigured `allkeys-lru` server before being committed green — it asserts the live server's policy, not a constant.

## Environment notes for reviewers

Both are documented in the service `CLAUDE.md`, and both cost real time here:

- **A native macOS Redis on `127.0.0.1:6379` shadows the compose container**, so `redis://localhost:6379` may not be the Redis in `docker-compose.yml` — with a different `maxmemory-policy`. This made the eviction test pass against the wrong server until caught.
- **The compose Kafka is heavy** — ZooKeeper mode, JVM heap, replays every persisted partition on boot; it crash-looped on a loaded machine. Tests use **Redpanda** (Kafka-API compatible, no ZooKeeper, ~400 MB, ready in ~30 s) and skip cleanly when no broker is reachable. CI does the same.

Also adds `/ready` and `/metrics` per §20, and a profiled `otel-collector` (`--profile with-otel`) so the default stack is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)