### PR TITLE
chore(ci): report the 25 slowest backend tests

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -67,7 +67,11 @@ jobs:
         run: |
           cd ai-brand-automator
           python manage.py migrate_schemas --shared --noinput
-          pytest --cov=. --cov-report=xml --cov-report=html
+          # --durations: the suite takes ~4h and nobody knows where it
+          # goes. Report the 25 slowest so the next change is aimed at
+          # evidence rather than a guess. Reporting only; no behaviour
+          # change, and no test is skipped or reordered.
+          pytest --cov=. --cov-report=xml --cov-report=html --durations=25
       
       - name: Test MCP Server
         env:


### PR DESCRIPTION
The backend suite takes **~4 hours** and nobody knows where the time goes. This adds `--durations=25` so the next change is aimed at evidence.

**Reporting only** — no test is skipped, reordered or deselected.

```diff
-          pytest --cov=. --cov-report=xml --cov-report=html
+          pytest --cov=. --cov-report=xml --cov-report=html --durations=25
```

## Why measure first

I profiled locally, and the result rules out the obvious answers rather than confirming them. Same 134 `orchestration` tests each run:

| Configuration | Wall | CPU |
|---|---|---|
| Neon + serial + coverage | 185 s | **16%** |
| Neon + **4 workers** + coverage | 192 s | 43% |
| Neon + serial, no coverage | 181 s | — |
| **Local Postgres** + serial | **63 s** | 40% |
| Local Postgres + 4 workers | 79 s | 80% |

The 16% CPU is the tell — the process is idle, waiting on the database. `--durations` showed ~**1.3 s of per-test `setup`** against near-zero call time: the fixtures do DB work per test, and against Neon (us-east-2) each query is a network round-trip.

Three conclusions, two of them counter-intuitive:

1. **Parallelism made it worse.** Each xdist worker builds its own test database, costing more than it saves at this size.
2. **Coverage is nearly free** here (185 s vs 181 s), so removing it is not the lever it appears to be.
3. **None of this explains CI.** CI never sets `DATABASE_URL` — it uses a local `postgres:15-alpine` service container, so it is not paying the Neon penalty at all. My numbers explain *local* slowness only.

That third point is the reason for this PR. Without CI-side durations we cannot tell a uniform per-test cost from a handful of pathological tests, and those need opposite fixes.

## What this rules in or out next

- **Uniform ~6 s/test** → fixture or DB-setup cost; look at session-scoped fixtures and `--reuse-db`.
- **A long tail of slow tests** → likely real sleeps, retries or network calls; fix those specifically.

## Note

`CLAUDE.md` lists `.github/workflows/ci-cd.yml` under "Do Not Modify — coordinate with team". Changed at the maintainer's explicit request, and deliberately kept to one line plus a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)