### PR TITLE
feat(oia): PREP execute endpoint, service-token auth and chat state (C-01, agent half)

### DIFF
--- a/onboarding-intelligence-agent-svc/app/api/deps.py
+++ b/onboarding-intelligence-agent-svc/app/api/deps.py
@@ -1,17 +1,57 @@
 """Shared request dependencies — service-token auth and tenant extraction.
 
-Design §15, §16 · implemented by story A-06.
+Design §15, §16 · scaffolded by A-05, implemented by C-01.
 
-Scaffolded by A-05. The body raises NotImplementedError deliberately: a
-stub that silently returns None would let a later story ship a no-op
-that passes its tests.
+``X-Service-Token`` rather than a JWT, and rather than anything invented here:
+§10.2 marks the agent endpoints "X-Service-Token · not exposed publicly", and
+the C-01 card is explicit — "mirroring the fleet. Do not invent a new auth
+scheme for this service."
 """
 
 from __future__ import annotations
 
-_NOT_YET = "app.api.deps — implemented by A-06"
+import hmac
+
+from fastapi import Header, HTTPException, Request, status
+
+from app.core.errors import ErrorCode
+
+SERVICE_TOKEN_HEADER = "X-Service-Token"
 
 
-async def verify_service_token(*args: object, **kwargs: object) -> None:
-    """Not yet implemented."""
-    raise NotImplementedError(_NOT_YET)
+async def verify_service_token(
+    request: Request,
+    x_service_token: str | None = Header(default=None, alias=SERVICE_TOKEN_HEADER),
+) -> None:
+    """Reject any caller without the configured service token.
+
+    ``hmac.compare_digest`` rather than ``==``: token comparison is the one
+    place where an early-exit equality check leaks length and prefix through
+    timing. The cost is nil and the habit is worth keeping.
+
+    An unset ``SERVICE_TOKEN`` refuses everything rather than allowing
+    everything. A service that authenticates nothing because its config is
+    missing is the failure mode that looks fine in staging.
+    """
+    expected = getattr(request.app.state.settings, "SERVICE_TOKEN", "")
+
+    if not expected:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={
+                "code": ErrorCode.INVALID_JWT,
+                "message": (
+                    "This service has no SERVICE_TOKEN configured and cannot "
+                    "authenticate callers."
+                ),
+            },
+        )
+
+    if not x_service_token or not hmac.compare_digest(x_service_token, expected):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={
+                "code": ErrorCode.INVALID_JWT,
+                "message": f"A valid {SERVICE_TOKEN_HEADER} header is required.",
+            },
+        )

--- a/onboarding-intelligence-agent-svc/app/api/routes.py
+++ b/onboarding-intelligence-agent-svc/app/api/routes.py
@@ -1,16 +1,26 @@
 """HTTP routes.
 
-A-05 delivers the health surface only. ``/v1/execute``, ``/v1/onboarding``,
-``/v1/process`` and ``/v1/process/{job_id}`` are declared in Design §4.2 and
-arrive with the stories that implement PREP and PROCESS.
+A-05 delivered the health surface. C-01 adds ``/v1/execute`` — the PREP
+envelope from §10.2.1 that C-02 through C-04 all ride. ``/v1/onboarding``,
+``/v1/process`` and ``/v1/process/{job_id}`` arrive with their own stories.
 """
 
 from __future__ import annotations
 
+import time
 from typing import Any
 
-from fastapi import APIRouter, Request, Response, status
+from fastapi import APIRouter, Depends, Request, Response, status
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+
+from app.api.deps import verify_service_token
+from app.api.schemas import (
+    ExecuteRequest,
+    ExecuteResponse,
+    GuardrailReport,
+    UsageReport,
+)
+from app.cache.conversation import ConversationStore
 
 router = APIRouter()
 
@@ -162,3 +172,53 @@ async def ready(request: Request, response: Response) -> dict[str, Any]:
 async def prometheus_metrics() -> Response:
     """Prometheus exposition (Design §20)."""
     return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)
+
+
+@router.post(
+    "/v1/execute",
+    response_model=ExecuteResponse,
+    dependencies=[Depends(verify_service_token)],
+)
+async def execute(request: Request, payload: ExecuteRequest) -> ExecuteResponse:
+    """A PREP turn (§10.2.1, §2.1).
+
+    C-01 delivers the envelope, the auth and the conversation state. It does
+    not yet run a skill: SKL-OIA-01 and 02 are C-02 and C-03, and the registry
+    has no PREP skill registered to call. So the turn is recorded, the history
+    is returned, and ``skill_id`` says plainly that none ran.
+
+    Returning a truthful empty result beats either faking one or 501-ing: C-02
+    needs this envelope to exist to build against, and Django needs to be able
+    to route a turn end to end before there is anything to say back.
+    """
+    started = time.monotonic()
+    tenant_id = payload.tenant_context.tenant_id
+
+    store = ConversationStore(request.app.state.redis)
+    await store.append(
+        tenant_id=tenant_id,
+        chat_session_id=payload.chat_session_id,
+        role="operator",
+        text=payload.input_prompt,
+    )
+    history = await store.history(
+        tenant_id=tenant_id, chat_session_id=payload.chat_session_id
+    )
+
+    return ExecuteResponse(
+        status="SUCCEEDED",
+        # Named rather than left blank, so a caller reading the response can
+        # tell "no skill is wired up yet" from "a skill ran and produced
+        # nothing" — which are different bugs.
+        skill_id="NONE",
+        output={
+            "turns": len(history),
+            "history": history,
+            "detail": (
+                "Conversation recorded. Question generation arrives with "
+                "SKL-OIA-01 and SKL-OIA-02 (C-02, C-03)."
+            ),
+        },
+        guardrails=GuardrailReport(),
+        usage=UsageReport(duration_ms=int((time.monotonic() - started) * 1000)),
+    )

--- a/onboarding-intelligence-agent-svc/app/api/schemas.py
+++ b/onboarding-intelligence-agent-svc/app/api/schemas.py
@@ -1,19 +1,94 @@
 """Request and response models for the HTTP and WebSocket surfaces.
 
-Design §10.2 · implemented by story A-06.
+Design §10.2 · scaffolded by A-05, the PREP envelope implemented by C-01.
 
-Scaffolded by A-05. The body raises NotImplementedError deliberately: a
-stub that silently returns None would let a later story ship a no-op
-that passes its tests.
+The shapes below are §10.2.1 verbatim. The C-01 card is unusually firm about
+this — "implement them exactly; C-02 through C-04 all ride this envelope" —
+so the field names are copied from the design rather than tidied, and
+``model_config`` forbids extras so a typo in a caller fails loudly instead of
+being silently dropped.
 """
 
 from __future__ import annotations
 
-_NOT_YET = "app.api.schemas — implemented by A-06"
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
 
 
-class ExecuteRequest:
-    """Not yet implemented."""
+class TenantContext(BaseModel):
+    """Who is asking, and under what trace (§10.2.1, §15).
 
-    def __init__(self, *args: object, **kwargs: object) -> None:
-        raise NotImplementedError(_NOT_YET)
+    The role is read from here and never from a request body field the caller
+    could set independently — §15 says roles come from the verified JWT claim
+    only. Django has already verified it; this is the propagation.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    tenant_id: str
+    user_id: str
+    role: Literal["OWNER", "ADMIN", "EDITOR", "VIEWER"]
+    trace_id: str
+    correlation_id: str | None = None
+
+
+class ExecuteRequest(BaseModel):
+    """``POST /v1/execute`` — a PREP turn (§10.2.1)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    tenant_context: TenantContext
+    session_id: str | None = Field(
+        default=None,
+        description=(
+            "The onboarding session, when one exists. A prep conversation "
+            "starts before it does, so this is optional — chat_session_id is "
+            "what conversation state is keyed on."
+        ),
+    )
+    chat_session_id: str = Field(
+        description="The chat this turn belongs to; the conversation-state key"
+    )
+    input_prompt: str
+    input_context: dict[str, Any] = Field(default_factory=dict)
+    config: dict[str, Any] = Field(default_factory=dict)
+    previous_outputs: dict[str, Any] = Field(default_factory=dict)
+
+
+class GuardrailReport(BaseModel):
+    """The three gate verdicts (§5). Reported on every response, because a
+    caller cannot otherwise tell a clean pass from a gate that never ran."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    input: Literal["PASS", "FAIL"] = "PASS"
+    plan: Literal["PASS", "FAIL"] = "PASS"
+    output: Literal["PASS", "FAIL"] = "PASS"
+
+
+class UsageReport(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    duration_ms: int = 0
+
+
+class ExecuteResponse(BaseModel):
+    """``POST /v1/execute`` 200 (§10.2.1).
+
+    ``output`` is deliberately untyped: §10.2.1 shows a questionnaire draft,
+    but C-02 through C-04 put different skill outputs in the same envelope.
+    Typing it to the questionnaire shape now would make this envelope a lie
+    for three of the four stories that ride it.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["SUCCEEDED", "FAILED"]
+    skill_id: str
+    prompt_version: dict[str, str] = Field(default_factory=dict)
+    output: dict[str, Any] = Field(default_factory=dict)
+    guardrails: GuardrailReport = Field(default_factory=GuardrailReport)
+    usage: UsageReport = Field(default_factory=UsageReport)

--- a/onboarding-intelligence-agent-svc/app/cache/conversation.py
+++ b/onboarding-intelligence-agent-svc/app/cache/conversation.py
@@ -1,0 +1,92 @@
+"""Prep conversation state, keyed on the chat session (C-01 AC-2).
+
+An operator prepares over several turns and refers back — "make the third
+question deeper" — so the agent needs what was said earlier. That history
+lives in Redis DB 2 under ``oia:v1:{tenant}:chat:{chat_session_id}``, per
+ERRATA-01 rather than §14's DB 27.
+
+**This story stores and returns the history; it does not resolve references
+against it.** Resolving "the third question" needs a questionnaire and a skill
+to reason over one, which are C-02 and C-03. Delivering the mechanism and
+saying so is more useful than a half-built resolver that appears to work.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Awaitable
+from typing import Any, cast
+
+from app.cache.redis_manager import TTL_CHAT, RedisManager
+
+logger = logging.getLogger(__name__)
+
+#: How many turns to keep. A prep conversation that ran past this has more
+#: context than a prompt window can use anyway, and an unbounded list on a
+#: shared Redis is the other half of the leak the TTL guards against.
+MAX_TURNS = 40
+
+
+class ConversationStore:
+    """Append-and-read the turns of one prep conversation.
+
+    Every method takes the tenant, and the key is built through ``TenantKeys``
+    — obtained from ``RedisManager.keys_for`` — so a tenant-less key cannot be
+    constructed. That is A-03's rule: "a helper that can be called without a
+    tenant will eventually be called without one."
+    """
+
+    def __init__(self, redis_manager: "RedisManager") -> None:
+        self._redis = redis_manager
+
+    def _key(self, tenant_id: str, chat_session_id: str) -> str:
+        key: str = self._redis.keys_for(tenant_id).chat(chat_session_id)
+        return key
+
+    async def append(
+        self, *, tenant_id: str, chat_session_id: str, role: str, text: str
+    ) -> None:
+        """Record one turn and refresh the sliding TTL.
+
+        The TTL is re-applied on every write rather than only on the first, so
+        an active conversation survives and an abandoned one expires — which
+        is what "sliding" means and what stops a busy tenant's keys from
+        vanishing mid-preparation.
+        """
+        key = self._key(tenant_id, chat_session_id)
+        turn = json.dumps({"role": role, "text": text}, separators=(",", ":"))
+
+        client = self._redis.client
+        pipe = client.pipeline()
+        pipe.rpush(key, turn)
+        pipe.ltrim(key, -MAX_TURNS, -1)
+        pipe.expire(key, TTL_CHAT)
+        await pipe.execute()
+
+    async def history(
+        self, *, tenant_id: str, chat_session_id: str
+    ) -> list[dict[str, Any]]:
+        """Every retained turn, oldest first.
+
+        A malformed entry is skipped rather than raising: one unparseable turn
+        should cost that turn, not the whole conversation the operator is in
+        the middle of.
+        """
+        key = self._key(tenant_id, chat_session_id)
+        # redis-py types lrange as Awaitable[list] | list, because the same
+        # signature serves the sync and async clients. This is always the
+        # async one, so the call is cast before it is awaited — casting the
+        # result instead leaves mypy awaiting a union.
+        raw = await cast("Awaitable[list[Any]]", self._redis.client.lrange(key, 0, -1))
+
+        turns: list[dict[str, Any]] = []
+        for entry in raw:
+            try:
+                turns.append(json.loads(entry))
+            except (TypeError, ValueError):
+                logger.warning("dropping an unparseable turn from %s", key)
+        return turns
+
+    async def clear(self, *, tenant_id: str, chat_session_id: str) -> None:
+        await self._redis.client.delete(self._key(tenant_id, chat_session_id))

--- a/onboarding-intelligence-agent-svc/app/cache/redis_manager.py
+++ b/onboarding-intelligence-agent-svc/app/cache/redis_manager.py
@@ -46,6 +46,12 @@ TTL_LOCK: Final[int] = 2 * 60 * 60
 #: or a documented exemption once the database is shared; this is the TTL.
 TTL_CONFIG: Final[int] = 7 * 24 * 60 * 60
 
+#: §14 lists no chat key at all — C-01 introduces one, so it needs a TTL the
+#: way TTL_CONFIG did. Four hours sliding, matching TTL_SESSION: a prep
+#: conversation is the same span of work as the session it prepares, and the
+#: card is explicit that "an untimed key on a shared Redis is a slow leak".
+TTL_CHAT: Final[int] = 4 * 60 * 60
+
 #: §14: the transcript list is capped so reconnect replay has a known worst
 #: case. ~8 segments/minute means a 60-minute meeting stays under 500.
 TRANSCRIPT_MAX_ENTRIES: Final[int] = 4000
@@ -74,6 +80,15 @@ class TenantKeys:
     def session_summary(self, session_id: str) -> str:
         """String · 24 h · compressed L3 summary."""
         return f"{self._scope}session:{session_id}:summary"
+
+    def chat(self, chat_session_id: str) -> str:
+        """List · 4 h sliding · prep conversation turns (C-01).
+
+        Keyed on the *chat* session, not the onboarding session: a prep
+        conversation starts before any OnboardingSession exists, which is the
+        whole point of preparing in the chat the operator already uses.
+        """
+        return f"{self._scope}chat:{chat_session_id}"
 
     # ── Live meeting ─────────────────────────────────────────
     def transcript(self, session_id: str) -> str:

--- a/onboarding-intelligence-agent-svc/app/core/errors.py
+++ b/onboarding-intelligence-agent-svc/app/core/errors.py
@@ -53,6 +53,14 @@ class ErrorCode(StrEnum):
     #: but §18.4 has already spent ERR-06 on live-session-active.
     SKILL_NOT_IN_ALLOWLIST = "ERR-17"
 
+    #: Provisional (C-01). Django could not reach this service — 503 or a
+    #: timeout. C-01's AC-3 asks for ERR-13, which §18.4 spends on a field
+    #: conflict requiring a human (202, SKL-OIA-14) — a different thing with a
+    #: different remedy. Nothing existing fits either: ERR-07/08/09 are *this*
+    #: service's own degraded dependencies and ERR-10 is a buffered write in
+    #: the agent-to-Django direction. There is no code for the reverse.
+    AGENT_UNAVAILABLE = "ERR-19"
+
 
 @dataclass(frozen=True)
 class ErrorSpec:

--- a/onboarding-intelligence-agent-svc/app/core/errors.py
+++ b/onboarding-intelligence-agent-svc/app/core/errors.py
@@ -211,6 +211,17 @@ ERROR_SPECS: dict[ErrorCode, ErrorSpec] = {
         False,
         "Indicates a caller or configuration bug, not a user error",
     ),
+    ErrorCode.AGENT_UNAVAILABLE: ErrorSpec(
+        ErrorCode.AGENT_UNAVAILABLE,
+        "Django could not reach this service (C-01)",
+        503,
+        None,
+        True,
+        (
+            "Chat names preparation as temporarily unavailable and points at "
+            "the manual path; the caller's circuit breaker opens"
+        ),
+    ),
 }
 
 

--- a/onboarding-intelligence-agent-svc/tests/conftest.py
+++ b/onboarding-intelligence-agent-svc/tests/conftest.py
@@ -15,6 +15,9 @@ import pytest
 REQUIRED_ENV = {
     "OIA_BACKEND_BASE_URL": "http://backend:8001",
     "OIA_GCS_BUCKET": "zorven-raw-assets",
+    # C-01: /v1/execute refuses every caller when this is unset, which is the
+    # correct production behaviour but would make every test a 503.
+    "OIA_SERVICE_TOKEN": "test-service-token",
 }
 
 REDIS_URL = os.environ.get("OIA_TEST_REDIS_URL", "redis://localhost:6379/2")

--- a/onboarding-intelligence-agent-svc/tests/test_execute_envelope.py
+++ b/onboarding-intelligence-agent-svc/tests/test_execute_envelope.py
@@ -1,0 +1,251 @@
+"""C-01 · the PREP envelope, its auth, and its conversation state.
+
+The C-01 card is firm about the envelope — "implement them exactly; C-02
+through C-04 all ride this envelope" — so these assert §10.2.1's field names
+rather than a shape that merely works.
+
+What this story does *not* deliver is asserted too: no PREP skill runs yet,
+because SKL-OIA-01 and 02 are C-02 and C-03. ``skill_id == "NONE"`` says so
+in the response rather than leaving a caller to infer it.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tests.conftest import REQUIRED_ENV
+
+SERVICE_TOKEN = REQUIRED_ENV.get("OIA_SERVICE_TOKEN", "")
+EXECUTE = "/v1/execute"
+
+
+def unique(prefix: str) -> str:
+    """A fresh id per test.
+
+    These run against a real Redis — no mocks — and the chat keys outlive the
+    process. Fixed ids made "this conversation has one turn" depend on how
+    many times the suite had been run, which passed once and then never again.
+    """
+    return f"{prefix}-{uuid.uuid4().hex[:10]}"
+
+
+def valid_body(**overrides) -> dict:
+    body = {
+        "tenant_context": {
+            "tenant_id": unique("t"),
+            "user_id": "u-1",
+            "role": "ADMIN",
+            "trace_id": "01J8TRACE",
+            "correlation_id": "01J8CORR",
+        },
+        "chat_session_id": unique("chat"),
+        "input_prompt": "We're onboarding a coffee roaster in Pune.",
+        "input_context": {"company_name": "Kalyani Roasters", "depth": 4},
+        "config": {"language": "en-IN"},
+        "previous_outputs": {},
+    }
+    body.update(overrides)
+    return body
+
+
+@pytest.fixture
+def client(app_with_live_redis):
+    """As a context manager, so the lifespan runs.
+
+    Without it app.state.settings and app.state.redis are never set — the
+    app object exists but nothing has wired it up, and every request fails
+    on an attribute that production would always have.
+    """
+    with TestClient(app_with_live_redis) as test_client:
+        yield test_client
+
+
+def headers(token: str | None = SERVICE_TOKEN) -> dict:
+    return {"X-Service-Token": token} if token is not None else {}
+
+
+# ── The §10.2.1 envelope ─────────────────────────────────────────────
+
+
+def test_execute_envelope(client):
+    """The card's named case: request and response match §10.2.1."""
+    response = client.post(EXECUTE, json=valid_body(), headers=headers())
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+
+    assert set(body) == {
+        "status",
+        "skill_id",
+        "prompt_version",
+        "output",
+        "guardrails",
+        "usage",
+    }
+    assert body["status"] == "SUCCEEDED"
+    assert set(body["guardrails"]) == {"input", "plan", "output"}
+    assert set(body["usage"]) == {"input_tokens", "output_tokens", "duration_ms"}
+
+
+def test_the_response_says_plainly_that_no_skill_ran(client):
+    """C-02 and C-03 bring the skills. Until then a caller must be able to
+    tell "nothing is wired up" from "a skill ran and produced nothing"."""
+    body = client.post(EXECUTE, json=valid_body(), headers=headers()).json()
+
+    assert body["skill_id"] == "NONE"
+    assert "SKL-OIA-01" in body["output"]["detail"]
+
+
+@pytest.mark.parametrize(
+    "missing", ["tenant_context", "chat_session_id", "input_prompt"]
+)
+def test_a_required_field_is_refused(client, missing):
+    body = valid_body()
+    del body[missing]
+
+    assert client.post(EXECUTE, json=body, headers=headers()).status_code == 422
+
+
+def test_an_unknown_field_is_refused(client):
+    """extra="forbid": a caller's typo should fail loudly, not be dropped —
+    three later stories build against this envelope."""
+    response = client.post(
+        EXECUTE, json=valid_body(inputPrompt="camelCase typo"), headers=headers()
+    )
+
+    assert response.status_code == 422
+
+
+def test_an_unknown_role_is_refused(client):
+    body = valid_body()
+    body["tenant_context"]["role"] = "SUPERUSER"
+
+    assert client.post(EXECUTE, json=body, headers=headers()).status_code == 422
+
+
+def test_session_id_is_optional(client):
+    """A prep conversation starts before an OnboardingSession exists — that is
+    the point of preparing in the chat the operator already uses."""
+    response = client.post(EXECUTE, json=valid_body(), headers=headers())
+
+    assert response.status_code == 200
+    assert "session_id" not in valid_body()
+
+
+# ── X-Service-Token (§10.2, §15) ─────────────────────────────────────
+
+
+def test_a_missing_token_is_refused(client):
+    assert client.post(EXECUTE, json=valid_body(), headers={}).status_code == 401
+
+
+def test_a_wrong_token_is_refused(client):
+    response = client.post(EXECUTE, json=valid_body(), headers=headers("nope"))
+
+    assert response.status_code == 401
+    assert response.json()["detail"]["code"] == "ERR-01"
+
+
+def test_an_empty_token_is_refused(client):
+    assert (
+        client.post(EXECUTE, json=valid_body(), headers=headers("")).status_code == 401
+    )
+
+
+def test_auth_runs_before_validation(client):
+    """An unauthenticated caller must not learn which fields are required.
+
+    A 422 here would turn the endpoint into a schema oracle for anyone who
+    can reach it.
+    """
+    response = client.post(EXECUTE, json={"garbage": True}, headers={})
+
+    assert response.status_code == 401
+
+
+def test_an_unconfigured_service_refuses_everything(monkeypatch, app_with_live_redis):
+    """A service that authenticates nothing because its config is missing is
+    the failure mode that looks fine in staging."""
+    with TestClient(app_with_live_redis) as test_client:
+        app_with_live_redis.state.settings.SERVICE_TOKEN = ""
+        response = test_client.post(EXECUTE, json=valid_body(), headers=headers())
+
+    assert response.status_code == 503
+
+
+# ── AC-2 · conversation state, as mechanism ──────────────────────────
+
+
+def test_multi_turn_history_accumulates(client):
+    """AC-2's mechanism half: a later turn sees the earlier ones.
+
+    Resolving "make the third question deeper" against that history needs a
+    questionnaire and a skill — C-02 and C-03. This is the state they will
+    read.
+    """
+    body = valid_body(chat_session_id=unique("chat"))
+
+    first = client.post(EXECUTE, json=body, headers=headers()).json()
+    assert first["output"]["turns"] == 1
+
+    body["input_prompt"] = "Go deeper on their supply chain."
+    second = client.post(EXECUTE, json=body, headers=headers()).json()
+
+    assert second["output"]["turns"] == 2
+    texts = [turn["text"] for turn in second["output"]["history"]]
+    assert texts[0] == "We're onboarding a coffee roaster in Pune."
+    assert texts[1] == "Go deeper on their supply chain."
+
+
+def test_conversations_do_not_bleed_between_chats(client):
+    client.post(
+        EXECUTE, json=valid_body(chat_session_id=unique("chat")), headers=headers()
+    )
+    other = client.post(
+        EXECUTE, json=valid_body(chat_session_id=unique("chat")), headers=headers()
+    ).json()
+
+    assert other["output"]["turns"] == 1
+
+
+def test_conversations_do_not_bleed_between_tenants(client):
+    body = valid_body(chat_session_id=unique("chat"))
+    client.post(EXECUTE, json=body, headers=headers())
+
+    body["tenant_context"]["tenant_id"] = unique("t")
+    other = client.post(EXECUTE, json=body, headers=headers()).json()
+
+    assert other["output"]["turns"] == 1, "a tenant saw another tenant's chat"
+
+
+@pytest.mark.integration
+async def test_the_chat_key_carries_a_ttl():
+    """An untimed key on a shared Redis is a slow leak — the card's words, and
+    ERRATA-01's rule since DB 2 is shared with ten other services.
+
+    Builds its own RedisManager rather than borrowing the app's: TestClient
+    drives the lifespan on its own event loop, and awaiting that connection
+    from an async test attaches a future to a different loop.
+    """
+    from app.cache.conversation import ConversationStore
+    from app.cache.redis_manager import TTL_CHAT, RedisManager
+    from app.core.config import get_settings
+
+    manager = RedisManager(get_settings())
+    await manager.connect()
+    try:
+        store = ConversationStore(manager)
+        tenant, chat = unique("t"), unique("c")
+
+        await store.append(
+            tenant_id=tenant, chat_session_id=chat, role="operator", text="hello"
+        )
+        ttl = await manager.client.ttl(manager.keys_for(tenant).chat(chat))
+
+        assert 0 < ttl <= TTL_CHAT
+        await store.clear(tenant_id=tenant, chat_session_id=chat)
+    finally:
+        await manager.close()

--- a/onboarding-intelligence-agent-svc/tests/test_scaffold.py
+++ b/onboarding-intelligence-agent-svc/tests/test_scaffold.py
@@ -105,6 +105,12 @@ IMPLEMENTED = {
     "app.skills.registry",
 }
 
+#: C-01 implemented the PREP envelope and its auth: app.api.schemas carries
+#: the §10.2.1 models and app.api.deps verifies X-Service-Token. Neither is a
+#: stub any more, and this test failing is how that became a deliberate edit
+#: rather than a silent one.
+IMPLEMENTED |= {"app.api.deps", "app.api.schemas"}
+
 #: A-06 turned the sixteen skill modules into registry-resolvable classes.
 #: They are no longer bare stubs — the class is real and instantiable, and it
 #: is the *body* that is deferred. test_skill_bodies_are_deferred covers them.

--- a/onboarding-intelligence-agent-svc/tests/test_scaffold.py
+++ b/onboarding-intelligence-agent-svc/tests/test_scaffold.py
@@ -217,3 +217,36 @@ def test_pyproject_pins_the_fleet_toolchain():
     assert "line-length = 88" in pyproject
     assert "strict = true" in pyproject
     assert 'python_version = "3.12"' in pyproject
+
+
+def test_every_error_code_has_a_spec():
+    """The taxonomy is "defined once, here" — so every member must resolve.
+
+    ``OIAError.code`` is a class attribute, so a subclass carrying a
+    spec-less code raises KeyError at construction: the failure surfaces the
+    first time that error is *raised*, which is exactly when nobody wants to
+    discover it. C-01 added ERR-19 to the enum and not to ERROR_SPECS, and
+    review caught it because no test did.
+    """
+    from app.core.errors import ERROR_SPECS, ErrorCode
+
+    missing = [code.name for code in ErrorCode if code not in ERROR_SPECS]
+    assert not missing, f"ErrorCode members with no ErrorSpec: {missing}"
+
+
+def test_no_spec_describes_a_code_that_does_not_exist():
+    """The reverse: a spec keyed to a retired code is dead weight that reads
+    as coverage."""
+    from app.core.errors import ERROR_SPECS, ErrorCode
+
+    unknown = [str(code) for code in ERROR_SPECS if code not in set(ErrorCode)]
+    assert not unknown, f"specs for unknown codes: {unknown}"
+
+
+def test_each_spec_is_self_consistent():
+    """A spec whose key and payload disagree would report the wrong code in
+    to_body(), which is what a caller logs and alerts on."""
+    from app.core.errors import ERROR_SPECS
+
+    for code, spec in ERROR_SPECS.items():
+        assert spec.code == code, f"{code} is keyed to a spec for {spec.code}"


### PR DESCRIPTION
**C-01 split, part 1 of 2.** This is the agent side; Django routing follows separately.

**Depends on** A-06 · **Blocks** C-02 · Design §2.1 PREP, §10.2.1 · FR-PREP-01, FR-PREP-02

## Why it's split

C-01 as written is not a 3-point story — **nothing on the agent side existed**:

| Piece | Before |
|---|---|
| `POST /v1/execute` | undeclared — `routes.py` said "A-05 delivers the health surface only" |
| `verify_service_token` | stub, `raise NotImplementedError` |
| Conversation state | not built |

So it isn't "route to an existing endpoint" — it's build the endpoint, its auth and its state, *then* route. Split so C-02 lands on a complete envelope and the Django half (intent classification, the fuzzier part) is reviewable on its own.

## The §10.2.1 envelope, verbatim

The card is firm — *"implement them exactly; C-02 through C-04 all ride this envelope"* — so field names are the design's, and `extra="forbid"` makes a caller's typo fail loudly rather than being dropped.

`output` is deliberately untyped. §10.2.1 shows a questionnaire draft, but three later stories put different skill outputs in the same field; typing it to the questionnaire shape now would make the envelope a lie for most of its users.

## No skill runs yet — and the response says so

SKL-OIA-01/02 are C-02 and C-03, so `skill_id` is `"NONE"` with a `detail` naming them. That lets a caller distinguish **"nothing is wired up"** from **"a skill ran and produced nothing"** — different bugs. A truthful empty result beats faking one or 501-ing: C-02 needs this envelope to exist to build against.

## Auth

`X-Service-Token` per §10.2 and the card's *"do not invent a new auth scheme"*. Constant-time comparison, and **an unset `SERVICE_TOKEN` refuses everything** rather than allowing everything — a service that authenticates nothing because its config is missing is the failure mode that looks fine in staging.

Verified load-bearing: removing the dependency fails all five auth tests, including `test_auth_runs_before_validation`, which stops the endpoint becoming a schema oracle for unauthenticated callers.

## AC-2 is the mechanism only

History accumulates under `oia:v1:{tenant}:chat:{chat_session_id}` — **ERRATA-01's DB 2, not §14's DB 27** — capped at 40 turns with a sliding 4 h TTL.

§14 lists no chat key at all, so `TTL_CHAT` is derived from `TTL_SESSION` and documented, exactly as `TTL_CONFIG` was in A-03.

Resolving *"make the third question deeper"* needs a questionnaire and a skill to reason over one. That's C-02, and the tests say so rather than implying AC-2 is fully met.

## ERR-19 is provisional

AC-3 asks for **ERR-13**, which §18.4 spends on *"field conflict requiring a human"* (202, SKL-OIA-14). Nothing existing fits: ERR-07/08/09 are this service's *own* degraded dependencies, ERR-10 is a buffered write in the agent→Django direction. There is no code for the reverse.

That's the **third provisional code** (ERR-17, ERR-18, ERR-19) and the **fifth miscited one**. I'd now argue the taxonomy needs a reconciliation pass more than a sixth patch.

## Two test-craft notes

My first version used **fixed chat ids against a real Redis** whose keys outlive the process — so "this conversation has one turn" silently became a function of how many times the suite had run. It passed once and would never have passed again. Every test now generates unique ids; a hazard of the no-mocks rule worth knowing.

The async TTL test builds its **own `RedisManager`** rather than borrowing the app's, because `TestClient` drives the lifespan on a different event loop.

A-05's scaffold test caught the two implemented stubs and forced a deliberate edit to its `IMPLEMENTED` set — which is what it exists for.

## Verification

- **358 passed**, `mypy --strict` clean, `black` and `flake8` clean
- No migration, no new dependency

## Not delivered

No Django routing (part 2), no PREP skills (C-02/C-03), no reference resolution, no circuit breaker — that lives with the Django half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)