### PR TITLE
fix(oia): three A-06 follow-ups from the PR #534 review

### DIFF
--- a/onboarding-intelligence-agent-svc/app/rbac/engine.py
+++ b/onboarding-intelligence-agent-svc/app/rbac/engine.py
@@ -120,13 +120,18 @@ MATRIX: dict[Capability, dict[Role, Verdict]] = {
         Role.VIEWER: D,
     },
     # SYSTEM in §15. The platform has no SYSTEM role, so §8 expresses it as the
-    # full role set plus internal_only: true — the registry refuses an
-    # externally-originated call regardless of the caller's role.
+    # full role set plus internal_only: true, and the registry's origin gate —
+    # not this row — is what refuses an external caller.
+    #
+    # VIEWER is ALLOW on purpose. The row must match the full role set the YAML
+    # declares, or an internal pipeline running under a VIEWER's session would
+    # be denied by RBAC before the origin gate ever spoke. Externally the skill
+    # is unreachable for every role, VIEWER included.
     Capability.RECORD_GOLDEN_CANDIDATES: {
         Role.OWNER: A,
         Role.ADMIN: A,
         Role.EDITOR: A,
-        Role.VIEWER: D,
+        Role.VIEWER: A,
     },
     Capability.CONFLICT_ESCALATION: {
         Role.OWNER: A,
@@ -188,8 +193,12 @@ SKILL_CAPABILITY: dict[str, Capability] = {
     "SKL-OIA-12": Capability.AUTOGEN_STRATEGY_IDENTITY,
     "SKL-OIA-13": Capability.RECORD_GOLDEN_CANDIDATES,
     "SKL-OIA-14": Capability.CONFLICT_ESCALATION,
-    # 15 and 16 are internal plumbing (prompt fetch, redaction) and carry no
-    # §15 row: they are never invoked by a user directly.
+    # 15 and 16 are internal plumbing (prompt fetch, redaction). §15 gives them
+    # no row of their own, so they borrow VIEW_RECORDINGS — the one row every
+    # role may use — precisely because RBAC is not their control. Both are
+    # internal_only, so the registry's origin gate is what stops an external
+    # caller; mapping them anywhere stricter would only break the internal
+    # pipelines that legitimately call them.
     "SKL-OIA-15": Capability.VIEW_RECORDINGS,
     "SKL-OIA-16": Capability.VIEW_RECORDINGS,
 }

--- a/onboarding-intelligence-agent-svc/tests/integration/test_kafka_roundtrip.py
+++ b/onboarding-intelligence-agent-svc/tests/integration/test_kafka_roundtrip.py
@@ -135,8 +135,12 @@ async def read_since(
         for partition, offset in offsets.items():
             consumer.seek(partition, offset)
 
-        deadline = asyncio.get_event_loop().time() + timeout
-        while asyncio.get_event_loop().time() < deadline:
+        # get_running_loop() rather than get_event_loop(): the latter is
+        # deprecated inside a coroutine on 3.12+ and warns or errors depending
+        # on the runtime.
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
+        while loop.time() < deadline:
             try:
                 message = await asyncio.wait_for(consumer.getone(), timeout=5)
             except asyncio.TimeoutError:

--- a/onboarding-intelligence-agent-svc/tests/test_rbac.py
+++ b/onboarding-intelligence-agent-svc/tests/test_rbac.py
@@ -139,3 +139,46 @@ def test_enforce_returns_the_verdict_when_not_denied(engine):
 def test_an_unknown_skill_denies_rather_than_raising_keyerror(engine):
     """The engine stays total; unknown ids are the registry's business."""
     assert engine.verdict_for_skill(Role.OWNER, "SKL-OIA-99") is Verdict.DENY
+
+
+# ── Regression cover for PR #534 review findings ──────────────────────────
+
+
+def test_internal_only_skills_allow_every_role_in_the_matrix(engine):
+    """The matrix must agree with the full role set the YAML declares.
+
+    Review finding: RECORD_GOLDEN_CANDIDATES denied VIEWER while §8 declares
+    all four roles and marks it internal_only. An internal pipeline running
+    under a VIEWER's session would have been denied by RBAC before the origin
+    gate ever spoke. Externally the skill is unreachable for every role, so
+    the gate — not this row — is the control.
+    """
+    for skill_id in ("SKL-OIA-13", "SKL-OIA-15", "SKL-OIA-16"):
+        for role in Role:
+            assert engine.verdict_for_skill(role, skill_id) is not Verdict.DENY, (
+                f"{skill_id} denies {role.value} in the matrix, which would "
+                "block an internal caller before the origin gate applies"
+            )
+
+
+def test_matrix_agrees_with_the_declared_roles_for_internal_only_skills():
+    """Cross-check the matrix against config/skills.yaml rather than a constant."""
+    from pathlib import Path as _Path
+
+    import yaml
+
+    root = _Path(__file__).resolve().parents[1]
+    declarations = yaml.safe_load((root / "config" / "skills.yaml").read_text())
+    engine = RBACEngine()
+
+    for declaration in declarations["skills"]:
+        if not declaration.get("internal_only"):
+            continue
+        declared = set(declaration["allowed_roles"])
+        assert declared == {r.value for r in Role}, declaration["skill_id"]
+        for role in Role:
+            verdict = engine.verdict_for_skill(role, declaration["skill_id"])
+            assert verdict is not Verdict.DENY, (
+                f"{declaration['skill_id']} declares {sorted(declared)} but the "
+                f"matrix denies {role.value}"
+            )


### PR DESCRIPTION
Three findings raised on #534 that are actually about **A-06 code already merged in #533** — they surfaced there only because #534 had accidentally re-proposed A-06's diff (now fixed by rebasing it). Split out here so both PRs are honestly scoped.

## 1. The matrix and the YAML disagreed about internal_only skills

`RECORD_GOLDEN_CANDIDATES` denied VIEWER, while `config/skills.yaml` declares all four roles for SKL-OIA-13 and marks it `internal_only`.

The matrix would have won. An internal pipeline running under a VIEWER's session would have been **denied by RBAC before the origin gate ever spoke** — the gate is checked first in `_authorize`, but it only rejects *external* callers, so an internal call fell through to a matrix row that said DENY.

VIEWER is now ALLOW, which is what "SYSTEM expressed as the full role set plus `internal_only: true`" actually means: the **gate**, not the row, refuses external callers. Externally the skill stays unreachable for every role, VIEWER included — that behaviour is unchanged and still covered by the tests added in #533.

## 2. A comment contradicted the code directly beneath it

The note above SKL-OIA-15/16 said they "carry no §15 row" — immediately above the two lines mapping them to `VIEW_RECORDINGS`. They do borrow that row, and deliberately: it is the one row every role may use, because RBAC is not their control. Corrected to say that, and to name the origin gate as the real mechanism.

## 3. `get_event_loop()` inside a coroutine

Deprecated on 3.12+, warns or errors depending on the runtime. Replaced with `get_running_loop()` in the Kafka test helper.

## Tests

Two additions, both aimed at the class of bug rather than the instance:

- every `internal_only` skill must be non-DENY for **every** role;
- the matrix is cross-checked against `config/skills.yaml` itself rather than against a hand-written constant, so a future skill whose declared roles and matrix row diverge fails immediately.

331 tests pass; `black`, `flake8` and `mypy --strict` clean.

## Note on #534

That PR now contains only its two deploy fixes (5 files). It had been branched from `feat/a-06-agent-skeleton` rather than `development_main`, and because #533 was squash-merged, git read A-06's original commits as new work — 38 files, ~2,987 insertions. Rebased onto `development_main`; the hotfix PR #535 against `main` was cherry-picked and was never affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)