### PR TITLE
feat(onboarding): consent API with per-session semantics (B-07)

### DIFF
--- a/ai-brand-automator/apps/onboarding/commands.py
+++ b/ai-brand-automator/apps/onboarding/commands.py
@@ -1,0 +1,90 @@
+"""Commands Django sends to the agent (§13, ``agent.commands.*``).
+
+Published rather than called. The B-07 technical note gives the reason: "a
+revocation must succeed even if the agent is down." A synchronous call would
+tie a legal action — withdrawing consent — to the availability of a service
+that has no business blocking it.
+
+So revocation is recorded in PostgreSQL first and the notification is
+best-effort, gated and queued exactly like EVT-109 in ``events.py``. If the
+broker is missing the consent is still revoked; only the agent's prompt
+awareness of it is delayed.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+#: The agent's command topic, provisioned by A-05.
+COMMANDS_TOPIC = "agent.commands.onboarding-intelligence"
+
+COMMAND_CONSENT_REVOKED = "consent.revoked"
+
+#: The close code the agent must use when it drops a live socket for revoked
+#: consent. §10.2.3 and §9 both say 4403; §5.1's IG-08 row says 4401, which is
+#: already spent on an invalid JWT — that row is a typo.
+CLOSE_CODE_CONSENT_REVOKED = 4403
+
+
+def build_consent_revoked(*, session_id, tenant_id, consent_id) -> dict:
+    """The command body, and nothing else.
+
+    Ids only — no subject name, no scope. NFR-PRIV-01 keeps personal data in
+    the tenant-scoped store, and a command topic is a lower-trust surface. The
+    agent can read the record if it needs the detail.
+    """
+    return {
+        "command": COMMAND_CONSENT_REVOKED,
+        "session_id": str(session_id),
+        "tenant_id": str(tenant_id) if tenant_id else None,
+        "consent_id": str(consent_id),
+        "close_code": CLOSE_CODE_CONSENT_REVOKED,
+    }
+
+
+def publish_consent_revoked(*, session_id, tenant_id, consent_id) -> dict:
+    """Tell the agent to drop any live socket for this session.
+
+    Never raises. Returns the payload so a caller — or a test — can assert on
+    its shape without a broker.
+    """
+    payload = build_consent_revoked(
+        session_id=session_id, tenant_id=tenant_id, consent_id=consent_id
+    )
+
+    if not commands_enabled():
+        logger.debug("consent.revoked not published: Kafka disabled (%s)", session_id)
+        return payload
+
+    try:
+        from kafka_service.tasks import publish_event_to_kafka
+
+        # .delay(): publish_event_to_kafka is a Celery @shared_task, and a
+        # revocation must not wait on Kafka I/O.
+        publish_event_to_kafka.delay(
+            topic=COMMANDS_TOPIC,
+            event_type=COMMAND_CONSENT_REVOKED,
+            data=payload,
+            key=str(session_id),
+        )
+    except Exception:  # noqa: BLE001 - the revocation already succeeded
+        logger.warning(
+            "consent.revoked not queued for session %s — consent is still revoked",
+            session_id,
+            exc_info=True,
+        )
+
+    return payload
+
+
+def commands_enabled() -> bool:
+    """Whether agent commands should be published at all.
+
+    A named predicate so the decision is testable without a broker and
+    without patching one out.
+    """
+    return bool(getattr(settings, "ONBOARDING_KAFKA_ENABLED", False))

--- a/ai-brand-automator/apps/onboarding/serializers.py
+++ b/ai-brand-automator/apps/onboarding/serializers.py
@@ -11,7 +11,11 @@ from __future__ import annotations
 
 from rest_framework import serializers
 
-from apps.onboarding.models import FieldProvenance, OnboardingSession
+from apps.onboarding.models import (
+    ConsentRecord,
+    FieldProvenance,
+    OnboardingSession,
+)
 
 
 class OnboardingSessionSerializer(serializers.ModelSerializer):
@@ -25,6 +29,9 @@ class OnboardingSessionSerializer(serializers.ModelSerializer):
 
     legal_next_states = serializers.SerializerMethodField(
         help_text="Statuses reachable from the current one (§9.4)",
+    )
+    consent = serializers.SerializerMethodField(
+        help_text="Consent state for this session (AC-2); granted: false when none",
     )
 
     class Meta:
@@ -40,6 +47,7 @@ class OnboardingSessionSerializer(serializers.ModelSerializer):
             "prompt_versions",
             "evidence_manifest_hash",
             "legal_next_states",
+            "consent",
             "created_at",
             "updated_at",
         ]
@@ -55,6 +63,7 @@ class OnboardingSessionSerializer(serializers.ModelSerializer):
             # L-03's, not a client's (§17.2).
             "prompt_versions",
             "legal_next_states",
+            "consent",
         ]
 
     def get_legal_next_states(self, obj) -> list[str]:
@@ -67,6 +76,34 @@ class OnboardingSessionSerializer(serializers.ModelSerializer):
         from apps.onboarding import state
 
         return sorted(state.legal_targets(obj.status, obj.escalated_from))
+
+    def get_consent(self, obj) -> dict:
+        """Consent state for this session, never inherited (AC-2, AC-4).
+
+        Consent attaches to the specific conversation being recorded, not to
+        the customer relationship — the card calls AC-4 "the one people get
+        wrong". Because the FK is to *session*, a new session simply has no
+        consent row and reports granted: false. There is no inheritance to
+        suppress; the absence is structural.
+        """
+        record = (
+            obj.consent_records.filter(revoked_at__isnull=True)
+            .order_by("-granted_at")
+            .first()
+        )
+        if record is None:
+            return {
+                "granted": False,
+                "granted_at": None,
+                "method": None,
+                "scope": None,
+            }
+        return {
+            "granted": True,
+            "granted_at": record.granted_at,
+            "method": record.method,
+            "scope": record.scope,
+        }
 
 
 class FieldProvenanceSerializer(serializers.ModelSerializer):
@@ -127,3 +164,88 @@ class ProvenanceEditSerializer(serializers.Serializer):
     """
 
     final_value = serializers.JSONField()
+
+
+class ConsentScopeSerializer(serializers.Serializer):
+    """The v1 shape of ``ConsentRecord.scope``.
+
+    The technical note asks for a declared shape now, because the column is
+    JSON precisely so it can grow — audio, transcript, captured media,
+    retention period — without a migration. Declaring it here means the growth
+    is deliberate rather than whatever a caller happened to send.
+
+    Every key is optional with a default, so an operator who ticks nothing
+    still produces a record that says what was consented to.
+    """
+
+    audio = serializers.BooleanField(default=True)
+    transcript = serializers.BooleanField(default=True)
+    captured_media = serializers.BooleanField(default=True)
+    retention_days = serializers.IntegerField(
+        required=False,
+        min_value=1,
+        max_value=3650,
+        help_text="Tenant retention window for this recording; M-03 erases on it",
+    )
+
+
+class ConsentRecordSerializer(serializers.ModelSerializer):
+    """Read and write shape for consent (§10.2, IG-08).
+
+    ``granted_at`` and ``granted_by`` are read-only. FR-REC-01 is explicit
+    that the timestamp is server-set, and a client-chosen consent time is the
+    single field an incident would turn on — so it is not accepted even to be
+    ignored politely.
+    """
+
+    is_active = serializers.BooleanField(read_only=True)
+
+    class Meta:
+        model = ConsentRecord
+        fields = [
+            "id",
+            "session",
+            "subject_name",
+            "granted_by",
+            "method",
+            "scope",
+            "granted_at",
+            "revoked_at",
+            "is_active",
+        ]
+        read_only_fields = [
+            "id",
+            "session",
+            # Server-set (FR-REC-01). A client-supplied value is discarded.
+            "granted_by",
+            "granted_at",
+            # Set by the revoke action, never by a body.
+            "revoked_at",
+            "is_active",
+        ]
+
+    def validate_scope(self, value):
+        if value is None:
+            return {}
+        if not isinstance(value, dict):
+            raise serializers.ValidationError("scope must be an object.")
+        nested = ConsentScopeSerializer(data=value)
+        nested.is_valid(raise_exception=True)
+        # The caller's dict, not validated_data: an unlisted key is kept so
+        # scope can grow without this serializer being the thing that drops
+        # it. Same reasoning as digital_presence in B-03.
+        return value
+
+
+class SessionConsentStateSerializer(serializers.Serializer):
+    """The ``consent`` object on a session read (AC-2).
+
+    A flat ``granted: false`` rather than a null, so the frontend renders a
+    state rather than checking for absence — and so "no consent" and "consent
+    we failed to load" cannot look alike.
+    """
+
+    granted = serializers.BooleanField()
+    granted_at = serializers.DateTimeField(allow_null=True)
+    method = serializers.CharField(allow_null=True)
+    scope = serializers.JSONField(allow_null=True)

--- a/ai-brand-automator/apps/onboarding/serializers.py
+++ b/ai-brand-automator/apps/onboarding/serializers.py
@@ -86,11 +86,19 @@ class OnboardingSessionSerializer(serializers.ModelSerializer):
         consent row and reports granted: false. There is no inheritance to
         suppress; the absence is structural.
         """
-        record = (
-            obj.consent_records.filter(revoked_at__isnull=True)
-            .order_by("-granted_at")
-            .first()
-        )
+        prefetched = getattr(obj, "active_consents", None)
+        if prefetched is not None:
+            # The list endpoint attaches this, so N sessions cost one query
+            # rather than N. Falling back below keeps the serializer correct
+            # when it is used without the prefetch.
+            record = prefetched[0] if prefetched else None
+        else:
+            record = (
+                obj.consent_records.filter(revoked_at__isnull=True)
+                .order_by("-granted_at")
+                .first()
+            )
+
         if record is None:
             return {
                 "granted": False,
@@ -231,10 +239,16 @@ class ConsentRecordSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError("scope must be an object.")
         nested = ConsentScopeSerializer(data=value)
         nested.is_valid(raise_exception=True)
-        # The caller's dict, not validated_data: an unlisted key is kept so
-        # scope can grow without this serializer being the thing that drops
-        # it. Same reasoning as digital_presence in B-03.
-        return value
+        # Merged rather than either alone. Returning ``value`` preserved
+        # unlisted keys but silently dropped the declared defaults, so a
+        # caller who ticked nothing stored ``{}`` — a record that does not say
+        # what was consented to, which is the opposite of the point. Returning
+        # ``validated_data`` alone would apply the defaults but discard the
+        # growth the JSON column exists for.
+        #
+        # Unlisted keys first, then the validated known keys on top: the
+        # latter carry both the defaults and any coercion.
+        return {**value, **nested.validated_data}
 
 
 class SessionConsentStateSerializer(serializers.Serializer):

--- a/ai-brand-automator/apps/onboarding/tests/test_consent_api.py
+++ b/ai-brand-automator/apps/onboarding/tests/test_consent_api.py
@@ -1,0 +1,394 @@
+"""B-07 · the consent API (AC-1 … AC-4).
+
+Consent is the prerequisite IG-08 checks before a recording can start, so
+these tests are about lawfulness being provable after the fact rather than
+about CRUD. Two of them matter more than the rest.
+
+``granted_at`` must be the server's. FR-REC-01 says so, and a client-chosen
+consent timestamp is the single field an incident would turn on.
+
+Consent must not be inherited between sessions. The card calls AC-4 "the one
+people get wrong": consent attaches to the conversation being recorded, not to
+the customer relationship, and inheriting it would be both a GDPR problem and
+a product problem.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+from django.contrib.auth.models import User
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from apps.onboarding.commands import (
+    CLOSE_CODE_CONSENT_REVOKED,
+    build_consent_revoked,
+    commands_enabled,
+)
+from apps.onboarding.models import ConsentMethod, SessionStatus
+from apps.onboarding.tests.factories import make_company, make_consent, make_session
+from tenants.models import Membership, Tenant
+
+pytestmark = pytest.mark.django_db
+
+SESSIONS = "/api/v1/onboarding/sessions/"
+
+
+def client_for(user, tenant) -> APIClient:
+    client = APIClient()
+    client.defaults["SERVER_NAME"] = "localhost"
+    client.force_authenticate(user=user)
+    client.defaults["HTTP_X_TENANT_ID"] = str(tenant.id)
+    return client
+
+
+def member(tenant, role, username) -> User:
+    user = User.objects.create_user(
+        username=username, email=f"{username}@test.com", password="TestPass123!"
+    )
+    Membership.objects.create(user=user, tenant=tenant, role=role)
+    return user
+
+
+@pytest.fixture
+def editor(public_tenant):
+    return member(public_tenant, Membership.Role.EDITOR, "b07_editor")
+
+
+@pytest.fixture
+def viewer(public_tenant):
+    return member(public_tenant, Membership.Role.VIEWER, "b07_viewer")
+
+
+def consent_url(session) -> str:
+    return f"{SESSIONS}{session.pk}/consent/"
+
+
+VALID_BODY = {
+    "subject_name": "Asha Kalyani",
+    "method": ConsentMethod.VERBAL_RECORDED,
+    "scope": {"audio": True, "transcript": True, "captured_media": False},
+}
+
+
+# ── AC-1 · consent captures who, how and what ────────────────────────
+
+
+def test_consent_records_subject_method_and_scope(public_tenant, editor):
+    session = make_session(tenant=public_tenant, status=SessionStatus.READY)
+
+    response = client_for(editor, public_tenant).post(
+        consent_url(session), VALID_BODY, format="json"
+    )
+
+    assert response.status_code == 201, response.data
+    assert response.data["subject_name"] == "Asha Kalyani"
+    assert response.data["method"] == ConsentMethod.VERBAL_RECORDED
+    assert response.data["scope"]["captured_media"] is False
+    assert response.data["granted_by"] == editor.pk
+    assert response.data["is_active"] is True
+
+
+def test_granted_at_server_side(public_tenant, editor):
+    """The card's named case: a client cannot backdate consent.
+
+    Not merely ignored — the serializer does not accept the field at all, so
+    there is no code path that could start trusting it.
+    """
+    session = make_session(tenant=public_tenant, status=SessionStatus.READY)
+    forged = timezone.now() - timedelta(days=400)
+
+    response = client_for(editor, public_tenant).post(
+        consent_url(session),
+        {**VALID_BODY, "granted_at": forged.isoformat()},
+        format="json",
+    )
+
+    assert response.status_code == 201
+    granted_at = session.consent_records.get().granted_at
+    assert granted_at != forged
+    assert (timezone.now() - granted_at).total_seconds() < 60
+
+
+def test_granted_by_cannot_be_supplied_by_a_client(public_tenant, editor):
+    """Consent recorded in someone else's name would be worse than none."""
+    other = member(public_tenant, Membership.Role.EDITOR, "b07_other")
+    session = make_session(tenant=public_tenant, status=SessionStatus.READY)
+
+    client_for(editor, public_tenant).post(
+        consent_url(session), {**VALID_BODY, "granted_by": other.pk}, format="json"
+    )
+
+    assert session.consent_records.get().granted_by == editor
+
+
+def test_a_second_grant_returns_the_existing_record(public_tenant, editor):
+    """Two consent rows for one conversation would make "was this lawful?"
+    ambiguous, so a repeat grant is idempotent rather than additive."""
+    session = make_session(tenant=public_tenant, status=SessionStatus.READY)
+    client = client_for(editor, public_tenant)
+
+    first = client.post(consent_url(session), VALID_BODY, format="json")
+    second = client.post(consent_url(session), VALID_BODY, format="json")
+
+    assert first.status_code == 201
+    assert second.status_code == 200
+    assert second.data["id"] == first.data["id"]
+    assert session.consent_records.count() == 1
+
+
+@pytest.mark.parametrize(
+    "bad_scope",
+    [
+        {"retention_days": 0},  # below the minimum
+        {"retention_days": 99999},  # above the maximum
+        {"audio": "yes please"},  # not a boolean
+        ["not", "an", "object"],
+    ],
+)
+def test_a_malformed_scope_is_refused(public_tenant, editor, bad_scope):
+    session = make_session(tenant=public_tenant, status=SessionStatus.READY)
+
+    response = client_for(editor, public_tenant).post(
+        consent_url(session), {**VALID_BODY, "scope": bad_scope}, format="json"
+    )
+
+    assert response.status_code == 400
+    assert "scope" in response.data
+
+
+def test_an_unlisted_scope_key_is_kept(public_tenant, editor):
+    """scope is JSON so it can grow without a migration — this serializer
+    must not be the thing that drops the growth."""
+    session = make_session(tenant=public_tenant, status=SessionStatus.READY)
+
+    client_for(editor, public_tenant).post(
+        consent_url(session),
+        {**VALID_BODY, "scope": {"audio": True, "future_key": "kept"}},
+        format="json",
+    )
+
+    assert session.consent_records.get().scope["future_key"] == "kept"
+
+
+# ── AC-2 · the session exposes consent state ─────────────────────────
+
+
+def test_a_session_without_consent_reports_granted_false(public_tenant, editor):
+    session = make_session(tenant=public_tenant, status=SessionStatus.READY)
+
+    response = client_for(editor, public_tenant).get(f"{SESSIONS}{session.pk}/")
+
+    assert response.data["consent"] == {
+        "granted": False,
+        "granted_at": None,
+        "method": None,
+        "scope": None,
+    }
+
+
+def test_a_session_with_consent_reports_the_details(public_tenant, editor):
+    session = make_session(tenant=public_tenant, status=SessionStatus.READY)
+    client = client_for(editor, public_tenant)
+    client.post(consent_url(session), VALID_BODY, format="json")
+
+    consent = client.get(f"{SESSIONS}{session.pk}/").data["consent"]
+
+    assert consent["granted"] is True
+    assert consent["granted_at"] is not None
+    assert consent["method"] == ConsentMethod.VERBAL_RECORDED
+    assert consent["scope"]["transcript"] is True
+
+
+# ── AC-3 · revocation is immediate and visible ───────────────────────
+
+
+def test_revocation_flips_the_session_state(public_tenant, editor):
+    session = make_session(tenant=public_tenant, status=SessionStatus.READY)
+    client = client_for(editor, public_tenant)
+    client.post(consent_url(session), VALID_BODY, format="json")
+
+    revoked = client.delete(consent_url(session))
+
+    assert revoked.status_code == 200
+    assert revoked.data["revoked_at"] is not None
+    assert revoked.data["is_active"] is False
+    assert client.get(f"{SESSIONS}{session.pk}/").data["consent"]["granted"] is False
+
+
+def test_revocation_is_idempotent(public_tenant, editor):
+    """A double-click is not a failure."""
+    session = make_session(tenant=public_tenant, status=SessionStatus.READY)
+    client = client_for(editor, public_tenant)
+    client.post(consent_url(session), VALID_BODY, format="json")
+
+    first = client.delete(consent_url(session))
+    revoked_at = session.consent_records.get().revoked_at
+    second = client.delete(consent_url(session))
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert session.consent_records.get().revoked_at == revoked_at
+
+
+def test_revoking_without_consent_is_not_an_error(public_tenant, editor):
+    session = make_session(tenant=public_tenant, status=SessionStatus.READY)
+
+    response = client_for(editor, public_tenant).delete(consent_url(session))
+
+    assert response.status_code == 200
+    assert response.data["granted"] is False
+
+
+def test_revocation_publishes_the_close_command(public_tenant, editor):
+    """AC-3's other half, as far as this story can take it.
+
+    The socket close itself is F-04's — ``app/api/ws.py`` still raises
+    NotImplementedError, so there is no live session to close. What B-07 owes
+    F-04 is a command with the right shape, and that is what this asserts.
+    """
+    session = make_session(tenant=public_tenant, status=SessionStatus.READY)
+    consent = make_consent(session=session)
+
+    payload = build_consent_revoked(
+        session_id=session.pk, tenant_id=public_tenant.id, consent_id=consent.pk
+    )
+
+    assert payload["command"] == "consent.revoked"
+    assert payload["close_code"] == CLOSE_CODE_CONSENT_REVOKED == 4403
+    assert payload["session_id"] == str(session.pk)
+
+
+def test_the_close_command_carries_no_personal_data():
+    """NFR-PRIV-01: a command topic is a lower-trust surface than the
+    tenant-scoped store, so it carries ids and not the subject's name."""
+    payload = build_consent_revoked(session_id=1, tenant_id=2, consent_id=3)
+
+    assert set(payload) == {
+        "command",
+        "session_id",
+        "tenant_id",
+        "consent_id",
+        "close_code",
+    }
+    assert "Asha" not in str(payload)
+    assert "subject_name" not in payload
+
+
+def test_revocation_succeeds_with_commands_disabled(public_tenant, editor, settings):
+    """ "A revocation must succeed even if the agent is down" — the technical
+    note's requirement, and the reason this is published rather than called."""
+    settings.ONBOARDING_KAFKA_ENABLED = False
+    assert commands_enabled() is False
+
+    session = make_session(tenant=public_tenant, status=SessionStatus.READY)
+    client = client_for(editor, public_tenant)
+    client.post(consent_url(session), VALID_BODY, format="json")
+
+    response = client.delete(consent_url(session))
+
+    assert response.status_code == 200
+    assert session.consent_records.get().revoked_at is not None
+
+
+# ── AC-4 · consent is per session, not per tenant ────────────────────
+
+
+def test_consent_not_inherited(public_tenant, editor):
+    """The card's named case, and the one it says people get wrong.
+
+    Consent attaches to the conversation being recorded. Inheriting it across
+    sessions would be a GDPR problem and a product problem at once.
+    """
+    company = make_company(tenant=None, name="Repeat Customer")
+    client = client_for(editor, public_tenant)
+
+    first = make_session(company=company, tenant=public_tenant, status="READY")
+    client.post(consent_url(first), VALID_BODY, format="json")
+    assert client.get(f"{SESSIONS}{first.pk}/").data["consent"]["granted"] is True
+
+    # Retire the first so the one-active-session index allows a second.
+    first.status = SessionStatus.COMPLETED
+    first.save(update_fields=["status"])
+
+    second = make_session(company=company, tenant=public_tenant, status="DRAFT")
+    consent = client.get(f"{SESSIONS}{second.pk}/").data["consent"]
+
+    assert consent["granted"] is False, "consent was inherited across sessions"
+    assert consent["granted_at"] is None
+
+
+def test_consent_is_not_shared_between_sessions_of_different_companies(
+    public_tenant, editor
+):
+    client = client_for(editor, public_tenant)
+    consented = make_session(
+        company=make_company(tenant=None, name="A"), tenant=public_tenant
+    )
+    client.post(consent_url(consented), VALID_BODY, format="json")
+
+    other = make_session(
+        company=make_company(tenant=None, name="B"), tenant=public_tenant
+    )
+    assert client.get(f"{SESSIONS}{other.pk}/").data["consent"]["granted"] is False
+
+
+# ── Roles and tenant scoping ─────────────────────────────────────────
+
+
+def test_viewer_cannot_record_or_revoke_consent(public_tenant, viewer):
+    session = make_session(tenant=public_tenant, status=SessionStatus.READY)
+    client = client_for(viewer, public_tenant)
+
+    assert (
+        client.post(consent_url(session), VALID_BODY, format="json").status_code == 403
+    )
+    assert client.delete(consent_url(session)).status_code == 403
+
+
+def test_the_consent_action_requires_tenant_access(public_tenant):
+    """A custom action absent from role_permissions would fall through to bare
+    IsAuthenticated — the hole review found on B-06."""
+    session = make_session(tenant=None)
+    outsider = User.objects.create_user(
+        username="b07_no_membership", email="n@test.com", password="TestPass123!"
+    )
+    client = APIClient()
+    client.defaults["SERVER_NAME"] = "localhost"
+    client.force_authenticate(user=outsider)
+
+    response = client.post(consent_url(session), VALID_BODY, format="json")
+
+    assert response.status_code in (403, 404)
+
+
+def test_cross_tenant_consent_is_404(public_tenant, editor):
+    other = Tenant.objects.create(name="Other B07", schema_name="other_b07")
+    theirs = make_session(company=make_company(tenant=other, name="Theirs"))
+
+    response = client_for(editor, public_tenant).post(
+        consent_url(theirs), VALID_BODY, format="json"
+    )
+
+    assert response.status_code == 404
+
+
+def test_the_serializer_itself_refuses_the_server_set_fields():
+    """Three layers protect granted_at and granted_by, and only two of them
+    are exercised by the tests above.
+
+    ``auto_now_add`` makes the model ignore an assigned timestamp, and the view
+    passes ``granted_by`` as a save kwarg, which wins over validated_data. So
+    those tests would still pass if the serializer stopped declaring these
+    read-only — which means they do not prove the serializer layer exists.
+
+    This asserts it directly, so the defence-in-depth stays deliberate rather
+    than becoming accidental.
+    """
+    from apps.onboarding.serializers import ConsentRecordSerializer
+
+    fields = ConsentRecordSerializer().fields
+    for name in ("granted_at", "granted_by", "revoked_at"):
+        assert fields[name].read_only, f"{name} is writable by a client"

--- a/ai-brand-automator/apps/onboarding/tests/test_consent_api.py
+++ b/ai-brand-automator/apps/onboarding/tests/test_consent_api.py
@@ -392,3 +392,105 @@ def test_the_serializer_itself_refuses_the_server_set_fields():
     fields = ConsentRecordSerializer().fields
     for name in ("granted_at", "granted_by", "revoked_at"):
         assert fields[name].read_only, f"{name} is writable by a client"
+
+
+# ── PR #549 review · all four findings were real ─────────────────────
+
+
+def test_scope_defaults_are_applied(public_tenant, editor):
+    """The docstring promised defaults; validate_scope returned the caller's
+    dict, so an operator who ticked nothing stored ``{}``.
+
+    A record that does not say what was consented to is the opposite of the
+    point of recording consent at all.
+    """
+    session = make_session(tenant=public_tenant, status=SessionStatus.READY)
+
+    client_for(editor, public_tenant).post(
+        consent_url(session),
+        {"subject_name": "Asha Kalyani", "method": ConsentMethod.CHECKBOX, "scope": {}},
+        format="json",
+    )
+
+    scope = session.consent_records.get().scope
+    assert scope["audio"] is True
+    assert scope["transcript"] is True
+    assert scope["captured_media"] is True
+
+
+def test_scope_defaults_do_not_overwrite_explicit_values(public_tenant, editor):
+    session = make_session(tenant=public_tenant, status=SessionStatus.READY)
+
+    client_for(editor, public_tenant).post(
+        consent_url(session),
+        {**VALID_BODY, "scope": {"audio": False}},
+        format="json",
+    )
+
+    scope = session.consent_records.get().scope
+    assert scope["audio"] is False, "an explicit value was overwritten by a default"
+    assert scope["transcript"] is True, "the default was not applied"
+
+
+def test_the_session_list_does_not_query_per_session(public_tenant, editor):
+    """The list and retrieve endpoints share a serializer, and the consent
+    field queried per row — 20 sessions meant 21 queries.
+
+    Asserted by counting, so a regression shows up as a number rather than as
+    a slow page nobody attributes to this.
+    """
+    from django.db import connection
+    from django.test.utils import CaptureQueriesContext
+
+    client = client_for(editor, public_tenant)
+    for name in ("One", "Two", "Three", "Four"):
+        session = make_session(
+            company=make_company(tenant=None, name=name), tenant=public_tenant
+        )
+        make_consent(session=session)
+
+    with CaptureQueriesContext(connection) as captured:
+        response = client.get(SESSIONS)
+        assert response.status_code == 200
+
+    consent_queries = [
+        q
+        for q in captured.captured_queries
+        if "onboarding_sessions_consentrecord" in q["sql"]
+    ]
+    assert len(consent_queries) <= 1, (
+        f"{len(consent_queries)} consent queries for 4 sessions — the prefetch "
+        "is not being used"
+    )
+
+
+def test_the_revocation_command_is_published_after_the_commit():
+    """The docstring claimed commit-then-notify; the publish ran inside the
+    action's atomic block, so the command could be queued before the
+    revocation was visible.
+
+    Asserted against the source rather than by patching, because this codebase
+    does not mock and the requirement is precisely that the call site defers.
+    """
+    import inspect
+
+    from apps.onboarding.views import OnboardingSessionViewSet
+
+    source = inspect.getsource(OnboardingSessionViewSet._revoke_consent)
+    assert "on_commit(" in source
+    assert "\n        publish_consent_revoked(" not in source
+
+
+def test_a_grant_locks_the_session_before_checking(public_tenant, editor):
+    """Idempotency was only sequential: two concurrent POSTs could both see no
+    consent and both create, with no unique constraint to catch the second.
+
+    Asserts the lock is taken rather than simulating the interleaving, which
+    would need two connections and be flaky in CI.
+    """
+    import inspect
+
+    from apps.onboarding.views import OnboardingSessionViewSet
+
+    source = inspect.getsource(OnboardingSessionViewSet._grant_consent)
+    assert "select_for_update()" in source

--- a/ai-brand-automator/apps/onboarding/views.py
+++ b/ai-brand-automator/apps/onboarding/views.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 
 from django.db import IntegrityError
+from django.db.models import Prefetch
 from django.db import transaction as db_transaction
 from django.utils import timezone
 from rest_framework import mixins
@@ -28,6 +29,7 @@ from apps.onboarding.events import (
     emit_provenance_reviewed,
 )
 from apps.onboarding.models import (
+    ConsentRecord,
     FieldClassification,
     FieldProvenance,
     OnboardingSession,
@@ -94,6 +96,17 @@ class OnboardingSessionViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):
         """
         queryset = OnboardingSession.objects.select_related(
             "company", "questionnaire", "created_by"
+        ).prefetch_related(
+            # Without this the serializer's consent field costs one query per
+            # session, and the list endpoint uses the same serializer as
+            # retrieve — so a page of 20 sessions became 21 queries.
+            Prefetch(
+                "consent_records",
+                queryset=ConsentRecord.objects.filter(revoked_at__isnull=True).order_by(
+                    "-granted_at"
+                ),
+                to_attr="active_consents",
+            )
         )
         # Never read request.tenant directly — the fleet's defensive pattern.
         tenant = getattr(self.request, "tenant", None)
@@ -235,6 +248,13 @@ class OnboardingSessionViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):
         is the single field an incident would turn on, so the serializer does
         not accept it at all rather than accepting and discarding it.
         """
+        # Lock the session before looking for existing consent. Without it
+        # the idempotency below is only sequential: two concurrent POSTs can
+        # both see none and both create, and there is no unique constraint to
+        # catch the second — which would make "was this lawful?" ambiguous in
+        # exactly the way one record per conversation exists to prevent.
+        OnboardingSession.objects.select_for_update().get(pk=session.pk)
+
         existing = (
             session.consent_records.filter(revoked_at__isnull=True)
             .order_by("-granted_at")
@@ -287,10 +307,17 @@ class OnboardingSessionViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):
         record.revoked_at = timezone.now()
         record.save(update_fields=["revoked_at", "updated_at"])
 
-        publish_consent_revoked(
-            session_id=session.pk,
-            tenant_id=session.tenant_id,
-            consent_id=record.pk,
+        # on_commit, not inline: this runs inside the action's atomic block,
+        # so publishing here would queue the command before the revocation is
+        # visible to anyone else — an agent acting on it could read the row
+        # and still see consent granted. The docstring above already claimed
+        # commit-then-notify; this makes it true.
+        db_transaction.on_commit(
+            lambda: publish_consent_revoked(
+                session_id=session.pk,
+                tenant_id=session.tenant_id,
+                consent_id=record.pk,
+            )
         )
         return Response(ConsentRecordSerializer(record).data, status=http.HTTP_200_OK)
 

--- a/ai-brand-automator/apps/onboarding/views.py
+++ b/ai-brand-automator/apps/onboarding/views.py
@@ -20,6 +20,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from apps.onboarding import errors
+from apps.onboarding.commands import publish_consent_revoked
 from apps.onboarding.field_map import label_for, page_for
 from apps.onboarding.events import (
     ACTION_CONFIRM,
@@ -34,6 +35,7 @@ from apps.onboarding.models import (
     tenant_scope_q,
 )
 from apps.onboarding.serializers import (
+    ConsentRecordSerializer,
     FieldProvenanceSerializer,
     OnboardingSessionSerializer,
     ProvenanceEditSerializer,
@@ -71,6 +73,15 @@ class OnboardingSessionViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):
         # which is bare IsAuthenticated. A user with no tenant membership
         # would then reach tenant_scope_q(None) and read pre-tenant rows.
         "provenance": [IsAuthenticated, IsTenantViewer],
+        # §10.2 says Editor+ for consent. The story narrative says "As an
+        # Admin", but the endpoint table is the contract, and an Editor
+        # running the meeting is who captures consent. This is not the
+        # KEY/SECONDARY asymmetry from B-06 — consent is not Admin-gated.
+        #
+        # Listed explicitly because a custom action missing from this dict
+        # falls through to DEFAULT_PERMISSION_CLASSES, which is bare
+        # IsAuthenticated. That was the hole review caught on B-06.
+        "consent": [IsAuthenticated, IsTenantEditor],
     }
 
     def get_queryset(self):
@@ -202,6 +213,86 @@ class OnboardingSessionViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):
             )
 
         return Response({"session": session.pk, "groups": groups})
+
+    @action(detail=True, methods=["post", "delete"])
+    @db_transaction.atomic
+    def consent(self, request, pk=None):
+        """``POST/DELETE /sessions/{id}/consent/`` — IG-08's prerequisite.
+
+        POST records consent; DELETE revokes it. One action for both because
+        they are the same resource, and a client that can find one can find
+        the other.
+        """
+        session = self.get_object()
+        if request.method == "DELETE":
+            return self._revoke_consent(session)
+        return self._grant_consent(request, session)
+
+    def _grant_consent(self, request, session):
+        """Record consent, with granted_by and granted_at set server-side.
+
+        FR-REC-01: the timestamp is the server's. A client-chosen consent time
+        is the single field an incident would turn on, so the serializer does
+        not accept it at all rather than accepting and discarding it.
+        """
+        existing = (
+            session.consent_records.filter(revoked_at__isnull=True)
+            .order_by("-granted_at")
+            .first()
+        )
+        if existing is not None:
+            # Idempotent rather than duplicating: two consent rows for one
+            # conversation would make "was this lawful?" ambiguous.
+            return Response(
+                ConsentRecordSerializer(existing).data, status=http.HTTP_200_OK
+            )
+
+        payload = ConsentRecordSerializer(data=request.data)
+        payload.is_valid(raise_exception=True)
+
+        record = payload.save(
+            session=session,
+            tenant=session.tenant,
+            granted_by=request.user if request.user.is_authenticated else None,
+        )
+        return Response(
+            ConsentRecordSerializer(record).data, status=http.HTTP_201_CREATED
+        )
+
+    def _revoke_consent(self, session):
+        """Revoke, then tell the agent to drop any live socket.
+
+        The order matters: the revocation is committed to PostgreSQL before
+        the notification is attempted, because a revocation must succeed even
+        if the agent — or the broker — is down.
+
+        Closing the socket itself is F-04's; ``app/api/ws.py`` is still a stub,
+        so there is no socket to close today. This publishes the command with
+        the shape F-04 will consume.
+        """
+        record = (
+            session.consent_records.filter(revoked_at__isnull=True)
+            .order_by("-granted_at")
+            .select_for_update()
+            .first()
+        )
+        if record is None:
+            # Idempotent: nothing to revoke is not an error, and a 404 here
+            # would make a double-click look like a failure.
+            return Response(
+                {"granted": False, "detail": "No active consent for this session."},
+                status=http.HTTP_200_OK,
+            )
+
+        record.revoked_at = timezone.now()
+        record.save(update_fields=["revoked_at", "updated_at"])
+
+        publish_consent_revoked(
+            session_id=session.pk,
+            tenant_id=session.tenant_id,
+            consent_id=record.pk,
+        )
+        return Response(ConsentRecordSerializer(record).data, status=http.HTTP_200_OK)
 
 
 class FieldProvenanceViewSet(


### PR DESCRIPTION
`POST/DELETE /sessions/{id}/consent/`, consent state on the session read, and a revocation command published for the agent.

**Depends on** B-02 (#540), B-04 (#546) · **Blocks** B-08, F-01 · Design §5.1 IG-08, §10.2 · FR-REC-01, NFR-PRIV-01

## Acceptance criteria

| AC | Covered by |
|---|---|
| **AC-1** captures who, how, what | `test_consent_records_subject_method_and_scope`, `test_granted_at_server_side` |
| **AC-2** session exposes consent state | `test_a_session_without_consent_reports_granted_false` + the populated case |
| **AC-3** revocation immediate and visible | `test_revocation_flips_the_session_state`, `test_revocation_publishes_the_close_command` — **partially**, see below |
| **AC-4** per session, not per tenant | `test_consent_not_inherited` |

## `granted_at` is protected three times, and only two were tested

FR-REC-01 says the timestamp is the server's, and a client-chosen consent time is the single field an incident would turn on. Three layers: `auto_now_add` on the model, `granted_by` passed as a save kwarg that wins over `validated_data`, and both declared read-only on the serializer.

**Removing the serializer guard did not fail the obvious tests** — the model and view already covered it. So those tests didn't prove the serializer layer existed. `test_the_serializer_itself_refuses_the_server_set_fields` now asserts it directly and fails without it, so the defence in depth stays deliberate rather than decaying by attrition.

## AC-3 is half-deliverable, and the test name says so

AC-3 wants revocation to close *"any open live session … with 4403"*. But:

```python
# onboarding-intelligence-agent-svc/app/api/ws.py
async def live_websocket(...):
    raise NotImplementedError(_NOT_YET)
```

There is no socket to close — **F-04 owns it**. B-07 flips the state and publishes a command with the shape F-04 will consume. The test is named `test_revocation_publishes_the_close_command`, not `..._closes_live_session`, so it can't be misread as proving the close.

Likewise, **M-03 doesn't exist**, so nothing yet acts on the retention notification.

The command carries **ids only, never the subject name** — a command topic is a lower-trust surface than the tenant-scoped store (NFR-PRIV-01), asserted by `test_the_close_command_carries_no_personal_data`.

## 4403, not 4401 — the design contradicts itself

| Source | Says |
|---|---|
| §5.1 IG-08 row | socket closed **4401** |
| §10.2.3 close codes | **4403** consent missing or revoked |
| §9 | **4403** consent_required |

4401 is already spent on *"invalid or expired JWT"*. Three sources against one — **the §5.1 row is a typo and needs correcting**.

## AC-4 needed no mechanism

The card calls it "the one people get wrong", but `ConsentRecord`'s FK is to *session*, so a new session simply has no row and reports `granted: false`. The test proves the absence rather than an inheritance-suppressing feature — which is the right shape for a structural property.

## The B-06 lesson, applied

The `consent` action has an **explicit `role_permissions` entry**. A custom `@action` missing from that dict falls through to `DEFAULT_PERMISSION_CLASSES` (bare `IsAuthenticated`) — the hole review caught last time. Verified: removing it fails both the viewer test and the no-membership test.

Per §10.2 the role is **Editor+**, not Admin. The story narrative says "As an Admin", but the endpoint table is the contract, and an Editor running the meeting is who captures consent. This is not B-06's KEY/SECONDARY asymmetry.

## `scope` v1 shape

```json
{ "audio": true, "transcript": true, "captured_media": true, "retention_days": 90 }
```

Validated by a nested serializer, all optional with defaults — and **unlisted keys are preserved**, so the JSON column can grow without a migration and without this serializer being what drops the growth.

## Verification

- 23 tests; every protection verified to bite when removed
- `black` (23.12.1), `flake8`, `manage.py check` clean
- No migration — B-02 already created `ConsentRecord`

## Not delivered

No 4403 socket close (F-04), no erasure (M-03), no recording endpoints (B-08), no capture control (F-01), no consent UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)