### PR TITLE
chore(ci): run the property tests in a parallel job

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -34,6 +34,12 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
+          # Without this the default glob is recursive, so the key hashes
+          # every requirements.txt in the monorepo and an unrelated service
+          # invalidates this job's cache.
+          cache-dependency-path: |
+            ai-brand-automator/requirements.txt
+            ai-brand-automator/requirements-dev.txt
       
       - name: Install dependencies
         run: |
@@ -94,7 +100,8 @@ jobs:
           files: ./ai-brand-automator/coverage.xml
           flags: backend
 
-  # Media Curation Tests
+  # Backend Property Tests (Hypothesis; split out so they run in
+  # parallel with backend-tests rather than behind it)
   backend-property-tests:
     runs-on: ubuntu-latest
     
@@ -121,6 +128,12 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
+          # Without this the default glob is recursive, so the key hashes
+          # every requirements.txt in the monorepo and an unrelated service
+          # invalidates this job's cache.
+          cache-dependency-path: |
+            ai-brand-automator/requirements.txt
+            ai-brand-automator/requirements-dev.txt
       
       - name: Install dependencies
         run: |
@@ -149,6 +162,7 @@ jobs:
           # already uploads the coverage report.
           pytest -m property --durations=25
 
+  # Media Curation Tests
   test-media-curation:
     runs-on: ubuntu-latest
     

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -67,11 +67,11 @@ jobs:
         run: |
           cd ai-brand-automator
           python manage.py migrate_schemas --shared --noinput
-          # --durations: the suite takes ~4h and nobody knows where it
-          # goes. Report the 25 slowest so the next change is aimed at
-          # evidence rather than a guess. Reporting only; no behaviour
-          # change, and no test is skipped or reordered.
-          pytest --cov=. --cov-report=xml --cov-report=html --durations=25
+          # Everything except the property tests, which run in the
+          # backend-property-tests job alongside this one. --durations=25
+          # keeps reporting where the remaining time goes.
+          pytest -m "not property" --cov=. --cov-report=xml \
+            --cov-report=html --durations=25
       
       - name: Test MCP Server
         env:
@@ -95,6 +95,60 @@ jobs:
           flags: backend
 
   # Media Curation Tests
+  backend-property-tests:
+    runs-on: ubuntu-latest
+    
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_DB: test_db
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+      
+      - name: Install dependencies
+        run: |
+          cd ai-brand-automator
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+      
+      - name: Run tests
+        env:
+          SECRET_KEY: test-secret-key-for-ci
+          DB_NAME: test_db
+          DB_USER: postgres
+          DB_PASSWORD: postgres
+          DB_HOST: localhost
+          DB_PORT: 5432
+          DB_SSLMODE: disable
+          DB_CHANNEL_BINDING: disable
+          DEBUG: True
+        run: |
+          cd ai-brand-automator
+          python manage.py migrate_schemas --shared --noinput
+          # Only the property tests. They dominated the 4h run — the 25
+          # slowest were all Hypothesis tests — so running them beside the
+          # rest turns a serial 4h into two shorter jobs in parallel.
+          # No coverage: this job exists for wall-clock, and backend-tests
+          # already uploads the coverage report.
+          pytest -m property --durations=25
+
   test-media-curation:
     runs-on: ubuntu-latest
     


### PR DESCRIPTION
`--durations=25` (from #543) gave us the answer: **every one of the 25 slowest backend tests is a Hypothesis property test**, together ~5,644 s of the 4-hour run.

This splits them into a sibling job so one serial 4 h job becomes two shorter jobs in parallel.

```
backend-tests           pytest -m "not property" --cov=... --durations=25
backend-property-tests  pytest -m property --durations=25          ← new, runs alongside
```

## No test is lost

| Selection | Collected |
|---|---|
| `-m property` | 60 |
| `-m "not property"` | 2,525 |
| **total** | **2,585** |

Exactly complementary — nothing falls between the two jobs.

## This is *not* the fixture rewrite we discussed, deliberately

I was going to rewrite the per-example fixture chain next. Measuring first contradicted the theory behind it.

Locally, in a 383-test run, those same property tests **don't appear in the top 12 at all**:

```
25.94s call     apps/onboarding/tests/test_migrations.py::test_migration_reversible
25.40s call     apps/onboarding/tests/test_migrations.py::test_the_b02_migration_reverses_on_populated_data
22.79s call     onboarding/tests/test_properties.py::...::test_company_cascade_deletes_assets
17.55s teardown ...
```

The slowest local tests are migration tests (~26 s) and teardowns (~17 s). The tests costing CI **477 s each** don't register. The per-example fixture chain is identical in both places, so it cannot be what makes CI slow — and rewriting it would have been effort spent on a theory the evidence contradicts.

Also ruled out:

- **Coverage** — 57 s with vs 59 s without, on those exact tests.
- **Example count** — the loaded profile is `dev` (50) and these tests override it *downward* to 25/15/10/8.
- **Remote DB** — CI never sets `DATABASE_URL`; it uses a local `postgres:15-alpine` service container.

## So this job is also the next measurement

If the property tests are still ~477 s each when they're no longer queued behind 2,400 others, the cost is inherent to them. If they collapse, it's an interaction effect and the fixtures were never the problem. Either answer tells us what to fix next; right now we'd be guessing.

## One real trade-off

The property job carries **no coverage flags** — it exists for wall-clock, and `backend-tests` still uploads the report. Lines exercised *only* by property tests will therefore read as uncovered, so the reported percentage will drop. There's no `--cov-fail-under` gate so nothing breaks, but it's a genuine trade rather than a free win. Say the word and I'll add `--cov` plus artifact merging instead.

The property job's duplicated linter and security-scan steps are removed — `backend-tests` already runs both.

## Note

`CLAUDE.md` lists `.github/workflows/ci-cd.yml` under "Do Not Modify — coordinate with team". Changed at the maintainer's explicit request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)