### PR TITLE
fix(onboarding): scope every row re-lock, and recover B-08's missed review fixes

### DIFF
--- a/ai-brand-automator/apps/onboarding/serializers.py
+++ b/ai-brand-automator/apps/onboarding/serializers.py
@@ -276,6 +276,7 @@ class MeetingRecordingSerializer(serializers.ModelSerializer):
     """
 
     has_summary = serializers.SerializerMethodField()
+    has_transcript = serializers.SerializerMethodField()
 
     class Meta:
         model = MeetingRecording
@@ -286,7 +287,14 @@ class MeetingRecordingSerializer(serializers.ModelSerializer):
             "status",
             "duration_s",
             "audio_asset",
-            "transcript_gcs_path",
+            # transcript_gcs_path is deliberately absent. It is an internal
+            # bucket path, and FR-LIB-01 says media is served "only through
+            # short-lived signed URLs minted per request" — handing out the
+            # raw path leaks infrastructure detail and routes around the
+            # design before it exists. The library only needs to know whether
+            # a transcript is there yet, which is the same reasoning that
+            # makes summary a presence flag.
+            "has_transcript",
             "has_summary",
             "started_at",
             "stopped_at",
@@ -295,6 +303,9 @@ class MeetingRecordingSerializer(serializers.ModelSerializer):
 
     def get_has_summary(self, obj) -> bool:
         return bool(obj.summary)
+
+    def get_has_transcript(self, obj) -> bool:
+        return bool(obj.transcript_gcs_path)
 
 
 class RecordingStopSerializer(serializers.Serializer):

--- a/ai-brand-automator/apps/onboarding/tests/test_consent_api.py
+++ b/ai-brand-automator/apps/onboarding/tests/test_consent_api.py
@@ -493,4 +493,4 @@ def test_a_grant_locks_the_session_before_checking(public_tenant, editor):
     from apps.onboarding.views import OnboardingSessionViewSet
 
     source = inspect.getsource(OnboardingSessionViewSet._grant_consent)
-    assert "select_for_update()" in source
+    assert "select_for_update(" in source

--- a/ai-brand-automator/apps/onboarding/tests/test_consent_api.py
+++ b/ai-brand-automator/apps/onboarding/tests/test_consent_api.py
@@ -479,18 +479,3 @@ def test_the_revocation_command_is_published_after_the_commit():
     source = inspect.getsource(OnboardingSessionViewSet._revoke_consent)
     assert "on_commit(" in source
     assert "\n        publish_consent_revoked(" not in source
-
-
-def test_a_grant_locks_the_session_before_checking(public_tenant, editor):
-    """Idempotency was only sequential: two concurrent POSTs could both see no
-    consent and both create, with no unique constraint to catch the second.
-
-    Asserts the lock is taken rather than simulating the interleaving, which
-    would need two connections and be flaky in CI.
-    """
-    import inspect
-
-    from apps.onboarding.views import OnboardingSessionViewSet
-
-    source = inspect.getsource(OnboardingSessionViewSet._grant_consent)
-    assert "select_for_update(" in source

--- a/ai-brand-automator/apps/onboarding/tests/test_locking_is_tenant_scoped.py
+++ b/ai-brand-automator/apps/onboarding/tests/test_locking_is_tenant_scoped.py
@@ -40,11 +40,21 @@ LOCKING_METHODS = [
     ids=[f"{v.__name__}.{m}" for v, m in LOCKING_METHODS],
 )
 def test_the_lock_uses_the_scoped_queryset(viewset, method):
-    source = inspect.getsource(getattr(viewset, method))
+    # Three independent facts rather than one adjacency match: the method
+    # locks, the lock derives from the scoped queryset, and it does not use
+    # the global manager.
+    #
+    # The first version required "self.get_queryset().select_for_update("
+    # literally, and broke as soon as a comment appeared mid-chain — the
+    # brittleness a source-inspection test earns by asserting on shape
+    # instead of substance.
+    source = " ".join(inspect.getsource(getattr(viewset, method)).split())
 
     assert "select_for_update(" in source, "this method no longer locks at all"
-    assert "self.get_queryset().select_for_update(" in source
-    assert ".objects.select_for_update()" not in source, (
+    assert (
+        "self.get_queryset()" in source
+    ), "the lock does not derive from the tenant-scoped queryset"
+    assert ".objects.select_for_update(" not in source, (
         "locking through the global manager: the lock and the permission "
         "check would disagree about which rows exist"
     )
@@ -53,5 +63,5 @@ def test_the_lock_uses_the_scoped_queryset(viewset, method):
 def test_no_view_reaches_for_a_global_lock():
     """A blanket check, so a *new* action cannot reintroduce the pattern
     without this file noticing."""
-    source = inspect.getsource(views)
-    assert ".objects.select_for_update()" not in source
+    source = " ".join(inspect.getsource(views).split())
+    assert ".objects.select_for_update(" not in source

--- a/ai-brand-automator/apps/onboarding/tests/test_locking_is_tenant_scoped.py
+++ b/ai-brand-automator/apps/onboarding/tests/test_locking_is_tenant_scoped.py
@@ -1,0 +1,57 @@
+"""Every row re-lock goes through the tenant-scoped queryset.
+
+Four review actions read-modify-write a row and lock it first: session
+consent (B-07), provenance confirm and edit (B-06), and recording stop
+(B-08). All four originally re-fetched through the model's global manager
+after ``get_object()`` had already applied the tenant filter.
+
+That is not a hole while ``get_object()`` runs first — it 404s a cross-tenant
+id — but it means the lock and the permission check disagree about which rows
+exist, and only the ordering keeps them honest. Reorder the two lines, or add
+a fifth action that locks without fetching first, and the disagreement becomes
+a cross-tenant write.
+
+Asserted across all four at once, in one file, because the fix is a pattern
+rather than four separate bugs: the next action to lock a row should fail here
+if it reaches for the global manager.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from apps.onboarding import views
+
+pytestmark = pytest.mark.unit
+
+LOCKING_METHODS = [
+    (views.OnboardingSessionViewSet, "_grant_consent"),
+    (views.FieldProvenanceViewSet, "confirm"),
+    (views.FieldProvenanceViewSet, "edit"),
+    (views.MeetingRecordingViewSet, "stop"),
+]
+
+
+@pytest.mark.parametrize(
+    "viewset,method",
+    LOCKING_METHODS,
+    ids=[f"{v.__name__}.{m}" for v, m in LOCKING_METHODS],
+)
+def test_the_lock_uses_the_scoped_queryset(viewset, method):
+    source = inspect.getsource(getattr(viewset, method))
+
+    assert "select_for_update()" in source, "this method no longer locks at all"
+    assert "self.get_queryset().select_for_update()" in source
+    assert ".objects.select_for_update()" not in source, (
+        "locking through the global manager: the lock and the permission "
+        "check would disagree about which rows exist"
+    )
+
+
+def test_no_view_reaches_for_a_global_lock():
+    """A blanket check, so a *new* action cannot reintroduce the pattern
+    without this file noticing."""
+    source = inspect.getsource(views)
+    assert ".objects.select_for_update()" not in source

--- a/ai-brand-automator/apps/onboarding/tests/test_locking_is_tenant_scoped.py
+++ b/ai-brand-automator/apps/onboarding/tests/test_locking_is_tenant_scoped.py
@@ -42,8 +42,8 @@ LOCKING_METHODS = [
 def test_the_lock_uses_the_scoped_queryset(viewset, method):
     source = inspect.getsource(getattr(viewset, method))
 
-    assert "select_for_update()" in source, "this method no longer locks at all"
-    assert "self.get_queryset().select_for_update()" in source
+    assert "select_for_update(" in source, "this method no longer locks at all"
+    assert "self.get_queryset().select_for_update(" in source
     assert ".objects.select_for_update()" not in source, (
         "locking through the global manager: the lock and the permission "
         "check would disagree about which rows exist"

--- a/ai-brand-automator/apps/onboarding/tests/test_recording_api.py
+++ b/ai-brand-automator/apps/onboarding/tests/test_recording_api.py
@@ -307,14 +307,19 @@ def test_the_sweeper_index_exists():
     """
     from django.db import connection
 
+    # Introspection rather than a raw pg_indexes query against a hardcoded
+    # table name: _meta.db_table survives a rename, and the assertion then
+    # describes the *columns* the sweeper needs rather than a string that
+    # happens to match today.
     with connection.cursor() as cursor:
-        cursor.execute(
-            "SELECT indexdef FROM pg_indexes "
-            "WHERE tablename = 'onboarding_sessions_meetingrecording'"
+        constraints = connection.introspection.get_constraints(
+            cursor, MeetingRecording._meta.db_table
         )
-        definitions = " ".join(row[0].lower() for row in cursor.fetchall())
 
-    assert "status" in definitions and "started_at" in definitions
+    indexed_column_sets = [
+        tuple(c["columns"]) for c in constraints.values() if c.get("index")
+    ]
+    assert ("status", "started_at") in indexed_column_sets, indexed_column_sets
 
 
 def test_failed_is_reachable_and_visible_in_the_library(
@@ -328,3 +333,53 @@ def test_failed_is_reachable_and_visible_in_the_library(
 
     assert any(row["id"] == recording.pk for row in rows)
     assert rows[0]["status"] == RecordingStatus.FAILED
+
+
+# ── PR #550 review · all three findings were real ────────────────────
+
+
+def test_the_storage_path_is_not_exposed(consented_session, public_tenant, editor):
+    """FR-LIB-01: media is served "only through short-lived signed URLs minted
+    per request".
+
+    Handing out the raw bucket path leaks infrastructure detail and routes
+    around that design before it exists. The library only needs to know
+    whether a transcript has arrived.
+    """
+    make_recording(
+        session=consented_session,
+        transcript_gcs_path="gs://zorven-raw-assets/_raw/t-1/transcript.json",
+    )
+
+    rows = client_for(editor, public_tenant).get(recordings_url(consented_session)).data
+
+    assert "transcript_gcs_path" not in rows[0]
+    assert rows[0]["has_transcript"] is True
+    assert "gs://" not in str(rows[0]), "a storage path reached the response"
+
+
+def test_has_transcript_is_false_before_one_arrives(
+    consented_session, public_tenant, editor
+):
+    make_recording(session=consented_session, transcript_gcs_path="")
+
+    rows = client_for(editor, public_tenant).get(recordings_url(consented_session)).data
+
+    assert rows[0]["has_transcript"] is False
+
+
+def test_stop_relocks_through_the_tenant_scoped_queryset():
+    """A global re-fetch means the lock and the permission check disagree
+    about which rows exist.
+
+    Not a hole today — get_object() 404s a cross-tenant id first — but the
+    two should not be able to drift apart, and the scoped queryset also keeps
+    select_related("session") applied.
+    """
+    import inspect
+
+    from apps.onboarding.views import MeetingRecordingViewSet
+
+    source = inspect.getsource(MeetingRecordingViewSet.stop)
+    assert "self.get_queryset().select_for_update()" in source
+    assert "MeetingRecording.objects.select_for_update()" not in source

--- a/ai-brand-automator/apps/onboarding/tests/test_recording_api.py
+++ b/ai-brand-automator/apps/onboarding/tests/test_recording_api.py
@@ -381,5 +381,5 @@ def test_stop_relocks_through_the_tenant_scoped_queryset():
     from apps.onboarding.views import MeetingRecordingViewSet
 
     source = inspect.getsource(MeetingRecordingViewSet.stop)
-    assert "self.get_queryset().select_for_update()" in source
+    assert "self.get_queryset().select_for_update(" in source
     assert "MeetingRecording.objects.select_for_update()" not in source

--- a/ai-brand-automator/apps/onboarding/tests/test_recording_api.py
+++ b/ai-brand-automator/apps/onboarding/tests/test_recording_api.py
@@ -366,20 +366,3 @@ def test_has_transcript_is_false_before_one_arrives(
     rows = client_for(editor, public_tenant).get(recordings_url(consented_session)).data
 
     assert rows[0]["has_transcript"] is False
-
-
-def test_stop_relocks_through_the_tenant_scoped_queryset():
-    """A global re-fetch means the lock and the permission check disagree
-    about which rows exist.
-
-    Not a hole today — get_object() 404s a cross-tenant id first — but the
-    two should not be able to drift apart, and the scoped queryset also keeps
-    select_related("session") applied.
-    """
-    import inspect
-
-    from apps.onboarding.views import MeetingRecordingViewSet
-
-    source = inspect.getsource(MeetingRecordingViewSet.stop)
-    assert "self.get_queryset().select_for_update(" in source
-    assert "MeetingRecording.objects.select_for_update()" not in source

--- a/ai-brand-automator/apps/onboarding/views.py
+++ b/ai-brand-automator/apps/onboarding/views.py
@@ -261,7 +261,7 @@ class OnboardingSessionViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):
         # both see none and both create, and there is no unique constraint to
         # catch the second — which would make "was this lawful?" ambiguous in
         # exactly the way one record per conversation exists to prevent.
-        OnboardingSession.objects.select_for_update().get(pk=session.pk)
+        self.get_queryset().select_for_update().get(pk=session.pk)
 
         existing = (
             session.consent_records.filter(revoked_at__isnull=True)
@@ -519,7 +519,7 @@ class FieldProvenanceViewSet(
         # is only *sequentially* idempotent: two concurrent confirms can both
         # read PENDING, both write CONFIRMED and both emit EVT-109, which
         # inflates the confirm-without-edit rate §17.3 reads as quality.
-        row = FieldProvenance.objects.select_for_update().get(pk=row.pk)
+        row = self.get_queryset().select_for_update().get(pk=row.pk)
 
         if row.status == ProvenanceStatus.CONFIRMED:
             return Response(self.get_serializer(row).data)
@@ -549,7 +549,7 @@ class FieldProvenanceViewSet(
         if refusal is not None:
             return refusal
 
-        row = FieldProvenance.objects.select_for_update().get(pk=row.pk)
+        row = self.get_queryset().select_for_update().get(pk=row.pk)
 
         payload = ProvenanceEditSerializer(data=request.data)
         payload.is_valid(raise_exception=True)

--- a/ai-brand-automator/apps/onboarding/views.py
+++ b/ai-brand-automator/apps/onboarding/views.py
@@ -261,7 +261,17 @@ class OnboardingSessionViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):
         # both see none and both create, and there is no unique constraint to
         # catch the second — which would make "was this lawful?" ambiguous in
         # exactly the way one record per conversation exists to prevent.
-        self.get_queryset().select_for_update(of=("self",)).get(pk=session.pk)
+        (
+            self.get_queryset()
+            # prefetch_related(None) because this get_queryset() prefetches
+            # consent_records for the list endpoint. The locked row is
+            # discarded — only the lock matters — so running that prefetch
+            # would be a second query inside the critical section, for a
+            # result nothing reads.
+            .prefetch_related(None)
+            .select_for_update(of=("self",))
+            .get(pk=session.pk)
+        )
 
         existing = (
             session.consent_records.filter(revoked_at__isnull=True)

--- a/ai-brand-automator/apps/onboarding/views.py
+++ b/ai-brand-automator/apps/onboarding/views.py
@@ -261,7 +261,7 @@ class OnboardingSessionViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):
         # both see none and both create, and there is no unique constraint to
         # catch the second — which would make "was this lawful?" ambiguous in
         # exactly the way one record per conversation exists to prevent.
-        self.get_queryset().select_for_update().get(pk=session.pk)
+        self.get_queryset().select_for_update(of=("self",)).get(pk=session.pk)
 
         existing = (
             session.consent_records.filter(revoked_at__isnull=True)
@@ -425,7 +425,16 @@ class MeetingRecordingViewSet(
         # 404s a cross-tenant id — but a global re-fetch means the lock and
         # the permission check disagree about which rows exist, and it costs
         # an extra session query during serialisation.
-        recording = self.get_queryset().select_for_update().get(pk=recording.pk)
+        #
+        # of=("self",) is required, not stylistic. These querysets
+        # select_related nullable FKs, which become LEFT OUTER JOINs, and
+        # PostgreSQL refuses "FOR UPDATE cannot be applied to the nullable
+        # side of an outer join". Locking only this table sidesteps that
+        # while still locking the row that is about to be written — and it
+        # is why the original code reached for the global manager.
+        recording = (
+            self.get_queryset().select_for_update(of=("self",)).get(pk=recording.pk)
+        )
 
         if recording.stopped_at is not None:
             # Idempotent: a second stop must not move the duration. An
@@ -519,7 +528,7 @@ class FieldProvenanceViewSet(
         # is only *sequentially* idempotent: two concurrent confirms can both
         # read PENDING, both write CONFIRMED and both emit EVT-109, which
         # inflates the confirm-without-edit rate §17.3 reads as quality.
-        row = self.get_queryset().select_for_update().get(pk=row.pk)
+        row = self.get_queryset().select_for_update(of=("self",)).get(pk=row.pk)
 
         if row.status == ProvenanceStatus.CONFIRMED:
             return Response(self.get_serializer(row).data)
@@ -549,7 +558,7 @@ class FieldProvenanceViewSet(
         if refusal is not None:
             return refusal
 
-        row = self.get_queryset().select_for_update().get(pk=row.pk)
+        row = self.get_queryset().select_for_update(of=("self",)).get(pk=row.pk)
 
         payload = ProvenanceEditSerializer(data=request.data)
         payload.is_valid(raise_exception=True)

--- a/ai-brand-automator/apps/onboarding/views.py
+++ b/ai-brand-automator/apps/onboarding/views.py
@@ -419,7 +419,13 @@ class MeetingRecordingViewSet(
         transcript that does not exist yet.
         """
         recording = self.get_object()
-        recording = MeetingRecording.objects.select_for_update().get(pk=recording.pk)
+        # Re-locked through get_queryset(), not the global manager: that
+        # keeps the tenant filter and select_related("session") applied. The
+        # authorisation is not lost today — get_object() above already
+        # 404s a cross-tenant id — but a global re-fetch means the lock and
+        # the permission check disagree about which rows exist, and it costs
+        # an extra session query during serialisation.
+        recording = self.get_queryset().select_for_update().get(pk=recording.pk)
 
         if recording.stopped_at is not None:
             # Idempotent: a second stop must not move the duration. An


### PR DESCRIPTION
Two things, both consequences of the same review round on #550.

## 1. Every row re-lock now uses the tenant-scoped queryset

Four review actions read-modify-write a row and lock it first:

| Action | Story |
|---|---|
| `_grant_consent` | B-07 |
| `confirm` | B-06 |
| `edit` | B-06 |
| `stop` | B-08 |

All four re-fetched through the **global manager** after `get_object()` had already applied the tenant filter:

```python
row = FieldProvenance.objects.select_for_update().get(pk=row.pk)   # before
row = self.get_queryset().select_for_update().get(pk=row.pk)       # after
```

**Not a hole today** — `get_object()` runs first and 404s a cross-tenant id. But the lock and the permission check then disagree about which rows exist, and only the *ordering* keeps them honest. Reorder those two lines, or add a fifth action that locks without fetching first, and the disagreement becomes a cross-tenant write. The scoped queryset also keeps `select_related` applied, saving a query during serialisation.

Review caught this on B-08. B-06's and B-07's were already merged, so they're fixed here rather than in #550 — avoiding the scope creep that bit #540.

`test_locking_is_tenant_scoped.py` asserts **all four sites at once**, because this is a pattern rather than four bugs, plus a blanket check over the module so a new action can't reintroduce it quietly. Verified: reverting one re-lock fails both the specific case and the blanket one.

## 2. B-08's review fixes missed their merge

**#550 was merged at 15:37, before those commits finished pushing.** So `development_main` still has none of them — confirmed by inspection, not assumption:

| Fix | State on `development_main` |
|---|---|
| `transcript_gcs_path` no longer exposed | ❌ still exposed |
| `stop()` re-locks through the scoped queryset | ❌ still global |
| Index test uses introspection, not a hardcoded table | ❌ still `pg_indexes` |

The first is the one that matters: an internal bucket path in the API response leaks infrastructure detail and routes around FR-LIB-01's *"only through short-lived signed URLs minted per request"* — before that mechanism exists. Replaced with a `has_transcript` flag.

Cherry-picked here so they aren't lost. My part in this: I reported the fixes as done while they were still pushing, which made merging then entirely reasonable.

## Verification

- `apps/onboarding` passes; `black`, `flake8`, `makemigrations --check` clean
- Both behavioural changes verified by reverting them and watching tests fail
- No migration, no new dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)