### PR TITLE
feat(chat): route onboarding-prep turns to the agent (C-01, Django half)

### DIFF
--- a/ai-brand-automator/ai_services/onboarding_agent.py
+++ b/ai-brand-automator/ai_services/onboarding_agent.py
@@ -1,0 +1,195 @@
+"""Dispatching prep chat turns to the Onboarding Intelligence Agent (C-01).
+
+§10.2 puts ``POST /v1/execute`` behind ``X-Service-Token`` and marks it "not
+exposed publicly", so Django is the only caller and holds the token.
+
+The design point worth keeping in view: preparation happens in the chat the
+operator already uses, so a failure here has to read as *this feature is
+unavailable*, not as a broken chat. AC-3 is explicit that a generic error or a
+silent hang are both wrong.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+
+import requests
+from decouple import config
+
+logger = logging.getLogger(__name__)
+
+#: Provisional, mirroring the agent's ErrorCode.AGENT_UNAVAILABLE.
+#:
+#: C-01's AC-3 asks for ERR-13, which §18.4 spends on a field conflict
+#: requiring a human (202, SKL-OIA-14) — a different thing needing a different
+#: response. Nothing existing covers "Django cannot reach the agent": ERR-07,
+#: 08 and 09 are the agent's *own* degraded dependencies and ERR-10 is a
+#: buffered write in the opposite direction.
+ERR_AGENT_UNAVAILABLE = "ERR-19"
+
+EXECUTE_PATH = "/v1/execute"
+
+#: Short on purpose. An operator is watching a chat box, and §2.1 puts PREP in
+#: the "≤60 s" latency class only for the *skill*; the dispatch itself either
+#: connects promptly or is not going to.
+CONNECT_TIMEOUT_S = 3
+READ_TIMEOUT_S = 60
+
+#: Consecutive failures before the breaker opens, and how long it stays open.
+#: Per-process and in memory: a shared breaker needs Redis and coordination
+#: across Cloud Run instances, which is a larger change than this story.
+#: Documented rather than implied, because an in-memory breaker on N instances
+#: opens N times independently.
+BREAKER_THRESHOLD = 3
+BREAKER_COOLDOWN_S = 60
+
+
+@dataclass
+class AgentResult:
+    """What the caller needs to decide what to show.
+
+    ``ok`` is separate from ``payload`` so a caller cannot mistake an error
+    body for a result — the failure path returns a message meant for a human,
+    and rendering that as if it were agent output is the confusion AC-3 is
+    trying to prevent.
+    """
+
+    ok: bool
+    payload: dict | None = None
+    code: str | None = None
+    message: str | None = None
+
+
+class _Breaker:
+    """Trips after repeated failures so a dead agent is not retried per turn.
+
+    Deliberately tiny. A dependency that has failed three times in a row will
+    almost certainly fail the fourth, and making the operator wait out the
+    connect timeout each time is worse than telling them immediately.
+    """
+
+    def __init__(self) -> None:
+        self._failures = 0
+        self._opened_at = 0.0
+
+    @property
+    def is_open(self) -> bool:
+        if self._failures < BREAKER_THRESHOLD:
+            return False
+        if time.monotonic() - self._opened_at >= BREAKER_COOLDOWN_S:
+            # Half-open: let the next call through to test the water.
+            self._failures = 0
+            return False
+        return True
+
+    def record_success(self) -> None:
+        self._failures = 0
+
+    def record_failure(self) -> None:
+        self._failures += 1
+        if self._failures == BREAKER_THRESHOLD:
+            self._opened_at = time.monotonic()
+            logger.warning(
+                "onboarding agent breaker opened after %s consecutive failures",
+                BREAKER_THRESHOLD,
+            )
+
+
+_breaker = _Breaker()
+
+UNAVAILABLE_MESSAGE = (
+    "Onboarding preparation is temporarily unavailable. You can still "
+    "prepare manually through the onboarding forms, and I'll pick this up "
+    "again once the service is back."
+)
+
+
+def reset_breaker() -> None:
+    """Test seam. The breaker is process state, and a test that trips it
+    would otherwise leak that into the next one."""
+    global _breaker
+    _breaker = _Breaker()
+
+
+def dispatch_prep_turn(
+    *,
+    tenant_id: str,
+    user_id: str,
+    role: str,
+    trace_id: str,
+    chat_session_id: str,
+    prompt: str,
+    session_id: str | None = None,
+    input_context: dict | None = None,
+) -> AgentResult:
+    """Send one prep turn to the agent.
+
+    Never raises. Every failure becomes an ``AgentResult`` naming preparation
+    as unavailable, because AC-3 requires a specific message rather than "a
+    generic error or a silent hang" — and because an exception escaping here
+    would break the whole chat turn, not just its prep half.
+    """
+    if _breaker.is_open:
+        logger.info("prep dispatch short-circuited: breaker open")
+        return AgentResult(
+            ok=False, code=ERR_AGENT_UNAVAILABLE, message=UNAVAILABLE_MESSAGE
+        )
+
+    base_url = config("OIA_SERVICE_URL", default="http://localhost:8120")
+    token = config("OIA_SERVICE_TOKEN", default="")
+
+    body = {
+        "tenant_context": {
+            "tenant_id": str(tenant_id),
+            "user_id": str(user_id),
+            "role": role,
+            "trace_id": str(trace_id),
+        },
+        "chat_session_id": str(chat_session_id),
+        "input_prompt": prompt,
+        "input_context": input_context or {},
+        "config": {},
+        "previous_outputs": {},
+    }
+    if session_id:
+        body["session_id"] = str(session_id)
+
+    try:
+        response = requests.post(
+            f"{base_url.rstrip('/')}{EXECUTE_PATH}",
+            json=body,
+            headers={"X-Service-Token": token},
+            timeout=(CONNECT_TIMEOUT_S, READ_TIMEOUT_S),
+        )
+    except requests.RequestException as exc:
+        _breaker.record_failure()
+        logger.warning("prep dispatch failed to reach the agent: %s", exc)
+        return AgentResult(
+            ok=False, code=ERR_AGENT_UNAVAILABLE, message=UNAVAILABLE_MESSAGE
+        )
+
+    if response.status_code >= 500:
+        # 5xx is the agent saying it is unwell; 4xx is Django sending
+        # something wrong, which is a bug here and must not trip the breaker
+        # or it would mask itself as an outage.
+        _breaker.record_failure()
+        logger.warning("prep dispatch got %s from the agent", response.status_code)
+        return AgentResult(
+            ok=False, code=ERR_AGENT_UNAVAILABLE, message=UNAVAILABLE_MESSAGE
+        )
+
+    if response.status_code >= 400:
+        logger.error(
+            "prep dispatch rejected with %s — this is a bug in the caller, "
+            "not an outage: %s",
+            response.status_code,
+            response.text[:300],
+        )
+        return AgentResult(
+            ok=False, code=ERR_AGENT_UNAVAILABLE, message=UNAVAILABLE_MESSAGE
+        )
+
+    _breaker.record_success()
+    return AgentResult(ok=True, payload=response.json())

--- a/ai-brand-automator/ai_services/onboarding_agent.py
+++ b/ai-brand-automator/ai_services/onboarding_agent.py
@@ -130,6 +130,11 @@ def dispatch_prep_turn(
     as unavailable, because AC-3 requires a specific message rather than "a
     generic error or a silent hang" — and because an exception escaping here
     would break the whole chat turn, not just its prep half.
+
+    "Never" includes the response body: an unreachable agent is the obvious
+    failure, but a *reachable* one answering 200 with a proxy's HTML error
+    page is the one that slipped through review. Decoding and shape-checking
+    are inside the guarantee, not after it.
     """
     if _breaker.is_open:
         logger.info("prep dispatch short-circuited: breaker open")
@@ -191,5 +196,35 @@ def dispatch_prep_turn(
             ok=False, code=ERR_AGENT_UNAVAILABLE, message=UNAVAILABLE_MESSAGE
         )
 
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        # A 2xx whose body is not JSON is something in front of the agent
+        # answering for it — a proxy error page served as 200 is the usual
+        # shape. requests raises JSONDecodeError here, which subclasses both
+        # ValueError and RequestException; ValueError is the portable half.
+        _breaker.record_failure()
+        logger.warning(
+            "prep dispatch got a %s with an undecodable body: %s",
+            response.status_code,
+            exc,
+        )
+        return AgentResult(
+            ok=False, code=ERR_AGENT_UNAVAILABLE, message=UNAVAILABLE_MESSAGE
+        )
+
+    if not isinstance(payload, dict):
+        # AgentResult.payload is typed dict | None and views.py calls .get()
+        # on it. A bare list or string decodes cleanly and then raises an
+        # AttributeError one frame further out, which is the same broken chat
+        # turn this function exists to prevent.
+        _breaker.record_failure()
+        logger.warning(
+            "prep dispatch got JSON that is not an object: %s", type(payload).__name__
+        )
+        return AgentResult(
+            ok=False, code=ERR_AGENT_UNAVAILABLE, message=UNAVAILABLE_MESSAGE
+        )
+
     _breaker.record_success()
-    return AgentResult(ok=True, payload=response.json())
+    return AgentResult(ok=True, payload=payload)

--- a/ai-brand-automator/ai_services/services.py
+++ b/ai-brand-automator/ai_services/services.py
@@ -972,6 +972,45 @@ class GeminiAIService:
         # When both RAG and pipeline signals are significant, prefer
         # "pipeline" — the orchestrator's PipelineComposer will include
         # RAG nodes in the dynamically composed pipeline.
+        # ── Onboarding preparation (C-01) ────────────────────────────
+        # Checked before the others because prep is a *specific* request that
+        # reads as generic to them: "prepare questions for the onboarding
+        # meeting" scores on pipeline keywords, and "what did we learn about
+        # this brand" scores on rag. Both would be routed away from the agent
+        # that exists to answer them.
+        #
+        # Two-signal, not keyword-count: the message must mention onboarding
+        # or a prep meeting *and* ask to prepare something. One signal alone
+        # is how "summarize the onboarding document" — a RAG query about an
+        # existing file — would get hijacked into the prep agent.
+        prep_subject = any(
+            kw in msg
+            for kw in (
+                "onboarding",
+                "onboarding call",
+                "onboarding meeting",
+                "discovery call",
+                "kickoff call",
+                "intake call",
+            )
+        )
+        prep_action = any(
+            kw in msg
+            for kw in (
+                "prepare",
+                "preparation",
+                "prep ",
+                "questionnaire",
+                "questions for",
+                "question list",
+                "what should i ask",
+                "what to ask",
+                "agenda",
+            )
+        )
+        if prep_subject and prep_action:
+            return {"intent": "onboarding_prep", "confidence": 0.9}
+
         if rag_score >= 2 and score >= 2:
             return {
                 "intent": "pipeline",

--- a/ai-brand-automator/ai_services/tests/test_prep_routing.py
+++ b/ai-brand-automator/ai_services/tests/test_prep_routing.py
@@ -214,3 +214,114 @@ def test_a_user_with_no_membership_is_a_viewer():
     user = User.objects.create_user("c01_none", "none@test.com", "TestPass123!")
 
     assert _agent_role_for(user, tenant) == "VIEWER"
+
+
+# ── AC-3 · a *reachable* agent that answers badly ────────────────────
+
+
+@pytest.fixture
+def bad_agent():
+    """A real HTTP server the dispatcher can actually call.
+
+    No mocks: a patched ``requests.post`` would prove the except-clause is
+    reachable, not that a real response takes it. The bug this covers —
+    ``response.json()`` outside the try — was invisible to every test that
+    pointed at a closed port, because a closed port never gets far enough to
+    decode a body.
+    """
+    import http.server
+    import threading
+
+    state = {"status": 200, "body": b"", "content_type": "application/json"}
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_POST(self):
+            self.send_response(state["status"])
+            self.send_header("Content-Type", state["content_type"])
+            self.send_header("Content-Length", str(len(state["body"])))
+            self.end_headers()
+            self.wfile.write(state["body"])
+
+        def log_message(self, *args):
+            pass
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+
+    import os
+
+    os.environ["OIA_SERVICE_URL"] = f"http://127.0.0.1:{server.server_address[1]}"
+    try:
+        yield state
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def call_prep():
+    return dispatch_prep_turn(
+        tenant_id="t-1",
+        user_id="u-1",
+        role="ADMIN",
+        trace_id="trace-1",
+        chat_session_id="chat-1",
+        prompt="prepare questions for the onboarding meeting",
+    )
+
+
+def test_a_200_that_is_not_json_degrades_instead_of_raising(bad_agent):
+    """The review finding. A proxy in front of the agent serving its own HTML
+    error page with a 200 status is the realistic source."""
+    bad_agent["body"] = b"<html>502 Bad Gateway</html>"
+    bad_agent["content_type"] = "text/html"
+
+    result = call_prep()
+
+    assert result.ok is False
+    assert result.code == ERR_AGENT_UNAVAILABLE
+    assert result.message == UNAVAILABLE_MESSAGE
+
+
+def test_an_empty_200_body_degrades_instead_of_raising(bad_agent):
+    bad_agent["body"] = b""
+
+    assert call_prep().ok is False
+
+
+@pytest.mark.parametrize("body", [b"[1, 2, 3]", b'"just a string"', b"null", b"42"])
+def test_json_that_is_not_an_object_degrades(bad_agent, body):
+    """These decode cleanly, so the try/except alone does not catch them.
+
+    ``views.py`` calls ``payload.get("output", {})`` — a list would raise
+    AttributeError one frame out, which is the same broken chat turn measured
+    from a different place.
+    """
+    bad_agent["body"] = body
+
+    result = call_prep()
+
+    assert result.ok is False, f"{body!r} was accepted as a payload"
+    assert result.code == ERR_AGENT_UNAVAILABLE
+
+
+def test_a_well_formed_response_still_succeeds(bad_agent):
+    """The guard must not reject the good case it sits in front of."""
+    bad_agent["body"] = b'{"status": "SUCCEEDED", "output": {"detail": "ok"}}'
+
+    result = call_prep()
+
+    assert result.ok is True
+    assert result.payload["output"]["detail"] == "ok"
+
+
+def test_a_malformed_body_counts_toward_the_breaker(bad_agent):
+    """An agent returning garbage is unwell. Repeated garbage should open the
+    breaker rather than make every turn pay a full round-trip."""
+    from ai_services.onboarding_agent import BREAKER_THRESHOLD, _breaker
+
+    bad_agent["body"] = b"<html>nope</html>"
+
+    for _ in range(BREAKER_THRESHOLD):
+        assert call_prep().ok is False
+
+    assert _breaker.is_open, "malformed responses never tripped the breaker"

--- a/ai-brand-automator/ai_services/tests/test_prep_routing.py
+++ b/ai-brand-automator/ai_services/tests/test_prep_routing.py
@@ -1,0 +1,216 @@
+"""C-01 (Django half) · routing prep chat turns to the agent.
+
+Lives in ``ai_services/tests/`` rather than the card's ``apps/chat/tests/``
+because there is no ``apps/chat`` — chat is the ``ai_services`` app, and the
+tests sit beside the code they cover.
+
+The load-bearing assertion is AC-1's second half: **non-prep turns route
+exactly as they do today.** A prep intent that swallowed ordinary questions
+would be a worse regression than prep not working at all, because it would
+break a feature people already rely on.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ai_services.onboarding_agent import (
+    ERR_AGENT_UNAVAILABLE,
+    UNAVAILABLE_MESSAGE,
+    AgentResult,
+    dispatch_prep_turn,
+    reset_breaker,
+)
+from ai_services.services import GeminiAIService
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _fresh_breaker():
+    """The breaker is process state; a test that trips it would leak into the
+    next one and make failures depend on ordering."""
+    reset_breaker()
+    yield
+    reset_breaker()
+
+
+# ── AC-1 · prep intents are recognised ───────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "prepare questions for the onboarding meeting",
+        "help me prep for the onboarding call tomorrow",
+        "what should I ask on the discovery call",
+        "build a questionnaire for the onboarding session",
+        "draft an agenda for the kickoff call",
+    ],
+)
+def test_prep_messages_are_classified_as_prep(message):
+    assert GeminiAIService.classify_intent(message)["intent"] == "onboarding_prep"
+
+
+# ── AC-1 · everything else routes exactly as before ──────────────────
+
+
+@pytest.mark.parametrize(
+    "message,expected",
+    [
+        # RAG queries that merely *mention* onboarding must stay RAG. This is
+        # the case a one-signal keyword match would have hijacked.
+        ("summarize the onboarding document", "rag"),
+        ("what does the uploaded file say about onboarding", "rag"),
+        # Pipeline work is unchanged.
+        ("write a blog post about our coffee and schedule it", "pipeline"),
+        # And ordinary conversation stays conversation.
+        ("what is the weather like", "conversation"),
+        ("thanks, that helps", "conversation"),
+        # "prepare" alone is not onboarding prep. Note this is
+        # "conversation", not "pipeline" — I expected the latter and was
+        # wrong; see the docstring.
+        ("prepare a social media post", "conversation"),
+    ],
+)
+def test_non_prep_intents_unchanged(message, expected):
+    """The card's named case. Prep is recognised on two signals — a subject
+    *and* an action — precisely so these keep their existing routes.
+
+    Every expected value here was captured by running the classifier with the
+    prep branch stashed, not by reading the keyword lists. That caught one of
+    my own guesses: "prepare a social media post" classifies as conversation,
+    not pipeline. Asserting what I assumed would have written a wrong baseline
+    into the regression guard for this AC.
+    """
+    assert GeminiAIService.classify_intent(message)["intent"] == expected
+
+
+def test_prep_needs_both_a_subject_and_an_action():
+    """Either signal alone is someone talking about something else."""
+    assert (
+        GeminiAIService.classify_intent("tell me about onboarding")["intent"]
+        != "onboarding_prep"
+    )
+    assert (
+        GeminiAIService.classify_intent("prepare the quarterly report")["intent"]
+        != "onboarding_prep"
+    )
+
+
+# ── AC-3 · the agent being down degrades honestly ────────────────────
+
+
+def test_an_unreachable_agent_names_preparation_as_unavailable(settings):
+    """AC-3: not "a generic error or a silent hang".
+
+    Pointed at a port with nothing behind it — a real closed socket rather
+    than a simulated outage, so the timeout path is the one production takes.
+    """
+    settings.OIA_SERVICE_URL = "http://127.0.0.1:1"
+
+    import os
+
+    os.environ["OIA_SERVICE_URL"] = "http://127.0.0.1:1"
+    result = dispatch_prep_turn(
+        tenant_id="t-1",
+        user_id="u-1",
+        role="ADMIN",
+        trace_id="trace-1",
+        chat_session_id="chat-1",
+        prompt="prepare questions for the onboarding meeting",
+    )
+
+    assert result.ok is False
+    assert result.code == ERR_AGENT_UNAVAILABLE == "ERR-19"
+    assert "preparation" in result.message.lower()
+    assert "manual" in result.message.lower(), "no manual path was suggested"
+
+
+def test_the_failure_message_is_not_a_stack_trace():
+    """An operator sees this in a chat bubble. It has to read as a sentence."""
+    assert UNAVAILABLE_MESSAGE.endswith(".")
+    for leak in ("Traceback", "Exception", "127.0.0.1", "ERR-"):
+        assert leak not in UNAVAILABLE_MESSAGE
+
+
+def test_a_failure_never_raises():
+    """An exception escaping the dispatcher would break the whole chat turn,
+    not just its prep half."""
+    import os
+
+    os.environ["OIA_SERVICE_URL"] = "http://127.0.0.1:1"
+    result = dispatch_prep_turn(
+        tenant_id="t-1",
+        user_id="u-1",
+        role="ADMIN",
+        trace_id="trace-1",
+        chat_session_id="chat-1",
+        prompt="prep the onboarding call",
+    )
+    assert isinstance(result, AgentResult)
+
+
+def test_the_breaker_opens_after_repeated_failures():
+    """A dependency that failed three times will almost certainly fail the
+    fourth, and making the operator wait out the connect timeout each time is
+    worse than telling them at once."""
+    import os
+    import time
+
+    from ai_services.onboarding_agent import BREAKER_THRESHOLD
+
+    os.environ["OIA_SERVICE_URL"] = "http://127.0.0.1:1"
+
+    def call():
+        return dispatch_prep_turn(
+            tenant_id="t-1",
+            user_id="u-1",
+            role="ADMIN",
+            trace_id="trace-1",
+            chat_session_id="chat-1",
+            prompt="prep the onboarding call",
+        )
+
+    for _ in range(BREAKER_THRESHOLD):
+        assert call().ok is False
+
+    started = time.monotonic()
+    assert call().ok is False
+    assert (
+        time.monotonic() - started < 0.1
+    ), "the breaker did not short-circuit — the caller waited on the network"
+
+
+# ── The role comes from the membership, never a request body ─────────
+
+
+@pytest.mark.django_db
+def test_the_role_is_read_from_the_membership():
+    """§15: roles come from the verified claim, never from a body or a header
+    the client controls."""
+    from django.contrib.auth.models import User
+
+    from ai_services.views import _agent_role_for
+    from tenants.models import Membership, Tenant
+
+    tenant = Tenant.objects.create(name="C01 Co", schema_name="c01_role")
+    user = User.objects.create_user("c01_user", "c01@test.com", "TestPass123!")
+    Membership.objects.create(user=user, tenant=tenant, role=Membership.Role.EDITOR)
+
+    assert _agent_role_for(user, tenant) == "EDITOR"
+
+
+@pytest.mark.django_db
+def test_a_user_with_no_membership_is_a_viewer():
+    """Least privilege on the way out: an unknown role must not become ADMIN
+    in the agent's tenant_context."""
+    from django.contrib.auth.models import User
+
+    from ai_services.views import _agent_role_for
+    from tenants.models import Tenant
+
+    tenant = Tenant.objects.create(name="C01 None", schema_name="c01_none")
+    user = User.objects.create_user("c01_none", "none@test.com", "TestPass123!")
+
+    assert _agent_role_for(user, tenant) == "VIEWER"

--- a/ai-brand-automator/ai_services/views.py
+++ b/ai-brand-automator/ai_services/views.py
@@ -314,6 +314,21 @@ def _resolve_brand_context(tenant, brand_context_id):
     return {}
 
 
+def _agent_role_for(user, tenant) -> str:
+    """The caller's platform role, for the agent's tenant_context.
+
+    §15 is explicit that roles come from the verified claim and never from a
+    body or a header the client controls. Django has already established the
+    membership; this reads it rather than trusting anything sent in.
+    """
+    from tenants.models import Membership
+
+    membership = Membership.objects.filter(user=user, tenant=tenant).first()
+    if membership is None:
+        return "VIEWER"
+    return str(membership.role).upper()
+
+
 def _process_chat_message(
     request, session, message, tenant, is_new_session, serializer
 ):
@@ -373,6 +388,63 @@ def _process_chat_message(
     # orchestrator selects a RAG-enabled manifest (e.g. rag-blog-social).
     if attachment_ids and intent_result["intent"] == "pipeline":
         intent_result["needs_rag"] = True
+
+    if intent_result["intent"] == "onboarding_prep":
+        # C-01: preparation happens in the chat the operator already uses,
+        # so this dispatches to the agent and answers in the same turn rather
+        # than spawning a pipeline job the operator would have to go and find.
+        from ai_services.onboarding_agent import dispatch_prep_turn
+
+        result = dispatch_prep_turn(
+            tenant_id=tenant.id,
+            user_id=request.user.id,
+            role=_agent_role_for(request.user, tenant),
+            trace_id=uuid.uuid4(),
+            chat_session_id=session.session_id,
+            prompt=message,
+        )
+
+        if result.ok:
+            payload = result.payload or {}
+            ai_response = payload.get("output", {}).get(
+                "detail", "Preparation is under way."
+            )
+            metadata = {
+                "onboarding_prep": True,
+                "skill_id": payload.get("skill_id"),
+            }
+        else:
+            # AC-3: name preparation as the thing that is unavailable and
+            # point at the manual path. A generic error would leave the
+            # operator retrying a feature that cannot answer.
+            ai_response = result.message
+            metadata = {"onboarding_prep": True, "error_code": result.code}
+
+        user_msg = ChatMessage.objects.create(
+            session=session, role="user", content=message
+        )
+        _push_input_history(tenant.id, session.session_id, message)
+        ChatMessage.objects.create(
+            session=session,
+            role="assistant",
+            content=ai_response,
+            metadata=metadata,
+        )
+        session.last_activity = timezone.now()
+        session.save(update_fields=["last_activity"])
+        _maybe_auto_title(session, message, is_new_session)
+        _invalidate_session_list_cache(tenant)
+
+        return Response(
+            {
+                "session_id": session.session_id,
+                "response": ai_response,
+                "thinking": "",
+                "onboarding_prep": metadata,
+                "user_message_id": user_msg.id,
+                "session_pk": session.pk,
+            }
+        )
 
     if intent_result["intent"] == "rag":
         # RAG / document query — dispatch to orchestrator general-chat pipeline


### PR DESCRIPTION
**C-01 split, part 2 of 2.** The agent side is #552; this is the Django routing.

**Depends on** A-06, and on #552 for the endpoint it calls · **Blocks** C-02 · Design §2.1 PREP, §10.2.1 · FR-PREP-01, FR-PREP-02

## Prep is recognised on two signals, not a keyword count

The message must mention onboarding or a prep meeting **and** ask to prepare something. One signal alone would hijack `"summarize the onboarding document"` — a RAG query about an existing file — into an agent that can't answer it.

It's checked **before** the rag and pipeline branches, because prep reads as generic to both: *"prepare questions for the onboarding meeting"* scores on pipeline keywords and would otherwise route away from the agent that exists for it.

## AC-1's second half is verified against reality, not assumption

Every expected value in `test_non_prep_intents_unchanged` was captured by running the classifier **with the prep branch stashed** — not by reading the keyword lists.

That caught one of my own guesses: `"prepare a social media post"` classifies as **`conversation`**, not `pipeline` as I'd written. Asserting what I assumed would have baked a wrong baseline into the regression guard for the AC that matters most here.

| Message | Route (unchanged) |
|---|---|
| `summarize the onboarding document` | rag |
| `what does the uploaded file say about onboarding` | rag |
| `write a blog post about our coffee and schedule it` | pipeline |
| `prepare a social media post` | conversation |
| `what is the weather like` | conversation |

## AC-3 names the feature, not the failure

An unreachable agent produces *"Onboarding preparation is temporarily unavailable"* plus the manual path — never a stack trace, never a hang. The dispatcher **cannot raise**: an exception escaping it would break the whole chat turn rather than just its prep half.

A circuit breaker opens after three consecutive failures so a dead agent isn't retried per turn. It's **per-process and in memory**, which on N Cloud Run instances means N independent breakers — documented rather than implied, since a shared one needs Redis and is a larger change than this story.

**One judgement worth challenging:** a 4xx returns the same user-facing message as a 5xx, but doesn't trip the breaker and is logged as a caller bug. So a malformed request from Django shows the operator "temporarily unavailable". I chose one honest message over two, since the operator can't act on the difference — but it's arguable.

## ERR-19, again

Mirrors the agent's `AGENT_UNAVAILABLE`. AC-3 asks for ERR-13, which §18.4 spends on a field conflict requiring a human (202, SKL-OIA-14). See #552 for the full reasoning — and for why I'd now recommend a taxonomy pass over a sixth patch.

## §15: the role comes from the Membership

Never from a request body. A user with no membership becomes **VIEWER** rather than defaulting up.

## Verification

- **232 passed** across `ai_services`, no regressions
- Disabling the prep branch fails exactly the five classification tests
- `black`, `flake8`, `makemigrations --check` clean
- Tests in `ai_services/tests/` — there is no `apps/chat`

## Not delivered

No PREP skills (C-02/C-03), so a successful dispatch returns the agent's `skill_id: "NONE"` detail. No shared circuit breaker. No reference resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)