### PR TITLE
chore: ignore Microsoft Office lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,9 @@ deployment/gcp/service-urls.env
 
 # Claude Code worktrees
 .claude/worktrees/
+
+# Microsoft Office lock files. Word, Excel and PowerPoint create a hidden
+# "~$name.docx" beside any open document and delete it on close, so these
+# appear and vanish as the design and backlog documents are edited. One was
+# committed by accident in B-02 and reappeared twice afterwards.
+~$*


### PR DESCRIPTION
Word creates a hidden `~$name.docx` beside any open document and deletes it on close, so these appear and vanish as the Onboarding Intelligence design and backlog documents are edited.

```gitignore
~$*
```

One was **committed by accident in B-02** (removed in that PR's cleanup) and has reappeared twice since — most recently tripping `gh pr create` with an uncommitted-change warning on #544.

Verified the rule works:

```console
$ touch 'docs/Onboarding_Intelligence/~$test.docx'
$ git status --short docs/
                      # ignored, as intended
```

The pattern is deliberately unanchored so it catches Excel and PowerPoint lock files anywhere in the tree, not just in `docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)