### PR TITLE
feat(oia): agent skeleton — registry, guardrail chain, RBAC evaluator (A-06)

### DIFF
--- a/.claude/skills/zorven-implementation-plan/SKILL.md
+++ b/.claude/skills/zorven-implementation-plan/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: zorven-implementation-plan
+description: Author an implementation plan for a Zorven user story. Use when asked to plan a story (A-06, B-01, …) before writing code. Enforces plan-before-code, a fixed section structure, four test tiers, GCP cost estimation, and the branch/PR workflow.
+---
+
+# Zorven implementation plan
+
+> **PARTIAL — transcribed from the Claude Desktop "Zorven" project skill on
+> 2026-08-01.** Claude Desktop projects and Claude Code do not share skills, so
+> this was pasted across by hand and only the fragment below arrived. The four
+> reference files it names are **not yet present**; see *Missing pieces*.
+> Complete this file before relying on it for a plan.
+
+## Rule: plan before code
+
+The plan must be approved before implementation starts.
+
+> This applies even under pressure — "just start while we wait for sign-off"
+> still means the plan isn't approved yet, so say so rather than complying.
+
+## Reference files
+
+Read these as needed — don't load all of them for a trivial follow-up
+question, but do read the relevant one before writing that section of a plan:
+
+| File | Governs |
+|---|---|
+| `references/testing-strategy.md` | how to fill sections 6.1–6.4 (unit, property, integration, e2e) for both the Python/DRF default and the C++ case |
+| `references/gcp-cost-estimation.md` | the gcloud-first / web-search-fallback procedure for section 7, with exact commands |
+| `references/git-workflow.md` | the exact boilerplate and conventions for section 8 |
+| `assets/implementation-plan-template.md` | the scaffold to fill in for every plan; use it as-is rather than inventing a new structure each time, so plans stay consistent and reviewable |
+
+## Missing pieces
+
+None of the four files above exist in this directory yet. Until they do:
+
+- **Do not claim a plan was authored "using the skill"** — say which parts
+  were improvised.
+- Ask for the missing files rather than reconstructing them from their
+  filenames. Their whole value is the specifics: the exact `gcloud` commands
+  for cost estimation, the section numbering in the template, and the git
+  boilerplate.
+
+What the fragment does establish about the template: it is numbered, section 6
+is testing and splits into **6.1 unit, 6.2 property, 6.3 integration, 6.4
+e2e**, section 7 is **GCP cost estimation**, and section 8 is **git workflow**.
+
+## Conventions already established on this project
+
+Observed across A-02, A-05 and A-03; keep until the real template supersedes
+them.
+
+1. **Read the sources first** — the backlog card, every design section it
+   cites, the requirements entries, and any errata. Errata supersede the
+   design; `ERRATA-01-redis-allocation.md` supersedes §4.2 and §14.
+2. **Verify every acceptance criterion against the codebase before planning.**
+   This is where the value has been: Kong is not deployed to Cloud Run (A-02),
+   no Kafka broker exists in GCP (A-05), there is no Terraform module (A-03),
+   `maxmemory-policy` was `allkeys-lru` (A-03 AC-5).
+3. **Surface doc-versus-reality conflicts explicitly**, each with a
+   recommendation, rather than implementing something that cannot work.
+4. **No mocks.** Real Redis, real broker, real container, real HTTP.
+5. **Deployment covers every registration point**: `docker-compose.yml`,
+   `docker-publish.yml` (paths filter *and* build matrix), `deploy-gcp.yml`
+   matrix, `deployment/gcp/08-deploy-services.sh`, and the CI job. Missing one
+   means the service silently never deploys.
+6. **State what the story does not deliver.** A-03 did not make events durable
+   in production; saying so is part of the plan.
+7. **Numbered assumptions**, and **decisions needing the user's call** with a
+   recommendation for each.
+8. Branch from `development_main`, PR back into `development_main`. Never
+   `main` until the OIA epics are complete.

--- a/onboarding-intelligence-agent-svc/CLAUDE.md
+++ b/onboarding-intelligence-agent-svc/CLAUDE.md
@@ -23,17 +23,50 @@ One deployable, three modes, decided by entry point rather than a runtime flag:
 - Backlog: `…_User_Story_Backlog_v2_1.md`
 - **Corrections that override both: `ERRATA-01-redis-allocation.md`**
 
-## Current state — scaffold plus the event and Redis baseline
+## Current state — scaffold, event baseline, agent skeleton
 
-A-05 and A-03 have landed. Working: configuration, logging, telemetry with W3C
-trace propagation, the Redis pool and tenant-scoped key builders, the Kafka
-producer/consumer with topic provisioning and DLQ routing, the §12 event
-catalogue and emitter, and the health, readiness and metrics surface.
+A-05, A-03 and A-06 have landed. Working: configuration, logging, telemetry
+with W3C trace propagation, the Redis pool and tenant-scoped key builders, the
+Kafka producer/consumer with topic provisioning and DLQ routing, the §12 event
+catalogue and emitter, the health/readiness/metrics surface, and the agent
+skeleton — SkillRegistry, the ordered guardrail chain, the RBAC evaluator and
+the §18.4 error taxonomy.
 Everything else is a stub that **raises `NotImplementedError` by design** — a
 stub returning `None` would let a later story ship a silent no-op. When you
 implement one, delete the raise; do not leave it returning nothing.
 
 Owning stories are named in each stub's docstring.
+
+## The registry is the only way to run a skill
+
+`SkillRegistry.execute` and `execute_stream` are the entry points. `BaseSkill`
+defines `run`, `StreamingSkill` defines `stream`, and neither class is
+callable — there is deliberately no convenient way to invoke a skill and skip
+IG → RBAC → PG → OG.
+
+- Skills load from `config/skills.yaml`, not from imports. A declaration whose
+  class is missing fails **at startup**, naming every missing skill at once.
+- Guardrail rule *bodies* are no-op stubs; M-01 fills them in through
+  `GuardrailChain.register`, which replaces a rule without changing the order.
+- Output guardrails run **per yielded chunk** for streaming skills. A chunk
+  already delivered to the browser cannot be recalled.
+- RBAC has **four** verdicts — ALLOW, DENY, ESCALATE, VIEW_RESULT — because
+  §15 uses all four. The matrix is data in `app/rbac/engine.py`; keep it that
+  way, or `test_rbac.py` cannot sweep it exhaustively.
+- The role comes from the verified JWT claim only, never a body or header.
+
+## Error codes
+
+`app/core/errors.py` is the §18.4 taxonomy. Two codes deviate from the
+documents, deliberately:
+
+| Situation | Docs say | We use | Why |
+|---|---|---|---|
+| Role denied | A-06 AC-3 says ERR-03 | **ERR-04** | §18.4 assigns ERR-03 to *consent* (IG-08). Collapsing them makes a permissions bug look like a consent bug on call. |
+| Unknown skill id | §5 PG-02 says ERR-06 | **ERR-17** (provisional) | §18.4 already spends ERR-06 on "live session already active" (409/4409). Reusing it would tell an operator a meeting is running when a skill id is simply wrong. |
+
+Both need reconciling in the design; until then the code is right and the
+documents are not.
 
 ## Non-negotiables in this service
 

--- a/onboarding-intelligence-agent-svc/app/core/errors.py
+++ b/onboarding-intelligence-agent-svc/app/core/errors.py
@@ -1,21 +1,279 @@
-"""Error taxonomy — ERR-01 … ERR-nn with recoverability flags.
+"""Error taxonomy (Design §18.4).
 
-Design §18.4 · implemented by story A-06.
+Defined once, here, so every failure surfaces as a typed condition a runbook
+can reference rather than an untyped 500. Each code carries its HTTP status,
+its WebSocket close code where §10.2.3 assigns one, and whether a caller
+should retry.
 
-Scaffolded by A-05. The body raises NotImplementedError deliberately: a
-stub that silently returns None would let a later story ship a no-op
-that passes its tests.
+Two documentation conflicts are resolved here rather than propagated.
+
+**ERR-06 is claimed twice.** §5 PG-02 says an unknown skill id "raises
+SkillNotFound and emits ERR-06", but §18.4 assigns ERR-06 to "Live session
+already active for company" (409/4409). Emitting it for a bad skill id would
+tell an operator that a meeting is already running. :class:`SkillNotFound`
+therefore carries a provisional **ERR-17** with a 404, and the documents need
+reconciling — either PG-02 names the wrong code or the taxonomy needs a row.
+
+A note on ERR-03 and ERR-04, because A-06's AC-3 conflates them. AC-3 asks for
+"the typed ERR-03 authorization error" on an RBAC denial, but §18.4 assigns
+ERR-03 to *consent* (IG-08) and **ERR-04 to role denial (PG-03)**. The two have
+different operator behaviour — "Consent modal re-presented" versus "Action
+hidden or disabled in UI" — so collapsing them would make a permissions bug
+look like a consent bug to whoever is on call. ERR-04 is used; the AC wording
+is the thing that is wrong.
 """
 
 from __future__ import annotations
 
-_NOT_YET = (
-    "Error taxonomy — ERR-01 … ERR-nn with recoverability flags. — implemented by A-06"
-)
+from dataclasses import dataclass
+from enum import StrEnum
 
 
-class OIAError:
-    """Not yet implemented."""
+class ErrorCode(StrEnum):
+    """§18.4 taxonomy."""
 
-    def __init__(self, *args: object, **kwargs: object) -> None:
-        raise NotImplementedError(_NOT_YET)
+    INVALID_JWT = "ERR-01"
+    TENANT_MISMATCH = "ERR-02"
+    CONSENT_MISSING = "ERR-03"
+    ROLE_DENIED = "ERR-04"
+    SESSION_NOT_FOUND = "ERR-05"
+    LIVE_SESSION_ACTIVE = "ERR-06"
+    STT_DEGRADED = "ERR-07"
+    LLM_DEGRADED = "ERR-08"
+    VISION_DEGRADED = "ERR-09"
+    BACKEND_WRITE_BUFFERED = "ERR-10"
+    GROUNDING_FAILURE = "ERR-11"
+    SCHEMA_VALIDATION_FAILURE = "ERR-12"
+    FIELD_CONFLICT = "ERR-13"
+    RATE_LIMITED = "ERR-14"
+    IDEMPOTENCY_CONFLICT = "ERR-15"
+    SPOOL_BOUND_EXCEEDED = "ERR-16"
+
+    #: Provisional — see the module docstring. §5 PG-02 asks for ERR-06 here,
+    #: but §18.4 has already spent ERR-06 on live-session-active.
+    SKILL_NOT_IN_ALLOWLIST = "ERR-17"
+
+
+@dataclass(frozen=True)
+class ErrorSpec:
+    """One row of the §18.4 table."""
+
+    code: ErrorCode
+    condition: str
+    http_status: int
+    ws_close_code: int | None
+    retryable: bool
+    operator_behaviour: str
+
+
+ERROR_SPECS: dict[ErrorCode, ErrorSpec] = {
+    ErrorCode.INVALID_JWT: ErrorSpec(
+        ErrorCode.INVALID_JWT,
+        "Invalid or expired JWT",
+        401,
+        4401,
+        False,
+        "Re-authenticate",
+    ),
+    ErrorCode.TENANT_MISMATCH: ErrorSpec(
+        ErrorCode.TENANT_MISMATCH,
+        "Tenant mismatch (IG-05)",
+        403,
+        None,
+        False,
+        "Blocked, security alert raised",
+    ),
+    ErrorCode.CONSENT_MISSING: ErrorSpec(
+        ErrorCode.CONSENT_MISSING,
+        "Consent missing or revoked (IG-08)",
+        403,
+        4403,
+        False,
+        "Consent modal re-presented",
+    ),
+    ErrorCode.ROLE_DENIED: ErrorSpec(
+        ErrorCode.ROLE_DENIED,
+        "Role denied (PG-03)",
+        403,
+        None,
+        False,
+        "Action hidden or disabled in UI",
+    ),
+    ErrorCode.SESSION_NOT_FOUND: ErrorSpec(
+        ErrorCode.SESSION_NOT_FOUND,
+        "Session not found or wrong state",
+        404,
+        4404,
+        False,
+        "Session list refreshed",
+    ),
+    ErrorCode.LIVE_SESSION_ACTIVE: ErrorSpec(
+        ErrorCode.LIVE_SESSION_ACTIVE,
+        "Live session already active for company",
+        409,
+        4409,
+        False,
+        "Offer to join or end the existing session",
+    ),
+    ErrorCode.STT_DEGRADED: ErrorSpec(
+        ErrorCode.STT_DEGRADED,
+        "STT dependency degraded",
+        200,
+        None,
+        True,
+        "RECORD_ONLY banner",
+    ),
+    ErrorCode.LLM_DEGRADED: ErrorSpec(
+        ErrorCode.LLM_DEGRADED,
+        "LLM dependency degraded",
+        200,
+        None,
+        True,
+        "Manual checkboxes banner",
+    ),
+    ErrorCode.VISION_DEGRADED: ErrorSpec(
+        ErrorCode.VISION_DEGRADED,
+        "Vision dependency degraded",
+        200,
+        None,
+        True,
+        "Reduced-accuracy OCR badge",
+    ),
+    ErrorCode.BACKEND_WRITE_BUFFERED: ErrorSpec(
+        ErrorCode.BACKEND_WRITE_BUFFERED,
+        "Backend write failed, buffered",
+        202,
+        None,
+        True,
+        "Saving delayed banner",
+    ),
+    ErrorCode.GROUNDING_FAILURE: ErrorSpec(
+        ErrorCode.GROUNDING_FAILURE,
+        "Grounding failure — value dropped (OG-01)",
+        200,
+        None,
+        False,
+        "Counted in dropped_ungrounded, shown on review page",
+    ),
+    ErrorCode.SCHEMA_VALIDATION_FAILURE: ErrorSpec(
+        ErrorCode.SCHEMA_VALIDATION_FAILURE,
+        "Schema validation failure on model output (OG-04)",
+        502,
+        None,
+        True,
+        "One retry with a repair instruction, then escalate",
+    ),
+    ErrorCode.FIELD_CONFLICT: ErrorSpec(
+        ErrorCode.FIELD_CONFLICT,
+        "Field conflict requiring a human (SKL-OIA-14)",
+        202,
+        None,
+        False,
+        "Escalation card on the review page",
+    ),
+    ErrorCode.RATE_LIMITED: ErrorSpec(
+        ErrorCode.RATE_LIMITED,
+        "Rate limited",
+        429,
+        4429,
+        True,
+        "Retry-After honoured by the client",
+    ),
+    ErrorCode.IDEMPOTENCY_CONFLICT: ErrorSpec(
+        ErrorCode.IDEMPOTENCY_CONFLICT,
+        "Idempotency conflict — same key, different payload",
+        409,
+        None,
+        False,
+        "Blocked; indicates a client bug, alerted",
+    ),
+    ErrorCode.SPOOL_BOUND_EXCEEDED: ErrorSpec(
+        ErrorCode.SPOOL_BOUND_EXCEEDED,
+        "GCS spool bound exceeded",
+        507,
+        None,
+        False,
+        "Recording stopped gracefully with an explicit warning",
+    ),
+    ErrorCode.SKILL_NOT_IN_ALLOWLIST: ErrorSpec(
+        ErrorCode.SKILL_NOT_IN_ALLOWLIST,
+        "Unknown skill id — not in the PG-02 tool allowlist",
+        404,
+        None,
+        False,
+        "Indicates a caller or configuration bug, not a user error",
+    ),
+}
+
+
+class OIAError(Exception):
+    """Base for every typed failure this service raises."""
+
+    code: ErrorCode = ErrorCode.SCHEMA_VALIDATION_FAILURE
+
+    def __init__(self, message: str = "", **context: object) -> None:
+        self.spec = ERROR_SPECS[self.code]
+        self.message = message or self.spec.condition
+        self.context = context
+        super().__init__(f"{self.code.value}: {self.message}")
+
+    @property
+    def http_status(self) -> int:
+        return self.spec.http_status
+
+    @property
+    def ws_close_code(self) -> int | None:
+        return self.spec.ws_close_code
+
+    @property
+    def retryable(self) -> bool:
+        return self.spec.retryable
+
+    def to_body(self) -> dict[str, object]:
+        """The standard error body (§18.4).
+
+        Deliberately carries no request payload: an authorization failure is
+        logged and returned without echoing what was attempted.
+        """
+        return {
+            "error_code": self.code.value,
+            "message": self.message,
+            "retryable": self.retryable,
+        }
+
+
+class AuthorizationError(OIAError):
+    """ERR-04 — role denied by the §15 matrix at PG-03."""
+
+    code = ErrorCode.ROLE_DENIED
+
+
+class ConsentError(OIAError):
+    """ERR-03 — consent missing or revoked (IG-08)."""
+
+    code = ErrorCode.CONSENT_MISSING
+
+
+class TenantMismatchError(OIAError):
+    """ERR-02 — the tenant header disagrees with the JWT claim (IG-05)."""
+
+    code = ErrorCode.TENANT_MISMATCH
+
+
+class SkillNotFound(OIAError):
+    """An unknown skill id — PG-02's tool allowlist rejected it.
+
+    Carries the provisional ERR-17 rather than the ERR-06 that PG-02 names,
+    because §18.4 assigns ERR-06 to "Live session already active for company"
+    with 409/4409. Reusing it would tell an operator a meeting is already
+    running when the truth is that a skill id is wrong. See the module
+    docstring; the documents need reconciling.
+    """
+
+    code = ErrorCode.SKILL_NOT_IN_ALLOWLIST
+
+
+class RateLimitedError(OIAError):
+    """ERR-14 — tenant or user throttle applied (IG-07)."""
+
+    code = ErrorCode.RATE_LIMITED

--- a/onboarding-intelligence-agent-svc/app/logic/guardrails.py
+++ b/onboarding-intelligence-agent-svc/app/logic/guardrails.py
@@ -127,11 +127,20 @@ class GuardrailChain:
             self.register(Layer.OUTPUT, rule_id, noop(rule_id))
 
     def register(self, layer: Layer, rule_id: str, evaluate: Rule) -> None:
-        """Add or replace a rule. M-01 replaces the no-ops through this."""
-        existing = [r for r in self._rules[layer] if r.rule_id == rule_id]
-        if existing:
-            self._rules[layer].remove(existing[0])
-        self._rules[layer].append(RegisteredRule(rule_id, layer, evaluate))
+        """Add or replace a rule, **preserving position**.
+
+        M-01 replaces the no-ops through this. Replacement must not reorder
+        the layer: §5 numbers its rules in the order an operator reads them,
+        and IG-04 (redaction) running after IG-06 (size limit) would truncate
+        text before it was redacted. A replacement lands where the original
+        was; only a genuinely new rule is appended.
+        """
+        registered = RegisteredRule(rule_id, layer, evaluate)
+        for index, existing in enumerate(self._rules[layer]):
+            if existing.rule_id == rule_id:
+                self._rules[layer][index] = registered
+                return
+        self._rules[layer].append(registered)
 
     def rules(self, layer: Layer) -> list[str]:
         return [r.rule_id for r in self._rules[layer]]
@@ -198,6 +207,11 @@ class GuardrailChain:
     def evaluate_result(
         self, result: SkillResult, context: SkillContext
     ) -> SkillResult:
-        """OG for the non-streaming case."""
-        self.evaluate(Layer.OUTPUT, result.output, context)
+        """OG for the non-streaming case.
+
+        The evaluated payload is written back. OG-02 re-applies redaction on
+        egress and OG-01 drops ungrounded values, so discarding the transform
+        would hand the caller exactly the output those rules just rewrote.
+        """
+        result.output = self.evaluate(Layer.OUTPUT, result.output, context)
         return result

--- a/onboarding-intelligence-agent-svc/app/logic/guardrails.py
+++ b/onboarding-intelligence-agent-svc/app/logic/guardrails.py
@@ -1,19 +1,203 @@
-"""Input, process and output guardrail chains.
+"""The three guardrail chains (Design §5), in fixed order.
 
-Design §5 · implemented by story A-06.
+A-06 proves the **ordering and the registration mechanism**; the rule bodies
+are no-op stubs that M-01 fills in. That split is deliberate — the guarantee
+worth having early is that no skill can run without passing through IG, PG and
+OG in that order, and that guarantee is testable long before any individual
+rule exists.
 
-Scaffolded by A-05. The body raises NotImplementedError deliberately: a
-stub that silently returns None would let a later story ship a no-op
-that passes its tests.
+Order is not a convention here, it is enforced:
+
+- **IG** runs before the prompt is built. A rule that ran after would be
+  inspecting a prompt that already contains the untrusted input.
+- **PG** runs around execution, so it can see both the plan and the outcome.
+- **OG** runs before the result is returned — and for a streaming skill,
+  before **each** chunk is yielded, not once at the end.
+
+Every evaluation emits a structured line carrying rule id, verdict and elapsed
+time (AC-2), and a triggered rule additionally emits EVT-004
+(``agent.guardrail.triggered``) per §5.
 """
 
 from __future__ import annotations
 
-_NOT_YET = "app.logic.guardrails — implemented by A-06"
+import time
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, AsyncIterator, Callable
+
+from app.core.logging import get_logger
+from app.skills.models import SkillContext, SkillResult
+
+logger = get_logger(__name__)
+
+
+class Layer(StrEnum):
+    """The three layers, in the order they run."""
+
+    INPUT = "IG"
+    PROCESS = "PG"
+    OUTPUT = "OG"
+
+
+class Action(StrEnum):
+    """What a rule decided. §5 uses these verbs across all three layers."""
+
+    PASS = "PASS"
+    BLOCK = "BLOCK"
+    REDACT = "REDACT"
+    TRUNCATE = "TRUNCATE"
+    ESCALATE = "ESCALATE"
+    DROP = "DROP"
+
+
+@dataclass(frozen=True)
+class Verdict:
+    """One rule's decision about one payload."""
+
+    rule_id: str
+    action: Action = Action.PASS
+    detail: str = ""
+    payload: Any = None
+
+    @property
+    def blocked(self) -> bool:
+        return self.action is Action.BLOCK
+
+
+class GuardrailViolation(Exception):
+    """Raised when a rule blocks. Carries the rule id for the error body."""
+
+    def __init__(self, verdict: Verdict) -> None:
+        self.verdict = verdict
+        super().__init__(f"{verdict.rule_id} blocked: {verdict.detail}")
+
+
+#: A rule takes the payload under inspection plus the calling context.
+Rule = Callable[[Any, SkillContext], Verdict]
+
+
+@dataclass
+class RegisteredRule:
+    rule_id: str
+    layer: Layer
+    evaluate: Rule
+
+
+def noop(rule_id: str) -> Rule:
+    """A rule that passes.
+
+    A-06 registers every §5 rule as one of these so the chain is complete and
+    ordered from the first commit. M-01 replaces the bodies. A no-op that
+    *records* itself is what makes the ordering test meaningful today.
+    """
+
+    def _evaluate(payload: Any, context: SkillContext) -> Verdict:
+        return Verdict(rule_id=rule_id, action=Action.PASS, payload=payload)
+
+    return _evaluate
+
+
+#: Every rule in §5, in declaration order. Ordering within a layer follows the
+#: design's own numbering, which is the order an operator reads them in.
+INPUT_RULES = [f"IG-{n:02d}" for n in range(1, 11)]
+PROCESS_RULES = [f"PG-{n:02d}" for n in range(1, 9)]
+OUTPUT_RULES = [f"OG-{n:02d}" for n in range(1, 7)]
 
 
 class GuardrailChain:
-    """Not yet implemented."""
+    """Runs the three layers in order. The registry owns one of these."""
 
-    def __init__(self, *args: object, **kwargs: object) -> None:
-        raise NotImplementedError(_NOT_YET)
+    def __init__(self, emitter: Any = None) -> None:
+        self._rules: dict[Layer, list[RegisteredRule]] = {
+            Layer.INPUT: [],
+            Layer.PROCESS: [],
+            Layer.OUTPUT: [],
+        }
+        self._emitter = emitter
+        self.calls: list[tuple[Layer, str]] = []
+        self._register_defaults()
+
+    def _register_defaults(self) -> None:
+        for rule_id in INPUT_RULES:
+            self.register(Layer.INPUT, rule_id, noop(rule_id))
+        for rule_id in PROCESS_RULES:
+            self.register(Layer.PROCESS, rule_id, noop(rule_id))
+        for rule_id in OUTPUT_RULES:
+            self.register(Layer.OUTPUT, rule_id, noop(rule_id))
+
+    def register(self, layer: Layer, rule_id: str, evaluate: Rule) -> None:
+        """Add or replace a rule. M-01 replaces the no-ops through this."""
+        existing = [r for r in self._rules[layer] if r.rule_id == rule_id]
+        if existing:
+            self._rules[layer].remove(existing[0])
+        self._rules[layer].append(RegisteredRule(rule_id, layer, evaluate))
+
+    def rules(self, layer: Layer) -> list[str]:
+        return [r.rule_id for r in self._rules[layer]]
+
+    def evaluate(self, layer: Layer, payload: Any, context: SkillContext) -> Any:
+        """Run one layer. Returns the payload, possibly transformed.
+
+        A BLOCK raises rather than returning, because a blocked payload must
+        not reach the next stage under any circumstances.
+        """
+        current = payload
+        for rule in self._rules[layer]:
+            started = time.perf_counter()
+            verdict = rule.evaluate(current, context)
+            elapsed_ms = (time.perf_counter() - started) * 1000
+            self.calls.append((layer, rule.rule_id))
+
+            logger.debug(
+                "guardrail_evaluated",
+                rule_id=verdict.rule_id,
+                layer=layer.value,
+                verdict=verdict.action.value,
+                elapsed_ms=round(elapsed_ms, 3),
+                skill_id=context.input_context.get("skill_id"),
+            )
+
+            if verdict.action is not Action.PASS:
+                self._emit_triggered(verdict, layer, context, elapsed_ms)
+            if verdict.blocked:
+                raise GuardrailViolation(verdict)
+            if verdict.payload is not None:
+                current = verdict.payload
+        return current
+
+    def _emit_triggered(
+        self, verdict: Verdict, layer: Layer, context: SkillContext, elapsed_ms: float
+    ) -> None:
+        """EVT-004 per §5 — every trigger is an event, not just a log line."""
+        logger.info(
+            "guardrail_triggered",
+            rule_id=verdict.rule_id,
+            layer=layer.value,
+            action=verdict.action.value,
+            detail=verdict.detail,
+            elapsed_ms=round(elapsed_ms, 3),
+            tenant_id=context.tenant_context.tenant_id,
+        )
+
+    async def wrap_stream(
+        self,
+        chunks: AsyncIterator[dict[str, Any]],
+        context: SkillContext,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Run OG over **every** yielded chunk.
+
+        The streaming case is the reason OG is an async-generator wrapper
+        rather than a single call: a chunk that has already been delivered to
+        the browser cannot be un-delivered, so each one is evaluated before it
+        leaves. The same rule objects serve both interfaces.
+        """
+        async for chunk in chunks:
+            yield self.evaluate(Layer.OUTPUT, chunk, context)
+
+    def evaluate_result(
+        self, result: SkillResult, context: SkillContext
+    ) -> SkillResult:
+        """OG for the non-streaming case."""
+        self.evaluate(Layer.OUTPUT, result.output, context)
+        return result

--- a/onboarding-intelligence-agent-svc/app/rbac/engine.py
+++ b/onboarding-intelligence-agent-svc/app/rbac/engine.py
@@ -1,19 +1,230 @@
-"""Role to skill matrix enforcement.
+"""Role-to-capability matrix (Design §15), evaluated at PG-03.
 
-Design §15 · implemented by story A-06.
+The matrix is **data**, not control flow. A-06's technical note is explicit
+about why: "a matrix written as if statements cannot be exhaustively tested."
+:data:`MATRIX` is parameterised the same way ``tests/test_rbac.py``
+parameterises it, so every role against every capability is a table lookup on
+both sides.
 
-Scaffolded by A-05. The body raises NotImplementedError deliberately: a
-stub that silently returns None would let a later story ship a no-op
-that passes its tests.
+Roles come from the verified JWT claim only — never from a request body, a
+client-controlled header, or session state (§15).
+
+Four verdicts, not two. A-06 AC-3 describes allow and deny, but §15 also uses
+ESCALATE (SKL-OIA-14 for EDITOR: "permitted but routed for Admin approval")
+and VIEW_RESULT (SKL-OIA-08/09 for VIEWER: may read the output, may not run
+it). Collapsing either into ALLOW or DENY would lose a distinction the design
+makes deliberately.
 """
 
 from __future__ import annotations
 
-_NOT_YET = "app.rbac.engine — implemented by A-06"
+from enum import StrEnum
+
+from app.core.errors import AuthorizationError
+
+
+class Role(StrEnum):
+    """Platform roles. There is no SYSTEM role — see :data:`INTERNAL_ONLY`."""
+
+    OWNER = "OWNER"
+    ADMIN = "ADMIN"
+    EDITOR = "EDITOR"
+    VIEWER = "VIEWER"
+
+
+class Verdict(StrEnum):
+    ALLOW = "ALLOW"
+    DENY = "DENY"
+    #: Permitted, but the result is routed for Admin approval rather than applied.
+    ESCALATE = "ESCALATE"
+    #: May read the result; may not invoke the capability.
+    VIEW_RESULT = "VIEW_RESULT"
+
+
+class Capability(StrEnum):
+    """Every row of the §15 matrix.
+
+    Skill capabilities are keyed by skill id so the registry can look one up
+    directly; the non-skill rows are named actions.
+    """
+
+    RESEARCH_AND_QUESTIONNAIRE = "SKL-OIA-01..03"
+    LIVE_ANALYSIS = "SKL-OIA-04..06"
+    ANALYZE_CAPTURED_MEDIA = "SKL-OIA-07"
+    SUMMARIZE_RECORDING = "SKL-OIA-08"
+    ASSESS_WORKFLOW_COVERAGE = "SKL-OIA-09"
+    EXTRACT_AND_MAP_FIELDS = "SKL-OIA-10"
+    REGISTER_MEETING_ASSETS = "SKL-OIA-11"
+    AUTOGEN_STRATEGY_IDENTITY = "SKL-OIA-12"
+    RECORD_GOLDEN_CANDIDATES = "SKL-OIA-13"
+    CONFLICT_ESCALATION = "SKL-OIA-14"
+    CONFIRM_KEY_FIELD = "confirm_key_field"
+    EDIT_SECONDARY_FIELD = "edit_secondary_field"
+    RETENTION_AND_ERASURE = "retention_and_erasure"
+    CALENDAR_OAUTH_CONNECT = "calendar_oauth_connect"
+    START_LIVE_SESSION = "start_live_session"
+    VIEW_RECORDINGS = "view_recordings"
+
+
+A, D, E, V = Verdict.ALLOW, Verdict.DENY, Verdict.ESCALATE, Verdict.VIEW_RESULT
+
+#: The §15 table, transcribed row for row. Column order: OWNER, ADMIN, EDITOR,
+#: VIEWER.
+MATRIX: dict[Capability, dict[Role, Verdict]] = {
+    Capability.RESEARCH_AND_QUESTIONNAIRE: {
+        Role.OWNER: A,
+        Role.ADMIN: A,
+        Role.EDITOR: A,
+        Role.VIEWER: D,
+    },
+    Capability.LIVE_ANALYSIS: {
+        Role.OWNER: A,
+        Role.ADMIN: A,
+        Role.EDITOR: A,
+        Role.VIEWER: D,
+    },
+    Capability.ANALYZE_CAPTURED_MEDIA: {
+        Role.OWNER: A,
+        Role.ADMIN: A,
+        Role.EDITOR: A,
+        Role.VIEWER: D,
+    },
+    Capability.SUMMARIZE_RECORDING: {
+        Role.OWNER: A,
+        Role.ADMIN: A,
+        Role.EDITOR: A,
+        Role.VIEWER: V,
+    },
+    Capability.ASSESS_WORKFLOW_COVERAGE: {
+        Role.OWNER: A,
+        Role.ADMIN: A,
+        Role.EDITOR: A,
+        Role.VIEWER: V,
+    },
+    Capability.EXTRACT_AND_MAP_FIELDS: {
+        Role.OWNER: A,
+        Role.ADMIN: A,
+        Role.EDITOR: A,
+        Role.VIEWER: D,
+    },
+    Capability.REGISTER_MEETING_ASSETS: {
+        Role.OWNER: A,
+        Role.ADMIN: A,
+        Role.EDITOR: A,
+        Role.VIEWER: D,
+    },
+    Capability.AUTOGEN_STRATEGY_IDENTITY: {
+        Role.OWNER: A,
+        Role.ADMIN: A,
+        Role.EDITOR: A,
+        Role.VIEWER: D,
+    },
+    # SYSTEM in §15. The platform has no SYSTEM role, so §8 expresses it as the
+    # full role set plus internal_only: true — the registry refuses an
+    # externally-originated call regardless of the caller's role.
+    Capability.RECORD_GOLDEN_CANDIDATES: {
+        Role.OWNER: A,
+        Role.ADMIN: A,
+        Role.EDITOR: A,
+        Role.VIEWER: D,
+    },
+    Capability.CONFLICT_ESCALATION: {
+        Role.OWNER: A,
+        Role.ADMIN: A,
+        Role.EDITOR: E,
+        Role.VIEWER: D,
+    },
+    Capability.CONFIRM_KEY_FIELD: {
+        Role.OWNER: A,
+        Role.ADMIN: A,
+        Role.EDITOR: D,
+        Role.VIEWER: D,
+    },
+    Capability.EDIT_SECONDARY_FIELD: {
+        Role.OWNER: A,
+        Role.ADMIN: A,
+        Role.EDITOR: A,
+        Role.VIEWER: D,
+    },
+    Capability.RETENTION_AND_ERASURE: {
+        Role.OWNER: A,
+        Role.ADMIN: A,
+        Role.EDITOR: D,
+        Role.VIEWER: D,
+    },
+    Capability.CALENDAR_OAUTH_CONNECT: {
+        Role.OWNER: A,
+        Role.ADMIN: A,
+        Role.EDITOR: D,
+        Role.VIEWER: D,
+    },
+    Capability.START_LIVE_SESSION: {
+        Role.OWNER: A,
+        Role.ADMIN: A,
+        Role.EDITOR: A,
+        Role.VIEWER: D,
+    },
+    Capability.VIEW_RECORDINGS: {
+        Role.OWNER: A,
+        Role.ADMIN: A,
+        Role.EDITOR: A,
+        Role.VIEWER: A,
+    },
+}
+
+#: Skill id → capability row. Skills 01–03 and 04–06 share a row in §15.
+SKILL_CAPABILITY: dict[str, Capability] = {
+    "SKL-OIA-01": Capability.RESEARCH_AND_QUESTIONNAIRE,
+    "SKL-OIA-02": Capability.RESEARCH_AND_QUESTIONNAIRE,
+    "SKL-OIA-03": Capability.RESEARCH_AND_QUESTIONNAIRE,
+    "SKL-OIA-04": Capability.LIVE_ANALYSIS,
+    "SKL-OIA-05": Capability.LIVE_ANALYSIS,
+    "SKL-OIA-06": Capability.LIVE_ANALYSIS,
+    "SKL-OIA-07": Capability.ANALYZE_CAPTURED_MEDIA,
+    "SKL-OIA-08": Capability.SUMMARIZE_RECORDING,
+    "SKL-OIA-09": Capability.ASSESS_WORKFLOW_COVERAGE,
+    "SKL-OIA-10": Capability.EXTRACT_AND_MAP_FIELDS,
+    "SKL-OIA-11": Capability.REGISTER_MEETING_ASSETS,
+    "SKL-OIA-12": Capability.AUTOGEN_STRATEGY_IDENTITY,
+    "SKL-OIA-13": Capability.RECORD_GOLDEN_CANDIDATES,
+    "SKL-OIA-14": Capability.CONFLICT_ESCALATION,
+    # 15 and 16 are internal plumbing (prompt fetch, redaction) and carry no
+    # §15 row: they are never invoked by a user directly.
+    "SKL-OIA-15": Capability.VIEW_RECORDINGS,
+    "SKL-OIA-16": Capability.VIEW_RECORDINGS,
+}
 
 
 class RBACEngine:
-    """Not yet implemented."""
+    """Evaluates a role against a capability. Pure lookup, no side effects."""
 
-    def __init__(self, *args: object, **kwargs: object) -> None:
-        raise NotImplementedError(_NOT_YET)
+    def __init__(self, matrix: dict[Capability, dict[Role, Verdict]] | None = None):
+        self._matrix = matrix if matrix is not None else MATRIX
+
+    def verdict(self, role: Role, capability: Capability) -> Verdict:
+        """The §15 verdict. Every (role, capability) pair has one."""
+        return self._matrix[capability][role]
+
+    def verdict_for_skill(self, role: Role, skill_id: str) -> Verdict:
+        capability = SKILL_CAPABILITY.get(skill_id)
+        if capability is None:
+            # Unknown ids are the registry's business (PG-02), not the
+            # matrix's. Denying here keeps the engine total.
+            return Verdict.DENY
+        return self.verdict(role, capability)
+
+    def enforce(self, role: Role, skill_id: str) -> Verdict:
+        """Raise :class:`AuthorizationError` (ERR-04) unless the call may run.
+
+        ESCALATE and VIEW_RESULT are returned rather than raised: both mean
+        "not a plain allow", and the caller decides what to do with them —
+        route for approval, or serve a cached result.
+        """
+        verdict = self.verdict_for_skill(role, skill_id)
+        if verdict is Verdict.DENY:
+            raise AuthorizationError(
+                f"role {role.value} may not invoke {skill_id}",
+                role=role.value,
+                skill_id=skill_id,
+            )
+        return verdict

--- a/onboarding-intelligence-agent-svc/app/skills/analyze_captured_media.py
+++ b/onboarding-intelligence-agent-svc/app/skills/analyze_captured_media.py
@@ -1,19 +1,23 @@
-"""SKL-OIA-07 — Describe and classify captured media.
+"""SKL-OIA-07 — Describe and classify media captured during the meeting, including OCR.
 
 Design §8.1 · implemented by story H-03.
 
-Scaffolded by A-05. The body raises NotImplementedError deliberately: a
-stub that silently returns None would let a later story ship a no-op
-that passes its tests.
+Registered by A-06: the class exists and the registry resolves and
+instantiates it, so the declaration in config/skills.yaml is proven to point
+at something real. The body is deferred — it raises NotImplementedError
+rather than returning None, so a later story cannot ship a silent no-op.
 """
 
 from __future__ import annotations
 
-_NOT_YET = "app.skills.analyze_captured_media — implemented by H-03"
+from app.skills.base import BaseSkill
+from app.skills.models import SkillContext, SkillResult
+
+_NOT_YET = "SKL-OIA-07 (analyze_captured_media) — implemented by H-03"
 
 
-class AnalyzeCapturedMedia:
-    """Not yet implemented."""
+class AnalyzeCapturedMedia(BaseSkill):
+    """Describe and classify media captured during the meeting, including OCR."""
 
-    def __init__(self, *args: object, **kwargs: object) -> None:
+    async def run(self, context: SkillContext) -> SkillResult:
         raise NotImplementedError(_NOT_YET)

--- a/onboarding-intelligence-agent-svc/app/skills/analyze_transcript_stream.py
+++ b/onboarding-intelligence-agent-svc/app/skills/analyze_transcript_stream.py
@@ -1,19 +1,29 @@
-"""SKL-OIA-04 — Analyse a finalised transcript segment.
+"""SKL-OIA-04 — Analyse a finalized transcript segment against the approved
+questionnaire.
 
 Design §8.1 · implemented by story G-02.
 
-Scaffolded by A-05. The body raises NotImplementedError deliberately: a
-stub that silently returns None would let a later story ship a no-op
-that passes its tests.
+Registered by A-06: the class exists and the registry resolves and
+instantiates it, so the declaration in config/skills.yaml is proven to point
+at something real. The body is deferred — it raises NotImplementedError
+rather than returning None, so a later story cannot ship a silent no-op.
 """
 
 from __future__ import annotations
 
-_NOT_YET = "app.skills.analyze_transcript_stream — implemented by G-02"
+from typing import Any, AsyncIterator
+
+from app.skills.base import StreamingSkill
+from app.skills.models import SkillContext
+
+_NOT_YET = "SKL-OIA-04 (analyze_transcript_stream) — implemented by G-02"
 
 
-class AnalyzeTranscriptStream:
-    """Not yet implemented."""
+class AnalyzeTranscriptStream(StreamingSkill):
+    """Analyse a finalized transcript segment against the approved questionnaire.
 
-    def __init__(self, *args: object, **kwargs: object) -> None:
+    Streaming: output guardrails run per yielded chunk, not once at the end.
+    """
+
+    def stream(self, context: SkillContext) -> AsyncIterator[dict[str, Any]]:
         raise NotImplementedError(_NOT_YET)

--- a/onboarding-intelligence-agent-svc/app/skills/autogen_strategy_identity.py
+++ b/onboarding-intelligence-agent-svc/app/skills/autogen_strategy_identity.py
@@ -1,21 +1,25 @@
-"""SKL-OIA-12 — Auto-generate strategy and identity drafts.
+"""SKL-OIA-12 — Auto-generate strategy and identity drafts from the confirmed onboarding
+profile.
 
 Design §8.1 · implemented by story K-02.
 
-Scaffolded by A-05. The body raises NotImplementedError deliberately: a
-stub that silently returns None would let a later story ship a no-op
-that passes its tests.
+Registered by A-06: the class exists and the registry resolves and
+instantiates it, so the declaration in config/skills.yaml is proven to point
+at something real. The body is deferred — it raises NotImplementedError
+rather than returning None, so a later story cannot ship a silent no-op.
 """
 
 from __future__ import annotations
 
-_NOT_YET = (
-    "SKL-OIA-12 — Auto-generate strategy and identity drafts. — implemented by K-02"
-)
+from app.skills.base import BaseSkill
+from app.skills.models import SkillContext, SkillResult
+
+_NOT_YET = "SKL-OIA-12 (autogen_strategy_identity) — implemented by K-02"
 
 
-class AutogenStrategyIdentity:
-    """Not yet implemented."""
+class AutogenStrategyIdentity(BaseSkill):
+    """Auto-generate strategy and identity drafts from the confirmed onboarding
+    profile."""
 
-    def __init__(self, *args: object, **kwargs: object) -> None:
+    async def run(self, context: SkillContext) -> SkillResult:
         raise NotImplementedError(_NOT_YET)

--- a/onboarding-intelligence-agent-svc/app/skills/base.py
+++ b/onboarding-intelligence-agent-svc/app/skills/base.py
@@ -1,19 +1,49 @@
-"""BaseSkill ABC.
+"""BaseSkill and StreamingSkill (Design §8, §4.5).
 
-Design §8 · implemented by story A-06.
+Neither is the public entry point. AC-2 requires that "a skill invoked
+directly, bypassing the registry, is impossible" — so ``run`` and ``stream``
+are the implementation hooks, and :meth:`SkillRegistry.execute` is the only
+caller. ``__call__`` is deliberately not defined on either class: a skill is
+not callable, so no caller can casually invoke one and skip the guardrails.
 
-Scaffolded by A-05. The body raises NotImplementedError deliberately: a
-stub that silently returns None would let a later story ship a no-op
-that passes its tests.
+``StreamingSkill`` is the one genuine extension over voc-agent-svc. It yields
+rather than returning, which means output guardrails run **per yield** rather
+than once — see :class:`app.logic.guardrails.GuardrailChain.wrap_stream`.
 """
 
 from __future__ import annotations
 
-_NOT_YET = "app.skills.base — implemented by A-06"
+from abc import ABC, abstractmethod
+from typing import Any, AsyncIterator
+
+from app.skills.models import SkillContext, SkillMeta, SkillResult
 
 
-class BaseSkill:
-    """Not yet implemented."""
+class Skill(ABC):
+    """Common surface: every skill knows its own declaration."""
 
-    def __init__(self, *args: object, **kwargs: object) -> None:
-        raise NotImplementedError(_NOT_YET)
+    meta: SkillMeta
+
+    def __init__(self, meta: SkillMeta) -> None:
+        self.meta = meta
+
+
+class BaseSkill(Skill):
+    """A request/response skill."""
+
+    @abstractmethod
+    async def run(self, context: SkillContext) -> SkillResult:
+        """Do the work. Called only by the registry."""
+
+
+class StreamingSkill(Skill):
+    """A skill that yields chunks as they become available.
+
+    Used by SKL-OIA-04, 05 and 06, which are invoked from
+    ``app/logic/live_session.py`` and must deliver partial results inside the
+    live latency budget rather than after the whole batch.
+    """
+
+    @abstractmethod
+    def stream(self, context: SkillContext) -> AsyncIterator[dict[str, Any]]:
+        """Yield result chunks. Called only by the registry."""

--- a/onboarding-intelligence-agent-svc/app/skills/check_workflow_coverage.py
+++ b/onboarding-intelligence-agent-svc/app/skills/check_workflow_coverage.py
@@ -1,19 +1,23 @@
-"""SKL-OIA-09 — Report WF1/WF2/WF3 coverage.
+"""SKL-OIA-09 — Report WF1, WF2 and WF3 coverage as fractions.
 
 Design §8.1 · implemented by story G-06.
 
-Scaffolded by A-05. The body raises NotImplementedError deliberately: a
-stub that silently returns None would let a later story ship a no-op
-that passes its tests.
+Registered by A-06: the class exists and the registry resolves and
+instantiates it, so the declaration in config/skills.yaml is proven to point
+at something real. The body is deferred — it raises NotImplementedError
+rather than returning None, so a later story cannot ship a silent no-op.
 """
 
 from __future__ import annotations
 
-_NOT_YET = "app.skills.check_workflow_coverage — implemented by G-06"
+from app.skills.base import BaseSkill
+from app.skills.models import SkillContext, SkillResult
+
+_NOT_YET = "SKL-OIA-09 (check_workflow_coverage) — implemented by G-06"
 
 
-class CheckWorkflowCoverage:
-    """Not yet implemented."""
+class CheckWorkflowCoverage(BaseSkill):
+    """Report WF1, WF2 and WF3 coverage as fractions."""
 
-    def __init__(self, *args: object, **kwargs: object) -> None:
+    async def run(self, context: SkillContext) -> SkillResult:
         raise NotImplementedError(_NOT_YET)

--- a/onboarding-intelligence-agent-svc/app/skills/evaluate_answer_sufficiency.py
+++ b/onboarding-intelligence-agent-svc/app/skills/evaluate_answer_sufficiency.py
@@ -1,19 +1,28 @@
-"""SKL-OIA-05 — Score whether a question has been answered sufficiently.
+"""SKL-OIA-05 — Score whether a prepared question has been answered sufficiently.
 
 Design §8.1 · implemented by story G-03.
 
-Scaffolded by A-05. The body raises NotImplementedError deliberately: a
-stub that silently returns None would let a later story ship a no-op
-that passes its tests.
+Registered by A-06: the class exists and the registry resolves and
+instantiates it, so the declaration in config/skills.yaml is proven to point
+at something real. The body is deferred — it raises NotImplementedError
+rather than returning None, so a later story cannot ship a silent no-op.
 """
 
 from __future__ import annotations
 
-_NOT_YET = "app.skills.evaluate_answer_sufficiency — implemented by G-03"
+from typing import Any, AsyncIterator
+
+from app.skills.base import StreamingSkill
+from app.skills.models import SkillContext
+
+_NOT_YET = "SKL-OIA-05 (evaluate_answer_sufficiency) — implemented by G-03"
 
 
-class EvaluateAnswerSufficiency:
-    """Not yet implemented."""
+class EvaluateAnswerSufficiency(StreamingSkill):
+    """Score whether a prepared question has been answered sufficiently.
 
-    def __init__(self, *args: object, **kwargs: object) -> None:
+    Streaming: output guardrails run per yielded chunk, not once at the end.
+    """
+
+    def stream(self, context: SkillContext) -> AsyncIterator[dict[str, Any]]:
         raise NotImplementedError(_NOT_YET)

--- a/onboarding-intelligence-agent-svc/app/skills/extract_and_map_fields.py
+++ b/onboarding-intelligence-agent-svc/app/skills/extract_and_map_fields.py
@@ -1,19 +1,25 @@
-"""SKL-OIA-10 — Extract Company fields from evidence and map them.
+"""SKL-OIA-10 — Extract Company fields from the evidence set and map them, attaching
+field-level provenance to every value.
 
 Design §8.1 · implemented by story J-01.
 
-Scaffolded by A-05. The body raises NotImplementedError deliberately: a
-stub that silently returns None would let a later story ship a no-op
-that passes its tests.
+Registered by A-06: the class exists and the registry resolves and
+instantiates it, so the declaration in config/skills.yaml is proven to point
+at something real. The body is deferred — it raises NotImplementedError
+rather than returning None, so a later story cannot ship a silent no-op.
 """
 
 from __future__ import annotations
 
-_NOT_YET = "app.skills.extract_and_map_fields — implemented by J-01"
+from app.skills.base import BaseSkill
+from app.skills.models import SkillContext, SkillResult
+
+_NOT_YET = "SKL-OIA-10 (extract_and_map_fields) — implemented by J-01"
 
 
-class ExtractAndMapFields:
-    """Not yet implemented."""
+class ExtractAndMapFields(BaseSkill):
+    """Extract Company fields from the evidence set and map them, attaching field-level
+    provenance to every value."""
 
-    def __init__(self, *args: object, **kwargs: object) -> None:
+    async def run(self, context: SkillContext) -> SkillResult:
         raise NotImplementedError(_NOT_YET)

--- a/onboarding-intelligence-agent-svc/app/skills/fetch_prompts.py
+++ b/onboarding-intelligence-agent-svc/app/skills/fetch_prompts.py
@@ -1,5 +1,5 @@
 """SKL-OIA-15 — Fetch the pinned prompt set for a session from POI, the Redis cache, or
-the fallbacks (§17.
+the fallbacks (§17.2).
 
 Design §8.1 · implemented by story C-01.
 
@@ -19,7 +19,7 @@ _NOT_YET = "SKL-OIA-15 (fetch_prompts) — implemented by C-01"
 
 class FetchPrompts(BaseSkill):
     """Fetch the pinned prompt set for a session from POI, the Redis cache, or the
-    fallbacks (§17."""
+    fallbacks (§17.2)."""
 
     async def run(self, context: SkillContext) -> SkillResult:
         raise NotImplementedError(_NOT_YET)

--- a/onboarding-intelligence-agent-svc/app/skills/fetch_prompts.py
+++ b/onboarding-intelligence-agent-svc/app/skills/fetch_prompts.py
@@ -1,19 +1,25 @@
-"""SKL-OIA-15 — Fetch pinned prompts for the session.
+"""SKL-OIA-15 — Fetch the pinned prompt set for a session from POI, the Redis cache, or
+the fallbacks (§17.
 
 Design §8.1 · implemented by story C-01.
 
-Scaffolded by A-05. The body raises NotImplementedError deliberately: a
-stub that silently returns None would let a later story ship a no-op
-that passes its tests.
+Registered by A-06: the class exists and the registry resolves and
+instantiates it, so the declaration in config/skills.yaml is proven to point
+at something real. The body is deferred — it raises NotImplementedError
+rather than returning None, so a later story cannot ship a silent no-op.
 """
 
 from __future__ import annotations
 
-_NOT_YET = "app.skills.fetch_prompts — implemented by C-01"
+from app.skills.base import BaseSkill
+from app.skills.models import SkillContext, SkillResult
+
+_NOT_YET = "SKL-OIA-15 (fetch_prompts) — implemented by C-01"
 
 
-class FetchPrompts:
-    """Not yet implemented."""
+class FetchPrompts(BaseSkill):
+    """Fetch the pinned prompt set for a session from POI, the Redis cache, or the
+    fallbacks (§17."""
 
-    def __init__(self, *args: object, **kwargs: object) -> None:
+    async def run(self, context: SkillContext) -> SkillResult:
         raise NotImplementedError(_NOT_YET)

--- a/onboarding-intelligence-agent-svc/app/skills/generate_followups.py
+++ b/onboarding-intelligence-agent-svc/app/skills/generate_followups.py
@@ -1,19 +1,28 @@
-"""SKL-OIA-06 — Suggest follow-up questions.
+"""SKL-OIA-06 — Suggest follow-up questions for a partially answered question.
 
 Design §8.1 · implemented by story G-04.
 
-Scaffolded by A-05. The body raises NotImplementedError deliberately: a
-stub that silently returns None would let a later story ship a no-op
-that passes its tests.
+Registered by A-06: the class exists and the registry resolves and
+instantiates it, so the declaration in config/skills.yaml is proven to point
+at something real. The body is deferred — it raises NotImplementedError
+rather than returning None, so a later story cannot ship a silent no-op.
 """
 
 from __future__ import annotations
 
-_NOT_YET = "app.skills.generate_followups — implemented by G-04"
+from typing import Any, AsyncIterator
+
+from app.skills.base import StreamingSkill
+from app.skills.models import SkillContext
+
+_NOT_YET = "SKL-OIA-06 (generate_followups) — implemented by G-04"
 
 
-class GenerateFollowups:
-    """Not yet implemented."""
+class GenerateFollowups(StreamingSkill):
+    """Suggest follow-up questions for a partially answered question.
 
-    def __init__(self, *args: object, **kwargs: object) -> None:
+    Streaming: output guardrails run per yielded chunk, not once at the end.
+    """
+
+    def stream(self, context: SkillContext) -> AsyncIterator[dict[str, Any]]:
         raise NotImplementedError(_NOT_YET)

--- a/onboarding-intelligence-agent-svc/app/skills/generate_questionnaire.py
+++ b/onboarding-intelligence-agent-svc/app/skills/generate_questionnaire.py
@@ -1,21 +1,23 @@
-"""SKL-OIA-02 — Generate a questionnaire to count and depth.
+"""SKL-OIA-02 — Generate a questionnaire to the operator's requested count and depth.
 
 Design §8.1 · implemented by story C-03.
 
-Scaffolded by A-05. The body raises NotImplementedError deliberately: a
-stub that silently returns None would let a later story ship a no-op
-that passes its tests.
+Registered by A-06: the class exists and the registry resolves and
+instantiates it, so the declaration in config/skills.yaml is proven to point
+at something real. The body is deferred — it raises NotImplementedError
+rather than returning None, so a later story cannot ship a silent no-op.
 """
 
 from __future__ import annotations
 
-_NOT_YET = (
-    "SKL-OIA-02 — Generate a questionnaire to count and depth. — implemented by C-03"
-)
+from app.skills.base import BaseSkill
+from app.skills.models import SkillContext, SkillResult
+
+_NOT_YET = "SKL-OIA-02 (generate_questionnaire) — implemented by C-03"
 
 
-class GenerateQuestionnaire:
-    """Not yet implemented."""
+class GenerateQuestionnaire(BaseSkill):
+    """Generate a questionnaire to the operator's requested count and depth."""
 
-    def __init__(self, *args: object, **kwargs: object) -> None:
+    async def run(self, context: SkillContext) -> SkillResult:
         raise NotImplementedError(_NOT_YET)

--- a/onboarding-intelligence-agent-svc/app/skills/models.py
+++ b/onboarding-intelligence-agent-svc/app/skills/models.py
@@ -9,6 +9,7 @@ declaration or in the skill body, not here.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import StrEnum
 from typing import Any
 
 DEFAULT_TIMEOUT_MS = 30000
@@ -28,6 +29,22 @@ class SkillMeta:
     max_retries: int = DEFAULT_MAX_RETRIES
     timeout_ms: int = DEFAULT_TIMEOUT_MS
     circuit_breaker_dependency: str = ""
+
+
+class Origin(StrEnum):
+    """Where an invocation came from.
+
+    ``internal_only`` skills (SKL-OIA-13, 15, 16) are SYSTEM in §15. The
+    platform has no SYSTEM role, so §8 expresses them as the full role set
+    plus a marker — which means RBAC alone would let any role invoke them.
+    The origin is what actually gates them: only the service's own pipelines
+    may call one, never a caller who arrived over HTTP or a socket.
+    """
+
+    #: Raised by this service's own executors and live-session loop.
+    INTERNAL = "INTERNAL"
+    #: Arrived from outside — an API request, a WebSocket frame.
+    EXTERNAL = "EXTERNAL"
 
 
 @dataclass
@@ -54,6 +71,9 @@ class SkillContext:
     config: dict[str, Any] = field(default_factory=dict)
     previous_outputs: dict[str, Any] = field(default_factory=dict)
     correlation_id: str = ""
+    #: Defaults to EXTERNAL so a caller who forgets to say gets the *stricter*
+    #: treatment rather than accidental access to an internal-only skill.
+    origin: Origin = Origin.EXTERNAL
 
 
 @dataclass

--- a/onboarding-intelligence-agent-svc/app/skills/models.py
+++ b/onboarding-intelligence-agent-svc/app/skills/models.py
@@ -1,19 +1,67 @@
-"""SkillMeta, SkillContext and SkillResult.
+"""SkillMeta, SkillContext and SkillResult (Design §8).
 
-Design §8 · implemented by story A-06.
-
-Scaffolded by A-05. The body raises NotImplementedError deliberately: a
-stub that silently returns None would let a later story ship a no-op
-that passes its tests.
+``SkillMeta`` is the **fleet shape**, matching voc-agent-svc field for field.
+A-06's technical note is blunt: "Do not add fields; a diverging dataclass
+breaks the shared contract test." Anything OIA-specific belongs in the YAML
+declaration or in the skill body, not here.
 """
 
 from __future__ import annotations
 
-_NOT_YET = "app.skills.models — implemented by A-06"
+from dataclasses import dataclass, field
+from typing import Any
+
+DEFAULT_TIMEOUT_MS = 30000
+DEFAULT_MAX_RETRIES = 1
+ALL_ROLES = ("OWNER", "ADMIN", "EDITOR", "VIEWER")
 
 
+@dataclass(frozen=True)
 class SkillMeta:
-    """Not yet implemented."""
+    """Declaration metadata for one skill."""
 
-    def __init__(self, *args: object, **kwargs: object) -> None:
-        raise NotImplementedError(_NOT_YET)
+    skill_id: str
+    name: str
+    description: str = ""
+    allowed_roles: tuple[str, ...] = ALL_ROLES
+    idempotent: bool = True
+    max_retries: int = DEFAULT_MAX_RETRIES
+    timeout_ms: int = DEFAULT_TIMEOUT_MS
+    circuit_breaker_dependency: str = ""
+
+
+@dataclass
+class TenantContext:
+    """Who is calling, resolved from the verified JWT — never from a body."""
+
+    tenant_id: str
+    user_id: str | None = None
+    role: str = "VIEWER"
+    session_id: str | None = None
+
+
+@dataclass
+class SkillContext:
+    """The fleet-standard five inputs (§8), plus who is asking.
+
+    Every skill takes the same five fields; the per-skill meaning of
+    ``input_context`` is documented in each declaration's description.
+    """
+
+    input_prompt: str
+    tenant_context: TenantContext
+    input_context: dict[str, Any] = field(default_factory=dict)
+    config: dict[str, Any] = field(default_factory=dict)
+    previous_outputs: dict[str, Any] = field(default_factory=dict)
+    correlation_id: str = ""
+
+
+@dataclass
+class SkillResult:
+    """What a non-streaming skill returns."""
+
+    skill_id: str
+    output: dict[str, Any] = field(default_factory=dict)
+    confidence: float | None = None
+    duration_ms: int = 0
+    prompt_version: str | None = None

--- a/onboarding-intelligence-agent-svc/app/skills/record_golden_candidates.py
+++ b/onboarding-intelligence-agent-svc/app/skills/record_golden_candidates.py
@@ -1,5 +1,5 @@
 """SKL-OIA-13 — Record admin-edit pairs as golden-dataset candidates for the prompt
-flywheel (§17.
+flywheel (§17.3).
 
 Design §8.1 · implemented by story L-02.
 
@@ -19,7 +19,7 @@ _NOT_YET = "SKL-OIA-13 (record_golden_candidates) — implemented by L-02"
 
 class RecordGoldenCandidates(BaseSkill):
     """Record admin-edit pairs as golden-dataset candidates for the prompt flywheel
-    (§17."""
+    (§17.3)."""
 
     async def run(self, context: SkillContext) -> SkillResult:
         raise NotImplementedError(_NOT_YET)

--- a/onboarding-intelligence-agent-svc/app/skills/record_golden_candidates.py
+++ b/onboarding-intelligence-agent-svc/app/skills/record_golden_candidates.py
@@ -1,19 +1,25 @@
-"""SKL-OIA-13 — Record golden-dataset candidates for the flywheel.
+"""SKL-OIA-13 — Record admin-edit pairs as golden-dataset candidates for the prompt
+flywheel (§17.
 
 Design §8.1 · implemented by story L-02.
 
-Scaffolded by A-05. The body raises NotImplementedError deliberately: a
-stub that silently returns None would let a later story ship a no-op
-that passes its tests.
+Registered by A-06: the class exists and the registry resolves and
+instantiates it, so the declaration in config/skills.yaml is proven to point
+at something real. The body is deferred — it raises NotImplementedError
+rather than returning None, so a later story cannot ship a silent no-op.
 """
 
 from __future__ import annotations
 
-_NOT_YET = "app.skills.record_golden_candidates — implemented by L-02"
+from app.skills.base import BaseSkill
+from app.skills.models import SkillContext, SkillResult
+
+_NOT_YET = "SKL-OIA-13 (record_golden_candidates) — implemented by L-02"
 
 
-class RecordGoldenCandidates:
-    """Not yet implemented."""
+class RecordGoldenCandidates(BaseSkill):
+    """Record admin-edit pairs as golden-dataset candidates for the prompt flywheel
+    (§17."""
 
-    def __init__(self, *args: object, **kwargs: object) -> None:
+    async def run(self, context: SkillContext) -> SkillResult:
         raise NotImplementedError(_NOT_YET)

--- a/onboarding-intelligence-agent-svc/app/skills/redact_pii.py
+++ b/onboarding-intelligence-agent-svc/app/skills/redact_pii.py
@@ -1,21 +1,25 @@
-"""SKL-OIA-16 — Redact PII before buffering or prompting.
+"""SKL-OIA-16 — Redact PII from a transcript segment before it is buffered, prompted or
+indexed (IG-04).
 
 Design §8.1 · implemented by story F-05.
 
-Scaffolded by A-05. The body raises NotImplementedError deliberately: a
-stub that silently returns None would let a later story ship a no-op
-that passes its tests.
+Registered by A-06: the class exists and the registry resolves and
+instantiates it, so the declaration in config/skills.yaml is proven to point
+at something real. The body is deferred — it raises NotImplementedError
+rather than returning None, so a later story cannot ship a silent no-op.
 """
 
 from __future__ import annotations
 
-_NOT_YET = (
-    "SKL-OIA-16 — Redact PII before buffering or prompting. — implemented by F-05"
-)
+from app.skills.base import BaseSkill
+from app.skills.models import SkillContext, SkillResult
+
+_NOT_YET = "SKL-OIA-16 (redact_pii) — implemented by F-05"
 
 
-class RedactPii:
-    """Not yet implemented."""
+class RedactPii(BaseSkill):
+    """Redact PII from a transcript segment before it is buffered, prompted or indexed
+    (IG-04)."""
 
-    def __init__(self, *args: object, **kwargs: object) -> None:
+    async def run(self, context: SkillContext) -> SkillResult:
         raise NotImplementedError(_NOT_YET)

--- a/onboarding-intelligence-agent-svc/app/skills/refine_questionnaire.py
+++ b/onboarding-intelligence-agent-svc/app/skills/refine_questionnaire.py
@@ -2,18 +2,22 @@
 
 Design §8.1 · implemented by story C-04.
 
-Scaffolded by A-05. The body raises NotImplementedError deliberately: a
-stub that silently returns None would let a later story ship a no-op
-that passes its tests.
+Registered by A-06: the class exists and the registry resolves and
+instantiates it, so the declaration in config/skills.yaml is proven to point
+at something real. The body is deferred — it raises NotImplementedError
+rather than returning None, so a later story cannot ship a silent no-op.
 """
 
 from __future__ import annotations
 
-_NOT_YET = "app.skills.refine_questionnaire — implemented by C-04"
+from app.skills.base import BaseSkill
+from app.skills.models import SkillContext, SkillResult
+
+_NOT_YET = "SKL-OIA-03 (refine_questionnaire) — implemented by C-04"
 
 
-class RefineQuestionnaire:
-    """Not yet implemented."""
+class RefineQuestionnaire(BaseSkill):
+    """Refine and approve the questionnaire interactively."""
 
-    def __init__(self, *args: object, **kwargs: object) -> None:
+    async def run(self, context: SkillContext) -> SkillResult:
         raise NotImplementedError(_NOT_YET)

--- a/onboarding-intelligence-agent-svc/app/skills/register_meeting_assets.py
+++ b/onboarding-intelligence-agent-svc/app/skills/register_meeting_assets.py
@@ -1,19 +1,25 @@
-"""SKL-OIA-11 — Register meeting media as BrandAssets.
+"""SKL-OIA-11 — Register recordings, transcripts and captured media as BrandAssets
+through the Django API.
 
 Design §8.1 · implemented by story J-03.
 
-Scaffolded by A-05. The body raises NotImplementedError deliberately: a
-stub that silently returns None would let a later story ship a no-op
-that passes its tests.
+Registered by A-06: the class exists and the registry resolves and
+instantiates it, so the declaration in config/skills.yaml is proven to point
+at something real. The body is deferred — it raises NotImplementedError
+rather than returning None, so a later story cannot ship a silent no-op.
 """
 
 from __future__ import annotations
 
-_NOT_YET = "app.skills.register_meeting_assets — implemented by J-03"
+from app.skills.base import BaseSkill
+from app.skills.models import SkillContext, SkillResult
+
+_NOT_YET = "SKL-OIA-11 (register_meeting_assets) — implemented by J-03"
 
 
-class RegisterMeetingAssets:
-    """Not yet implemented."""
+class RegisterMeetingAssets(BaseSkill):
+    """Register recordings, transcripts and captured media as BrandAssets through the
+    Django API."""
 
-    def __init__(self, *args: object, **kwargs: object) -> None:
+    async def run(self, context: SkillContext) -> SkillResult:
         raise NotImplementedError(_NOT_YET)

--- a/onboarding-intelligence-agent-svc/app/skills/registry.py
+++ b/onboarding-intelligence-agent-svc/app/skills/registry.py
@@ -1,19 +1,223 @@
-"""SkillRegistry with dual id and name lookup.
+"""SkillRegistry — the only way a skill runs (Design §8, §4.5).
 
-Design §8 · implemented by story A-06.
+Three properties AC-1 and AC-2 turn on:
 
-Scaffolded by A-05. The body raises NotImplementedError deliberately: a
-stub that silently returns None would let a later story ship a no-op
-that passes its tests.
+**Skills load from configuration, not from imports.** ``config/skills.yaml``
+is the source of truth; the registry resolves each declaration to its
+implementing class. A declaration whose class is missing fails **at startup**
+with a message naming the skill, not on first invocation six weeks later.
+
+**Lookup is by both id and name.** ``SKL-OIA-04`` and
+``analyze_transcript_stream`` reach the same skill.
+
+**Guardrails cannot be skipped.** :meth:`execute` is the public entry point;
+``BaseSkill`` defines ``run`` and is not callable, so there is no convenient
+way to invoke a skill without passing IG → PG → OG and the §15 matrix.
 """
 
 from __future__ import annotations
 
-_NOT_YET = "app.skills.registry — implemented by A-06"
+import importlib
+import time
+from pathlib import Path
+from typing import Any, AsyncIterator
+
+import yaml
+
+from app.core.errors import SkillNotFound
+from app.core.logging import get_logger
+from app.logic.guardrails import GuardrailChain, Layer
+from app.rbac.engine import RBACEngine, Role, Verdict
+from app.skills.base import BaseSkill, Skill, StreamingSkill
+from app.skills.models import SkillContext, SkillMeta, SkillResult
+
+logger = get_logger(__name__)
+
+DEFAULT_CONFIG = Path(__file__).resolve().parents[2] / "config" / "skills.yaml"
+
+#: Declaration name → module under app.skills. The module is the name; the
+#: class is its PascalCase form, matching what A-05 scaffolded.
+MODULE_TEMPLATE = "app.skills.{name}"
+
+
+class SkillRegistryError(RuntimeError):
+    """Startup failure: a declaration could not be resolved."""
 
 
 class SkillRegistry:
-    """Not yet implemented."""
+    """Loads, resolves and executes the sixteen declared skills."""
 
-    def __init__(self, *args: object, **kwargs: object) -> None:
-        raise NotImplementedError(_NOT_YET)
+    def __init__(
+        self,
+        chain: GuardrailChain | None = None,
+        rbac: RBACEngine | None = None,
+    ) -> None:
+        self._by_id: dict[str, Skill] = {}
+        self._by_name: dict[str, Skill] = {}
+        self._meta: dict[str, SkillMeta] = {}
+        self._internal_only: set[str] = set()
+        self.chain = chain or GuardrailChain()
+        self.rbac = rbac or RBACEngine()
+
+    # ── Loading ──────────────────────────────────────────────
+    def load(self, config_path: Path | None = None, *, resolve: bool = True) -> None:
+        """Read the YAML and resolve every declaration.
+
+        ``resolve=False`` loads metadata without importing implementations —
+        used by the contract test, which validates the YAML rather than the
+        code behind it.
+        """
+        path = config_path or DEFAULT_CONFIG
+        document = yaml.safe_load(path.read_text())
+        declarations = document.get("skills") or []
+
+        missing: list[str] = []
+        for declaration in declarations:
+            meta = self._meta_from(declaration)
+            self._meta[meta.skill_id] = meta
+            if declaration.get("internal_only"):
+                self._internal_only.add(meta.skill_id)
+
+            if not resolve:
+                continue
+            try:
+                skill = self._resolve(meta)
+            except SkillRegistryError as exc:
+                missing.append(str(exc))
+                continue
+            self._by_id[meta.skill_id] = skill
+            self._by_name[meta.name] = skill
+
+        if missing:
+            # Named, and all of them — reporting one at a time would mean one
+            # failed deploy per missing skill.
+            raise SkillRegistryError(
+                "skill declarations could not be resolved:\n  " + "\n  ".join(missing)
+            )
+
+        logger.info(
+            "skill_registry_loaded",
+            declared=len(self._meta),
+            resolved=len(self._by_id),
+            internal_only=sorted(self._internal_only),
+        )
+
+    @staticmethod
+    def _meta_from(declaration: dict[str, Any]) -> SkillMeta:
+        return SkillMeta(
+            skill_id=declaration["skill_id"],
+            name=declaration["name"],
+            description=(declaration.get("description") or "").strip(),
+            allowed_roles=tuple(declaration.get("allowed_roles") or ()),
+            idempotent=bool(declaration.get("idempotent", True)),
+            max_retries=int(declaration.get("max_retries", 1)),
+            timeout_ms=int(declaration.get("timeout_ms", 30000)),
+            circuit_breaker_dependency=declaration.get("circuit_breaker_dependency", "")
+            or "",
+        )
+
+    @staticmethod
+    def _resolve(meta: SkillMeta) -> Skill:
+        """Import the module and instantiate the class named by the skill."""
+        module_path = MODULE_TEMPLATE.format(name=meta.name)
+        class_name = "".join(part.title() for part in meta.name.split("_"))
+        try:
+            module = importlib.import_module(module_path)
+        except ImportError as exc:
+            raise SkillRegistryError(
+                f"{meta.skill_id} ({meta.name}): module {module_path} "
+                f"not importable — {exc}"
+            ) from exc
+
+        implementation = getattr(module, class_name, None)
+        if implementation is None:
+            raise SkillRegistryError(
+                f"{meta.skill_id} ({meta.name}): {module_path} has no class "
+                f"{class_name}"
+            )
+        if not isinstance(implementation, type) or not issubclass(
+            implementation, (BaseSkill, StreamingSkill)
+        ):
+            raise SkillRegistryError(
+                f"{meta.skill_id} ({meta.name}): {class_name} is not a BaseSkill "
+                "or StreamingSkill"
+            )
+        return implementation(meta)
+
+    # ── Lookup ───────────────────────────────────────────────
+    def get(self, key: str) -> Skill:
+        """Look up by skill id or by name. PG-02's allowlist in one method."""
+        skill = self._by_id.get(key) or self._by_name.get(key)
+        if skill is None:
+            raise SkillNotFound(f"no skill registered as {key!r}", skill_id=key)
+        return skill
+
+    def meta(self, key: str) -> SkillMeta:
+        meta = self._meta.get(key)
+        if meta is None:
+            for candidate in self._meta.values():
+                if candidate.name == key:
+                    return candidate
+            raise SkillNotFound(f"no skill declared as {key!r}", skill_id=key)
+        return meta
+
+    def is_internal_only(self, skill_id: str) -> bool:
+        return skill_id in self._internal_only
+
+    @property
+    def skill_ids(self) -> list[str]:
+        return sorted(self._meta)
+
+    # ── Execution ────────────────────────────────────────────
+    async def execute(self, key: str, context: SkillContext) -> SkillResult:
+        """Run a non-streaming skill through the full chain.
+
+        Order is IG → RBAC (PG-03) → PG → skill → OG, and none of it is
+        optional. A caller who wants to skip a layer has to edit this method,
+        which is the point.
+        """
+        skill = self.get(key)
+        meta = skill.meta
+
+        self.chain.evaluate(Layer.INPUT, context.input_context, context)
+        self._authorize(meta, context)
+        self.chain.evaluate(Layer.PROCESS, meta, context)
+
+        started = time.perf_counter()
+        if not isinstance(skill, BaseSkill):
+            raise SkillNotFound(
+                f"{meta.skill_id} is a streaming skill — use execute_stream",
+                skill_id=meta.skill_id,
+            )
+        result = await skill.run(context)
+        result.duration_ms = int((time.perf_counter() - started) * 1000)
+
+        return self.chain.evaluate_result(result, context)
+
+    async def execute_stream(
+        self, key: str, context: SkillContext
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Run a streaming skill, evaluating OG on every chunk."""
+        skill = self.get(key)
+        meta = skill.meta
+
+        self.chain.evaluate(Layer.INPUT, context.input_context, context)
+        self._authorize(meta, context)
+        self.chain.evaluate(Layer.PROCESS, meta, context)
+
+        if not isinstance(skill, StreamingSkill):
+            raise SkillNotFound(
+                f"{meta.skill_id} is not a streaming skill — use execute",
+                skill_id=meta.skill_id,
+            )
+        async for chunk in self.chain.wrap_stream(skill.stream(context), context):
+            yield chunk
+
+    def _authorize(self, meta: SkillMeta, context: SkillContext) -> Verdict:
+        """PG-03. Raises ERR-04 on a denial; ESCALATE and VIEW_RESULT pass through.
+
+        The role is taken from the tenant context, which is populated from the
+        verified JWT claim — §15 forbids reading it from a body or a header.
+        """
+        role = Role(context.tenant_context.role)
+        return self.rbac.enforce(role, meta.skill_id)

--- a/onboarding-intelligence-agent-svc/app/skills/registry.py
+++ b/onboarding-intelligence-agent-svc/app/skills/registry.py
@@ -24,12 +24,12 @@ from typing import Any, AsyncIterator
 
 import yaml
 
-from app.core.errors import SkillNotFound
+from app.core.errors import AuthorizationError, SkillNotFound
 from app.core.logging import get_logger
 from app.logic.guardrails import GuardrailChain, Layer
 from app.rbac.engine import RBACEngine, Role, Verdict
 from app.skills.base import BaseSkill, Skill, StreamingSkill
-from app.skills.models import SkillContext, SkillMeta, SkillResult
+from app.skills.models import Origin, SkillContext, SkillMeta, SkillResult
 
 logger = get_logger(__name__)
 
@@ -179,7 +179,11 @@ class SkillRegistry:
         skill = self.get(key)
         meta = skill.meta
 
-        self.chain.evaluate(Layer.INPUT, context.input_context, context)
+        # The evaluated payload is assigned back: IG-04 redacts and IG-06
+        # truncates, and a transform the skill never sees is not a guardrail.
+        context.input_context = self.chain.evaluate(
+            Layer.INPUT, context.input_context, context
+        )
         self._authorize(meta, context)
         self.chain.evaluate(Layer.PROCESS, meta, context)
 
@@ -201,7 +205,9 @@ class SkillRegistry:
         skill = self.get(key)
         meta = skill.meta
 
-        self.chain.evaluate(Layer.INPUT, context.input_context, context)
+        context.input_context = self.chain.evaluate(
+            Layer.INPUT, context.input_context, context
+        )
         self._authorize(meta, context)
         self.chain.evaluate(Layer.PROCESS, meta, context)
 
@@ -218,6 +224,20 @@ class SkillRegistry:
 
         The role is taken from the tenant context, which is populated from the
         verified JWT claim — §15 forbids reading it from a body or a header.
+
+        ``internal_only`` is checked **before** the matrix, because the matrix
+        cannot express it: those skills carry the full role set precisely
+        because the platform has no SYSTEM role, so every role would pass.
+        Origin is the gate.
         """
+        if (
+            self.is_internal_only(meta.skill_id)
+            and context.origin is not Origin.INTERNAL
+        ):
+            raise AuthorizationError(
+                f"{meta.skill_id} is internal-only and cannot be invoked externally",
+                skill_id=meta.skill_id,
+                origin=context.origin.value,
+            )
         role = Role(context.tenant_context.role)
         return self.rbac.enforce(role, meta.skill_id)

--- a/onboarding-intelligence-agent-svc/app/skills/research_business.py
+++ b/onboarding-intelligence-agent-svc/app/skills/research_business.py
@@ -1,21 +1,24 @@
-"""SKL-OIA-01 — Research the business from operator hints.
+"""SKL-OIA-01 — Research the prospective brand's business ahead of the onboarding
+meeting.
 
 Design §8.1 · implemented by story C-02.
 
-Scaffolded by A-05. The body raises NotImplementedError deliberately: a
-stub that silently returns None would let a later story ship a no-op
-that passes its tests.
+Registered by A-06: the class exists and the registry resolves and
+instantiates it, so the declaration in config/skills.yaml is proven to point
+at something real. The body is deferred — it raises NotImplementedError
+rather than returning None, so a later story cannot ship a silent no-op.
 """
 
 from __future__ import annotations
 
-_NOT_YET = (
-    "SKL-OIA-01 — Research the business from operator hints. — implemented by C-02"
-)
+from app.skills.base import BaseSkill
+from app.skills.models import SkillContext, SkillResult
+
+_NOT_YET = "SKL-OIA-01 (research_business) — implemented by C-02"
 
 
-class ResearchBusiness:
-    """Not yet implemented."""
+class ResearchBusiness(BaseSkill):
+    """Research the prospective brand's business ahead of the onboarding meeting."""
 
-    def __init__(self, *args: object, **kwargs: object) -> None:
+    async def run(self, context: SkillContext) -> SkillResult:
         raise NotImplementedError(_NOT_YET)

--- a/onboarding-intelligence-agent-svc/app/skills/summarize_recording.py
+++ b/onboarding-intelligence-agent-svc/app/skills/summarize_recording.py
@@ -1,19 +1,23 @@
-"""SKL-OIA-08 — Summarise a recording into key moments.
+"""SKL-OIA-08 — Summarise a recording into key moments with timestamps.
 
 Design §8.1 · implemented by story I-02.
 
-Scaffolded by A-05. The body raises NotImplementedError deliberately: a
-stub that silently returns None would let a later story ship a no-op
-that passes its tests.
+Registered by A-06: the class exists and the registry resolves and
+instantiates it, so the declaration in config/skills.yaml is proven to point
+at something real. The body is deferred — it raises NotImplementedError
+rather than returning None, so a later story cannot ship a silent no-op.
 """
 
 from __future__ import annotations
 
-_NOT_YET = "app.skills.summarize_recording — implemented by I-02"
+from app.skills.base import BaseSkill
+from app.skills.models import SkillContext, SkillResult
+
+_NOT_YET = "SKL-OIA-08 (summarize_recording) — implemented by I-02"
 
 
-class SummarizeRecording:
-    """Not yet implemented."""
+class SummarizeRecording(BaseSkill):
+    """Summarise a recording into key moments with timestamps."""
 
-    def __init__(self, *args: object, **kwargs: object) -> None:
+    async def run(self, context: SkillContext) -> SkillResult:
         raise NotImplementedError(_NOT_YET)

--- a/onboarding-intelligence-agent-svc/app/skills/surface_conflicts_and_escalate.py
+++ b/onboarding-intelligence-agent-svc/app/skills/surface_conflicts_and_escalate.py
@@ -1,21 +1,24 @@
-"""SKL-OIA-14 — Surface conflicting evidence and escalate.
+"""SKL-OIA-14 — Surface conflicting evidence for a field and escalate for human
+resolution.
 
 Design §8.1 · implemented by story J-04.
 
-Scaffolded by A-05. The body raises NotImplementedError deliberately: a
-stub that silently returns None would let a later story ship a no-op
-that passes its tests.
+Registered by A-06: the class exists and the registry resolves and
+instantiates it, so the declaration in config/skills.yaml is proven to point
+at something real. The body is deferred — it raises NotImplementedError
+rather than returning None, so a later story cannot ship a silent no-op.
 """
 
 from __future__ import annotations
 
-_NOT_YET = (
-    "SKL-OIA-14 — Surface conflicting evidence and escalate. — implemented by J-04"
-)
+from app.skills.base import BaseSkill
+from app.skills.models import SkillContext, SkillResult
+
+_NOT_YET = "SKL-OIA-14 (surface_conflicts_and_escalate) — implemented by J-04"
 
 
-class SurfaceConflictsAndEscalate:
-    """Not yet implemented."""
+class SurfaceConflictsAndEscalate(BaseSkill):
+    """Surface conflicting evidence for a field and escalate for human resolution."""
 
-    def __init__(self, *args: object, **kwargs: object) -> None:
+    async def run(self, context: SkillContext) -> SkillResult:
         raise NotImplementedError(_NOT_YET)

--- a/onboarding-intelligence-agent-svc/config/skills.yaml
+++ b/onboarding-intelligence-agent-svc/config/skills.yaml
@@ -1,20 +1,442 @@
-# Machine-readable skill registry — Design §8.
+# Onboarding Intelligence Agent (OIA) — Skill Registry
 #
-# A-05 lands this file empty of skills so that config loading, schema
-# validation and tests/test_skills_yaml.py have something real to parse from
-# the first commit. Each skill is declared here by the story that implements
-# it, alongside its module in app/skills/.
+# This file IS Design §8. It follows the fleet contract established by
+# voc-agent-svc/config/skills.yaml and is validated by
+# tests/test_skills_yaml.py: ids match ^SKL-OIA-\d{2}[a-z]?$, roles are drawn
+# from {OWNER, ADMIN, EDITOR, VIEWER}, timeout_ms <= 120000, every
+# input_schema entry carries field/type/required, and the count is exactly 16.
 #
-# Declaration shape (see Design §8.1):
+# Every skill takes the same five inputs; the per-skill meaning of
+# input_context is documented in each description.
 #
-#   - id: SKL-OIA-01
-#     name: research_business
-#     module: app.skills.research_business
-#     modes: [PREP]
-#     roles: [Owner, Admin, Editor]
-#     input_schema: {...}
-#     output_schema: {...}
+# SYSTEM in §15's allowed_roles is expressed as the full role set plus
+# internal_only: true, because the platform has no SYSTEM role.
+#
+# Streaming skills (04, 05, 06) are invoked from app/logic/live_session.py
+# only, and their output guardrails run per yielded chunk.
 
 version: 1
 service: onboarding-intelligence-agent
-skills: []
+skills:
+  - skill_id: SKL-OIA-01
+    name: research_business
+    description: >-
+      Research the prospective brand's business ahead of the onboarding meeting. input_context carries {company_name, website, industry, operator_notes}.
+    input_schema:
+      - field: input_prompt
+        type: string
+        required: true
+      - field: input_context
+        type: object
+        required: true
+      - field: tenant_context
+        type: TenantContext
+        required: true
+      - field: config
+        type: object
+        required: false
+      - field: previous_outputs
+        type: object
+        required: false
+    timeout_ms: 60000
+    max_retries: 2
+    allowed_roles: [OWNER, ADMIN, EDITOR]
+    idempotent: true
+    circuit_breaker_dependency: "tavily"
+
+  - skill_id: SKL-OIA-02
+    name: generate_questionnaire
+    description: >-
+      Generate a questionnaire to the operator's requested count and depth. input_context carries the BusinessResearchBrief from SKL-OIA-01.
+    input_schema:
+      - field: input_prompt
+        type: string
+        required: true
+      - field: input_context
+        type: object
+        required: true
+      - field: tenant_context
+        type: TenantContext
+        required: true
+      - field: config
+        type: object
+        required: false
+      - field: previous_outputs
+        type: object
+        required: false
+    timeout_ms: 30000
+    max_retries: 2
+    allowed_roles: [OWNER, ADMIN, EDITOR]
+    idempotent: true
+    circuit_breaker_dependency: "llm"
+
+  - skill_id: SKL-OIA-03
+    name: refine_questionnaire
+    description: >-
+      Refine and approve the questionnaire interactively. input_context carries the current draft and the operator's edit instruction.
+    input_schema:
+      - field: input_prompt
+        type: string
+        required: true
+      - field: input_context
+        type: object
+        required: true
+      - field: tenant_context
+        type: TenantContext
+        required: true
+      - field: config
+        type: object
+        required: false
+      - field: previous_outputs
+        type: object
+        required: false
+    timeout_ms: 20000
+    max_retries: 2
+    allowed_roles: [OWNER, ADMIN, EDITOR]
+    idempotent: false
+    circuit_breaker_dependency: "llm"
+
+  - skill_id: SKL-OIA-04
+    name: analyze_transcript_stream
+    description: >-
+      Analyse a finalized transcript segment against the approved questionnaire. Invoked from app/logic/live_session.py only.
+    input_schema:
+      - field: input_prompt
+        type: string
+        required: true
+      - field: input_context
+        type: object
+        required: true
+      - field: tenant_context
+        type: TenantContext
+        required: true
+      - field: config
+        type: object
+        required: false
+      - field: previous_outputs
+        type: object
+        required: false
+    timeout_ms: 5000
+    max_retries: 1
+    allowed_roles: [OWNER, ADMIN, EDITOR]
+    idempotent: true
+    circuit_breaker_dependency: "llm"
+    streaming: true
+
+  - skill_id: SKL-OIA-05
+    name: evaluate_answer_sufficiency
+    description: >-
+      Score whether a prepared question has been answered sufficiently. Emits the green signal above the configured threshold.
+    input_schema:
+      - field: input_prompt
+        type: string
+        required: true
+      - field: input_context
+        type: object
+        required: true
+      - field: tenant_context
+        type: TenantContext
+        required: true
+      - field: config
+        type: object
+        required: false
+      - field: previous_outputs
+        type: object
+        required: false
+    timeout_ms: 5000
+    max_retries: 1
+    allowed_roles: [OWNER, ADMIN, EDITOR]
+    idempotent: true
+    circuit_breaker_dependency: "llm"
+    streaming: true
+
+  - skill_id: SKL-OIA-06
+    name: generate_followups
+    description: >-
+      Suggest follow-up questions for a partially answered question. Acceptance is backfilled on use (EVT-105).
+    input_schema:
+      - field: input_prompt
+        type: string
+        required: true
+      - field: input_context
+        type: object
+        required: true
+      - field: tenant_context
+        type: TenantContext
+        required: true
+      - field: config
+        type: object
+        required: false
+      - field: previous_outputs
+        type: object
+        required: false
+    timeout_ms: 5000
+    max_retries: 1
+    allowed_roles: [OWNER, ADMIN, EDITOR]
+    idempotent: false
+    circuit_breaker_dependency: "llm"
+    streaming: true
+
+  - skill_id: SKL-OIA-07
+    name: analyze_captured_media
+    description: >-
+      Describe and classify media captured during the meeting, including OCR. input_context carries {media_id, gcs_uri, usage_tag}.
+    input_schema:
+      - field: input_prompt
+        type: string
+        required: true
+      - field: input_context
+        type: object
+        required: true
+      - field: tenant_context
+        type: TenantContext
+        required: true
+      - field: config
+        type: object
+        required: false
+      - field: previous_outputs
+        type: object
+        required: false
+    timeout_ms: 90000
+    max_retries: 2
+    allowed_roles: [OWNER, ADMIN, EDITOR]
+    idempotent: true
+    circuit_breaker_dependency: "vision"
+
+  - skill_id: SKL-OIA-08
+    name: summarize_recording
+    description: >-
+      Summarise a recording into key moments with timestamps. VIEWER may read the result but not invoke it (§15).
+    input_schema:
+      - field: input_prompt
+        type: string
+        required: true
+      - field: input_context
+        type: object
+        required: true
+      - field: tenant_context
+        type: TenantContext
+        required: true
+      - field: config
+        type: object
+        required: false
+      - field: previous_outputs
+        type: object
+        required: false
+    timeout_ms: 60000
+    max_retries: 2
+    allowed_roles: [OWNER, ADMIN, EDITOR, VIEWER]
+    idempotent: true
+    circuit_breaker_dependency: "llm"
+
+  - skill_id: SKL-OIA-09
+    name: check_workflow_coverage
+    description: >-
+      Report WF1, WF2 and WF3 coverage as fractions. Runs incrementally during LIVE and fully during PROCESS.
+    input_schema:
+      - field: input_prompt
+        type: string
+        required: true
+      - field: input_context
+        type: object
+        required: true
+      - field: tenant_context
+        type: TenantContext
+        required: true
+      - field: config
+        type: object
+        required: false
+      - field: previous_outputs
+        type: object
+        required: false
+    timeout_ms: 20000
+    max_retries: 2
+    allowed_roles: [OWNER, ADMIN, EDITOR, VIEWER]
+    idempotent: true
+    circuit_breaker_dependency: "llm"
+
+  - skill_id: SKL-OIA-10
+    name: extract_and_map_fields
+    description: >-
+      Extract Company fields from the evidence set and map them, attaching field-level provenance to every value.
+    input_schema:
+      - field: input_prompt
+        type: string
+        required: true
+      - field: input_context
+        type: object
+        required: true
+      - field: tenant_context
+        type: TenantContext
+        required: true
+      - field: config
+        type: object
+        required: false
+      - field: previous_outputs
+        type: object
+        required: false
+    timeout_ms: 120000
+    max_retries: 1
+    allowed_roles: [OWNER, ADMIN, EDITOR]
+    idempotent: true
+    circuit_breaker_dependency: "backend"
+
+  - skill_id: SKL-OIA-11
+    name: register_meeting_assets
+    description: >-
+      Register recordings, transcripts and captured media as BrandAssets through the Django API.
+    input_schema:
+      - field: input_prompt
+        type: string
+        required: true
+      - field: input_context
+        type: object
+        required: true
+      - field: tenant_context
+        type: TenantContext
+        required: true
+      - field: config
+        type: object
+        required: false
+      - field: previous_outputs
+        type: object
+        required: false
+    timeout_ms: 30000
+    max_retries: 3
+    allowed_roles: [OWNER, ADMIN, EDITOR]
+    idempotent: true
+    circuit_breaker_dependency: "backend"
+
+  - skill_id: SKL-OIA-12
+    name: autogen_strategy_identity
+    description: >-
+      Auto-generate strategy and identity drafts from the confirmed onboarding profile.
+    input_schema:
+      - field: input_prompt
+        type: string
+        required: true
+      - field: input_context
+        type: object
+        required: true
+      - field: tenant_context
+        type: TenantContext
+        required: true
+      - field: config
+        type: object
+        required: false
+      - field: previous_outputs
+        type: object
+        required: false
+    timeout_ms: 90000
+    max_retries: 1
+    allowed_roles: [OWNER, ADMIN, EDITOR]
+    idempotent: true
+    circuit_breaker_dependency: "backend"
+
+  - skill_id: SKL-OIA-13
+    name: record_golden_candidates
+    description: >-
+      Record admin-edit pairs as golden-dataset candidates for the prompt flywheel (§17.3). SYSTEM in §15; internal_only here because the platform has no SYSTEM role.
+    input_schema:
+      - field: input_prompt
+        type: string
+        required: true
+      - field: input_context
+        type: object
+        required: true
+      - field: tenant_context
+        type: TenantContext
+        required: true
+      - field: config
+        type: object
+        required: false
+      - field: previous_outputs
+        type: object
+        required: false
+    timeout_ms: 30000
+    max_retries: 3
+    allowed_roles: [OWNER, ADMIN, EDITOR, VIEWER]
+    idempotent: true
+    circuit_breaker_dependency: "poi"
+    internal_only: true
+
+  - skill_id: SKL-OIA-14
+    name: surface_conflicts_and_escalate
+    description: >-
+      Surface conflicting evidence for a field and escalate for human resolution. EDITOR is ESCALATE rather than ALLOW (§15).
+    input_schema:
+      - field: input_prompt
+        type: string
+        required: true
+      - field: input_context
+        type: object
+        required: true
+      - field: tenant_context
+        type: TenantContext
+        required: true
+      - field: config
+        type: object
+        required: false
+      - field: previous_outputs
+        type: object
+        required: false
+    timeout_ms: 10000
+    max_retries: 2
+    allowed_roles: [OWNER, ADMIN, EDITOR]
+    idempotent: false
+    circuit_breaker_dependency: ""
+
+  - skill_id: SKL-OIA-15
+    name: fetch_prompts
+    description: >-
+      Fetch the pinned prompt set for a session from POI, the Redis cache, or the fallbacks (§17.2). Internal plumbing.
+    input_schema:
+      - field: input_prompt
+        type: string
+        required: true
+      - field: input_context
+        type: object
+        required: true
+      - field: tenant_context
+        type: TenantContext
+        required: true
+      - field: config
+        type: object
+        required: false
+      - field: previous_outputs
+        type: object
+        required: false
+    timeout_ms: 3000
+    max_retries: 1
+    allowed_roles: [OWNER, ADMIN, EDITOR, VIEWER]
+    idempotent: true
+    circuit_breaker_dependency: "poi"
+    internal_only: true
+
+  - skill_id: SKL-OIA-16
+    name: redact_pii
+    description: >-
+      Redact PII from a transcript segment before it is buffered, prompted or indexed (IG-04). Internal plumbing.
+    input_schema:
+      - field: input_prompt
+        type: string
+        required: true
+      - field: input_context
+        type: object
+        required: true
+      - field: tenant_context
+        type: TenantContext
+        required: true
+      - field: config
+        type: object
+        required: false
+      - field: previous_outputs
+        type: object
+        required: false
+    timeout_ms: 2000
+    max_retries: 1
+    allowed_roles: [OWNER, ADMIN, EDITOR, VIEWER]
+    idempotent: true
+    circuit_breaker_dependency: ""
+    internal_only: true
+

--- a/onboarding-intelligence-agent-svc/requirements-dev.txt
+++ b/onboarding-intelligence-agent-svc/requirements-dev.txt
@@ -5,3 +5,4 @@ hypothesis>=6.100.0
 black>=24.0.0
 flake8>=7.0.0
 mypy>=1.11.0
+types-PyYAML>=6.0.12

--- a/onboarding-intelligence-agent-svc/tests/integration/test_kafka_roundtrip.py
+++ b/onboarding-intelligence-agent-svc/tests/integration/test_kafka_roundtrip.py
@@ -101,33 +101,46 @@ async def read_one(topic: str, timeout: float = 30.0) -> dict | None:
         await consumer.stop()
 
 
-async def read_matching(
-    topic: str, predicate, limit: int = 100, timeout: float = 20.0
-) -> dict | None:
-    """Return the first message on ``topic`` satisfying ``predicate``.
+async def end_offsets(topic: str) -> dict:
+    """Where the topic ends *now*, so a test can read only what it adds.
 
-    Position-independent on purpose. These topics accumulate across tests and
-    across runs — the round-trip probe and the dead letters share the DLQ — so
-    "the first message" is not necessarily the one under test.
+    Scanning from the beginning does not scale: these topics retain messages
+    for 1-30 days, so after a few runs the message under test sits behind a
+    growing backlog and a bounded scan stops finding it. Reading forward from
+    a captured offset is O(1) in history.
     """
-    consumer = AIOKafkaConsumer(
-        bootstrap_servers=BOOTSTRAP,
-        auto_offset_reset="earliest",
-        enable_auto_commit=False,
-    )
+    consumer = AIOKafkaConsumer(bootstrap_servers=BOOTSTRAP)
     await consumer.start()
     try:
-        partitions = consumer.partitions_for_topic(topic)
-        if not partitions:
-            return None
+        partitions = consumer.partitions_for_topic(topic) or set()
         assignment = [TopicPartition(topic, p) for p in partitions]
+        if not assignment:
+            return {}
         consumer.assign(assignment)
-        await consumer.seek_to_beginning(*assignment)
-        for _ in range(limit):
+        return await consumer.end_offsets(assignment)
+    finally:
+        await consumer.stop()
+
+
+async def read_since(
+    topic: str, offsets: dict, predicate, timeout: float = 30.0
+) -> dict | None:
+    """Return the first message after ``offsets`` satisfying ``predicate``."""
+    if not offsets:
+        return None
+    consumer = AIOKafkaConsumer(bootstrap_servers=BOOTSTRAP, enable_auto_commit=False)
+    await consumer.start()
+    try:
+        consumer.assign(list(offsets))
+        for partition, offset in offsets.items():
+            consumer.seek(partition, offset)
+
+        deadline = asyncio.get_event_loop().time() + timeout
+        while asyncio.get_event_loop().time() < deadline:
             try:
-                message = await asyncio.wait_for(consumer.getone(), timeout=timeout)
+                message = await asyncio.wait_for(consumer.getone(), timeout=5)
             except asyncio.TimeoutError:
-                return None
+                continue
             body = json.loads(message.value)
             if predicate(body):
                 return body
@@ -163,12 +176,16 @@ async def test_publish_consume_each_fleet_topic(producer, broker):
     for spec in FLEET_TOPICS:
         probe_id = str(uuid.uuid4())
         payload = {"probe": spec.name, "id": probe_id}
+
+        offsets = await end_offsets(spec.name)
         sent = await producer.send(
             spec.name, key="tenant:session", value=json.dumps(payload).encode()
         )
         assert sent, f"publish to {spec.name} reported no broker"
 
-        received = await read_matching(spec.name, lambda b: b.get("id") == probe_id)
+        received = await read_since(
+            spec.name, offsets, lambda b: b.get("id") == probe_id
+        )
         assert received is not None, f"no message returned from {spec.name}"
         assert received["probe"] == spec.name
 
@@ -179,6 +196,9 @@ async def test_event_reaches_the_per_tenant_events_topic(producer, broker):
     await emitter.start()
     tenant = uuid.uuid4()
     try:
+        # A fresh tenant means a fresh topic, but capture offsets anyway so
+        # the read is uniform with the others.
+        await provision(broker)
         event = await emitter.emit(
             EventType.COVERAGE_UPDATED,
             tenant_id=tenant,
@@ -187,7 +207,11 @@ async def test_event_reaches_the_per_tenant_events_topic(producer, broker):
         )
         assert await emitter.flush(timeout=20)
 
-        received = await read_one(events_topic(str(tenant)))
+        received = await read_since(
+            events_topic(str(tenant)),
+            await end_offsets(events_topic(str(tenant))) or {},
+            lambda b: b.get("event_id") == str(event.event_id),
+        ) or await read_one(events_topic(str(tenant)))
         assert received is not None
         assert received["event_type"] == "onboarding.coverage.updated"
         assert received["event_id"] == str(event.event_id)
@@ -206,26 +230,28 @@ async def test_command_that_keeps_failing_is_dead_lettered(settings, producer, b
     consumer = CommandConsumer(
         settings, producer, always_fails, max_attempts=2, backoff_s=0.01
     )
+    idempotency_key = f"idem-{uuid.uuid4().hex[:8]}"
     command = {
         "job_id": "job-1",
         "session_id": str(uuid.uuid4()),
         "evidence_manifest": {"manifest_hash": "abc123"},
-        "idempotency_key": "idem-key-1",
+        "idempotency_key": idempotency_key,
     }
 
+    offsets = await end_offsets(DLQ.name)
     handled = await consumer.handle_raw(json.dumps(command).encode(), key="t:s")
     assert handled is False
     assert consumer.dead_lettered == 1
 
-    letter = await read_matching(
-        DLQ.name, lambda b: b.get("idempotency_key") == "idem-key-1"
+    letter = await read_since(
+        DLQ.name, offsets, lambda b: b.get("idempotency_key") == idempotency_key
     )
     assert letter is not None, "no dead letter for this command reached the DLQ"
     assert letter["original_topic"] == COMMANDS.name
     assert letter["attempts"] == 2
     assert letter["error_code"] == "ERR-CMD-01"
     # §20: replay re-publishes with the same key, so it must survive.
-    assert letter["idempotency_key"] == "idem-key-1"
+    assert letter["idempotency_key"] == idempotency_key
 
 
 async def test_unparseable_command_is_dead_lettered_immediately(

--- a/onboarding-intelligence-agent-svc/tests/property/test_rbac_invariants.py
+++ b/onboarding-intelligence-agent-svc/tests/property/test_rbac_invariants.py
@@ -1,0 +1,119 @@
+"""Property tests for the RBAC evaluator and the guardrail chain.
+
+The example-based suites check the rows §15 argues for. These check that the
+evaluator is *total* and the chain's ordering holds under inputs nobody
+enumerated — arbitrary registration orders, arbitrary yield counts.
+"""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from app.logic.guardrails import (
+    OUTPUT_RULES,
+    Action,
+    GuardrailChain,
+    Layer,
+    Verdict as RuleVerdict,
+)
+from app.rbac.engine import Capability, RBACEngine, Role, Verdict
+from app.skills.models import SkillContext, TenantContext
+
+pytestmark = pytest.mark.property
+
+roles = st.sampled_from(list(Role))
+capabilities = st.sampled_from(list(Capability))
+skill_ids = st.sampled_from([f"SKL-OIA-{n:02d}" for n in range(1, 17)])
+
+
+def context() -> SkillContext:
+    return SkillContext(
+        input_prompt="p",
+        tenant_context=TenantContext(tenant_id="t-1", role="ADMIN"),
+    )
+
+
+@given(role=roles, capability=capabilities)
+def test_evaluator_is_total(role, capability):
+    """Every pair returns exactly one known verdict and never raises."""
+    assert RBACEngine().verdict(role, capability) in set(Verdict)
+
+
+@given(role=roles, skill_id=skill_ids)
+def test_every_declared_skill_is_decided(role, skill_id):
+    assert RBACEngine().verdict_for_skill(role, skill_id) in set(Verdict)
+
+
+@given(role=roles, skill_id=skill_ids)
+def test_enforce_raises_exactly_when_the_verdict_is_deny(role, skill_id):
+    from app.core.errors import AuthorizationError
+
+    engine = RBACEngine()
+    verdict = engine.verdict_for_skill(role, skill_id)
+    if verdict is Verdict.DENY:
+        with pytest.raises(AuthorizationError):
+            engine.enforce(role, skill_id)
+    else:
+        assert engine.enforce(role, skill_id) is verdict
+
+
+@given(role=roles, skill_id=st.text(min_size=1, max_size=20))
+def test_an_unknown_skill_is_never_allowed(role, skill_id):
+    """A typo in a skill id must not become an accidental grant."""
+    engine = RBACEngine()
+    if skill_id in [f"SKL-OIA-{n:02d}" for n in range(1, 17)]:
+        return
+    assert engine.verdict_for_skill(role, skill_id) is Verdict.DENY
+
+
+@given(order=st.permutations(["OG-01", "OG-02", "OG-03"]))
+def test_registration_order_does_not_change_layer_membership(order):
+    """Rules may be registered in any order; the layer still holds all of them."""
+    chain = GuardrailChain()
+    for rule_id in order:
+        chain.register(
+            Layer.OUTPUT, rule_id, lambda p, c, r=rule_id: RuleVerdict(rule_id=r)
+        )
+    assert set(chain.rules(Layer.OUTPUT)) == set(OUTPUT_RULES)
+    assert len(chain.rules(Layer.OUTPUT)) == len(OUTPUT_RULES)
+
+
+@given(chunks=st.integers(min_value=0, max_value=20))
+@settings(max_examples=30)
+def test_output_guardrails_run_once_per_chunk(chunks):
+    """For any yield count, OG evaluates exactly that many times."""
+    import asyncio
+
+    async def produce():
+        for index in range(chunks):
+            yield {"seq": index}
+
+    async def drain():
+        chain = GuardrailChain()
+        seen = [c async for c in chain.wrap_stream(produce(), context())]
+        og = [c for c in chain.calls if c[0] is Layer.OUTPUT]
+        assert len(seen) == chunks
+        assert len(og) == chunks * len(OUTPUT_RULES)
+
+    asyncio.run(drain())
+
+
+@given(blocking_index=st.integers(min_value=0, max_value=5))
+def test_a_block_anywhere_stops_the_layer(blocking_index):
+    """Whichever rule blocks, nothing after it runs."""
+    from app.logic.guardrails import GuardrailViolation
+
+    chain = GuardrailChain()
+    rule_ids = chain.rules(Layer.OUTPUT)
+    target = rule_ids[blocking_index % len(rule_ids)]
+    chain.register(
+        Layer.OUTPUT,
+        target,
+        lambda p, c: RuleVerdict(rule_id=target, action=Action.BLOCK),
+    )
+
+    with pytest.raises(GuardrailViolation) as exc:
+        chain.evaluate(Layer.OUTPUT, {"x": 1}, context())
+    assert exc.value.verdict.rule_id == target

--- a/onboarding-intelligence-agent-svc/tests/test_guardrails.py
+++ b/onboarding-intelligence-agent-svc/tests/test_guardrails.py
@@ -152,16 +152,28 @@ def test_a_rule_may_transform_the_payload(chain):
     assert chain.evaluate(Layer.INPUT, {"x": "secret"}, context()) == {"x": "***"}
 
 
-def test_registering_a_rule_replaces_the_no_op(chain):
-    """M-01 fills bodies in through this door without changing the order."""
+def test_registering_a_rule_replaces_it_in_place(chain):
+    """M-01 fills bodies in through this door **without changing the order**.
+
+    §5 numbers its rules in the order an operator reads them, and the order is
+    load-bearing: IG-04 redacts, IG-06 truncates, and truncating before
+    redacting would cut text that had not been redacted yet.
+    """
     before = chain.rules(Layer.INPUT)
 
     def rule(payload, ctx):
         return Verdict(rule_id="IG-01")
 
     chain.register(Layer.INPUT, "IG-01", rule)
-    assert chain.rules(Layer.INPUT) == [r for r in before if r != "IG-01"] + ["IG-01"]
-    assert len(chain.rules(Layer.INPUT)) == len(before)
+
+    assert chain.rules(Layer.INPUT) == before, "replacement reordered the layer"
+
+
+def test_registering_a_new_rule_appends_it(chain):
+    """A rule §5 does not declare is appended rather than silently dropped."""
+    before = chain.rules(Layer.OUTPUT)
+    chain.register(Layer.OUTPUT, "OG-99", lambda p, c: Verdict(rule_id="OG-99"))
+    assert chain.rules(Layer.OUTPUT) == before + ["OG-99"]
 
 
 async def test_a_skill_cannot_be_reached_except_through_the_registry():
@@ -193,3 +205,68 @@ async def test_rbac_runs_before_the_skill_body(chain):
         await registry.execute("SKL-OIA-01", context(role=Role.VIEWER.value))
 
     assert log == [], "the skill body ran despite the denial"
+
+
+# ── Regression cover for PR #533 review findings ──────────────────────────
+
+
+async def test_input_transforms_reach_the_skill_body(chain):
+    """Review finding: execute() discarded the evaluated payload.
+
+    IG-04 redacts and IG-06 truncates. A transform the skill never sees is
+    not a guardrail, it is a log line.
+    """
+    seen: dict = {}
+
+    class Capturing(BaseSkill):
+        async def run(self, ctx: SkillContext) -> SkillResult:
+            seen.update(ctx.input_context)
+            return SkillResult(skill_id=self.meta.skill_id, output={"ok": True})
+
+    def redactor(payload, ctx):
+        return Verdict(
+            rule_id="IG-04",
+            action=Action.REDACT,
+            payload={**payload, "secret": "***"},
+        )
+
+    chain.register(Layer.INPUT, "IG-04", redactor)
+
+    meta = SkillMeta(skill_id="SKL-OIA-01", name="research_business")
+    registry = SkillRegistry(chain=chain, rbac=RBACEngine())
+    registry._by_id[meta.skill_id] = Capturing(meta)
+    registry._meta[meta.skill_id] = meta
+
+    ctx = context()
+    ctx.input_context["secret"] = "hunter2"
+    await registry.execute("SKL-OIA-01", ctx)
+
+    assert seen["secret"] == "***", "the skill saw the un-redacted input"
+    assert ctx.input_context["secret"] == "***"
+
+
+async def test_output_transforms_reach_the_caller(chain):
+    """Review finding: evaluate_result() discarded the transformed output.
+
+    OG-02 re-applies redaction on egress; discarding it would hand the caller
+    exactly the output that rule just rewrote.
+    """
+
+    class Emitting(BaseSkill):
+        async def run(self, ctx: SkillContext) -> SkillResult:
+            return SkillResult(skill_id=self.meta.skill_id, output={"email": "a@b.c"})
+
+    def scrubber(payload, ctx):
+        return Verdict(
+            rule_id="OG-02", action=Action.REDACT, payload={**payload, "email": "***"}
+        )
+
+    chain.register(Layer.OUTPUT, "OG-02", scrubber)
+
+    meta = SkillMeta(skill_id="SKL-OIA-01", name="research_business")
+    registry = SkillRegistry(chain=chain, rbac=RBACEngine())
+    registry._by_id[meta.skill_id] = Emitting(meta)
+    registry._meta[meta.skill_id] = meta
+
+    result = await registry.execute("SKL-OIA-01", context())
+    assert result.output["email"] == "***", "the caller got the pre-guardrail output"

--- a/onboarding-intelligence-agent-svc/tests/test_guardrails.py
+++ b/onboarding-intelligence-agent-svc/tests/test_guardrails.py
@@ -1,0 +1,195 @@
+"""AC-2 — guardrails run in a fixed order and cannot be skipped.
+
+A-06 proves the ordering, not the rules: every §5 rule is registered as a
+recording no-op, and these tests assert that IG runs before the prompt is
+built, PG around execution, and OG before the result is returned — for the
+streaming case, before *each* chunk.
+"""
+
+from __future__ import annotations
+
+from typing import Any, AsyncIterator
+
+import pytest
+
+from app.logic.guardrails import (
+    INPUT_RULES,
+    OUTPUT_RULES,
+    PROCESS_RULES,
+    Action,
+    GuardrailChain,
+    GuardrailViolation,
+    Layer,
+    Verdict,
+)
+from app.rbac.engine import RBACEngine, Role
+from app.skills.base import BaseSkill, StreamingSkill
+from app.skills.models import SkillContext, SkillMeta, SkillResult, TenantContext
+from app.skills.registry import SkillRegistry
+
+pytestmark = pytest.mark.unit
+
+
+def context(role: str = "ADMIN") -> SkillContext:
+    return SkillContext(
+        input_prompt="hello",
+        tenant_context=TenantContext(tenant_id="t-1", user_id="u-1", role=role),
+        input_context={"skill_id": "SKL-OIA-01"},
+        correlation_id="corr-1",
+    )
+
+
+class RecordingSkill(BaseSkill):
+    """Records when its body ran, relative to the guardrail calls."""
+
+    def __init__(self, meta: SkillMeta, log: list[str]) -> None:
+        super().__init__(meta)
+        self.log = log
+
+    async def run(self, ctx: SkillContext) -> SkillResult:
+        self.log.append("SKILL")
+        return SkillResult(skill_id=self.meta.skill_id, output={"ok": True})
+
+
+class RecordingStream(StreamingSkill):
+    def __init__(self, meta: SkillMeta, chunks: int = 3) -> None:
+        super().__init__(meta)
+        self.chunks = chunks
+
+    async def stream(self, ctx: SkillContext) -> AsyncIterator[dict[str, Any]]:
+        for index in range(self.chunks):
+            yield {"seq": index}
+
+
+@pytest.fixture
+def chain() -> GuardrailChain:
+    return GuardrailChain()
+
+
+def test_every_section_5_rule_is_registered(chain):
+    """The chain is complete from the first commit, even as no-ops."""
+    assert chain.rules(Layer.INPUT) == INPUT_RULES
+    assert chain.rules(Layer.PROCESS) == PROCESS_RULES
+    assert chain.rules(Layer.OUTPUT) == OUTPUT_RULES
+    assert len(INPUT_RULES) == 10
+    assert len(PROCESS_RULES) == 8
+    assert len(OUTPUT_RULES) == 6
+
+
+async def test_hook_ordering(chain):
+    """IG before the skill, PG around it, OG after — by recorded call order."""
+    log: list[str] = []
+    meta = SkillMeta(skill_id="SKL-OIA-01", name="research_business")
+    registry = SkillRegistry(chain=chain, rbac=RBACEngine())
+    skill = RecordingSkill(meta, log)
+    registry._by_id[meta.skill_id] = skill
+    registry._meta[meta.skill_id] = meta
+
+    original_evaluate = chain.evaluate
+
+    def tracking(layer, payload, ctx):
+        log.append(layer.value)
+        return original_evaluate(layer, payload, ctx)
+
+    chain.evaluate = tracking  # type: ignore[method-assign]
+
+    await registry.execute("SKL-OIA-01", context())
+
+    assert log == ["IG", "PG", "SKILL", "OG"], log
+
+
+async def test_streaming_og_per_yield(chain):
+    """Output guardrails evaluate each yielded chunk, not only the final one."""
+    meta = SkillMeta(skill_id="SKL-OIA-04", name="analyze_transcript_stream")
+    registry = SkillRegistry(chain=chain, rbac=RBACEngine())
+    skill = RecordingStream(meta, chunks=4)
+    registry._by_id[meta.skill_id] = skill
+    registry._meta[meta.skill_id] = meta
+
+    chunks = [c async for c in registry.execute_stream("SKL-OIA-04", context())]
+
+    assert len(chunks) == 4
+    og_calls = [c for c in chain.calls if c[0] is Layer.OUTPUT]
+    # Six OG rules, evaluated once per chunk.
+    assert len(og_calls) == 4 * len(OUTPUT_RULES)
+
+
+async def test_streaming_chunks_are_evaluated_before_they_are_yielded(chain):
+    """A chunk already sent to the browser cannot be recalled."""
+    meta = SkillMeta(skill_id="SKL-OIA-04", name="analyze_transcript_stream")
+    registry = SkillRegistry(chain=chain, rbac=RBACEngine())
+    registry._by_id[meta.skill_id] = RecordingStream(meta, chunks=3)
+    registry._meta[meta.skill_id] = meta
+
+    seen = 0
+    async for _ in registry.execute_stream("SKL-OIA-04", context()):
+        seen += 1
+        og_calls = len([c for c in chain.calls if c[0] is Layer.OUTPUT])
+        assert og_calls == seen * len(OUTPUT_RULES)
+
+
+def test_a_blocking_rule_stops_the_chain(chain):
+    """BLOCK raises: a blocked payload must not reach the next stage."""
+
+    def blocker(payload, ctx):
+        return Verdict(rule_id="IG-02", action=Action.BLOCK, detail="scam pattern")
+
+    chain.register(Layer.INPUT, "IG-02", blocker)
+
+    with pytest.raises(GuardrailViolation) as exc:
+        chain.evaluate(Layer.INPUT, {"x": 1}, context())
+
+    assert exc.value.verdict.rule_id == "IG-02"
+
+
+def test_a_rule_may_transform_the_payload(chain):
+    """REDACT and TRUNCATE hand the next rule the modified payload."""
+
+    def redactor(payload, ctx):
+        return Verdict(rule_id="IG-04", action=Action.REDACT, payload={"x": "***"})
+
+    chain.register(Layer.INPUT, "IG-04", redactor)
+    assert chain.evaluate(Layer.INPUT, {"x": "secret"}, context()) == {"x": "***"}
+
+
+def test_registering_a_rule_replaces_the_no_op(chain):
+    """M-01 fills bodies in through this door without changing the order."""
+    before = chain.rules(Layer.INPUT)
+
+    def rule(payload, ctx):
+        return Verdict(rule_id="IG-01")
+
+    chain.register(Layer.INPUT, "IG-01", rule)
+    assert chain.rules(Layer.INPUT) == [r for r in before if r != "IG-01"] + ["IG-01"]
+    assert len(chain.rules(Layer.INPUT)) == len(before)
+
+
+async def test_a_skill_cannot_be_reached_except_through_the_registry():
+    """AC-2: BaseSkill is not callable, so there is no bypass to reach for."""
+    meta = SkillMeta(skill_id="SKL-OIA-01", name="research_business")
+    skill = RecordingSkill(meta, [])
+
+    assert (
+        not callable(getattr(skill, "__call__", None))
+        or not hasattr(type(skill), "__call__")
+        or type(skill).__call__ is type.__call__
+    )
+
+    with pytest.raises(TypeError):
+        skill()  # type: ignore[operator]
+
+
+async def test_rbac_runs_before_the_skill_body(chain):
+    """A denied call must not execute anything."""
+    from app.core.errors import AuthorizationError
+
+    log: list[str] = []
+    meta = SkillMeta(skill_id="SKL-OIA-01", name="research_business")
+    registry = SkillRegistry(chain=chain, rbac=RBACEngine())
+    registry._by_id[meta.skill_id] = RecordingSkill(meta, log)
+    registry._meta[meta.skill_id] = meta
+
+    with pytest.raises(AuthorizationError):
+        await registry.execute("SKL-OIA-01", context(role=Role.VIEWER.value))
+
+    assert log == [], "the skill body ran despite the denial"

--- a/onboarding-intelligence-agent-svc/tests/test_rbac.py
+++ b/onboarding-intelligence-agent-svc/tests/test_rbac.py
@@ -1,0 +1,141 @@
+"""AC-3 — the §15 matrix, exhaustively.
+
+The matrix is data precisely so this test can be a table sweep. Every role
+against every capability, with both allow and deny asserted — a matrix written
+as `if` statements could not be covered this way, which is why A-06's technical
+note forbids one.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.errors import AuthorizationError, ErrorCode
+from app.rbac.engine import (
+    MATRIX,
+    SKILL_CAPABILITY,
+    Capability,
+    RBACEngine,
+    Role,
+    Verdict,
+)
+
+pytestmark = pytest.mark.unit
+
+ALL_PAIRS = [(role, cap) for cap in Capability for role in Role]
+
+
+@pytest.fixture
+def engine() -> RBACEngine:
+    return RBACEngine()
+
+
+def test_matrix_exhaustive(engine):
+    """Every (role, capability) pair resolves to exactly one known verdict."""
+    assert len(ALL_PAIRS) == len(list(Role)) * len(list(Capability)) == 64
+
+    for role, capability in ALL_PAIRS:
+        verdict = engine.verdict(role, capability)
+        assert isinstance(verdict, Verdict), (role, capability)
+
+
+def test_matrix_covers_every_capability():
+    """A capability missing a row would KeyError at runtime, not in review."""
+    assert set(MATRIX) == set(Capability)
+    for capability, row in MATRIX.items():
+        assert set(row) == set(Role), capability
+
+
+@pytest.mark.parametrize("role,capability", ALL_PAIRS)
+def test_every_pair_is_decided(engine, role, capability):
+    assert engine.verdict(role, capability) in set(Verdict)
+
+
+def test_both_allow_and_deny_are_present():
+    """A matrix that only ever allows would pass a weaker test vacuously."""
+    verdicts = {v for row in MATRIX.values() for v in row.values()}
+    assert Verdict.ALLOW in verdicts
+    assert Verdict.DENY in verdicts
+    assert Verdict.ESCALATE in verdicts
+    assert Verdict.VIEW_RESULT in verdicts
+
+
+# ── The specific rows §15 argues for ─────────────────────────
+
+
+def test_viewer_is_denied_the_research_and_extraction_skills(engine):
+    for skill_id in ("SKL-OIA-01", "SKL-OIA-04", "SKL-OIA-10", "SKL-OIA-12"):
+        assert engine.verdict_for_skill(Role.VIEWER, skill_id) is Verdict.DENY
+
+
+def test_viewer_may_read_summaries_and_coverage(engine):
+    """§15 gives VIEWER VIEW RESULT on 08 and 09 — not ALLOW, not DENY."""
+    for skill_id in ("SKL-OIA-08", "SKL-OIA-09"):
+        assert engine.verdict_for_skill(Role.VIEWER, skill_id) is Verdict.VIEW_RESULT
+
+
+def test_editor_escalates_on_conflict_resolution(engine):
+    """SKL-OIA-14: permitted, but routed for Admin approval."""
+    assert engine.verdict_for_skill(Role.EDITOR, "SKL-OIA-14") is Verdict.ESCALATE
+    assert engine.verdict_for_skill(Role.ADMIN, "SKL-OIA-14") is Verdict.ALLOW
+
+
+def test_editor_cannot_confirm_a_key_field(engine):
+    """§15's deliberate asymmetry: extraction is reversible, confirmation is not."""
+    assert engine.verdict(Role.EDITOR, Capability.CONFIRM_KEY_FIELD) is Verdict.DENY
+    assert engine.verdict(Role.EDITOR, Capability.EDIT_SECONDARY_FIELD) is Verdict.ALLOW
+
+
+def test_editor_cannot_touch_retention_or_calendar(engine):
+    assert engine.verdict(Role.EDITOR, Capability.RETENTION_AND_ERASURE) is Verdict.DENY
+    assert (
+        engine.verdict(Role.EDITOR, Capability.CALENDAR_OAUTH_CONNECT) is Verdict.DENY
+    )
+
+
+def test_everyone_may_view_recordings(engine):
+    for role in Role:
+        assert engine.verdict(role, Capability.VIEW_RECORDINGS) is Verdict.ALLOW
+
+
+def test_every_skill_id_maps_to_a_capability():
+    """A skill absent from the map would silently deny in production."""
+    assert len(SKILL_CAPABILITY) == 16
+    for skill_id, capability in SKILL_CAPABILITY.items():
+        assert capability in MATRIX, skill_id
+
+
+# ── Enforcement ──────────────────────────────────────────────
+
+
+def test_enforce_raises_err_04_on_denial(engine):
+    """AC-3, corrected: role denial is ERR-04, not ERR-03 (§18.4)."""
+    with pytest.raises(AuthorizationError) as exc:
+        engine.enforce(Role.VIEWER, "SKL-OIA-01")
+
+    error = exc.value
+    assert error.code is ErrorCode.ROLE_DENIED
+    assert error.code.value == "ERR-04"
+    assert error.http_status == 403
+    assert error.retryable is False
+
+
+def test_denial_body_carries_no_request_payload(engine):
+    """AC-3: the event and the response name the role and skill, nothing else."""
+    with pytest.raises(AuthorizationError) as exc:
+        engine.enforce(Role.VIEWER, "SKL-OIA-10")
+
+    body = exc.value.to_body()
+    assert set(body) == {"error_code", "message", "retryable"}
+    assert exc.value.context == {"role": "VIEWER", "skill_id": "SKL-OIA-10"}
+
+
+def test_enforce_returns_the_verdict_when_not_denied(engine):
+    assert engine.enforce(Role.ADMIN, "SKL-OIA-01") is Verdict.ALLOW
+    assert engine.enforce(Role.EDITOR, "SKL-OIA-14") is Verdict.ESCALATE
+    assert engine.enforce(Role.VIEWER, "SKL-OIA-08") is Verdict.VIEW_RESULT
+
+
+def test_an_unknown_skill_denies_rather_than_raising_keyerror(engine):
+    """The engine stays total; unknown ids are the registry's business."""
+    assert engine.verdict_for_skill(Role.OWNER, "SKL-OIA-99") is Verdict.DENY

--- a/onboarding-intelligence-agent-svc/tests/test_registry.py
+++ b/onboarding-intelligence-agent-svc/tests/test_registry.py
@@ -151,3 +151,69 @@ async def test_executing_a_streaming_skill_through_execute_is_refused(registry):
     )
     with pytest.raises((SkillNotFound, NotImplementedError)):
         await registry.execute("SKL-OIA-04", context)
+
+
+# ── Regression cover for PR #533 review findings ──────────────────────────
+
+
+async def test_internal_only_skills_reject_an_external_caller(registry):
+    """Review finding: internal_only was tracked but never enforced.
+
+    §15 marks SKL-OIA-13 SYSTEM. The platform has no SYSTEM role, so §8
+    expresses it as the full role set — which means RBAC alone lets every role
+    through. Origin is what actually gates it.
+    """
+    from app.core.errors import AuthorizationError, ErrorCode
+    from app.skills.models import Origin, SkillContext, TenantContext
+
+    for skill_id in ("SKL-OIA-13", "SKL-OIA-15", "SKL-OIA-16"):
+        ctx = SkillContext(
+            input_prompt="p",
+            tenant_context=TenantContext(tenant_id="t-1", role="OWNER"),
+            origin=Origin.EXTERNAL,
+        )
+        with pytest.raises(AuthorizationError) as exc:
+            await registry.execute(skill_id, ctx)
+        assert exc.value.code is ErrorCode.ROLE_DENIED
+        assert "internal-only" in str(exc.value)
+
+
+async def test_origin_defaults_to_external(registry):
+    """A caller who forgets to say gets the stricter treatment."""
+    from app.core.errors import AuthorizationError
+    from app.skills.models import Origin, SkillContext, TenantContext
+
+    ctx = SkillContext(
+        input_prompt="p",
+        tenant_context=TenantContext(tenant_id="t-1", role="OWNER"),
+    )
+    assert ctx.origin is Origin.EXTERNAL
+    with pytest.raises(AuthorizationError):
+        await registry.execute("SKL-OIA-13", ctx)
+
+
+async def test_internal_callers_pass_the_origin_gate(registry):
+    """The service's own pipelines may invoke them — reaching the deferred body."""
+    from app.skills.models import Origin, SkillContext, TenantContext
+
+    ctx = SkillContext(
+        input_prompt="p",
+        tenant_context=TenantContext(tenant_id="t-1", role="OWNER"),
+        origin=Origin.INTERNAL,
+    )
+    # Past the gate, into the body A-06 leaves deferred.
+    with pytest.raises(NotImplementedError):
+        await registry.execute("SKL-OIA-13", ctx)
+
+
+async def test_a_normal_skill_is_unaffected_by_origin(registry):
+    """Only the three internal_only skills are gated."""
+    from app.skills.models import Origin, SkillContext, TenantContext
+
+    ctx = SkillContext(
+        input_prompt="p",
+        tenant_context=TenantContext(tenant_id="t-1", role="ADMIN"),
+        origin=Origin.EXTERNAL,
+    )
+    with pytest.raises(NotImplementedError):
+        await registry.execute("SKL-OIA-01", ctx)

--- a/onboarding-intelligence-agent-svc/tests/test_registry.py
+++ b/onboarding-intelligence-agent-svc/tests/test_registry.py
@@ -1,0 +1,153 @@
+"""AC-1 — skills load from configuration, not from imports.
+
+The load path against the real config/skills.yaml and the real skill modules,
+plus the failure AC-1 names specifically: a declaration whose implementing
+class is missing must fail **at startup**, naming the skill, rather than at
+first invocation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from app.core.errors import ErrorCode, SkillNotFound
+from app.skills.base import BaseSkill, StreamingSkill
+from app.skills.registry import SkillRegistry, SkillRegistryError
+
+pytestmark = pytest.mark.unit
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="module")
+def registry() -> SkillRegistry:
+    loaded = SkillRegistry()
+    loaded.load()
+    return loaded
+
+
+def test_all_sixteen_declarations_resolve(registry):
+    assert len(registry.skill_ids) == 16
+
+
+def test_lookup_by_id_and_by_name_reach_the_same_skill(registry):
+    by_id = registry.get("SKL-OIA-04")
+    by_name = registry.get("analyze_transcript_stream")
+    assert by_id is by_name
+
+
+def test_every_skill_is_a_base_or_streaming_skill(registry):
+    for skill_id in registry.skill_ids:
+        skill = registry.get(skill_id)
+        assert isinstance(skill, (BaseSkill, StreamingSkill)), skill_id
+
+
+def test_streaming_skills_are_streaming_and_the_rest_are_not(registry):
+    streaming = {"SKL-OIA-04", "SKL-OIA-05", "SKL-OIA-06"}
+    for skill_id in registry.skill_ids:
+        skill = registry.get(skill_id)
+        if skill_id in streaming:
+            assert isinstance(skill, StreamingSkill), skill_id
+        else:
+            assert isinstance(skill, BaseSkill), skill_id
+
+
+def test_meta_matches_the_declaration(registry):
+    meta = registry.meta("SKL-OIA-10")
+    assert meta.name == "extract_and_map_fields"
+    assert meta.timeout_ms == 120000
+    assert meta.max_retries == 1
+    assert meta.circuit_breaker_dependency == "backend"
+    assert meta.allowed_roles == ("OWNER", "ADMIN", "EDITOR")
+
+
+def test_internal_only_skills_are_flagged(registry):
+    internal = [s for s in registry.skill_ids if registry.is_internal_only(s)]
+    assert internal == ["SKL-OIA-13", "SKL-OIA-15", "SKL-OIA-16"]
+
+
+def test_unknown_id_raises_skill_not_found(registry):
+    """PG-02's tool allowlist: an unknown id is refused, not guessed at."""
+    with pytest.raises(SkillNotFound) as exc:
+        registry.get("SKL-OIA-99")
+    assert exc.value.code is ErrorCode.SKILL_NOT_IN_ALLOWLIST
+    assert exc.value.http_status == 404
+
+
+def test_a_missing_implementing_class_fails_at_startup(tmp_path):
+    """AC-1: named, at load time — not at first invocation."""
+    declaration = {
+        "version": 1,
+        "service": "onboarding-intelligence-agent",
+        "skills": [
+            {
+                "skill_id": "SKL-OIA-97",
+                "name": "no_such_skill_module",
+                "description": "deliberately unresolvable",
+                "input_schema": [],
+                "timeout_ms": 1000,
+                "max_retries": 1,
+                "allowed_roles": ["OWNER"],
+            }
+        ],
+    }
+    path = tmp_path / "skills.yaml"
+    path.write_text(yaml.safe_dump(declaration))
+
+    with pytest.raises(SkillRegistryError) as exc:
+        SkillRegistry().load(path)
+
+    message = str(exc.value)
+    assert "SKL-OIA-97" in message
+    assert "no_such_skill_module" in message
+
+
+def test_startup_reports_every_missing_skill_at_once(tmp_path):
+    """One failed deploy, not one per missing skill."""
+    declaration = {
+        "version": 1,
+        "service": "onboarding-intelligence-agent",
+        "skills": [
+            {
+                "skill_id": f"SKL-OIA-9{n}",
+                "name": f"missing_module_{n}",
+                "input_schema": [],
+                "timeout_ms": 1000,
+                "max_retries": 1,
+                "allowed_roles": ["OWNER"],
+            }
+            for n in (5, 6, 7)
+        ],
+    }
+    path = tmp_path / "skills.yaml"
+    path.write_text(yaml.safe_dump(declaration))
+
+    with pytest.raises(SkillRegistryError) as exc:
+        SkillRegistry().load(path)
+
+    for n in (5, 6, 7):
+        assert f"SKL-OIA-9{n}" in str(exc.value)
+
+
+def test_metadata_can_be_loaded_without_resolving_implementations():
+    """The contract test validates the YAML, not the code behind it."""
+    registry = SkillRegistry()
+    registry.load(resolve=False)
+    assert len(registry.skill_ids) == 16
+    with pytest.raises(SkillNotFound):
+        registry.get("SKL-OIA-01")
+
+
+async def test_executing_a_streaming_skill_through_execute_is_refused(registry):
+    """The two entry points are not interchangeable."""
+    from app.skills.models import SkillContext, TenantContext
+
+    context = SkillContext(
+        input_prompt="p",
+        tenant_context=TenantContext(tenant_id="t-1", role="ADMIN"),
+    )
+    with pytest.raises((SkillNotFound, NotImplementedError)):
+        await registry.execute("SKL-OIA-04", context)

--- a/onboarding-intelligence-agent-svc/tests/test_scaffold.py
+++ b/onboarding-intelligence-agent-svc/tests/test_scaffold.py
@@ -96,7 +96,19 @@ IMPLEMENTED = {
     "app.messaging.schemas",
     "app.messaging.topics",
     "app.messaging.provision",
+    # Implemented by A-06.
+    "app.core.errors",
+    "app.logic.guardrails",
+    "app.rbac.engine",
+    "app.skills.base",
+    "app.skills.models",
+    "app.skills.registry",
 }
+
+#: A-06 turned the sixteen skill modules into registry-resolvable classes.
+#: They are no longer bare stubs — the class is real and instantiable, and it
+#: is the *body* that is deferred. test_skill_bodies_are_deferred covers them.
+IMPLEMENTED |= set(SKILL_MODULES)
 
 
 @pytest.mark.parametrize("dotted", EXPECTED_MODULES + SKILL_MODULES)
@@ -138,12 +150,47 @@ def test_config_directory_and_skills_manifest_exist():
     assert (ROOT / "config" / "skills.yaml").is_file()
 
 
-def test_skills_yaml_parses_even_while_empty():
-    """The manifest must be valid from the first commit, not from the first skill."""
+def test_skills_yaml_declares_all_sixteen_skills():
+    """A-05 landed this empty; A-06 filled it from Design §8."""
     parsed = yaml.safe_load((ROOT / "config" / "skills.yaml").read_text())
     assert parsed["service"] == "onboarding-intelligence-agent"
     assert parsed["version"] == 1
-    assert parsed["skills"] == []
+    assert len(parsed["skills"]) == 16
+
+
+@pytest.mark.parametrize("dotted", SKILL_MODULES)
+def test_skill_bodies_are_deferred(dotted):
+    """The class resolves and instantiates; run/stream still refuse to run.
+
+    A-06 needs the class to exist so the registry can resolve the declaration
+    at startup. What stays deferred is the body — which must raise rather than
+    return None, so a later story cannot ship a silent no-op.
+    """
+    import asyncio
+    import inspect
+
+    from app.skills.base import BaseSkill, StreamingSkill
+    from app.skills.models import SkillContext, SkillMeta, TenantContext
+
+    module = importlib.import_module(dotted)
+    name = dotted.rsplit(".", 1)[1]
+    cls = getattr(module, "".join(p.title() for p in name.split("_")))
+
+    assert issubclass(cls, (BaseSkill, StreamingSkill)), dotted
+    skill = cls(SkillMeta(skill_id="SKL-OIA-00", name=name))
+
+    context = SkillContext(
+        input_prompt="p",
+        tenant_context=TenantContext(tenant_id="t-1", role="ADMIN"),
+    )
+
+    with pytest.raises(NotImplementedError):
+        if isinstance(skill, StreamingSkill):
+            stream = skill.stream(context)
+            if inspect.isasyncgen(stream):
+                asyncio.run(anext(stream))
+        else:
+            asyncio.run(skill.run(context))
 
 
 def test_fleet_files_are_present():

--- a/onboarding-intelligence-agent-svc/tests/test_skills_yaml.py
+++ b/onboarding-intelligence-agent-svc/tests/test_skills_yaml.py
@@ -1,0 +1,132 @@
+"""AC-4 — the YAML contract, adapted from the fleet original.
+
+config/skills.yaml IS Design §8. This file is what stops the two drifting:
+every constraint the design states about the registry is asserted here, so a
+declaration that violates one fails in CI rather than at the first invocation.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.unit
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILLS_YAML = ROOT / "config" / "skills.yaml"
+
+EXPECTED_SKILL_COUNT = 16
+EXPECTED_ID_PREFIX = "SKL-OIA-"
+ID_PATTERN = re.compile(r"^SKL-OIA-\d{2}[a-z]?$")
+VALID_ROLES = {"OWNER", "ADMIN", "EDITOR", "VIEWER"}
+MAX_TIMEOUT_MS = 120000
+REQUIRED_SCHEMA_KEYS = {"field", "type", "required"}
+#: §8: every skill takes the same five inputs.
+FLEET_INPUTS = {
+    "input_prompt",
+    "input_context",
+    "tenant_context",
+    "config",
+    "previous_outputs",
+}
+
+
+@pytest.fixture(scope="module")
+def document() -> dict:
+    return yaml.safe_load(SKILLS_YAML.read_text())
+
+
+@pytest.fixture(scope="module")
+def skills(document) -> list[dict]:
+    return document["skills"]
+
+
+def test_file_parses(document):
+    """The manifest must be valid YAML with the fleet envelope."""
+    assert document["service"] == "onboarding-intelligence-agent"
+    assert document["version"] == 1
+    assert isinstance(document["skills"], list)
+
+
+def test_skill_count(skills):
+    assert len(skills) == EXPECTED_SKILL_COUNT
+
+
+def test_ids_match_the_pattern(skills):
+    for skill in skills:
+        assert skill["skill_id"].startswith(EXPECTED_ID_PREFIX)
+        assert ID_PATTERN.match(skill["skill_id"]), skill["skill_id"]
+
+
+def test_ids_are_unique(skills):
+    ids = [s["skill_id"] for s in skills]
+    assert len(ids) == len(set(ids))
+
+
+def test_names_are_unique(skills):
+    names = [s["name"] for s in skills]
+    assert len(names) == len(set(names))
+
+
+def test_roles_are_drawn_only_from_the_platform_set(skills):
+    """§15: there is no SYSTEM role — internal_only expresses that instead."""
+    for skill in skills:
+        roles = set(skill["allowed_roles"])
+        assert roles, f"{skill['skill_id']} declares no roles"
+        assert roles <= VALID_ROLES, f"{skill['skill_id']}: {roles - VALID_ROLES}"
+
+
+def test_timeout_ceiling(skills):
+    for skill in skills:
+        assert 0 < skill["timeout_ms"] <= MAX_TIMEOUT_MS, skill["skill_id"]
+
+
+def test_every_input_schema_entry_carries_the_required_keys(skills):
+    for skill in skills:
+        for entry in skill["input_schema"]:
+            missing = REQUIRED_SCHEMA_KEYS - set(entry)
+            assert not missing, f"{skill['skill_id']}/{entry.get('field')}: {missing}"
+
+
+def test_every_skill_takes_the_fleet_standard_five_inputs(skills):
+    for skill in skills:
+        fields = {entry["field"] for entry in skill["input_schema"]}
+        assert fields == FLEET_INPUTS, f"{skill['skill_id']}: {fields}"
+
+
+def test_max_retries_is_sane(skills):
+    for skill in skills:
+        assert 0 <= skill["max_retries"] <= 5, skill["skill_id"]
+
+
+def test_descriptions_are_present(skills):
+    for skill in skills:
+        assert skill.get("description", "").strip(), skill["skill_id"]
+
+
+def test_streaming_skills_are_the_three_live_ones(skills):
+    """§8: streaming skills 04/05/06 are driven from live_session.py only."""
+    streaming = {s["skill_id"] for s in skills if s.get("streaming")}
+    assert streaming == {"SKL-OIA-04", "SKL-OIA-05", "SKL-OIA-06"}
+
+
+def test_internal_only_skills_carry_the_full_role_set(skills):
+    """§8: SYSTEM is expressed as all roles plus internal_only: true."""
+    internal = [s for s in skills if s.get("internal_only")]
+    assert {s["skill_id"] for s in internal} == {
+        "SKL-OIA-13",
+        "SKL-OIA-15",
+        "SKL-OIA-16",
+    }
+    for skill in internal:
+        assert set(skill["allowed_roles"]) == VALID_ROLES, skill["skill_id"]
+
+
+def test_declared_skills_match_the_registry_modules(skills):
+    """A declaration naming a module that does not exist is a startup failure."""
+    for skill in skills:
+        module = ROOT / "app" / "skills" / f"{skill['name']}.py"
+        assert module.is_file(), f"{skill['skill_id']} has no module {module.name}"


### PR DESCRIPTION
Closes **A-06**. All sixteen skills now plug in uniformly, and no skill can bypass a guardrail by being written carelessly. **Epic A is complete.**

## AC-1 · Skills load from configuration

`config/skills.yaml` carries the sixteen §8 declarations transcribed with the design's own values — timeouts from 2 s (`redact_pii`) to 120 s (`extract_and_map_fields`), per-skill circuit-breaker dependencies, and the three `internal_only` skills that §15 marks SYSTEM (which §8 expresses as the full role set plus a marker, because the platform has no SYSTEM role).

Lookup works by **id and by name** — `SKL-OIA-04` and `analyze_transcript_stream` reach the same object. A declaration whose class is missing fails **at startup**, naming *every* missing skill at once rather than one failed deploy per skill.

## AC-2 · Guardrails cannot be skipped

Order is IG → RBAC → PG → skill → OG, enforced structurally: `execute()` is the entry point, `BaseSkill` defines `run`, `StreamingSkill` defines `stream`, and **neither class is callable** — there is no convenient bypass to reach for.

Every §5 rule is registered as a recording no-op — 10 IG, 8 PG, 6 OG. M-01 fills the bodies in through `register()`, which replaces a rule without changing the order. This story proves the ordering, not the rules.

**Streaming is the genuine extension** over `voc-agent-svc`: OG is an async-generator wrapper, so it runs **per yielded chunk**. A chunk already delivered to a browser cannot be recalled, so evaluating once at the end would be too late.

## AC-3 · RBAC

The §15 matrix as **data**, swept exhaustively — 4 roles × 16 capabilities = 64 pairs, allow and deny both asserted. A matrix of `if` statements could not be covered this way, which is why the technical note forbids one.

**Four verdicts, not two.** AC-3 describes allow and deny, but §15 also uses **ESCALATE** (SKL-OIA-14 for EDITOR — "permitted but routed for Admin approval") and **VIEW_RESULT** (SKL-OIA-08/09 for VIEWER). Collapsing either into ALLOW or DENY loses a distinction the design makes deliberately — including §15's defended asymmetry that EDITOR may run every extraction skill but may not confirm a KEY field.

## Two documentation conflicts, resolved rather than propagated

| Situation | Docs say | This PR | Why |
|---|---|---|---|
| Role denied | AC-3 says **ERR-03** | **ERR-04** | §18.4 assigns ERR-03 to *consent* (IG-08) and ERR-04 to role denied (PG-03). They have different operator behaviour — "Consent modal re-presented" vs "Action hidden or disabled in UI" — so collapsing them makes a permissions bug look like a consent bug to whoever is on call. |
| Unknown skill id | §5 PG-02 says **ERR-06** | **ERR-17** (provisional) | §18.4 already spends ERR-06 on "Live session already active for company" (409/4409). Emitting it for a bad skill id would tell an operator that a meeting is running when the truth is a skill id is wrong. |

Both need reconciling in the design documents. The code is right and documents why in place; **ERR-17 is provisional** and wants either a taxonomy row or a corrected PG-02.

## Testing — 337, no mocks

| Suite | Count | Proves |
|---|---|---|
| `test_skills_yaml.py` | 14 | 16 skills, `^SKL-OIA-\d{2}[a-z]?$`, roles from the four, `timeout_ms ≤ 120000`, schema keys, the fleet-standard five inputs |
| `test_rbac.py` | 78 | exhaustive matrix sweep, plus the specific rows §15 argues for |
| `test_guardrails.py` | 9 | hook ordering by recorded call order; OG per yield; RBAC before the body |
| `test_registry.py` | 11 | dual lookup, startup failure naming the skill, metadata-only load |
| `property/test_rbac_invariants.py` | 7 | the evaluator is total; ordering holds under arbitrary registration order; OG runs once per chunk for any yield count |

`black`, `flake8` and `mypy --strict` clean across 67 modules.

`test_scaffold.py` is updated for two changes A-06 makes by design: the skill modules are now registry-resolvable classes whose *bodies* are deferred (rather than stubs raising on construction), and `skills.yaml` is no longer empty.

## Note on the planning skill

This PR adds `.claude/skills/zorven-implementation-plan/SKILL.md`, transcribed from the Claude Desktop "Zorven" project skill — Desktop and Claude Code don't share skills, so it had to come across by hand.

It is **marked PARTIAL**: the four files it references (`assets/implementation-plan-template.md` and three under `references/`) didn't survive the paste, so the A-06 plan followed the section shape I could infer plus this project's established conventions. The file says so rather than implying the plan was authored against the full skill. Sending those four files would let me complete it.

**Epic A is done** — A-01 through A-06, with A-04 withdrawn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)