### PR TITLE
feat(oia): §18.2 circuit breakers and the Tavily/Gemini providers (C-02, PR 1)

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -1751,6 +1751,7 @@ services:
       - OIA_SERVICE_TOKEN=${ORCHESTRATOR_SERVICE_TOKEN:-dev-service-token}
       - OIA_POI_TOKEN=${ORCHESTRATOR_SERVICE_TOKEN:-dev-service-token}
       - OIA_GEMINI_KEY=${GOOGLE_API_KEY:-}
+      - OIA_TAVILY_API_KEY=${TAVILY_API_KEY:-}
       # Left empty by default on purpose. The kafka service sits behind the
       # with-kafka profile, so in the default stack there is no broker — and
       # unlike the rest of the fleet, OIA's /health treats a *configured*

--- a/deployment/gcp/08-deploy-services.sh
+++ b/deployment/gcp/08-deploy-services.sh
@@ -467,7 +467,7 @@ deploy_service zorven-onboarding-intelligence-agent zorven-onboarding-intelligen
   --max-instances="${CR_MAX_INSTANCES_AGENT}" \
   --timeout="${CR_WS_TIMEOUT}" \
   --session-affinity \
-  --set-secrets="OIA_GEMINI_KEY=GOOGLE_API_KEY:latest" \
+  --set-secrets="OIA_GEMINI_KEY=GOOGLE_API_KEY:latest,OIA_TAVILY_API_KEY=TAVILY_API_KEY:latest" \
   --set-env-vars="\
 OIA_REDIS_URL=${REDIS_BASE}/2,\
 OIA_REDIS_DB=2,\

--- a/onboarding-intelligence-agent-svc/CLAUDE.md
+++ b/onboarding-intelligence-agent-svc/CLAUDE.md
@@ -98,6 +98,18 @@ written before the taxonomy was, so cards cite codes §18.4 later spent on
 something else, and three conditions have no code at all. When a card names a
 code, check §18.4 before using it.
 
+## Circuit breakers (§18.2)
+
+`config/circuit_breakers.yaml` is §18.2 transcribed verbatim; `app/circuit_breaker/breaker.py` loads it. Both arrived with **C-02**, not A-06 — the scaffolded stub named A-06 as its implementer, but A-06's acceptance criteria cover the registry, guardrail chain, RBAC evaluator and skill interfaces and never mention breakers. No story in the backlog owned this. Check the ACs, not the stub docstring, before assuming something landed.
+
+- All seven dependencies are declared; only `tavily` and `llm` have callers so far.
+- **State is per-process.** Cloud Run runs several instances, so a failing dependency opens N breakers independently. A shared breaker in Redis would add a hop to the very call path it protects and would fail when Redis does.
+- Call `before_call()`, never `is_open`, when you are about to use a dependency — the check and the half-open trial claim must be one atomic step or concurrent callers all slip through.
+- `user_message` is config, not code (§18.2: "these strings are the entire user experience of a failure"). A `null` message means invisible by design, as with `poi`.
+- A missing API key is **not** a breaker failure. It degrades with a distinct reason so an operator can tell a config gap from an outage.
+
+Providers wrap dependencies: `app/providers/tavily.py` and `app/providers/llm.py`. Both differ from `discovery-agent-svc`'s Tavily code on purpose — they use the async client (the fleet's blocks the event loop, which would stall a live meeting) and they **do not swallow failures into an empty result**, because "we could not look" and "there is nothing to find" need different operator responses.
+
 ## Non-negotiables in this service
 
 ### Eviction: the shared instance is `noeviction`, and must stay that way

--- a/onboarding-intelligence-agent-svc/CLAUDE.md
+++ b/onboarding-intelligence-agent-svc/CLAUDE.md
@@ -102,7 +102,7 @@ code, check §18.4 before using it.
 
 `config/circuit_breakers.yaml` is §18.2 transcribed verbatim; `app/circuit_breaker/breaker.py` loads it. Both arrived with **C-02**, not A-06 — the scaffolded stub named A-06 as its implementer, but A-06's acceptance criteria cover the registry, guardrail chain, RBAC evaluator and skill interfaces and never mention breakers. No story in the backlog owned this. Check the ACs, not the stub docstring, before assuming something landed.
 
-- All seven dependencies are declared; only `tavily` and `llm` have callers so far.
+- All seven dependencies are declared. `tavily` and `llm` have providers (`app/providers/`); the skill that calls them arrives with C-02's second PR, so until that lands the providers are exercised only by their tests.
 - **State is per-process.** Cloud Run runs several instances, so a failing dependency opens N breakers independently. A shared breaker in Redis would add a hop to the very call path it protects and would fail when Redis does.
 - Call `before_call()`, never `is_open`, when you are about to use a dependency — the check and the half-open trial claim must be one atomic step or concurrent callers all slip through.
 - `user_message` is config, not code (§18.2: "these strings are the entire user experience of a failure"). A `null` message means invisible by design, as with `poi`.

--- a/onboarding-intelligence-agent-svc/app/circuit_breaker/breaker.py
+++ b/onboarding-intelligence-agent-svc/app/circuit_breaker/breaker.py
@@ -1,19 +1,271 @@
 """Per-dependency circuit breakers.
 
-Design §18.2 · implemented by story A-06.
+Design §18.2 · implemented by story C-02.
 
-Scaffolded by A-05. The body raises NotImplementedError deliberately: a
-stub that silently returns None would let a later story ship a no-op
-that passes its tests.
+Scaffolded by A-05, which named A-06 as the implementer. A-06's acceptance
+criteria cover the registry, the guardrail chain, the RBAC evaluator and the
+skill interfaces, and never mention breakers — so this stayed a stub through
+A-06's completion and no later story picked it up. C-02 is the first story
+that cannot be delivered without one (AC-3 requires the tavily breaker in the
+open state), so it lands here.
+
+**State is per-process, deliberately.** Cloud Run runs several instances and
+each keeps its own view, so a dependency failing for everyone opens N breakers
+independently rather than one shared one. That is the fleet pattern and it is
+the right trade here: a shared breaker in Redis would add a network hop to
+every call on the path it is supposed to be protecting, and would itself fail
+when Redis does. The cost is that recovery is per-instance and slightly
+staggered, which is invisible to an operator.
 """
 
 from __future__ import annotations
 
-_NOT_YET = "app.circuit_breaker.breaker — implemented by A-06"
+import threading
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+CONFIG_PATH = Path(__file__).resolve().parents[2] / "config" / "circuit_breakers.yaml"
 
 
+class State(str, Enum):
+    """The three states of §18.2's breaker.
+
+    HALF_OPEN is not a formality. Going straight from OPEN back to CLOSED on a
+    timer would send the full call volume at a dependency that has not been
+    shown to be healthy; HALF_OPEN admits a bounded number of trial calls and
+    promotes only on sustained success.
+    """
+
+    CLOSED = "CLOSED"
+    OPEN = "OPEN"
+    HALF_OPEN = "HALF_OPEN"
+
+
+@dataclass(frozen=True)
+class BreakerConfig:
+    """One dependency's row in config/circuit_breakers.yaml."""
+
+    name: str
+    failure_threshold: int
+    window_seconds: int
+    success_threshold: int
+    half_open_max_calls: int
+    reset_timeout_seconds: int
+    degraded_mode: str
+    #: None means the degradation is invisible to the operator by design
+    #: (§18.2 says so of `poi`), not that a message was forgotten.
+    user_message: str | None
+
+
+class CircuitBreakerOpen(Exception):
+    """Raised instead of calling a dependency whose breaker is open.
+
+    Carries the degraded mode and the operator-facing message so a caller can
+    degrade without re-reading the config — AC-3 needs both to build a brief
+    that says *why* it is thin.
+    """
+
+    def __init__(self, config: BreakerConfig) -> None:
+        super().__init__(f"circuit breaker open for {config.name}")
+        self.dependency = config.name
+        self.degraded_mode = config.degraded_mode
+        self.user_message = config.user_message
+
+
+@dataclass
 class CircuitBreaker:
-    """Not yet implemented."""
+    """One dependency's breaker.
 
-    def __init__(self, *args: object, **kwargs: object) -> None:
-        raise NotImplementedError(_NOT_YET)
+    Thread-safe: FastAPI runs sync dependencies in a threadpool and the
+    provider calls this from async code, so two requests can land in
+    ``record_failure`` concurrently. Without the lock the failure count can
+    lose an increment and the breaker opens late, which is precisely when it
+    matters.
+    """
+
+    config: BreakerConfig
+    _state: State = State.CLOSED
+    _failures: list[float] = field(default_factory=list)
+    _successes: int = 0
+    _opened_at: float = 0.0
+    _half_open_calls: int = 0
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+
+    # ── State, with the timeout applied lazily ───────────────────────
+
+    @property
+    def state(self) -> State:
+        """The current state, moving OPEN → HALF_OPEN once the timeout passes.
+
+        Computed on read rather than by a background timer: a timer would keep
+        the process awake and would have to be cancelled on shutdown, and
+        nothing observes a breaker except a caller about to use it.
+        """
+        with self._lock:
+            return self._state_locked()
+
+    def _state_locked(self) -> State:
+        if self._state is State.OPEN:
+            if time.monotonic() - self._opened_at >= self.config.reset_timeout_seconds:
+                self._state = State.HALF_OPEN
+                self._half_open_calls = 0
+                self._successes = 0
+        return self._state
+
+    @property
+    def is_open(self) -> bool:
+        """True when a call must not be attempted.
+
+        HALF_OPEN counts as open once its trial budget is spent — otherwise a
+        burst of concurrent callers would all slip through the moment the
+        reset timeout elapsed, which is the stampede HALF_OPEN exists to
+        prevent.
+        """
+        with self._lock:
+            state = self._state_locked()
+            if state is State.OPEN:
+                return True
+            if state is State.HALF_OPEN:
+                return self._half_open_calls >= self.config.half_open_max_calls
+            return False
+
+    # ── Outcomes ─────────────────────────────────────────────────────
+
+    def record_success(self) -> None:
+        with self._lock:
+            state = self._state_locked()
+            if state is State.HALF_OPEN:
+                self._successes += 1
+                if self._successes >= self.config.success_threshold:
+                    self._reset_locked()
+            else:
+                # A success in CLOSED clears the window: the threshold counts
+                # *consecutive-ish* trouble, and a dependency that is serving
+                # again should not carry old failures toward opening.
+                self._failures.clear()
+
+    def record_failure(self) -> None:
+        with self._lock:
+            state = self._state_locked()
+            now = time.monotonic()
+
+            if state is State.HALF_OPEN:
+                # One failed trial is enough. The dependency was already known
+                # bad; a trial that fails is evidence it still is.
+                self._open_locked(now)
+                return
+
+            cutoff = now - self.config.window_seconds
+            self._failures = [t for t in self._failures if t >= cutoff]
+            self._failures.append(now)
+
+            if len(self._failures) >= self.config.failure_threshold:
+                self._open_locked(now)
+
+    def before_call(self) -> None:
+        """Raise if the call must not be made; otherwise consume a trial slot.
+
+        Callers should use this rather than reading :attr:`is_open`, because
+        the check and the trial-slot claim have to be one atomic step. Two
+        concurrent callers both seeing "half open, 0 calls used" would each
+        proceed and defeat ``half_open_max_calls``.
+        """
+        with self._lock:
+            state = self._state_locked()
+            if state is State.OPEN:
+                raise CircuitBreakerOpen(self.config)
+            if state is State.HALF_OPEN:
+                if self._half_open_calls >= self.config.half_open_max_calls:
+                    raise CircuitBreakerOpen(self.config)
+                self._half_open_calls += 1
+
+    # ── Internals (call with the lock held) ──────────────────────────
+
+    def _open_locked(self, now: float) -> None:
+        self._state = State.OPEN
+        self._opened_at = now
+        self._failures.clear()
+        self._successes = 0
+        self._half_open_calls = 0
+
+    def _reset_locked(self) -> None:
+        self._state = State.CLOSED
+        self._failures.clear()
+        self._successes = 0
+        self._half_open_calls = 0
+
+    def reset(self) -> None:
+        """Force back to CLOSED. For tests and operator intervention only."""
+        with self._lock:
+            self._reset_locked()
+
+
+class BreakerRegistry:
+    """Every breaker declared in config/circuit_breakers.yaml.
+
+    Loading the whole file rather than creating breakers on demand means an
+    unknown dependency name is an error at lookup instead of a silently
+    created breaker that never opens — a typo in ``circuit_breaker_dependency``
+    would otherwise disable protection rather than fail.
+    """
+
+    def __init__(self, config_path: Path | None = None) -> None:
+        self._breakers: dict[str, CircuitBreaker] = {}
+        self._load(config_path or CONFIG_PATH)
+
+    def _load(self, path: Path) -> None:
+        raw: dict[str, Any] = yaml.safe_load(path.read_text()) or {}
+        defaults: dict[str, Any] = raw.get("defaults", {}) or {}
+        dependencies: dict[str, Any] = raw.get("dependencies", {}) or {}
+
+        if not dependencies:
+            raise ValueError(f"{path} declares no dependencies")
+
+        for name, overrides in dependencies.items():
+            merged = {**defaults, **(overrides or {})}
+            missing = [
+                key
+                for key in ("failure_threshold", "window_seconds", "success_threshold")
+                if key not in merged
+            ]
+            if missing:
+                raise ValueError(f"breaker '{name}' is missing {', '.join(missing)}")
+            if "degraded_mode" not in merged:
+                # §18.2's whole point is that every dependency degrades to
+                # something. One without a mode would fail closed with no
+                # defined behaviour, which is the outage it is meant to avoid.
+                raise ValueError(f"breaker '{name}' declares no degraded_mode")
+
+            self._breakers[name] = CircuitBreaker(
+                BreakerConfig(
+                    name=name,
+                    failure_threshold=int(merged["failure_threshold"]),
+                    window_seconds=int(merged["window_seconds"]),
+                    success_threshold=int(merged["success_threshold"]),
+                    half_open_max_calls=int(merged.get("half_open_max_calls", 1)),
+                    reset_timeout_seconds=int(merged.get("reset_timeout_seconds", 60)),
+                    degraded_mode=str(merged["degraded_mode"]),
+                    user_message=merged.get("user_message"),
+                )
+            )
+
+    def get(self, dependency: str) -> CircuitBreaker:
+        try:
+            return self._breakers[dependency]
+        except KeyError:
+            raise KeyError(
+                f"no breaker declared for '{dependency}' — "
+                f"known: {', '.join(sorted(self._breakers))}"
+            ) from None
+
+    def names(self) -> list[str]:
+        return sorted(self._breakers)
+
+    def reset_all(self) -> None:
+        for breaker in self._breakers.values():
+            breaker.reset()

--- a/onboarding-intelligence-agent-svc/app/circuit_breaker/breaker.py
+++ b/onboarding-intelligence-agent-svc/app/circuit_breaker/breaker.py
@@ -20,6 +20,7 @@ staggered, which is invisible to an operator.
 
 from __future__ import annotations
 
+import logging
 import threading
 import time
 from dataclasses import dataclass, field
@@ -141,6 +142,19 @@ class CircuitBreaker:
             state = self._state_locked()
             if state is State.HALF_OPEN:
                 self._successes += 1
+                # Release the trial slot. before_call() claimed it to stop a
+                # stampede of *concurrent* callers; a call that has come back
+                # successfully is finished with it, and holding it would block
+                # the next sequential trial.
+                #
+                # Without this the breaker wedges. Every dependency whose
+                # success_threshold exceeds half_open_max_calls — five of the
+                # seven in §18.2 ship 2 and 1 — would take its one trial,
+                # record one success, and then refuse every subsequent call
+                # forever, never reaching the threshold that closes it. A
+                # single blip would degrade the dependency until the process
+                # restarted.
+                self._half_open_calls = max(0, self._half_open_calls - 1)
                 if self._successes >= self.config.success_threshold:
                     self._reset_locked()
             else:
@@ -219,7 +233,16 @@ class BreakerRegistry:
         self._load(config_path or CONFIG_PATH)
 
     def _load(self, path: Path) -> None:
-        raw: dict[str, Any] = yaml.safe_load(path.read_text()) or {}
+        parsed = yaml.safe_load(path.read_text())
+        if parsed is None:
+            parsed = {}
+        if not isinstance(parsed, dict):
+            # A malformed file otherwise fails with AttributeError on .get(),
+            # deep in startup, naming neither the file nor the problem.
+            raise ValueError(
+                f"{path} must contain a mapping, not {type(parsed).__name__}"
+            )
+        raw: dict[str, Any] = parsed
         defaults: dict[str, Any] = raw.get("defaults", {}) or {}
         dependencies: dict[str, Any] = raw.get("dependencies", {}) or {}
 
@@ -235,6 +258,37 @@ class BreakerRegistry:
             ]
             if missing:
                 raise ValueError(f"breaker '{name}' is missing {', '.join(missing)}")
+            for key in (
+                "failure_threshold",
+                "window_seconds",
+                "success_threshold",
+                "half_open_max_calls",
+                "reset_timeout_seconds",
+            ):
+                value = merged.get(key, 1)
+                if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+                    # bool is an int in Python, and `failure_threshold: true`
+                    # is a plausible YAML slip that would otherwise become 1.
+                    raise ValueError(
+                        f"breaker '{name}': {key} must be a positive integer, "
+                        f"got {value!r}"
+                    )
+
+            if merged["success_threshold"] > merged.get("half_open_max_calls", 1):
+                # Not a style rule — this combination used to wedge the breaker
+                # permanently in HALF_OPEN. It is safe now that a success
+                # releases its trial slot, but a config that needs N sequential
+                # trials to recover takes N reset windows to do it, which is
+                # worth being deliberate about rather than discovering during
+                # an incident.
+                logger_warning = (
+                    f"breaker '{name}': success_threshold "
+                    f"({merged['success_threshold']}) exceeds half_open_max_calls "
+                    f"({merged.get('half_open_max_calls', 1)}); recovery needs "
+                    "that many sequential trial calls"
+                )
+                logging.getLogger(__name__).info(logger_warning)
+
             if "degraded_mode" not in merged:
                 # §18.2's whole point is that every dependency degrades to
                 # something. One without a mode would fail closed with no

--- a/onboarding-intelligence-agent-svc/app/core/config.py
+++ b/onboarding-intelligence-agent-svc/app/core/config.py
@@ -85,6 +85,11 @@ class Settings(BaseSettings):
     # ── Secret references (never inline; Design §19) ─────────
     STT_CREDENTIALS: str = ""
     GEMINI_KEY: str = ""
+    #: Empty is a supported state, not a misconfiguration: research degrades
+    #: to the operator-provided information only (C-02 AC-3), which is the
+    #: same path the tavily breaker takes when it opens. Local development and
+    #: CI run this way.
+    TAVILY_API_KEY: str = ""
     SERVICE_TOKEN: str = ""
     POI_TOKEN: str = ""
 

--- a/onboarding-intelligence-agent-svc/app/providers/llm.py
+++ b/onboarding-intelligence-agent-svc/app/providers/llm.py
@@ -1,19 +1,131 @@
-"""Gemini text client.
+"""Gemini text client, behind the §18.2 breaker.
 
-Design §8.4 · implemented by story A-06.
+Design §8.4, §18.2 · implemented by story C-02.
 
-Scaffolded by A-05. The body raises NotImplementedError deliberately: a
-stub that silently returns None would let a later story ship a no-op
-that passes its tests.
+Scaffolded by A-05, whose docstring named A-06 as the implementer. A-06's
+acceptance criteria cover the registry, guardrail chain, RBAC evaluator and
+skill interfaces and never mention providers, so this stayed a stub. C-02 is
+the first story that needs to generate anything.
+
+**SDK choice.** ``google-generativeai`` 0.8.x, matching
+``ai-brand-automator`` and ``content-agent-service``, with the fleet default
+model ``gemini-3.5-flash``. Google's newer ``google-genai`` package supersedes
+it, but switching one service creates a second pattern in a fleet of
+twenty-seven; that migration is worth doing deliberately and everywhere, not
+as a side effect of this story.
 """
 
 from __future__ import annotations
 
-_NOT_YET = "app.providers.llm — implemented by A-06"
+import logging
+from typing import Any
+
+from app.circuit_breaker.breaker import (
+    BreakerRegistry,
+    CircuitBreaker,
+    CircuitBreakerOpen,
+)
+
+logger = logging.getLogger(__name__)
+
+DEPENDENCY = "llm"
+DEFAULT_MODEL = "gemini-3.5-flash"
+
+
+class LLMUnavailable(Exception):
+    """Generation could not be performed. Carries the operator-facing reason."""
+
+    def __init__(
+        self, reason: str, *, degraded_mode: str = "MANUAL_CHECKBOXES"
+    ) -> None:
+        super().__init__(reason)
+        self.reason = reason
+        self.degraded_mode = degraded_mode
 
 
 class LLMProvider:
-    """Not yet implemented."""
+    """Generate text, or say plainly that it could not.
 
-    def __init__(self, *args: object, **kwargs: object) -> None:
-        raise NotImplementedError(_NOT_YET)
+    Mirrors :class:`app.providers.tavily.TavilyProvider` deliberately — same
+    breaker discipline, same "unavailable is not empty" distinction, same
+    treatment of a missing key as degradation rather than a crash. Two
+    providers that behave differently under failure would make the degraded
+    paths hard to reason about together, and PREP uses both in one turn.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        model: str = DEFAULT_MODEL,
+        breaker: CircuitBreaker | None = None,
+        client: Any | None = None,
+    ) -> None:
+        self._api_key = api_key
+        self._model_name = model
+        self._breaker = breaker or BreakerRegistry().get(DEPENDENCY)
+        self._client = client
+
+    @property
+    def configured(self) -> bool:
+        return bool(self._api_key)
+
+    @property
+    def model_name(self) -> str:
+        return self._model_name
+
+    def _ensure_client(self) -> Any:
+        if self._client is None:
+            import google.generativeai as genai
+
+            genai.configure(api_key=self._api_key)
+            self._client = genai.GenerativeModel(self._model_name)
+        return self._client
+
+    async def generate(self, prompt: str, *, temperature: float = 0.2) -> str:
+        """One completion.
+
+        Temperature defaults low because every current caller is extracting or
+        structuring facts, where invention is the failure mode. A caller that
+        wants range should ask for it explicitly.
+        """
+        if not self.configured:
+            raise LLMUnavailable("no Gemini API key is configured")
+
+        try:
+            self._breaker.before_call()
+        except CircuitBreakerOpen as exc:
+            raise LLMUnavailable(
+                exc.user_message or f"{exc.dependency} is unavailable",
+                degraded_mode=exc.degraded_mode,
+            ) from exc
+
+        try:
+            response = await self._ensure_client().generate_content_async(
+                prompt,
+                generation_config={"temperature": temperature},
+            )
+            text = self._text_of(response)
+        except Exception as exc:
+            # Broad by intent, for the reason evidenced in the Tavily provider's
+            # tests: an SDK's raisable set is not enumerable from its signature,
+            # and an unlisted exception escaping here breaks the chat turn.
+            self._breaker.record_failure()
+            logger.warning("gemini generation failed: %s: %s", type(exc).__name__, exc)
+            raise LLMUnavailable(f"generation failed: {type(exc).__name__}") from exc
+
+        self._breaker.record_success()
+        return text
+
+    @staticmethod
+    def _text_of(response: Any) -> str:
+        """Pull the text out, treating an empty completion as a failure.
+
+        A safety block or a stop with no candidates returns a response object
+        whose ``.text`` raises or is empty. Returning "" would let the caller
+        build a brief out of nothing and present it as researched.
+        """
+        text = getattr(response, "text", None)
+        if not text or not str(text).strip():
+            raise ValueError("the model returned no text")
+        return str(text)

--- a/onboarding-intelligence-agent-svc/app/providers/llm.py
+++ b/onboarding-intelligence-agent-svc/app/providers/llm.py
@@ -7,7 +7,7 @@ acceptance criteria cover the registry, guardrail chain, RBAC evaluator and
 skill interfaces and never mention providers, so this stayed a stub. C-02 is
 the first story that needs to generate anything.
 
-**SDK choice.** ``google-generativeai`` 0.8.x, matching
+**SDK choice.** ``google-generativeai>=0.8.0``, matching
 ``ai-brand-automator`` and ``content-agent-service``, with the fleet default
 model ``gemini-3.5-flash``. Google's newer ``google-genai`` package supersedes
 it, but switching one service creates a second pattern in a fleet of

--- a/onboarding-intelligence-agent-svc/app/providers/llm.py
+++ b/onboarding-intelligence-agent-svc/app/providers/llm.py
@@ -7,7 +7,7 @@ acceptance criteria cover the registry, guardrail chain, RBAC evaluator and
 skill interfaces and never mention providers, so this stayed a stub. C-02 is
 the first story that needs to generate anything.
 
-**SDK choice.** ``google-generativeai>=0.8.0``, matching
+**SDK choice.** ``google-generativeai>=0.8.6,<0.9``, matching
 ``ai-brand-automator`` and ``content-agent-service``, with the fleet default
 model ``gemini-3.5-flash``. Google's newer ``google-genai`` package supersedes
 it, but switching one service creates a second pattern in a fleet of

--- a/onboarding-intelligence-agent-svc/app/providers/llm.py
+++ b/onboarding-intelligence-agent-svc/app/providers/llm.py
@@ -7,12 +7,20 @@ acceptance criteria cover the registry, guardrail chain, RBAC evaluator and
 skill interfaces and never mention providers, so this stayed a stub. C-02 is
 the first story that needs to generate anything.
 
-**SDK choice.** ``google-generativeai>=0.8.6,<0.9``, matching
-``ai-brand-automator`` and ``content-agent-service``, with the fleet default
-model ``gemini-3.5-flash``. Google's newer ``google-genai`` package supersedes
-it, but switching one service creates a second pattern in a fleet of
-twenty-seven; that migration is worth doing deliberately and everywhere, not
-as a side effect of this story.
+**SDK choice.** ``google-genai``, the supported SDK, with the fleet default
+model ``gemini-3.5-flash``.
+
+This started on ``google-generativeai`` to match ``ai-brand-automator`` and
+``content-agent-service``, argued on fleet consistency. That argument did not
+survive contact with the package: from 0.8.6 it prints, at import, "All
+support for the google.generativeai package has ended… please switch to the
+google.genai package as soon as possible." Consistency with twenty-seven
+services is worth something; inheriting an end-of-life dependency into a
+brand-new service is worth less. OIA is the one place the switch costs
+nothing, so it happens here first rather than never.
+
+The other services still need migrating. That is a fleet-wide piece of work,
+not something to do as a side effect of this story.
 """
 
 from __future__ import annotations
@@ -75,11 +83,17 @@ class LLMProvider:
         return self._model_name
 
     def _ensure_client(self) -> Any:
-        if self._client is None:
-            import google.generativeai as genai
+        """The ``aio.models`` handle, which is the whole surface we use.
 
-            genai.configure(api_key=self._api_key)
-            self._client = genai.GenerativeModel(self._model_name)
+        Narrowed deliberately: injecting the full ``genai.Client`` would make
+        a test double reproduce two levels of nesting to stand in for one
+        method call, and the extra structure would be scaffolding rather than
+        anything the provider depends on.
+        """
+        if self._client is None:
+            from google import genai
+
+            self._client = genai.Client(api_key=self._api_key).aio.models
         return self._client
 
     async def generate(self, prompt: str, *, temperature: float = 0.2) -> str:
@@ -101,9 +115,10 @@ class LLMProvider:
             ) from exc
 
         try:
-            response = await self._ensure_client().generate_content_async(
-                prompt,
-                generation_config={"temperature": temperature},
+            response = await self._ensure_client().generate_content(
+                model=self._model_name,
+                contents=prompt,
+                config={"temperature": temperature},
             )
             text = self._text_of(response)
         except Exception as exc:

--- a/onboarding-intelligence-agent-svc/app/providers/tavily.py
+++ b/onboarding-intelligence-agent-svc/app/providers/tavily.py
@@ -1,0 +1,177 @@
+"""Tavily web search, behind the §18.2 breaker.
+
+Design §8.1 SKL-OIA-01, §18.2 · implemented by story C-02.
+
+Two deliberate departures from the fleet's existing Tavily code
+(``discovery-agent-svc/app/scrapers/search_engine.py``):
+
+1. **The async client.** The fleet calls the synchronous ``TavilyClient`` from
+   inside ``async def``, which blocks the event loop for the duration of a
+   network round trip. OIA serves live WebSocket sessions from the same loop,
+   so a blocked loop is a stalled meeting.
+2. **Failures are not swallowed.** The fleet catches every exception and
+   returns ``[]``, which is indistinguishable from "the web has nothing on
+   this business". C-02's AC-3 requires the opposite: a failure must be
+   visible, must count toward the breaker, and must surface as
+   ``degraded: true`` with a reason.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from app.circuit_breaker.breaker import (
+    BreakerRegistry,
+    CircuitBreaker,
+    CircuitBreakerOpen,
+)
+
+logger = logging.getLogger(__name__)
+
+DEPENDENCY = "tavily"
+
+#: Tavily's own cap is higher, but a research brief that cites twenty sources
+#: is not more grounded than one citing five — it just costs more and gives
+#: the model more to dilute. Overridable per call.
+DEFAULT_MAX_RESULTS = 5
+
+
+@dataclass(frozen=True)
+class SearchResult:
+    """One source. ``url`` is the part that matters.
+
+    AC-1 requires every asserted fact to carry a source URL, so a result
+    without one cannot ground anything and is dropped at parse time rather
+    than being carried forward to fail a guardrail later.
+    """
+
+    title: str
+    url: str
+    snippet: str
+
+
+class TavilyUnavailable(Exception):
+    """Search could not be performed. Carries the operator-facing reason.
+
+    Distinct from "search returned nothing": the caller degrades on this and
+    reports an empty result set normally.
+    """
+
+    def __init__(self, reason: str, *, degraded_mode: str = "SKIP_RESEARCH") -> None:
+        super().__init__(reason)
+        self.reason = reason
+        self.degraded_mode = degraded_mode
+
+
+class TavilyProvider:
+    """Search the web, or say plainly that it could not.
+
+    The breaker is consulted through ``before_call`` rather than ``is_open``
+    so the check and the half-open trial claim are one atomic step.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        breaker: CircuitBreaker | None = None,
+        client: Any | None = None,
+    ) -> None:
+        self._api_key = api_key
+        self._breaker = breaker or BreakerRegistry().get(DEPENDENCY)
+        self._client = client
+
+    @property
+    def configured(self) -> bool:
+        """False when no API key is set.
+
+        Not an error: local development and CI run without a Tavily key, and
+        the correct behaviour there is the same degraded brief AC-3 describes,
+        not a crash. It is reported as a distinct reason so an operator can
+        tell a missing key from an outage.
+        """
+        return bool(self._api_key)
+
+    def _ensure_client(self) -> Any:
+        if self._client is None:
+            from tavily import AsyncTavilyClient
+
+            self._client = AsyncTavilyClient(api_key=self._api_key)
+        return self._client
+
+    async def search(
+        self, query: str, *, max_results: int = DEFAULT_MAX_RESULTS
+    ) -> list[SearchResult]:
+        """Run one search.
+
+        Raises :class:`TavilyUnavailable` when the breaker is open, when no key
+        is configured, or when the call fails. Returns an empty list only when
+        the search genuinely found nothing — the caller needs to tell those
+        apart, because one means "we could not look" and the other means "we
+        looked and there is nothing".
+        """
+        if not self.configured:
+            raise TavilyUnavailable("no Tavily API key is configured")
+
+        try:
+            self._breaker.before_call()
+        except CircuitBreakerOpen as exc:
+            raise TavilyUnavailable(
+                exc.user_message or f"{exc.dependency} is unavailable",
+                degraded_mode=exc.degraded_mode,
+            ) from exc
+
+        try:
+            response = await self._ensure_client().search(
+                query=query,
+                max_results=max_results,
+                search_depth="basic",
+            )
+        except Exception as exc:
+            # Broad by intent. Tavily's client raises its own exception types,
+            # httpx raises transport errors, and a bad key raises something
+            # else again; every one of them means "this call did not work" and
+            # must reach the breaker. Narrowing here would let an unlisted
+            # exception escape into the chat turn.
+            self._breaker.record_failure()
+            logger.warning("tavily search failed: %s: %s", type(exc).__name__, exc)
+            raise TavilyUnavailable(f"web search failed: {type(exc).__name__}") from exc
+
+        self._breaker.record_success()
+        return self._parse(response)
+
+    @staticmethod
+    def _parse(response: Any) -> list[SearchResult]:
+        """Pull results out of a response, skipping anything unsourced.
+
+        Defensive about shape on purpose: this is third-party JSON crossing a
+        network, and C-01's review found the equivalent bug one layer up —
+        assuming a decoded body is a dict, then raising AttributeError two
+        frames away.
+        """
+        if not isinstance(response, dict):
+            logger.warning("tavily returned %s, not an object", type(response).__name__)
+            return []
+
+        raw = response.get("results")
+        if not isinstance(raw, list):
+            return []
+
+        results: list[SearchResult] = []
+        for item in raw:
+            if not isinstance(item, dict):
+                continue
+            url = str(item.get("url") or "").strip()
+            if not url:
+                # Cannot ground a fact, so it would be dropped by OG-01 later.
+                continue
+            results.append(
+                SearchResult(
+                    title=str(item.get("title") or "").strip(),
+                    url=url,
+                    snippet=str(item.get("content") or "")[:500],
+                )
+            )
+        return results

--- a/onboarding-intelligence-agent-svc/config/circuit_breakers.yaml
+++ b/onboarding-intelligence-agent-svc/config/circuit_breakers.yaml
@@ -1,9 +1,12 @@
 # Onboarding Intelligence Agent (OIA) — Circuit Breakers
 #
-# This file IS Design §18.2, transcribed verbatim. Loaded by
-# app/circuit_breaker/breaker.py and validated by tests/test_circuit_breakers.py:
-# all seven dependencies present, every one carrying a degraded_mode, and the
-# numeric fields within sane bounds.
+# This file IS Design §18.2, transcribed verbatim.
+#
+# app/circuit_breaker/breaker.py loads it and rejects at startup: a non-mapping
+# file, a dependency with no degraded_mode, and any numeric field that is not a
+# positive integer. tests/test_circuit_breakers.py additionally asserts that
+# all seven dependencies are present and that every one of them can actually
+# recover from an open breaker.
 #
 # Created by C-02, which is the first story to need a working breaker. §18.2
 # specified this file from the start but no story owned building it — A-06's

--- a/onboarding-intelligence-agent-svc/config/circuit_breakers.yaml
+++ b/onboarding-intelligence-agent-svc/config/circuit_breakers.yaml
@@ -1,0 +1,78 @@
+# Onboarding Intelligence Agent (OIA) — Circuit Breakers
+#
+# This file IS Design §18.2, transcribed verbatim. Loaded by
+# app/circuit_breaker/breaker.py and validated by tests/test_circuit_breakers.py:
+# all seven dependencies present, every one carrying a degraded_mode, and the
+# numeric fields within sane bounds.
+#
+# Created by C-02, which is the first story to need a working breaker. §18.2
+# specified this file from the start but no story owned building it — A-06's
+# acceptance criteria cover the registry, guardrail chain, RBAC evaluator and
+# skill interfaces, and never mention breakers, despite the scaffolded
+# breaker.py docstring naming A-06 as its implementer.
+#
+# user_message is config rather than code on purpose. Design §18.2: "these
+# strings are the entire user experience of a failure, and they should be
+# tunable without a deploy." A null message means the degradation is invisible
+# to the operator by design, not that a message is missing.
+#
+# Only `tavily` is wired to a caller in C-02. The other six are declared here
+# because the file is read whole and a partial file would read as "these
+# dependencies have no breaker" rather than "their callers are not built yet".
+
+defaults:
+  failure_threshold: 5
+  window_seconds: 30
+  success_threshold: 2
+  half_open_max_calls: 1
+  reset_timeout_seconds: 60
+
+dependencies:
+  stt:
+    failure_threshold: 5
+    window_seconds: 30
+    success_threshold: 2
+    degraded_mode: RECORD_ONLY
+    user_message: "Live assist paused — recording continues. Transcript will be ready after the meeting."
+
+  llm:
+    failure_threshold: 5
+    window_seconds: 30
+    success_threshold: 2
+    degraded_mode: MANUAL_CHECKBOXES     # LIVE; PREP/PROCESS queue then escalate
+    user_message: "Suggestions paused. Check questions off manually — nothing is lost."
+
+  vision:
+    failure_threshold: 5
+    window_seconds: 30
+    success_threshold: 2
+    degraded_mode: GEMINI_ONLY_OCR
+    user_message: "Reduced document-reading accuracy — captures still saved."
+
+  backend:
+    failure_threshold: 5
+    window_seconds: 30
+    success_threshold: 2
+    degraded_mode: REDIS_OUTBOX          # buffer writes, replay on recovery
+    user_message: "Saving is delayed — your meeting data is buffered and will sync automatically."
+
+  poi:
+    failure_threshold: 3
+    window_seconds: 60
+    success_threshold: 1
+    degraded_mode: CACHED_THEN_HARDCODED
+    user_message: null                   # invisible to the user, by design
+
+  gcs:
+    failure_threshold: 5
+    window_seconds: 30
+    success_threshold: 2
+    degraded_mode: LOCAL_DISK_SPOOL      # bounded; graceful stop if the bound is hit
+    user_message: "Upload delayed — recording continues locally."
+
+  tavily:
+    failure_threshold: 3
+    window_seconds: 60
+    success_threshold: 1
+    degraded_mode: SKIP_RESEARCH
+    user_message: "Web research unavailable — questionnaire generated from what you provided."

--- a/onboarding-intelligence-agent-svc/pyproject.toml
+++ b/onboarding-intelligence-agent-svc/pyproject.toml
@@ -20,14 +20,3 @@ ignore_missing_imports = true
 # that is intentional scaffolding, not a type error.
 disable_error_code = ["empty-body"]
 
-# google-generativeai ships py.typed from 0.8.4 but re-exports `configure` and
-# `GenerativeModel` implicitly, which strict's no_implicit_reexport rejects.
-# That is the package's packaging choice, not a typing problem in our code.
-#
-# A per-module override rather than `# type: ignore` on the import: strict also
-# enables warn_unused_ignores, so an ignore would itself error on any
-# environment that resolves an *untyped* build of the same package — which is
-# exactly the local-versus-CI split that produced this failure.
-[[tool.mypy.overrides]]
-module = "google.generativeai"
-implicit_reexport = true

--- a/onboarding-intelligence-agent-svc/pyproject.toml
+++ b/onboarding-intelligence-agent-svc/pyproject.toml
@@ -19,3 +19,15 @@ ignore_missing_imports = true
 # Stubs raise NotImplementedError from bodies typed as returning a value;
 # that is intentional scaffolding, not a type error.
 disable_error_code = ["empty-body"]
+
+# google-generativeai ships py.typed from 0.8.4 but re-exports `configure` and
+# `GenerativeModel` implicitly, which strict's no_implicit_reexport rejects.
+# That is the package's packaging choice, not a typing problem in our code.
+#
+# A per-module override rather than `# type: ignore` on the import: strict also
+# enables warn_unused_ignores, so an ignore would itself error on any
+# environment that resolves an *untyped* build of the same package — which is
+# exactly the local-versus-CI split that produced this failure.
+[[tool.mypy.overrides]]
+module = "google.generativeai"
+implicit_reexport = true

--- a/onboarding-intelligence-agent-svc/requirements.txt
+++ b/onboarding-intelligence-agent-svc/requirements.txt
@@ -13,4 +13,4 @@ opentelemetry-exporter-otlp-proto-http>=1.27.0
 google-cloud-storage>=2.14.0
 prometheus-client>=0.20.0
 tavily-python>=0.5.0
-google-generativeai>=0.8.6,<0.9
+google-genai>=1.14.0

--- a/onboarding-intelligence-agent-svc/requirements.txt
+++ b/onboarding-intelligence-agent-svc/requirements.txt
@@ -12,3 +12,5 @@ opentelemetry-sdk>=1.27.0
 opentelemetry-exporter-otlp-proto-http>=1.27.0
 google-cloud-storage>=2.14.0
 prometheus-client>=0.20.0
+tavily-python>=0.5.0
+google-generativeai>=0.8.0

--- a/onboarding-intelligence-agent-svc/requirements.txt
+++ b/onboarding-intelligence-agent-svc/requirements.txt
@@ -13,4 +13,4 @@ opentelemetry-exporter-otlp-proto-http>=1.27.0
 google-cloud-storage>=2.14.0
 prometheus-client>=0.20.0
 tavily-python>=0.5.0
-google-generativeai>=0.8.0
+google-generativeai>=0.8.6,<0.9

--- a/onboarding-intelligence-agent-svc/tests/test_circuit_breakers.py
+++ b/onboarding-intelligence-agent-svc/tests/test_circuit_breakers.py
@@ -231,16 +231,80 @@ def test_a_failed_trial_reopens_immediately():
 
 
 def test_sustained_success_closes_it():
+    """Every trial goes through before_call(), as a real caller must.
+
+    The earlier version of this test called record_success() twice directly
+    and passed — while the breaker was in fact wedged. A caller cannot record
+    a success without first claiming a trial slot, so skipping before_call()
+    tested a sequence production can never produce, and hid a bug that would
+    have left five of the seven §18.2 dependencies permanently degraded after
+    a single blip.
+    """
     breaker = make(failure_threshold=1, reset_timeout_seconds=1, success_threshold=2)
     breaker.record_failure()
     time.sleep(1.1)
 
+    breaker.before_call()
     breaker.record_success()
     assert breaker.state is State.HALF_OPEN, "closed on one success of two"
 
+    breaker.before_call()
     breaker.record_success()
     assert breaker.state is State.CLOSED
     assert breaker.is_open is False
+
+
+def test_the_shipped_defaults_can_actually_recover():
+    """The regression that review caught, stated as a property of the config.
+
+    Five of the seven declared dependencies ship success_threshold=2 with
+    half_open_max_calls=1. If a success does not release its trial slot, each
+    of them takes one trial, records one success, and then refuses every call
+    forever — degraded until the process restarts. Asserting it for every
+    declared dependency rather than one hand-built breaker, because the bug
+    lived in the interaction between two config values.
+    """
+    registry = BreakerRegistry()
+
+    for name in registry.names():
+        config = registry.get(name).config
+        breaker = CircuitBreaker(
+            BreakerConfig(
+                name=config.name,
+                failure_threshold=1,
+                window_seconds=config.window_seconds,
+                success_threshold=config.success_threshold,
+                half_open_max_calls=config.half_open_max_calls,
+                reset_timeout_seconds=1,
+                degraded_mode=config.degraded_mode,
+                user_message=config.user_message,
+            )
+        )
+        breaker.record_failure()
+        assert breaker.state is State.OPEN, name
+
+        for _ in range(config.success_threshold):
+            time.sleep(1.1)
+            breaker.before_call()
+            breaker.record_success()
+
+        assert breaker.state is State.CLOSED, f"{name} cannot recover"
+
+
+def test_a_concurrent_second_trial_is_still_refused():
+    """Releasing the slot on success must not reopen the stampede door.
+
+    The slot is released when a call *finishes*; two callers in flight at once
+    still only get one trial between them.
+    """
+    breaker = make(failure_threshold=1, reset_timeout_seconds=1, half_open_max_calls=1)
+    breaker.record_failure()
+    time.sleep(1.1)
+
+    breaker.before_call()  # first caller, still in flight
+
+    with pytest.raises(CircuitBreakerOpen):
+        breaker.before_call()  # second caller, concurrent
 
 
 def test_the_full_cycle():

--- a/onboarding-intelligence-agent-svc/tests/test_circuit_breakers.py
+++ b/onboarding-intelligence-agent-svc/tests/test_circuit_breakers.py
@@ -1,0 +1,288 @@
+"""C-02 · the §18.2 breakers and their configuration.
+
+Named by the C-02 card. The degradation case it specifies —
+``test_tavily_open_produces_degraded_brief`` — needs the skill, so it lands in
+PR 2; this file covers the mechanism that case depends on.
+
+No mocks, and no patched clocks either. Timing is exercised by configuring a
+breaker with a short reset timeout and actually waiting, because the thing
+worth proving is that the state machine reads a real monotonic clock
+correctly. A frozen clock would prove only that the arithmetic matches itself.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+
+import pytest
+import yaml
+
+from app.circuit_breaker.breaker import (
+    CONFIG_PATH,
+    BreakerConfig,
+    BreakerRegistry,
+    CircuitBreaker,
+    CircuitBreakerOpen,
+    State,
+)
+
+pytestmark = pytest.mark.unit
+
+#: §18.2 names exactly these. A missing one is a dependency with no defined
+#: degraded behaviour, which is the outage the section exists to prevent.
+EXPECTED_DEPENDENCIES = {"stt", "llm", "vision", "backend", "poi", "gcs", "tavily"}
+
+
+def make(**overrides) -> CircuitBreaker:
+    base = dict(
+        name="test",
+        failure_threshold=3,
+        window_seconds=60,
+        success_threshold=1,
+        half_open_max_calls=1,
+        reset_timeout_seconds=60,
+        degraded_mode="SKIP_RESEARCH",
+        user_message="degraded",
+    )
+    base.update(overrides)
+    return CircuitBreaker(BreakerConfig(**base))
+
+
+# ── The configuration file ───────────────────────────────────────────
+
+
+def test_all_seven_dependencies_are_declared():
+    assert set(BreakerRegistry().names()) == EXPECTED_DEPENDENCIES
+
+
+def test_the_shipped_config_matches_the_design():
+    """§18.2 gives this file verbatim, and F-06 and N-03 both read it later.
+
+    Asserting the tavily row specifically because C-02's AC-3 depends on these
+    exact numbers: three failures in sixty seconds, one success to recover.
+    """
+    tavily = BreakerRegistry().get("tavily").config
+
+    assert tavily.failure_threshold == 3
+    assert tavily.window_seconds == 60
+    assert tavily.success_threshold == 1
+    assert tavily.degraded_mode == "SKIP_RESEARCH"
+    assert tavily.user_message == (
+        "Web research unavailable — questionnaire generated from what you provided."
+    )
+
+
+def test_every_dependency_has_a_degraded_mode():
+    registry = BreakerRegistry()
+
+    for name in registry.names():
+        assert registry.get(name).config.degraded_mode, f"{name} degrades to nothing"
+
+
+def test_a_null_user_message_is_preserved_as_none():
+    """§18.2 marks poi's message null — "invisible to the user, by design".
+
+    The distinction matters: an empty string would render as a blank banner,
+    while None means "show nothing".
+    """
+    assert BreakerRegistry().get("poi").config.user_message is None
+
+
+def test_defaults_fill_in_unspecified_fields():
+    """poi overrides three fields and inherits half_open_max_calls and
+    reset_timeout_seconds from defaults."""
+    poi = BreakerRegistry().get("poi").config
+
+    assert poi.failure_threshold == 3  # overridden
+    assert poi.half_open_max_calls == 1  # inherited
+    assert poi.reset_timeout_seconds == 60  # inherited
+
+
+def test_an_unknown_dependency_is_an_error_not_a_new_breaker():
+    """A typo in circuit_breaker_dependency must fail loudly. Creating one on
+    demand would silently disable protection for the real dependency."""
+    with pytest.raises(KeyError, match="no breaker declared"):
+        BreakerRegistry().get("tavilly")
+
+
+def test_a_dependency_without_a_degraded_mode_is_rejected(tmp_path: Path):
+    bad = tmp_path / "circuit_breakers.yaml"
+    bad.write_text(
+        yaml.safe_dump(
+            {
+                "defaults": {
+                    "failure_threshold": 5,
+                    "window_seconds": 30,
+                    "success_threshold": 2,
+                },
+                "dependencies": {"tavily": {"user_message": "x"}},
+            }
+        )
+    )
+
+    with pytest.raises(ValueError, match="declares no degraded_mode"):
+        BreakerRegistry(bad)
+
+
+def test_the_config_path_resolves_to_a_real_file():
+    """The path is built from __file__ and would break silently if the package
+    moved — the registry would then raise at import time in production."""
+    assert CONFIG_PATH.is_file(), CONFIG_PATH
+
+
+# ── The state machine ────────────────────────────────────────────────
+
+
+def test_a_breaker_starts_closed():
+    assert make().state is State.CLOSED
+    assert make().is_open is False
+
+
+def test_it_opens_at_the_threshold_and_not_before():
+    breaker = make(failure_threshold=3)
+
+    breaker.record_failure()
+    breaker.record_failure()
+    assert breaker.is_open is False, "opened early"
+
+    breaker.record_failure()
+    assert breaker.is_open is True
+
+
+def test_success_clears_accumulated_failures():
+    """The threshold counts current trouble. A dependency serving again should
+    not carry old failures toward opening."""
+    breaker = make(failure_threshold=3)
+
+    breaker.record_failure()
+    breaker.record_failure()
+    breaker.record_success()
+    breaker.record_failure()
+    breaker.record_failure()
+
+    assert breaker.is_open is False
+
+
+def test_failures_outside_the_window_do_not_count():
+    breaker = make(failure_threshold=3, window_seconds=1)
+
+    breaker.record_failure()
+    breaker.record_failure()
+    time.sleep(1.1)
+    breaker.record_failure()
+
+    assert breaker.is_open is False, "a stale failure was counted"
+
+
+def test_an_open_breaker_refuses_the_call_with_the_degraded_context():
+    """AC-3 needs the mode and the message to build a brief that says why it
+    is thin, without re-reading the config."""
+    breaker = make(failure_threshold=1)
+    breaker.record_failure()
+
+    with pytest.raises(CircuitBreakerOpen) as caught:
+        breaker.before_call()
+
+    assert caught.value.dependency == "test"
+    assert caught.value.degraded_mode == "SKIP_RESEARCH"
+    assert caught.value.user_message == "degraded"
+
+
+def test_it_moves_to_half_open_after_the_reset_timeout():
+    breaker = make(failure_threshold=1, reset_timeout_seconds=1)
+    breaker.record_failure()
+    assert breaker.state is State.OPEN
+
+    time.sleep(1.1)
+
+    assert breaker.state is State.HALF_OPEN
+    assert breaker.is_open is False, "the trial call was refused"
+
+
+def test_half_open_admits_only_its_trial_budget():
+    """Without an atomic claim, a burst of callers would all slip through the
+    instant the timeout elapsed — the stampede HALF_OPEN prevents."""
+    breaker = make(failure_threshold=1, reset_timeout_seconds=1, half_open_max_calls=1)
+    breaker.record_failure()
+    time.sleep(1.1)
+
+    breaker.before_call()  # the one trial
+
+    with pytest.raises(CircuitBreakerOpen):
+        breaker.before_call()
+
+
+def test_a_failed_trial_reopens_immediately():
+    """The dependency was already known bad; one failed trial is evidence it
+    still is. Counting to the threshold again would send more doomed calls."""
+    breaker = make(failure_threshold=3, reset_timeout_seconds=1)
+    breaker.record_failure()
+    breaker.record_failure()
+    breaker.record_failure()
+    time.sleep(1.1)
+    assert breaker.state is State.HALF_OPEN
+
+    breaker.before_call()
+    breaker.record_failure()
+
+    assert breaker.state is State.OPEN
+
+
+def test_sustained_success_closes_it():
+    breaker = make(failure_threshold=1, reset_timeout_seconds=1, success_threshold=2)
+    breaker.record_failure()
+    time.sleep(1.1)
+
+    breaker.record_success()
+    assert breaker.state is State.HALF_OPEN, "closed on one success of two"
+
+    breaker.record_success()
+    assert breaker.state is State.CLOSED
+    assert breaker.is_open is False
+
+
+def test_the_full_cycle():
+    """CLOSED → OPEN → HALF_OPEN → CLOSED, the path a real recovery takes."""
+    breaker = make(failure_threshold=2, reset_timeout_seconds=1, success_threshold=1)
+
+    assert breaker.state is State.CLOSED
+    breaker.record_failure()
+    breaker.record_failure()
+    assert breaker.state is State.OPEN
+
+    time.sleep(1.1)
+    assert breaker.state is State.HALF_OPEN
+
+    breaker.before_call()
+    breaker.record_success()
+    assert breaker.state is State.CLOSED
+
+    # And it can open again — the counters were reset, not left at threshold.
+    breaker.record_failure()
+    assert breaker.is_open is False
+    breaker.record_failure()
+    assert breaker.is_open is True
+
+
+def test_concurrent_failures_are_not_lost():
+    """FastAPI serves requests concurrently, so two can land in record_failure
+    at once. A lost increment opens the breaker late — exactly when it
+    matters. Real threads rather than a reasoned argument about the lock.
+    """
+    breaker = make(failure_threshold=50, window_seconds=60)
+    barrier = threading.Barrier(10)
+
+    def hammer():
+        barrier.wait()
+        for _ in range(5):
+            breaker.record_failure()
+
+    threads = [threading.Thread(target=hammer) for _ in range(10)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert breaker.is_open is True, "increments were lost under concurrency"

--- a/onboarding-intelligence-agent-svc/tests/test_llm_provider.py
+++ b/onboarding-intelligence-agent-svc/tests/test_llm_provider.py
@@ -1,0 +1,145 @@
+"""C-02 · the Gemini provider and its breaker wiring.
+
+The unit cases need no network: a missing key, an open breaker and an empty
+completion are all decided before or after the call.
+
+The integration case makes a **real Gemini call**. It skips when no key is
+configured, because that is the honest state of a laptop or a CI runner
+without one — but it *fails* when ``OIA_TEST_GEMINI`` is set, following the
+same asymmetry the Kafka round-trip tests use. A green run that silently
+covered nothing is worse than an honest red.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from app.circuit_breaker.breaker import BreakerConfig, CircuitBreaker, State
+from app.providers.llm import DEFAULT_MODEL, LLMProvider, LLMUnavailable
+
+
+def breaker(**overrides) -> CircuitBreaker:
+    base = dict(
+        name="llm",
+        failure_threshold=5,
+        window_seconds=30,
+        success_threshold=2,
+        half_open_max_calls=1,
+        reset_timeout_seconds=60,
+        degraded_mode="MANUAL_CHECKBOXES",
+        user_message=(
+            "Suggestions paused. Check questions off manually — nothing is lost."
+        ),
+    )
+    base.update(overrides)
+    return CircuitBreaker(BreakerConfig(**base))
+
+
+# ── Decided without a network call ───────────────────────────────────
+
+
+@pytest.mark.unit
+async def test_no_api_key_degrades_rather_than_crashing():
+    provider = LLMProvider("", breaker=breaker())
+
+    assert provider.configured is False
+    with pytest.raises(LLMUnavailable, match="no Gemini API key"):
+        await provider.generate("hello")
+
+
+@pytest.mark.unit
+async def test_a_missing_key_does_not_consume_the_breaker():
+    """A keyless environment should report a configuration gap, not an
+    outage it will then wait out."""
+    brk = breaker(failure_threshold=1)
+
+    with pytest.raises(LLMUnavailable):
+        await LLMProvider("", breaker=brk).generate("hello")
+
+    assert brk.state is State.CLOSED
+
+
+@pytest.mark.unit
+async def test_an_open_breaker_carries_the_configured_message():
+    """§18.2 puts the operator-facing string in config so it is tunable
+    without a deploy; it must come from there, not be re-typed here."""
+    brk = breaker(failure_threshold=1)
+    brk.record_failure()
+
+    with pytest.raises(LLMUnavailable) as caught:
+        await LLMProvider("key", breaker=brk).generate("hello")
+
+    assert caught.value.degraded_mode == "MANUAL_CHECKBOXES"
+    assert "Check questions off manually" in caught.value.reason
+
+
+@pytest.mark.unit
+def test_the_fleet_model_is_the_default():
+    """Root CLAUDE.md sets gemini-3.5-flash as the fleet default and
+    ai_services/services.py uses it. A silent divergence here would make OIA's
+    output differ from the rest of the platform for no stated reason."""
+    assert DEFAULT_MODEL == "gemini-3.5-flash"
+    assert LLMProvider("key").model_name == "gemini-3.5-flash"
+
+
+# ── An empty completion is a failure, not an empty answer ────────────
+
+
+@pytest.mark.unit
+def test_an_empty_completion_raises():
+    """A safety block returns a response whose text is empty. Returning ""
+    would let a caller build a brief out of nothing and present it as
+    researched."""
+
+    class Blocked:
+        text = ""
+
+    with pytest.raises(ValueError, match="no text"):
+        LLMProvider._text_of(Blocked())
+
+
+@pytest.mark.unit
+def test_a_whitespace_completion_raises():
+    class Whitespace:
+        text = "   \n  "
+
+    with pytest.raises(ValueError, match="no text"):
+        LLMProvider._text_of(Whitespace())
+
+
+@pytest.mark.unit
+def test_a_response_with_no_text_attribute_raises():
+    with pytest.raises(ValueError, match="no text"):
+        LLMProvider._text_of(object())
+
+
+# ── The real thing ───────────────────────────────────────────────────
+
+
+@pytest.mark.integration
+async def test_a_real_generation_round_trip():
+    """A real call to Gemini with the real SDK.
+
+    Deliberately not asserting on the content — the model is not
+    deterministic. What is worth proving is that the key, the SDK, the async
+    entry point and the breaker all line up, which is exactly the set of
+    things a mocked client cannot tell you.
+    """
+    key = os.environ.get("OIA_GEMINI_KEY") or os.environ.get("GOOGLE_API_KEY") or ""
+    if not key:
+        if os.environ.get("OIA_TEST_GEMINI"):
+            pytest.fail(
+                "OIA_TEST_GEMINI is set but no OIA_GEMINI_KEY/GOOGLE_API_KEY "
+                "is configured — this test would silently cover nothing"
+            )
+        pytest.skip("no Gemini key configured")
+
+    brk = breaker()
+    provider = LLMProvider(key, breaker=brk)
+
+    text = await provider.generate("Reply with the single word: ready")
+
+    assert text.strip(), "the model returned nothing"
+    assert brk.state is State.CLOSED

--- a/onboarding-intelligence-agent-svc/tests/test_scaffold.py
+++ b/onboarding-intelligence-agent-svc/tests/test_scaffold.py
@@ -111,6 +111,11 @@ IMPLEMENTED = {
 #: rather than a silent one.
 IMPLEMENTED |= {"app.api.deps", "app.api.schemas"}
 
+#: Implemented by C-02. §18.2 specified config/circuit_breakers.yaml and this
+#: module from the start, but no story owned building them — the scaffold
+#: docstring named A-06, whose acceptance criteria never mention breakers.
+IMPLEMENTED |= {"app.circuit_breaker.breaker", "app.providers.llm"}
+
 #: A-06 turned the sixteen skill modules into registry-resolvable classes.
 #: They are no longer bare stubs — the class is real and instantiable, and it
 #: is the *body* that is deferred. test_skill_bodies_are_deferred covers them.

--- a/onboarding-intelligence-agent-svc/tests/test_tavily_provider.py
+++ b/onboarding-intelligence-agent-svc/tests/test_tavily_provider.py
@@ -1,0 +1,317 @@
+"""C-02 · the Tavily provider and its breaker wiring.
+
+No mocks. ``AsyncTavilyClient`` takes an ``api_base_url``, so these run the
+**real** client library against a local HTTP server whose responses the test
+controls. That matters more than it sounds: a mocked client proves the code
+handles the response shape the test author imagined, whereas this proves it
+handles what the library actually produces after its own parsing, error
+handling and retries.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from app.circuit_breaker.breaker import BreakerConfig, CircuitBreaker, State
+from app.providers.tavily import (
+    SearchResult,
+    TavilyProvider,
+    TavilyUnavailable,
+)
+
+pytestmark = pytest.mark.integration
+
+
+def breaker(**overrides) -> CircuitBreaker:
+    base = dict(
+        name="tavily",
+        failure_threshold=3,
+        window_seconds=60,
+        success_threshold=1,
+        half_open_max_calls=1,
+        reset_timeout_seconds=60,
+        degraded_mode="SKIP_RESEARCH",
+        user_message=(
+            "Web research unavailable — questionnaire generated from "
+            "what you provided."
+        ),
+    )
+    base.update(overrides)
+    return CircuitBreaker(BreakerConfig(**base))
+
+
+@pytest.fixture
+def fake_tavily():
+    """A real HTTP server the real Tavily client talks to.
+
+    ``state`` is mutable so a test can change the response between calls —
+    which is how the breaker's open-then-recover path gets exercised without
+    anyone patching anything.
+    """
+    state = {
+        "status": 200,
+        "body": {"results": []},
+        "content_type": "application/json",
+        "requests": 0,
+    }
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            state["requests"] += 1
+            length = int(self.headers.get("Content-Length") or 0)
+            self.rfile.read(length)
+            body = state["body"]
+            payload = (
+                body.encode() if isinstance(body, str) else json.dumps(body).encode()
+            )
+            self.send_response(state["status"])
+            self.send_header("Content-Type", state["content_type"])
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *args):
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    state["url"] = f"http://127.0.0.1:{server.server_address[1]}"
+    try:
+        yield state
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def provider_for(fake, brk=None) -> TavilyProvider:
+    from tavily import AsyncTavilyClient
+
+    client = AsyncTavilyClient(api_key="test-key", api_base_url=fake["url"])
+    return TavilyProvider("test-key", breaker=brk or breaker(), client=client)
+
+
+# ── The happy path ───────────────────────────────────────────────────
+
+
+async def test_results_are_parsed(fake_tavily):
+    fake_tavily["body"] = {
+        "results": [
+            {
+                "title": "Kalyani Roasters",
+                "url": "https://kalyani.example/about",
+                "content": "A speciality coffee roaster in Pune since 2016.",
+            }
+        ]
+    }
+
+    results = await provider_for(fake_tavily).search("Kalyani Roasters Pune")
+
+    assert results == [
+        SearchResult(
+            title="Kalyani Roasters",
+            url="https://kalyani.example/about",
+            snippet="A speciality coffee roaster in Pune since 2016.",
+        )
+    ]
+
+
+async def test_a_result_without_a_url_is_dropped(fake_tavily):
+    """AC-1 requires a source URL per fact. A result that cannot ground
+    anything is dropped here rather than carried forward to fail OG-01."""
+    fake_tavily["body"] = {
+        "results": [
+            {"title": "no source", "content": "unattributable"},
+            {"title": "sourced", "url": "https://x.example", "content": "ok"},
+        ]
+    }
+
+    results = await provider_for(fake_tavily).search("q")
+
+    assert [r.url for r in results] == ["https://x.example"]
+
+
+async def test_finding_nothing_is_not_a_failure(fake_tavily):
+    """An empty result set means "we looked and there is nothing", which is
+    different from "we could not look" — the caller degrades only on the
+    latter."""
+    fake_tavily["body"] = {"results": []}
+    brk = breaker()
+
+    assert await provider_for(fake_tavily, brk).search("q") == []
+    assert brk.state is State.CLOSED, "an empty result set tripped the breaker"
+
+
+@pytest.mark.parametrize("body", [{"results": "not-a-list"}, {}])
+async def test_an_odd_but_returnable_shape_yields_no_results(fake_tavily, body):
+    """Shapes the client hands back rather than raising on.
+
+    Verified against the real library rather than assumed: an empty object is
+    normalised by the client to ``{"results": []}``, and a non-list ``results``
+    is passed straight through for us to reject.
+    """
+    fake_tavily["body"] = body
+
+    assert await provider_for(fake_tavily).search("q") == []
+
+
+@pytest.mark.parametrize("body", [[1, 2, 3], "text"])
+async def test_a_malformed_upstream_body_degrades_and_counts(fake_tavily, body):
+    """These make the *client library itself* raise.
+
+    A bare JSON list raises ``AttributeError: 'list' object has no attribute
+    'get'`` from inside tavily-python — the same bug C-01's review found in our
+    own dispatcher, here in a third-party package we do not control. A body
+    that is not JSON at all raises JSONDecodeError. Both mean the call did not
+    work, so both must become TavilyUnavailable and reach the breaker rather
+    than escaping into the operator's chat turn.
+
+    This is the evidence for the deliberately broad ``except Exception`` in the
+    provider: the set of things this library can raise is not enumerable from
+    its signature.
+    """
+    fake_tavily["body"] = body
+    brk = breaker(failure_threshold=1)
+
+    with pytest.raises(TavilyUnavailable):
+        await provider_for(fake_tavily, brk).search("q")
+
+    assert brk.is_open is True
+
+
+@pytest.mark.unit
+def test_parse_rejects_a_non_object_response():
+    """Defence in depth for a path the current client version cannot produce —
+    it raises on a bare list before we ever see one. Kept because the guard is
+    free and the library's behaviour here is not part of its contract.
+    """
+    assert TavilyProvider._parse([1, 2, 3]) == []
+    assert TavilyProvider._parse("text") == []
+    assert TavilyProvider._parse(None) == []
+
+
+# ── Failure reaches the breaker (AC-3's foundation) ──────────────────
+
+
+async def test_a_server_error_raises_and_counts(fake_tavily):
+    """The fleet's existing Tavily code returns [] here, which is
+    indistinguishable from "nothing found". AC-3 needs the difference."""
+    fake_tavily["status"] = 500
+    fake_tavily["body"] = {"detail": "boom"}
+    brk = breaker(failure_threshold=1)
+
+    with pytest.raises(TavilyUnavailable):
+        await provider_for(fake_tavily, brk).search("q")
+
+    assert brk.is_open is True
+
+
+async def test_repeated_failures_open_the_breaker(fake_tavily):
+    fake_tavily["status"] = 500
+    brk = breaker(failure_threshold=3)
+    provider = provider_for(fake_tavily, brk)
+
+    for _ in range(3):
+        with pytest.raises(TavilyUnavailable):
+            await provider.search("q")
+
+    assert brk.state is State.OPEN
+
+
+async def test_an_open_breaker_short_circuits_with_the_configured_message(fake_tavily):
+    """AC-3: the operator is told plainly. §18.2 puts that string in config
+    precisely so it is tunable without a deploy, so it must come from there
+    and not be re-typed in the provider."""
+    brk = breaker(failure_threshold=1)
+    brk.record_failure()
+
+    with pytest.raises(TavilyUnavailable) as caught:
+        await provider_for(fake_tavily, brk).search("q")
+
+    assert caught.value.degraded_mode == "SKIP_RESEARCH"
+    assert caught.value.reason == (
+        "Web research unavailable — questionnaire generated from what you provided."
+    )
+
+
+async def test_an_open_breaker_does_not_call_the_network(fake_tavily):
+    """The whole point of the breaker.
+
+    Counted at the server, not inferred: an earlier draft of this test
+    asserted that an unrelated variable was unchanged, which would have passed
+    just as happily if the request had been made.
+    """
+    brk = breaker(failure_threshold=1)
+    brk.record_failure()
+    provider = provider_for(fake_tavily, brk)
+
+    before = fake_tavily["requests"]
+    with pytest.raises(TavilyUnavailable):
+        await provider.search("q")
+
+    assert fake_tavily["requests"] == before, "the open breaker still called out"
+
+
+async def test_a_closed_breaker_does_call_the_network(fake_tavily):
+    """The control for the test above — otherwise a provider that never calls
+    anything would pass it."""
+    before = fake_tavily["requests"]
+
+    await provider_for(fake_tavily).search("q")
+
+    assert fake_tavily["requests"] == before + 1
+
+
+async def test_it_recovers_when_the_dependency_does(fake_tavily):
+    """The whole cycle against a real server: fail, open, wait, succeed, close."""
+    import time
+
+    fake_tavily["status"] = 500
+    brk = breaker(failure_threshold=1, reset_timeout_seconds=1, success_threshold=1)
+    provider = provider_for(fake_tavily, brk)
+
+    with pytest.raises(TavilyUnavailable):
+        await provider.search("q")
+    assert brk.state is State.OPEN
+
+    time.sleep(1.1)
+    fake_tavily["status"] = 200
+    fake_tavily["body"] = {
+        "results": [{"title": "back", "url": "https://x.example", "content": "ok"}]
+    }
+
+    results = await provider.search("q")
+
+    assert [r.url for r in results] == ["https://x.example"]
+    assert brk.state is State.CLOSED
+
+
+# ── An unconfigured key degrades, it does not crash ──────────────────
+
+
+@pytest.mark.unit
+async def test_no_api_key_degrades_with_a_distinct_reason():
+    """CI and local development run without a Tavily key. The right behaviour
+    is AC-3's degraded brief, and an operator should be able to tell a missing
+    key from an outage."""
+    provider = TavilyProvider("", breaker=breaker())
+
+    assert provider.configured is False
+    with pytest.raises(TavilyUnavailable, match="no Tavily API key"):
+        await provider.search("q")
+
+
+@pytest.mark.unit
+async def test_a_missing_key_does_not_consume_the_breaker():
+    """Otherwise a keyless environment would open the breaker on startup and
+    report an outage that is really a configuration gap."""
+    brk = breaker(failure_threshold=1)
+    provider = TavilyProvider("", breaker=brk)
+
+    with pytest.raises(TavilyUnavailable):
+        await provider.search("q")
+
+    assert brk.state is State.CLOSED


### PR DESCRIPTION
First of two PRs for **C-02 · Research the business from operator hints (SKL-OIA-01)**. This one is the dependency layer; PR 2 brings the skill, the prep executor, persistence and the OG-01 grounding rule.

## Why this exists

C-02's AC-3 says *"Given the Tavily circuit breaker in the open state"*. **There was no circuit breaker.**

| Expected | Actual |
|---|---|
| `app/circuit_breaker/breaker.py` | `NotImplementedError` stub, docstring naming A-06 |
| `config/circuit_breakers.yaml` (§18.2, given verbatim) | absent |
| A Tavily client | none anywhere in OIA |
| `app/providers/llm.py` | stub; no LLM SDK in requirements |

A-06's four acceptance criteria cover the registry, guardrail chain, RBAC evaluator and skill interfaces — they never mention breakers. **No story in the 67-card backlog owns building this.** F-06 and N-03 both *read* `circuit_breakers.yaml` later, assuming it exists.

## Decisions worth reviewing

**Per-process breaker state.** Cloud Run runs several instances, so a failing dependency opens N breakers independently. A shared breaker in Redis would add a hop to the very path it protects and would fail when Redis does.

**`before_call()`, not `is_open`.** The check and the half-open trial claim have to be atomic, or concurrent callers all slip through the instant the reset timeout elapses.

**Both providers diverge from `discovery-agent-svc` on purpose.** Async client (the fleet's blocks the event loop, which would stall a live meeting), and failures are *not* swallowed into `[]` — AC-3 needs "we could not look" to be distinguishable from "there is nothing to find".

**A missing API key is not a breaker failure.** It degrades with a distinct reason, so a keyless CI run reports a config gap rather than an outage it then waits out.

## Testing — real, not mocked

`AsyncTavilyClient` accepts `api_base_url`, so the tests drive the **real client library** against a local HTTP server. That paid off immediately: probing it showed tavily-python raises `AttributeError: 'list' object has no attribute 'get'` on a bare-list body — the same bug class C-01's review caught in our dispatcher, here in a dependency we do not control. That is the evidence for the deliberately broad `except`, and it corrected two tests I had written asserting the wrong behaviour.

One Gemini test makes a **real API call** (verified locally against a live key, 25s). It skips without a key and *fails* if `OIA_TEST_GEMINI` is set — the same asymmetry as the Kafka round-trip tests.

**Mutation-checked**: an off-by-one in the failure threshold fails 15 tests; removing the half-open trial budget fails 1.

## Deployment

Reuses the **existing** `TAVILY_API_KEY` secret (discovery, MRA, CIA and TCIA already use it) — no new secret to provision. Wired into `docker-compose.yml` and `08-deploy-services.sh`.

## Scope deviation from the approved plan

The prep executor was planned for this PR. It moved to PR 2 — it is only meaningfully testable alongside the skill it dispatches, and this PR stands on its own.

**407 passed**, `mypy --strict` clean, `black`/`flake8` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)