### PR TITLE
fix(oia): give X-Service-Token failures their own error codes (C-01 review follow-up)

### DIFF
--- a/onboarding-intelligence-agent-svc/CLAUDE.md
+++ b/onboarding-intelligence-agent-svc/CLAUDE.md
@@ -19,9 +19,33 @@ One deployable, three modes, decided by entry point rather than a runtime flag:
 | PROCESS | `POST /v1/process` | ≤5 min p95 | SKL-OIA-08 … 14 |
 
 - **Port** 8120 · **Env prefix** `OIA_` · **Redis** DB 2 (see below)
-- Design: `docs/Onboarding_Intelligence/Onboarding_Intelligence_Agent_Design_Document_v2_2.md`
-- Backlog: `…_User_Story_Backlog_v2_1.md`
-- **Corrections that override both: `ERRATA-01-redis-allocation.md`**
+All three live in `docs/Onboarding_Intelligence/`:
+
+- Design: `Onboarding_Intelligence_Agent_Design_Document_v2_2.docx`
+- Backlog: `Onboarding_Intelligence_Agent_User_Story_Backlog_v2_1.docx`
+- Requirements: `AI_Assisted_Onboarding_Requirements_v1_3.docx`
+- **Corrections that override the design: `ERRATA-01-redis-allocation.md`** (the
+  one that is genuinely Markdown)
+
+The first three are **`.docx`, not `.md`** — grep finds nothing in them, which
+reads as "the design does not mention this" when it does. Extract before
+searching:
+
+```python
+import zipfile
+from xml.etree import ElementTree as ET
+W = "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}"
+doc = ET.fromstring(zipfile.ZipFile(PATH).read("word/document.xml"))
+text = lambda el: "".join(t.text or "" for t in el.iter(W + "t"))
+# paragraphs: [text(p) for p in doc.iter(W + "p")]
+# tables:     [[text(c) for c in tr.iter(W + "tc")] for tr in doc.iter(W + "tr")]
+```
+
+Paragraph iteration *does* reach table cells — Word nests each cell's text in
+its own `w:p` — but it flattens them, so you get "ERR-16" and "507" as
+unrelated strings. §18.4 and §5's guardrail rules are tables, and reading them
+needs the row grouping: iterate `w:tr` when you care which condition maps to
+which status.
 
 ## Current state — scaffold, event baseline, agent skeleton
 
@@ -52,7 +76,7 @@ IG → RBAC → PG → OG.
   already delivered to the browser cannot be recalled.
 - RBAC has **four** verdicts — ALLOW, DENY, ESCALATE, VIEW_RESULT — because
   §15 uses all four. The matrix is data in `app/rbac/engine.py`; keep it that
-  way, or `test_rbac.py` cannot sweep it exhaustively.
+  way, or `tests/test_rbac.py` cannot sweep it exhaustively.
 - The role comes from the verified JWT claim only, never a body or header.
 
 ## Error codes

--- a/onboarding-intelligence-agent-svc/CLAUDE.md
+++ b/onboarding-intelligence-agent-svc/CLAUDE.md
@@ -64,6 +64,9 @@ documents, deliberately:
 |---|---|---|---|
 | Role denied | A-06 AC-3 says ERR-03 | **ERR-04** | §18.4 assigns ERR-03 to *consent* (IG-08). Collapsing them makes a permissions bug look like a consent bug on call. |
 | Unknown skill id | §5 PG-02 says ERR-06 | **ERR-17** (provisional) | §18.4 already spends ERR-06 on "live session already active" (409/4409). Reusing it would tell an operator a meeting is running when a skill id is simply wrong. |
+| Django cannot reach this service | C-01 AC-3 says ERR-13 | **ERR-19** (provisional) | §18.4 spends ERR-13 on a field conflict needing a human (202). ERR-07/08/09 are *this* service's degraded dependencies; nothing covers the reverse direction. |
+| Bad `X-Service-Token` | *(no code exists)* | **ERR-20** (provisional) | C-01 reached for ERR-01, which §18.4 defines as "Invalid or expired JWT" at 401. These endpoints have no JWT to be invalid. |
+| `SERVICE_TOKEN` unset | *(no code exists)* | **ERR-21** (provisional) | Distinct from ERR-20: a 503 the operator fixes by setting a secret, not a 401 the caller fixes. C-01 returned the 401-coded ERR-01 with a 503 status. |
 
 Both need reconciling in the design; until then the code is right and the
 documents are not.

--- a/onboarding-intelligence-agent-svc/CLAUDE.md
+++ b/onboarding-intelligence-agent-svc/CLAUDE.md
@@ -57,7 +57,7 @@ IG → RBAC → PG → OG.
 
 ## Error codes
 
-`app/core/errors.py` is the §18.4 taxonomy. Two codes deviate from the
+`app/core/errors.py` is the §18.4 taxonomy. Five codes deviate from the
 documents, deliberately:
 
 | Situation | Docs say | We use | Why |
@@ -68,8 +68,11 @@ documents, deliberately:
 | Bad `X-Service-Token` | *(no code exists)* | **ERR-20** (provisional) | C-01 reached for ERR-01, which §18.4 defines as "Invalid or expired JWT" at 401. These endpoints have no JWT to be invalid. |
 | `SERVICE_TOKEN` unset | *(no code exists)* | **ERR-21** (provisional) | Distinct from ERR-20: a 503 the operator fixes by setting a secret, not a 401 the caller fixes. C-01 returned the 401-coded ERR-01 with a 503 status. |
 
-Both need reconciling in the design; until then the code is right and the
-documents are not.
+All five need reconciling in the design; until then the code is right and the
+documents are not. The pattern behind them is worth naming: the documents were
+written before the taxonomy was, so cards cite codes §18.4 later spent on
+something else, and three conditions have no code at all. When a card names a
+code, check §18.4 before using it.
 
 ## Non-negotiables in this service
 

--- a/onboarding-intelligence-agent-svc/app/api/deps.py
+++ b/onboarding-intelligence-agent-svc/app/api/deps.py
@@ -39,7 +39,7 @@ async def verify_service_token(
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail={
-                "code": ErrorCode.INVALID_JWT,
+                "code": ErrorCode.SERVICE_TOKEN_NOT_CONFIGURED,
                 "message": (
                     "This service has no SERVICE_TOKEN configured and cannot "
                     "authenticate callers."
@@ -51,7 +51,7 @@ async def verify_service_token(
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail={
-                "code": ErrorCode.INVALID_JWT,
+                "code": ErrorCode.SERVICE_TOKEN_INVALID,
                 "message": f"A valid {SERVICE_TOKEN_HEADER} header is required.",
             },
         )

--- a/onboarding-intelligence-agent-svc/app/core/errors.py
+++ b/onboarding-intelligence-agent-svc/app/core/errors.py
@@ -61,6 +61,16 @@ class ErrorCode(StrEnum):
     #: the agent-to-Django direction. There is no code for the reverse.
     AGENT_UNAVAILABLE = "ERR-19"
 
+    #: Provisional (C-01 review). §10.2 authenticates the agent endpoints with
+    #: X-Service-Token, but §18.4 has no code for one — so C-01 reached for
+    #: ERR-01, which the taxonomy defines as "Invalid or expired JWT" at 401.
+    #: That misreports a service-token problem as an end-user auth problem,
+    #: and on the unconfigured path it pairs a 401 code with a 503 response.
+    #: These are two distinct conditions with different operator remedies, so
+    #: they get two codes rather than one shared "auth failed".
+    SERVICE_TOKEN_INVALID = "ERR-20"
+    SERVICE_TOKEN_NOT_CONFIGURED = "ERR-21"
+
 
 @dataclass(frozen=True)
 class ErrorSpec:
@@ -210,6 +220,28 @@ ERROR_SPECS: dict[ErrorCode, ErrorSpec] = {
         None,
         False,
         "Indicates a caller or configuration bug, not a user error",
+    ),
+    ErrorCode.SERVICE_TOKEN_INVALID: ErrorSpec(
+        ErrorCode.SERVICE_TOKEN_INVALID,
+        "Missing or incorrect X-Service-Token on an internal endpoint",
+        401,
+        None,
+        False,
+        (
+            "Check the caller's OIA_SERVICE_TOKEN matches this service's "
+            "SERVICE_TOKEN secret; retrying an unchanged token cannot succeed"
+        ),
+    ),
+    ErrorCode.SERVICE_TOKEN_NOT_CONFIGURED: ErrorSpec(
+        ErrorCode.SERVICE_TOKEN_NOT_CONFIGURED,
+        "This service has no SERVICE_TOKEN set and so authenticates nobody",
+        503,
+        None,
+        True,
+        (
+            "Set the SERVICE_TOKEN secret and redeploy; the service refuses "
+            "every caller until then, deliberately"
+        ),
     ),
     ErrorCode.AGENT_UNAVAILABLE: ErrorSpec(
         ErrorCode.AGENT_UNAVAILABLE,

--- a/onboarding-intelligence-agent-svc/app/core/errors.py
+++ b/onboarding-intelligence-agent-svc/app/core/errors.py
@@ -237,7 +237,15 @@ ERROR_SPECS: dict[ErrorCode, ErrorSpec] = {
         "This service has no SERVICE_TOKEN set and so authenticates nobody",
         503,
         None,
-        True,
+        # Not retryable, though it is a 503 and it does resolve on its own
+        # eventually. Every other retryable=True code clears within seconds
+        # and without a human — a degraded dependency recovers, a rate limit
+        # expires, a buffered write flushes. This one needs someone to set a
+        # secret and redeploy, so the flag would only buy a retry storm across
+        # an unbounded window. It also contradicted this spec's own remedy
+        # text, which is the same kind of internal disagreement as the
+        # code/status mismatch that prompted these codes.
+        False,
         (
             "Set the SERVICE_TOKEN secret and redeploy; the service refuses "
             "every caller until then, deliberately"

--- a/onboarding-intelligence-agent-svc/tests/test_execute_envelope.py
+++ b/onboarding-intelligence-agent-svc/tests/test_execute_envelope.py
@@ -146,7 +146,7 @@ def test_a_wrong_token_is_refused(client):
     response = client.post(EXECUTE, json=valid_body(), headers=headers("nope"))
 
     assert response.status_code == 401
-    assert response.json()["detail"]["code"] == "ERR-01"
+    assert response.json()["detail"]["code"] == "ERR-20"
 
 
 def test_an_empty_token_is_refused(client):
@@ -174,6 +174,10 @@ def test_an_unconfigured_service_refuses_everything(monkeypatch, app_with_live_r
         response = test_client.post(EXECUTE, json=valid_body(), headers=headers())
 
     assert response.status_code == 503
+    assert response.json()["detail"]["code"] == "ERR-21", (
+        "a misconfigured service must not report itself as a caller auth "
+        "failure — that sends an operator to the wrong runbook"
+    )
 
 
 # ── AC-2 · conversation state, as mechanism ──────────────────────────
@@ -249,3 +253,45 @@ async def test_the_chat_key_carries_a_ttl():
         await store.clear(tenant_id=tenant, chat_session_id=chat)
     finally:
         await manager.close()
+
+
+# ── The code and the status must agree with the taxonomy ─────────────
+
+
+@pytest.mark.parametrize(
+    "make_request,expected_code",
+    [
+        (lambda c: c.post(EXECUTE, json=valid_body(), headers={}), "ERR-20"),
+        (
+            lambda c: c.post(EXECUTE, json=valid_body(), headers=headers("nope")),
+            "ERR-20",
+        ),
+        (lambda c: c.post(EXECUTE, json=valid_body(), headers=headers("")), "ERR-20"),
+    ],
+)
+def test_an_auth_refusal_matches_its_own_spec(client, make_request, expected_code):
+    """C-01 shipped ERR-01 ("Invalid or expired JWT", 401) on a 503 branch.
+
+    The status happened to match on one of the two paths, which is why it read
+    as fine. Asserting the response against ERROR_SPECS rather than against a
+    hardcoded number is what makes the mismatch visible.
+    """
+    from app.core.errors import ERROR_SPECS, ErrorCode
+
+    response = make_request(client)
+    code = response.json()["detail"]["code"]
+
+    assert code == expected_code
+    spec = ERROR_SPECS[ErrorCode(code)]
+    assert response.status_code == spec.http_status, (
+        f"{code} responded {response.status_code} but its spec says "
+        f"{spec.http_status}"
+    )
+
+
+def test_service_token_failures_do_not_reuse_the_jwt_code(client):
+    """§18.4 reserves ERR-01 for JWT. This endpoint has no JWT to be invalid —
+    reporting one sends operators looking at the wrong subsystem."""
+    for hdrs in ({}, headers("nope"), headers("")):
+        body = client.post(EXECUTE, json=valid_body(), headers=hdrs).json()
+        assert body["detail"]["code"] != "ERR-01"

--- a/onboarding-intelligence-agent-svc/tests/test_execute_envelope.py
+++ b/onboarding-intelligence-agent-svc/tests/test_execute_envelope.py
@@ -259,26 +259,33 @@ async def test_the_chat_key_carries_a_ttl():
 
 
 @pytest.mark.parametrize(
-    "make_request,expected_code",
+    "token,unconfigured,expected_code",
     [
-        (lambda c: c.post(EXECUTE, json=valid_body(), headers={}), "ERR-20"),
-        (
-            lambda c: c.post(EXECUTE, json=valid_body(), headers=headers("nope")),
-            "ERR-20",
-        ),
-        (lambda c: c.post(EXECUTE, json=valid_body(), headers=headers("")), "ERR-20"),
+        (None, False, "ERR-20"),
+        ("nope", False, "ERR-20"),
+        ("", False, "ERR-20"),
+        # The branch the whole change exists for. Review caught its absence:
+        # the three cases above are one code path sampled three ways, and the
+        # mismatch being fixed was on the *other* one.
+        (SERVICE_TOKEN, True, "ERR-21"),
     ],
 )
-def test_an_auth_refusal_matches_its_own_spec(client, make_request, expected_code):
+def test_an_auth_refusal_matches_its_own_spec(
+    app_with_live_redis, token, unconfigured, expected_code
+):
     """C-01 shipped ERR-01 ("Invalid or expired JWT", 401) on a 503 branch.
 
     The status happened to match on one of the two paths, which is why it read
     as fine. Asserting the response against ERROR_SPECS rather than against a
-    hardcoded number is what makes the mismatch visible.
+    hardcoded number is what makes the mismatch visible — on both paths.
     """
     from app.core.errors import ERROR_SPECS, ErrorCode
 
-    response = make_request(client)
+    with TestClient(app_with_live_redis) as test_client:
+        if unconfigured:
+            app_with_live_redis.state.settings.SERVICE_TOKEN = ""
+        response = test_client.post(EXECUTE, json=valid_body(), headers=headers(token))
+
     code = response.json()["detail"]["code"]
 
     assert code == expected_code
@@ -287,6 +294,21 @@ def test_an_auth_refusal_matches_its_own_spec(client, make_request, expected_cod
         f"{code} responded {response.status_code} but its spec says "
         f"{spec.http_status}"
     )
+
+
+def test_a_retryable_flag_must_not_promise_a_retry_that_cannot_work():
+    """ERR-21 shipped retryable=True while its own remedy said "redeploy".
+
+    Encoded as an invariant rather than a one-off: this flag is in to_body(),
+    so a client can act on it, and a 5xx that needs a human is the shape where
+    True turns into a retry storm across an unbounded window.
+    """
+    from app.core.errors import ERROR_SPECS, ErrorCode
+
+    spec = ERROR_SPECS[ErrorCode.SERVICE_TOKEN_NOT_CONFIGURED]
+
+    assert spec.retryable is False
+    assert "redeploy" in spec.operator_behaviour
 
 
 def test_service_token_failures_do_not_reuse_the_jwt_code(client):


### PR DESCRIPTION
Follow-up to the review on #553. Both findings are in `app/api/deps.py`, which merged with #552, so they could not be fixed on #553 itself.

## The finding

`deps.py` reported both auth failures as `ErrorCode.INVALID_JWT` (ERR-01). §18.4 defines ERR-01 as *"Invalid or expired JWT"* at HTTP 401.

- These endpoints authenticate with `X-Service-Token`. There is no JWT to be invalid, so ERR-01 points an operator at the wrong subsystem.
- The unconfigured-service branch returned that **401-coded** error with a **503** status — the code and the response contradicted each other.

## The fix

| Code | Status | Condition | Operator remedy |
|---|---|---|---|
| `ERR-20` | 401 | Missing or incorrect `X-Service-Token` | Align the caller's `OIA_SERVICE_TOKEN` — retrying unchanged cannot succeed |
| `ERR-21` | 503 | This service has no `SERVICE_TOKEN` set | Set the secret and redeploy |

Two codes rather than one shared "auth failed", because the remedies differ and would otherwise share a runbook. Both are provisional — §18.4 has no service-token code at all — and join ERR-04, ERR-17 and ERR-19 in the deviations table in `CLAUDE.md`.

## On the test

The replaced assertion checked a literal `401`, which is why the mismatch read as correct on the one path where the number happened to line up. The new one resolves the returned code through `ERROR_SPECS` and asserts the response status matches the spec, so a code/status contradiction fails regardless of which pair drifts.

**365 passed**, `mypy --strict` clean, `black`/`flake8` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)