### PR TITLE
feat(oia): SKL-OIA-01 research brief, OG-01 grounding and the PREP executor (C-02, PR 2)

### DIFF
--- a/deployment/gcp/10-redeploy-with-urls.sh
+++ b/deployment/gcp/10-redeploy-with-urls.sh
@@ -105,6 +105,16 @@ update_service zorven-content-agent \
 update_service zorven-social-agent \
   "SOCIAL_CORE_API_URL=${ZORVEN_BACKEND_URL},SOCIAL_MLFLOW_TRACKING_URI=${ZORVEN_MLFLOW_URL}" &
 
+# Onboarding intelligence needs the backend API URL (C-02).
+#
+# It was missing from this second pass entirely — 08-deploy-services.sh sets
+# OIA_BACKEND_BASE_URL=PLACEHOLDER like every other service, but nothing ever
+# replaced it, so the deployed service has held the literal string
+# "PLACEHOLDER" since it was first deployed. Nothing had called the backend
+# yet, so it cost nothing and stayed invisible.
+update_service zorven-onboarding-intelligence-agent \
+  "OIA_BACKEND_BASE_URL=${ZORVEN_BACKEND_URL}" &
+
 wait
 
 # ═══════════════════════════════════════════════════════════════

--- a/onboarding-intelligence-agent-svc/CLAUDE.md
+++ b/onboarding-intelligence-agent-svc/CLAUDE.md
@@ -110,6 +110,19 @@ code, check §18.4 before using it.
 
 Providers wrap dependencies: `app/providers/tavily.py` and `app/providers/llm.py`. Both differ from `discovery-agent-svc`'s Tavily code on purpose — they use the async client (the fleet's blocks the event loop, which would stall a live meeting) and they **do not swallow failures into an empty result**, because "we could not look" and "there is nothing to find" need different operator responses.
 
+## PREP: how a turn becomes research (C-02)
+
+`POST /v1/execute` → `PrepExecutor` (`app/logic/prep_executor.py`, on `app.state.prep`) → `SkillRegistry.execute("SKL-OIA-01")` → `ResearchBusiness`. The executor owns the registry and the brief cache because both are decisions that move as C-03 and C-04 land, and neither belongs in an HTTP handler.
+
+- **The model never researches.** It only organises text Tavily retrieved. A model asked to research a small business produces fluent, plausible, unsourced claims — the exact failure AC-1 exists to prevent.
+- **Two grounding checks, not one.** The skill drops any fact whose `source_url` was not in the retrieved set (an invented-but-plausible citation passes a URL-shape check), and OG-01 then demotes anything still unsourced.
+- **OG-01 is a real registered rule**, not logic inside the skill — installed via `GuardrailChain.register`, which replaces a body in place without reordering the layer. M-01 will extend it rather than find a no-op plus a private copy.
+- **Unsourced facts are demoted, never deleted.** SKL-OIA-02 turns `open_unknowns` into questions, so a claim the agent could not source is signal, not noise.
+- **A degraded brief is never cached.** It is the *absence* of research; caching it would let a one-minute Tavily outage suppress real research for the next hour with nothing to tell the operator why.
+- `output.detail` is load-bearing: Django renders it into the chat bubble and falls back to "Preparation is under way." if absent.
+
+Skills receive shared dependencies through `SkillRegistry(providers={...})`, matched against each skill's `__init__` signature. A skill that grows a dependency picks it up by adding the parameter — there is no second place to register it.
+
 ## Non-negotiables in this service
 
 ### Eviction: the shared instance is `noeviction`, and must stay that way

--- a/onboarding-intelligence-agent-svc/app/api/routes.py
+++ b/onboarding-intelligence-agent-svc/app/api/routes.py
@@ -21,6 +21,9 @@ from app.api.schemas import (
     UsageReport,
 )
 from app.cache.conversation import ConversationStore
+from app.logic.prep_executor import RESEARCH_SKILL
+from app.skills.models import TenantContext
+from app.skills.research_brief import BusinessResearchBrief
 
 router = APIRouter()
 
@@ -205,20 +208,51 @@ async def execute(request: Request, payload: ExecuteRequest) -> ExecuteResponse:
         tenant_id=tenant_id, chat_session_id=payload.chat_session_id
     )
 
+    brief, from_cache = await request.app.state.prep.research(
+        tenant=TenantContext(
+            tenant_id=tenant_id,
+            user_id=payload.tenant_context.user_id,
+            role=payload.tenant_context.role,
+            session_id=payload.session_id,
+        ),
+        input_context=payload.input_context,
+        input_prompt=payload.input_prompt,
+        correlation_id=payload.tenant_context.correlation_id or "",
+    )
+
+    summary = BusinessResearchBrief.model_validate(brief).summary_line()
+
+    # The brief is recorded as an agent turn so the next turn sees it. C-01
+    # built the history for exactly this — an operator saying "go deeper on
+    # their supply chain" needs the agent to know what it already found.
+    await store.append(
+        tenant_id=tenant_id,
+        chat_session_id=payload.chat_session_id,
+        role="agent",
+        text=summary,
+    )
+
     return ExecuteResponse(
         status="SUCCEEDED",
-        # Named rather than left blank, so a caller reading the response can
-        # tell "no skill is wired up yet" from "a skill ran and produced
-        # nothing" — which are different bugs.
-        skill_id="NONE",
+        skill_id=RESEARCH_SKILL,
         output={
             "turns": len(history),
             "history": history,
-            "detail": (
-                "Conversation recorded. Question generation arrives with "
-                "SKL-OIA-01 and SKL-OIA-02 (C-02, C-03)."
-            ),
+            # `detail` is what the operator actually reads: Django's dispatcher
+            # renders output.detail into the chat bubble and falls back to
+            # "Preparation is under way." when it is absent. Dropping this key
+            # would replace every prep reply with that placeholder, and no test
+            # on this side would have noticed.
+            "detail": summary,
+            "research_brief": brief,
+            "from_cache": from_cache,
         },
-        guardrails=GuardrailReport(),
+        guardrails=GuardrailReport(
+            # OG-01 demotes rather than blocks, so a brief that lost facts
+            # still passes — the demotion is visible in open_unknowns, and
+            # reporting FAIL would tell an operator the turn failed when it
+            # did exactly what it should.
+            output="PASS",
+        ),
         usage=UsageReport(duration_ms=int((time.monotonic() - started) * 1000)),
     )

--- a/onboarding-intelligence-agent-svc/app/cache/redis_manager.py
+++ b/onboarding-intelligence-agent-svc/app/cache/redis_manager.py
@@ -37,6 +37,7 @@ PROMPT_CACHE_PREFIX: Final[str] = "poi:"
 TTL_SESSION: Final[int] = 4 * 60 * 60  # sliding
 TTL_LIVE: Final[int] = 4 * 60 * 60
 TTL_SUMMARY: Final[int] = 24 * 60 * 60
+TTL_BRIEF: Final[int] = 60 * 60  # research brief (C-02)
 TTL_IDEMPOTENCY: Final[int] = 24 * 60 * 60
 TTL_OUTBOX: Final[int] = 24 * 60 * 60
 TTL_CIRCUIT: Final[int] = 5 * 60
@@ -80,6 +81,17 @@ class TenantKeys:
     def session_summary(self, session_id: str) -> str:
         """String · 24 h · compressed L3 summary."""
         return f"{self._scope}session:{session_id}:summary"
+
+    def brief(self, company_slug: str) -> str:
+        """String · 1 h · a BusinessResearchBrief (C-02).
+
+        Keyed on the *normalised* company name rather than a session or a
+        chat: the card asks for "(tenant, normalised business name)" because
+        an operator re-running prep for the same business — often in a new
+        chat while tuning question count — should not pay for a fresh round
+        of Tavily searches each time.
+        """
+        return f"{self._scope}brief:{company_slug}"
 
     def chat(self, chat_session_id: str) -> str:
         """List · 4 h sliding · prep conversation turns (C-01).

--- a/onboarding-intelligence-agent-svc/app/logic/grounding.py
+++ b/onboarding-intelligence-agent-svc/app/logic/grounding.py
@@ -1,0 +1,113 @@
+"""OG-01 — every asserted value must be grounded in a source.
+
+Design §5 OG-01, §18.4 ERR-11 · story C-02.
+
+This is a **real rule body registered into the chain**, not grounding logic
+hidden inside the skill. Three reasons:
+
+1. C-02's own test case says so — ``test_og_unsourced_fact_moves_to_unknowns``
+   lives in ``tests/test_guardrails.py`` and proves "OG grounding applies to
+   research too".
+2. A-06 built ``GuardrailChain.register`` precisely so a rule body can replace
+   a no-op without reordering the layer. Using it is what that mechanism is
+   for.
+3. M-01 completes the guardrail suite later. It should find a working OG-01 to
+   extend, not a no-op plus a private copy of the same logic in one skill —
+   the second of which it would have no reason to look for.
+
+**What it does not do.** It does not verify that a source *supports* its
+claim; that is a factuality question §17.4 evaluates offline against
+``oia.research_brief``. OG-01 asks only whether a claim is attributed at all,
+which is checkable here and now.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.logging import get_logger
+from app.logic.guardrails import Action, Verdict
+from app.skills.models import SkillContext
+
+logger = get_logger(__name__)
+
+RULE_ID = "OG-01"
+
+#: Keys whose list values are subject to grounding. Scoped rather than
+#: universal: OG-01 governs asserted *facts*, and applying it to every list in
+#: every skill's output would strip legitimately unsourced material — the
+#: open_unknowns list being the obvious one, since an unknown is by definition
+#: not sourced.
+GROUNDED_LIST_KEYS = ("facts",)
+
+UNKNOWNS_KEY = "open_unknowns"
+
+
+def _is_sourced(item: Any) -> bool:
+    if not isinstance(item, dict):
+        # A fact that is not a mapping cannot carry a source, so it cannot be
+        # grounded. Dropping it to unknowns is the safe reading.
+        return False
+    url = item.get("source_url")
+    return isinstance(url, str) and url.strip().startswith(("http://", "https://"))
+
+
+def _describe(item: Any) -> str:
+    """Turn a dropped fact into an unknown an operator can act on."""
+    if isinstance(item, dict):
+        statement = str(item.get("statement") or "").strip()
+        if statement:
+            return f"Unverified: {statement}"
+    return "Unverified claim dropped for lack of a source"
+
+
+def ground_output(payload: Any, context: SkillContext) -> Verdict:
+    """Move every unsourced fact into ``open_unknowns``.
+
+    Returns DROP when anything moved, PASS otherwise. The transformed payload
+    is carried on the verdict because ``evaluate_result`` assigns it back —
+    "a transform the skill never sees is not a guardrail".
+
+    Demotion rather than deletion is the whole design. A claim the agent could
+    not source is not worthless: it is a thing worth *asking about*, and
+    SKL-OIA-02 turns unknowns straight into questions. Deleting it would throw
+    away the signal that the agent went looking and came back empty.
+    """
+    if not isinstance(payload, dict):
+        return Verdict(rule_id=RULE_ID, action=Action.PASS, payload=payload)
+
+    moved: list[str] = []
+    result = dict(payload)
+
+    for key in GROUNDED_LIST_KEYS:
+        items = result.get(key)
+        if not isinstance(items, list):
+            continue
+
+        kept = [item for item in items if _is_sourced(item)]
+        if len(kept) != len(items):
+            moved.extend(_describe(item) for item in items if not _is_sourced(item))
+            result[key] = kept
+
+    if not moved:
+        return Verdict(rule_id=RULE_ID, action=Action.PASS, payload=payload)
+
+    unknowns = result.get(UNKNOWNS_KEY)
+    result[UNKNOWNS_KEY] = (
+        list(unknowns) if isinstance(unknowns, list) else []
+    ) + moved
+
+    logger.warning(
+        "og_01_dropped_ungrounded",
+        rule_id=RULE_ID,
+        dropped=len(moved),
+        tenant_id=context.tenant_context.tenant_id,
+        skill_hint=context.input_context.get("skill_id", ""),
+    )
+
+    return Verdict(
+        rule_id=RULE_ID,
+        action=Action.DROP,
+        detail=f"{len(moved)} unsourced value(s) moved to {UNKNOWNS_KEY}",
+        payload=result,
+    )

--- a/onboarding-intelligence-agent-svc/app/logic/prep_executor.py
+++ b/onboarding-intelligence-agent-svc/app/logic/prep_executor.py
@@ -1,19 +1,168 @@
 """PREP mode orchestration.
 
-Design §9.1 · implemented by story C-01.
+Design §9.1, §2.1 · implemented by story C-02.
 
-Scaffolded by A-05. The body raises NotImplementedError deliberately: a
-stub that silently returns None would let a later story ship a no-op
-that passes its tests.
+Scaffolded by A-05 with a docstring naming C-01 as the implementer. C-01
+delivered the envelope, the auth and the conversation store, and wired
+``/v1/execute`` straight to the store because no PREP skill had a body yet —
+the endpoint honestly returned ``skill_id: "NONE"``. C-02 gives SKL-OIA-01 a
+body, so the route now needs something that turns a turn into a skill call.
+
+The executor owns the registry rather than the route handler, because it also
+owns two things the handler should not know about: which skill a PREP turn
+maps to, and the research-brief cache. Both are decisions that will change as
+C-03 and C-04 land, and neither belongs in an HTTP layer.
 """
 
 from __future__ import annotations
 
-_NOT_YET = "app.logic.prep_executor — implemented by C-01"
+import json
+from typing import Any
+
+from app.cache.redis_manager import TTL_BRIEF, RedisManager
+from app.core.logging import get_logger
+from app.logic.grounding import RULE_ID as OG_01
+from app.logic.grounding import ground_output
+from app.logic.guardrails import Layer
+from app.providers.llm import LLMProvider
+from app.providers.tavily import TavilyProvider
+from app.skills.models import Origin, SkillContext, TenantContext
+from app.skills.registry import SkillRegistry
+from app.skills.research_business import normalise_company_name
+
+logger = get_logger(__name__)
+
+RESEARCH_SKILL = "SKL-OIA-01"
+
+# TTL_BRIEF is one hour, declared beside the other TTLs in redis_manager. The
+# card asks for "a short TTL" because "operators re-run prep several times
+# while tuning question count, and each re-run is otherwise a fresh round of
+# paid search". Tuning cycles are minutes; a business's public footprint does
+# not move within the hour, and a stale brief is worse than a paid search once
+# it does.
 
 
 class PrepExecutor:
-    """Not yet implemented."""
+    """Runs one PREP turn.
 
-    def __init__(self, *args: object, **kwargs: object) -> None:
-        raise NotImplementedError(_NOT_YET)
+    Constructed once at startup and held on ``app.state``: loading the
+    registry parses YAML and imports sixteen modules, which is startup work,
+    not per-request work.
+    """
+
+    def __init__(
+        self,
+        redis: RedisManager,
+        *,
+        tavily: TavilyProvider | None = None,
+        llm: LLMProvider | None = None,
+        registry: SkillRegistry | None = None,
+    ) -> None:
+        self._redis = redis
+        self._registry = registry or self._build_registry(tavily, llm)
+
+    @staticmethod
+    def _build_registry(
+        tavily: TavilyProvider | None, llm: LLMProvider | None
+    ) -> SkillRegistry:
+        """Load the sixteen skills and install the real OG-01.
+
+        The grounding rule is registered here rather than inside the chain's
+        defaults so A-06's "every rule starts as a recorded no-op" property
+        survives: the chain is still complete and ordered on construction, and
+        this replaces one body in place. That is exactly the mechanism
+        ``register`` documents, and M-01 will use it for the rest.
+        """
+        registry = SkillRegistry(providers={"tavily": tavily, "llm": llm})
+        registry.load()
+        registry.chain.register(Layer.OUTPUT, OG_01, ground_output)
+        return registry
+
+    @property
+    def registry(self) -> SkillRegistry:
+        return self._registry
+
+    # ── The research brief ───────────────────────────────────────────
+
+    def _brief_key(self, tenant_id: str, company_name: str) -> str:
+        """``(tenant, normalised business name)``, per the card.
+
+        Built through ``TenantKeys`` so a tenant-less key cannot be written —
+        A-03's rule, and the reason the tenant is a constructor argument
+        there rather than a parameter here.
+        """
+        slug = normalise_company_name(company_name) or "unnamed"
+        return self._redis.keys_for(tenant_id).brief(slug)
+
+    async def cached_brief(
+        self, tenant_id: str, company_name: str
+    ) -> dict[str, Any] | None:
+        """A previous brief for this business, if one is still warm."""
+        raw = await self._redis.client.get(self._brief_key(tenant_id, company_name))
+        if not raw:
+            return None
+        try:
+            brief = json.loads(raw)
+        except ValueError:
+            # A corrupt entry should cost a re-run, not the turn.
+            logger.warning("discarding an unparseable cached brief")
+            return None
+        return brief if isinstance(brief, dict) else None
+
+    async def store_brief(
+        self, tenant_id: str, company_name: str, brief: dict[str, Any]
+    ) -> None:
+        """Cache a brief — unless it is degraded.
+
+        A degraded brief is the *absence* of research. Caching it would mean a
+        one-minute Tavily outage silently suppresses real research for the
+        next hour, and the operator would have no way to tell why their
+        questions stayed thin.
+        """
+        if brief.get("degraded"):
+            return
+        await self._redis.client.set(
+            self._brief_key(tenant_id, company_name),
+            json.dumps(brief, separators=(",", ":")),
+            ex=TTL_BRIEF,
+        )
+
+    # ── One turn ─────────────────────────────────────────────────────
+
+    async def research(
+        self,
+        *,
+        tenant: TenantContext,
+        input_context: dict[str, Any],
+        input_prompt: str,
+        correlation_id: str = "",
+        use_cache: bool = True,
+    ) -> tuple[dict[str, Any], bool]:
+        """Run SKL-OIA-01, returning ``(brief, came_from_cache)``.
+
+        The cache is consulted before the skill, not inside it: a skill that
+        silently returns cached data cannot be tested for what it does, and
+        AC-2's "available without re-running research" is a property of the
+        turn rather than of the research itself.
+        """
+        company_name = str(input_context.get("company_name") or "").strip()
+
+        if use_cache and company_name:
+            cached = await self.cached_brief(tenant.tenant_id, company_name)
+            if cached is not None:
+                logger.info("research_brief_cache_hit", company=company_name)
+                return cached, True
+
+        context = SkillContext(
+            input_prompt=input_prompt,
+            tenant_context=tenant,
+            input_context=dict(input_context),
+            correlation_id=correlation_id,
+            origin=Origin.EXTERNAL,
+        )
+        result = await self._registry.execute(RESEARCH_SKILL, context)
+
+        if company_name:
+            await self.store_brief(tenant.tenant_id, company_name, result.output)
+
+        return result.output, False

--- a/onboarding-intelligence-agent-svc/app/main.py
+++ b/onboarding-intelligence-agent-svc/app/main.py
@@ -20,7 +20,10 @@ from app.core.logging import configure_logging, get_logger
 from app.core.telemetry import TraceContextMiddleware, configure_telemetry
 from app.events.emitter import EventEmitter
 from app.messaging.consumer import CommandConsumer
+from app.logic.prep_executor import PrepExecutor
 from app.messaging.producer import KafkaProducer
+from app.providers.llm import LLMProvider
+from app.providers.tavily import TavilyProvider
 from app.messaging.provision import provision, verify
 
 settings = get_settings()
@@ -66,6 +69,21 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             )
         except Exception as exc:  # noqa: BLE001 — reported via /health
             logger.warning("kafka_topic_provisioning_failed", error=str(exc))
+
+    # C-02. Built once: loading the registry parses YAML and imports sixteen
+    # modules, which is startup work rather than per-request work. The
+    # providers are constructed here so a missing key is visible at boot in
+    # the logs rather than on the first operator's turn.
+    app.state.prep = PrepExecutor(
+        app.state.redis,
+        tavily=TavilyProvider(settings.TAVILY_API_KEY),
+        llm=LLMProvider(settings.GEMINI_KEY),
+    )
+    if not settings.TAVILY_API_KEY:
+        logger.warning(
+            "tavily_not_configured",
+            detail="research will degrade to operator-provided information only",
+        )
 
     app.state.events = EventEmitter(app.state.kafka)
     await app.state.events.start()

--- a/onboarding-intelligence-agent-svc/app/skills/registry.py
+++ b/onboarding-intelligence-agent-svc/app/skills/registry.py
@@ -18,7 +18,9 @@ way to invoke a skill without passing IG → PG → OG and the §15 matrix.
 from __future__ import annotations
 
 import importlib
+import inspect
 import time
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, AsyncIterator
 
@@ -51,6 +53,7 @@ class SkillRegistry:
         self,
         chain: GuardrailChain | None = None,
         rbac: RBACEngine | None = None,
+        providers: Mapping[str, Any] | None = None,
     ) -> None:
         self._by_id: dict[str, Skill] = {}
         self._by_name: dict[str, Skill] = {}
@@ -58,6 +61,12 @@ class SkillRegistry:
         self._internal_only: set[str] = set()
         self.chain = chain or GuardrailChain()
         self.rbac = rbac or RBACEngine()
+        #: Shared dependencies offered to skills that declare them (C-02).
+        #: Keyed by keyword-argument name — "tavily", "llm", "vision" — and
+        #: passed only to skills whose __init__ accepts that name, so a skill
+        #: takes what it needs and nothing else. Doing this generically once
+        #: avoids a bespoke wiring method on each of the sixteen.
+        self._providers: Mapping[str, Any] = providers or {}
 
     # ── Loading ──────────────────────────────────────────────
     def load(self, config_path: Path | None = None, *, resolve: bool = True) -> None:
@@ -116,8 +125,7 @@ class SkillRegistry:
             or "",
         )
 
-    @staticmethod
-    def _resolve(meta: SkillMeta) -> Skill:
+    def _resolve(self, meta: SkillMeta) -> Skill:
         """Import the module and instantiate the class named by the skill."""
         module_path = MODULE_TEMPLATE.format(name=meta.name)
         class_name = "".join(part.title() for part in meta.name.split("_"))
@@ -142,7 +150,25 @@ class SkillRegistry:
                 f"{meta.skill_id} ({meta.name}): {class_name} is not a BaseSkill "
                 "or StreamingSkill"
             )
-        return implementation(meta)
+        return implementation(meta, **self._provider_kwargs(implementation))
+
+    def _provider_kwargs(self, implementation: type) -> dict[str, Any]:
+        """The subset of shared providers this skill's __init__ accepts.
+
+        Signature-driven rather than declaration-driven: a skill that grows a
+        dependency picks it up by adding the parameter, with no second place
+        to remember to update. A skill that accepts none — most of them — is
+        constructed exactly as before.
+        """
+        if not self._providers:
+            return {}
+        try:
+            parameters = inspect.signature(implementation).parameters
+        except (TypeError, ValueError):  # pragma: no cover - builtins only
+            return {}
+        return {
+            name: value for name, value in self._providers.items() if name in parameters
+        }
 
     # ── Lookup ───────────────────────────────────────────────
     def get(self, key: str) -> Skill:

--- a/onboarding-intelligence-agent-svc/app/skills/research_brief.py
+++ b/onboarding-intelligence-agent-svc/app/skills/research_brief.py
@@ -1,0 +1,109 @@
+"""The BusinessResearchBrief — SKL-OIA-01's output shape.
+
+Design §8.1 ("BusinessResearchBrief {facts[], competitors_seen[],
+digital_presence{}, open_unknowns[]}") · story C-02.
+
+The field names come from the design string above rather than being tidied,
+because SKL-OIA-02 consumes this directly: C-03's declaration says
+"input_context carries the BusinessResearchBrief from SKL-OIA-01".
+
+**Unknowns are the point.** The card is explicit: "Unknowns are not a
+consolation prize — they are the highest-value output of this skill, because
+SKL-OIA-02 turns them directly into questions." A brief with many unknowns and
+few facts is a *good* brief for a business with a thin web presence; the
+failure mode is a brief that invents facts to look complete.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class Fact(BaseModel):
+    """One established fact, and where it came from.
+
+    ``source_url`` is required and non-empty. AC-1: "every asserted fact
+    carries a source URL; a fact the agent cannot source is placed under
+    unknowns rather than stated." Making it optional here would push that
+    guarantee into every consumer.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    statement: str = Field(min_length=1)
+    source_url: str = Field(min_length=1)
+
+    @field_validator("source_url")
+    @classmethod
+    def _must_look_like_a_url(cls, v: str) -> str:
+        # Deliberately shallow: the job is to reject "the company website" and
+        # "unknown" being passed off as citations, not to validate reachability.
+        # A dead link is still a checkable claim; a non-link is not.
+        if not v.startswith(("http://", "https://")):
+            raise ValueError("a source must be an http(s) URL")
+        return v
+
+
+class DigitalPresence(BaseModel):
+    """What the business looks like online.
+
+    Every field is optional because absence is meaningful here — no LinkedIn
+    is a real finding about a business, and SKL-OIA-02 can ask about it.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    website: str | None = None
+    social_profiles: list[str] = Field(default_factory=list)
+    notes: str = ""
+
+
+class BusinessResearchBrief(BaseModel):
+    """What SKL-OIA-01 returns (§8.1)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    company_name: str
+    facts: list[Fact] = Field(default_factory=list)
+    competitors_seen: list[str] = Field(default_factory=list)
+    digital_presence: DigitalPresence = Field(default_factory=DigitalPresence)
+    open_unknowns: list[str] = Field(default_factory=list)
+
+    #: AC-3. True when research could not run — the breaker was open, the key
+    #: was absent, or the search failed. The operator is told, because the
+    #: questions that follow are less grounded than usual.
+    degraded: bool = False
+    degraded_reason: str = ""
+
+    sources: list[str] = Field(
+        default_factory=list,
+        description="Every URL consulted, including ones that yielded nothing",
+    )
+
+    @property
+    def is_grounded(self) -> bool:
+        """True when every fact carries a source.
+
+        Always true by construction — Fact requires one — but stated so the
+        OG-01 rule has something to assert against rather than re-deriving the
+        invariant.
+        """
+        return all(f.source_url for f in self.facts)
+
+    def summary_line(self) -> str:
+        """One line for the chat turn.
+
+        A degraded brief says so first. Burying that after the counts would
+        let an operator skim past the reason their questions are thinner.
+        """
+        if self.degraded:
+            return (
+                f"Research unavailable for {self.company_name} "
+                f"({self.degraded_reason}) — "
+                f"{len(self.open_unknowns)} open questions to cover."
+            )
+        return (
+            f"{len(self.facts)} sourced facts about {self.company_name}, "
+            f"{len(self.competitors_seen)} likely competitors, "
+            f"{len(self.open_unknowns)} open unknowns."
+        )

--- a/onboarding-intelligence-agent-svc/app/skills/research_business.py
+++ b/onboarding-intelligence-agent-svc/app/skills/research_business.py
@@ -201,14 +201,7 @@ class ResearchBusiness(BaseSkill):
                 continue
             facts.append(Fact(statement=statement, source_url=url))
 
-        presence = payload.get("digital_presence")
-        digital = DigitalPresence(
-            website=(presence or {}).get("website"),
-            social_profiles=[
-                str(p) for p in (presence or {}).get("social_profiles", []) if p
-            ],
-            notes=str((presence or {}).get("notes") or ""),
-        )
+        digital = self._digital_presence(payload.get("digital_presence"))
 
         return BusinessResearchBrief(
             company_name=company_name,
@@ -221,6 +214,37 @@ class ResearchBusiness(BaseSkill):
             digital_presence=digital,
             open_unknowns=unknowns,
             sources=[r.url for r in results],
+        )
+
+    @staticmethod
+    def _digital_presence(presence: Any) -> DigitalPresence:
+        """Read the digital-presence block, whatever the model actually sent.
+
+        Two distinct failures, both found by review:
+
+        A non-object — a list, a bare string, a number — made ``.get()`` raise
+        ``AttributeError`` and took down the whole turn, which is precisely
+        what the degraded path exists to avoid.
+
+        A *string* ``social_profiles`` was quieter and worse: iterating it
+        yields single characters, so ``"twitter"`` became eight one-letter
+        "profiles" and was carried into the brief as if it were data. A crash
+        gets noticed; this would not have.
+        """
+        if not isinstance(presence, dict):
+            return DigitalPresence()
+
+        website = presence.get("website")
+        profiles = presence.get("social_profiles")
+
+        return DigitalPresence(
+            website=website if isinstance(website, str) and website.strip() else None,
+            social_profiles=(
+                [str(p).strip() for p in profiles if str(p).strip()]
+                if isinstance(profiles, list)
+                else []
+            ),
+            notes=str(presence.get("notes") or ""),
         )
 
     @staticmethod

--- a/onboarding-intelligence-agent-svc/app/skills/research_business.py
+++ b/onboarding-intelligence-agent-svc/app/skills/research_business.py
@@ -1,24 +1,286 @@
-"""SKL-OIA-01 — Research the prospective brand's business ahead of the onboarding
-meeting.
+"""SKL-OIA-01 — Research the prospective brand's business ahead of the meeting.
 
 Design §8.1 · implemented by story C-02.
 
-Registered by A-06: the class exists and the registry resolves and
-instantiates it, so the declaration in config/skills.yaml is proven to point
-at something real. The body is deferred — it raises NotImplementedError
-rather than returning None, so a later story cannot ship a silent no-op.
+The shape of the work: search the web for the business, hand what came back to
+the model, and ask it to separate *what the sources establish* from *what
+remains unknown*. The model never researches on its own — it only organises
+retrieved text — because a model asked to "research" a small business will
+produce fluent, plausible, unsourced claims, which is the failure AC-1 exists
+to prevent.
+
+Degradation (AC-3) is not an error path bolted on. Every failure — breaker
+open, no API key, search failed — produces a *real brief* built from the
+operator's own hints, flagged ``degraded: true`` with the reason. The operator
+still gets questions; they are told the questions are less grounded.
 """
 
 from __future__ import annotations
 
+import json
+import re
+from typing import Any
+
+from app.core.logging import get_logger
+from app.providers.llm import LLMProvider, LLMUnavailable
+from app.providers.tavily import SearchResult, TavilyProvider, TavilyUnavailable
 from app.skills.base import BaseSkill
 from app.skills.models import SkillContext, SkillResult
+from app.skills.research_brief import BusinessResearchBrief, DigitalPresence, Fact
 
-_NOT_YET = "SKL-OIA-01 (research_business) — implemented by C-02"
+logger = get_logger(__name__)
+
+SKILL_ID = "SKL-OIA-01"
+
+#: Asked for explicitly, because the card is emphatic that unknowns are the
+#: highest-value output — SKL-OIA-02 turns them straight into questions. A
+#: model left to its own devices optimises for looking complete.
+PROMPT = """\
+You are preparing for a brand onboarding meeting with a business.
+
+Operator-provided hints:
+- Company name: {company_name}
+- Website: {website}
+- Industry: {industry}
+- Notes from the operator: {notes}
+
+Web search results (the ONLY source material you may assert facts from):
+{sources}
+
+Produce a JSON object with exactly these keys:
+  "facts": a list of {{"statement": str, "source_url": str}}. Every statement
+    MUST be supported by one of the search results above, and source_url MUST
+    be that result's URL, copied exactly. If you cannot point to a result, do
+    not state it as a fact.
+  "competitors_seen": a list of competitor names appearing in the results.
+  "digital_presence": {{"website": str or null, "social_profiles": [str],
+    "notes": str}}.
+  "open_unknowns": a list of specific things you could NOT establish and that
+    an interviewer should ask about. This is the most valuable part of your
+    output. Be concrete — "what is their average order value" beats "more
+    financial detail". Aim for at least five when the sources are thin.
+
+Return ONLY the JSON object, no prose and no code fence.
+"""
+
+
+def normalise_company_name(name: str) -> str:
+    """A stable cache key component.
+
+    The card asks for caching by ``(tenant, normalised business name)``.
+    Operators retype the name across turns while tuning question count, and
+    "Kalyani Roasters", "kalyani roasters" and "Kalyani  Roasters Pvt. Ltd."
+    should not each cost a fresh round of paid search.
+    """
+    lowered = name.strip().lower()
+    lowered = re.sub(r"[.,]", "", lowered)
+    # Common suffixes carry no identity and vary by how the operator typed it.
+    lowered = re.sub(
+        r"\b(pvt|private|ltd|limited|llp|inc|incorporated|co|corp|llc)\b", " ", lowered
+    )
+    return re.sub(r"\s+", " ", lowered).strip()
 
 
 class ResearchBusiness(BaseSkill):
     """Research the prospective brand's business ahead of the onboarding meeting."""
 
+    def __init__(
+        self,
+        meta: Any,
+        *,
+        tavily: TavilyProvider | None = None,
+        llm: LLMProvider | None = None,
+    ) -> None:
+        super().__init__(meta)
+        self._tavily = tavily
+        self._llm = llm
+
     async def run(self, context: SkillContext) -> SkillResult:
-        raise NotImplementedError(_NOT_YET)
+        hints = context.input_context or {}
+        company_name = str(hints.get("company_name") or "").strip()
+
+        if not company_name:
+            # Without a name there is nothing to search for and nothing to
+            # cache against. Degrading is more useful than raising: the
+            # operator gets a brief that says what it needs from them.
+            brief = self._degraded(
+                company_name="(unnamed business)",
+                reason="no company name was provided",
+                hints=hints,
+            )
+            return SkillResult(skill_id=SKILL_ID, output=brief.model_dump())
+
+        try:
+            results = await self._search(company_name, hints)
+        except TavilyUnavailable as exc:
+            logger.warning("research_degraded", company=company_name, reason=exc.reason)
+            brief = self._degraded(company_name, exc.reason, hints)
+            return SkillResult(skill_id=SKILL_ID, output=brief.model_dump())
+
+        try:
+            brief = await self._synthesise(company_name, hints, results)
+        except LLMUnavailable as exc:
+            logger.warning(
+                "research_synthesis_degraded", company=company_name, reason=exc.reason
+            )
+            brief = self._degraded(company_name, exc.reason, hints, sources=results)
+            return SkillResult(skill_id=SKILL_ID, output=brief.model_dump())
+
+        return SkillResult(skill_id=SKILL_ID, output=brief.model_dump())
+
+    # ── The two external calls ───────────────────────────────────────
+
+    async def _search(
+        self, company_name: str, hints: dict[str, Any]
+    ) -> list[SearchResult]:
+        if self._tavily is None:
+            raise TavilyUnavailable("web research is not configured")
+
+        website = str(hints.get("website") or "").strip()
+        industry = str(hints.get("industry") or "").strip()
+        query = " ".join(part for part in (company_name, industry, website) if part)
+        return await self._tavily.search(query)
+
+    async def _synthesise(
+        self,
+        company_name: str,
+        hints: dict[str, Any],
+        results: list[SearchResult],
+    ) -> BusinessResearchBrief:
+        if self._llm is None:
+            raise LLMUnavailable("no LLM is configured")
+
+        prompt = PROMPT.format(
+            company_name=company_name,
+            website=hints.get("website") or "(not provided)",
+            industry=hints.get("industry") or "(not provided)",
+            notes=hints.get("operator_notes") or "(none)",
+            sources=self._render(results),
+        )
+        raw = await self._llm.generate(prompt)
+        return self._parse(raw, company_name, results)
+
+    @staticmethod
+    def _render(results: list[SearchResult]) -> str:
+        if not results:
+            return "(no search results — you may not assert any facts)"
+        return "\n".join(
+            f"[{i}] {r.title}\n    URL: {r.url}\n    {r.snippet}"
+            for i, r in enumerate(results, 1)
+        )
+
+    # ── Turning a completion into a brief ────────────────────────────
+
+    def _parse(
+        self, raw: str, company_name: str, results: list[SearchResult]
+    ) -> BusinessResearchBrief:
+        """Build a brief from the model's JSON, keeping only sourced facts.
+
+        A fact whose ``source_url`` is not one of the URLs we actually
+        retrieved is dropped to unknowns here, before OG-01 sees it. The model
+        inventing a plausible citation is a real failure mode and it defeats a
+        grounding rule that only checks the field is present and URL-shaped.
+        """
+        payload = self._json_object(raw)
+        known_urls = {r.url for r in results}
+
+        facts: list[Fact] = []
+        unknowns: list[str] = [
+            str(u).strip() for u in payload.get("open_unknowns", []) if str(u).strip()
+        ]
+
+        for item in payload.get("facts", []):
+            if not isinstance(item, dict):
+                continue
+            statement = str(item.get("statement") or "").strip()
+            url = str(item.get("source_url") or "").strip()
+            if not statement:
+                continue
+            if url not in known_urls:
+                unknowns.append(f"Unverified: {statement}")
+                continue
+            facts.append(Fact(statement=statement, source_url=url))
+
+        presence = payload.get("digital_presence")
+        digital = DigitalPresence(
+            website=(presence or {}).get("website"),
+            social_profiles=[
+                str(p) for p in (presence or {}).get("social_profiles", []) if p
+            ],
+            notes=str((presence or {}).get("notes") or ""),
+        )
+
+        return BusinessResearchBrief(
+            company_name=company_name,
+            facts=facts,
+            competitors_seen=[
+                str(c).strip()
+                for c in payload.get("competitors_seen", [])
+                if str(c).strip()
+            ],
+            digital_presence=digital,
+            open_unknowns=unknowns,
+            sources=[r.url for r in results],
+        )
+
+    @staticmethod
+    def _json_object(raw: str) -> dict[str, Any]:
+        """Extract the JSON object from a completion.
+
+        Models wrap JSON in code fences and prose despite instructions, so the
+        first ``{`` to the last ``}`` is taken rather than trusting the whole
+        string. An unparseable completion yields an empty object, which
+        degrades to a brief of pure unknowns rather than raising — the
+        operator is better served by questions than by an error.
+        """
+        text = raw.strip()
+        start, end = text.find("{"), text.rfind("}")
+        if start == -1 or end <= start:
+            logger.warning("research_completion_had_no_json_object")
+            return {}
+        try:
+            parsed = json.loads(text[start : end + 1])
+        except ValueError:
+            logger.warning("research_completion_was_not_valid_json")
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+
+    # ── AC-3 ─────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _degraded(
+        company_name: str,
+        reason: str,
+        hints: dict[str, Any],
+        sources: list[SearchResult] | None = None,
+    ) -> BusinessResearchBrief:
+        """A brief built from the operator's own words, flagged as thin.
+
+        The unknowns here are deliberately generic — with no research there is
+        nothing specific to be curious about, and pretending otherwise would
+        misrepresent what the agent knows. They still give SKL-OIA-02 the
+        skeleton of a questionnaire, which is the point of degrading rather
+        than failing.
+        """
+        notes = str(hints.get("operator_notes") or "").strip()
+        website = str(hints.get("website") or "").strip() or None
+
+        return BusinessResearchBrief(
+            company_name=company_name,
+            facts=[],
+            competitors_seen=[],
+            digital_presence=DigitalPresence(
+                website=website,
+                notes=notes,
+            ),
+            open_unknowns=[
+                "What does the business actually sell, and to whom?",
+                "Who are its main competitors, and how does it differ from them?",
+                "What is its current marketing and digital presence?",
+                "Who is the target customer, in the operator's own words?",
+                "What does the business believe makes it distinctive?",
+            ],
+            degraded=True,
+            degraded_reason=reason,
+            sources=[r.url for r in (sources or [])],
+        )

--- a/onboarding-intelligence-agent-svc/tests/test_execute_envelope.py
+++ b/onboarding-intelligence-agent-svc/tests/test_execute_envelope.py
@@ -90,13 +90,19 @@ def test_execute_envelope(client):
     assert set(body["usage"]) == {"input_tokens", "output_tokens", "duration_ms"}
 
 
-def test_the_response_says_plainly_that_no_skill_ran(client):
-    """C-02 and C-03 bring the skills. Until then a caller must be able to
-    tell "nothing is wired up" from "a skill ran and produced nothing"."""
+def test_the_response_names_the_skill_that_ran(client):
+    """Superseded C-01's ``skill_id == "NONE"`` case.
+
+    C-01 returned NONE so a caller could tell "nothing is wired up" from "a
+    skill ran and produced nothing", and said in its own docstring that C-02
+    and C-03 bring the skills. C-02 gives SKL-OIA-01 a body, so the honest
+    answer changed. Rewritten rather than deleted, because the property worth
+    keeping is that the response says truthfully what ran.
+    """
     body = client.post(EXECUTE, json=valid_body(), headers=headers()).json()
 
-    assert body["skill_id"] == "NONE"
-    assert "SKL-OIA-01" in body["output"]["detail"]
+    assert body["skill_id"] == "SKL-OIA-01"
+    assert "research_brief" in body["output"]
 
 
 @pytest.mark.parametrize(
@@ -198,10 +204,17 @@ def test_multi_turn_history_accumulates(client):
     body["input_prompt"] = "Go deeper on their supply chain."
     second = client.post(EXECUTE, json=body, headers=headers()).json()
 
-    assert second["output"]["turns"] == 2
-    texts = [turn["text"] for turn in second["output"]["history"]]
-    assert texts[0] == "We're onboarding a coffee roaster in Pune."
-    assert texts[1] == "Go deeper on their supply chain."
+    # C-02 appends the agent's reply too, so the operator's turns are every
+    # other one. Asserting on the filtered operator turns rather than on
+    # positions keeps this about accumulation, which is what AC-2 is for.
+    assert second["output"]["turns"] == 3
+    operator_said = [
+        t["text"] for t in second["output"]["history"] if t["role"] == "operator"
+    ]
+    assert operator_said == [
+        "We're onboarding a coffee roaster in Pune.",
+        "Go deeper on their supply chain.",
+    ]
 
 
 def test_conversations_do_not_bleed_between_chats(client):

--- a/onboarding-intelligence-agent-svc/tests/test_guardrails.py
+++ b/onboarding-intelligence-agent-svc/tests/test_guardrails.py
@@ -270,3 +270,108 @@ async def test_output_transforms_reach_the_caller(chain):
 
     result = await registry.execute("SKL-OIA-01", context())
     assert result.output["email"] == "***", "the caller got the pre-guardrail output"
+
+
+# ── OG-01, with a real body (C-02) ───────────────────────────────────
+
+
+def _research_context():
+    from app.skills.models import SkillContext, TenantContext
+
+    return SkillContext(
+        input_prompt="prep",
+        tenant_context=TenantContext(tenant_id="t-1", user_id="u-1", role="ADMIN"),
+        input_context={},
+    )
+
+
+def test_og_unsourced_fact_moves_to_unknowns():
+    """The C-02 card's named case: "OG grounding applies to research too".
+
+    Demotion, not deletion. A claim the agent could not source is a thing
+    worth *asking about*, and SKL-OIA-02 turns unknowns straight into
+    questions — deleting it would throw away the signal that the agent looked
+    and came back empty.
+    """
+    from app.logic.grounding import ground_output
+
+    verdict = ground_output(
+        {
+            "facts": [
+                {"statement": "Founded 2016.", "source_url": "https://x.example/a"},
+                {"statement": "Revenue is 40 crore.", "source_url": ""},
+            ],
+            "open_unknowns": ["What is their AOV?"],
+        },
+        _research_context(),
+    )
+
+    assert verdict.action is Action.DROP
+    assert verdict.payload["facts"] == [
+        {"statement": "Founded 2016.", "source_url": "https://x.example/a"}
+    ]
+    assert verdict.payload["open_unknowns"] == [
+        "What is their AOV?",
+        "Unverified: Revenue is 40 crore.",
+    ]
+
+
+def test_og_01_passes_a_fully_sourced_payload_through_unchanged():
+    from app.logic.grounding import ground_output
+
+    payload = {
+        "facts": [{"statement": "Founded 2016.", "source_url": "https://x.example/a"}],
+        "open_unknowns": [],
+    }
+
+    verdict = ground_output(payload, _research_context())
+
+    assert verdict.action is Action.PASS
+    assert verdict.payload == payload
+
+
+def test_og_01_does_not_ground_the_unknowns_list():
+    """An unknown is by definition unsourced. A universal rule would strip the
+    most valuable part of the brief."""
+    from app.logic.grounding import ground_output
+
+    verdict = ground_output(
+        {"facts": [], "open_unknowns": ["no source, and that is the point"]},
+        _research_context(),
+    )
+
+    assert verdict.action is Action.PASS
+    assert verdict.payload["open_unknowns"] == ["no source, and that is the point"]
+
+
+@pytest.mark.parametrize(
+    "bad_url", ["", "   ", "unknown", "the company website", "ftp://x", None, 42]
+)
+def test_og_01_rejects_anything_that_is_not_an_http_url(bad_url):
+    """ "the company website" is not a citation. The rule exists to stop a
+    plausible-looking string standing in for one."""
+    from app.logic.grounding import ground_output
+
+    verdict = ground_output(
+        {"facts": [{"statement": "A claim.", "source_url": bad_url}]},
+        _research_context(),
+    )
+
+    assert verdict.payload["facts"] == []
+    assert verdict.payload["open_unknowns"] == ["Unverified: A claim."]
+
+
+def test_og_01_is_registered_in_place_not_appended():
+    """A-06's ordering guarantee. §5 numbers its rules in reading order, and a
+    replacement that moved OG-01 to the end would let later rules act on
+    ungrounded values first.
+    """
+    from app.logic.grounding import RULE_ID, ground_output
+
+    chain = GuardrailChain()
+    before = chain.rules(Layer.OUTPUT)
+
+    chain.register(Layer.OUTPUT, RULE_ID, ground_output)
+
+    assert chain.rules(Layer.OUTPUT) == before
+    assert chain.rules(Layer.OUTPUT)[0] == "OG-01"

--- a/onboarding-intelligence-agent-svc/tests/test_prep_executor.py
+++ b/onboarding-intelligence-agent-svc/tests/test_prep_executor.py
@@ -1,0 +1,186 @@
+"""C-02 · the PREP executor and the research-brief cache (AC-2).
+
+Real Redis throughout — the cache is the feature under test, and a fake one
+would prove only that the code calls the methods the author expected.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.cache.redis_manager import TTL_BRIEF, RedisManager
+from app.core.config import get_settings
+from app.logic.grounding import RULE_ID as OG_01
+from app.logic.guardrails import Layer
+from app.logic.prep_executor import RESEARCH_SKILL, PrepExecutor
+from app.skills.models import TenantContext
+
+pytestmark = pytest.mark.integration
+
+
+def unique(prefix: str) -> str:
+    """Real Redis outlives the process; fixed ids made C-01's tests pass once
+    and never again."""
+    return f"{prefix}-{uuid.uuid4().hex[:10]}"
+
+
+@pytest.fixture
+async def redis():
+    manager = RedisManager(get_settings())
+    await manager.connect()
+    try:
+        yield manager
+    finally:
+        await manager.close()
+
+
+@pytest.fixture
+def executor(redis):
+    """No providers wired, so the skill degrades — which is the right default
+    for these tests: they are about caching and dispatch, not research."""
+    return PrepExecutor(redis)
+
+
+def tenant(tenant_id: str) -> TenantContext:
+    return TenantContext(tenant_id=tenant_id, user_id="u-1", role="ADMIN")
+
+
+# ── Dispatch ─────────────────────────────────────────────────────────
+
+
+async def test_the_executor_runs_the_research_skill(executor):
+    brief, from_cache = await executor.research(
+        tenant=tenant(unique("t")),
+        input_context={"company_name": unique("Acme")},
+        input_prompt="prep",
+    )
+
+    assert from_cache is False
+    assert "open_unknowns" in brief
+    assert brief["degraded"] is True, "no providers were wired"
+
+
+async def test_the_real_og_01_is_installed_on_the_chain(executor):
+    """Not the A-06 no-op. If the registration were missed, grounding would
+    silently stop applying and every test of it would still pass in isolation.
+    """
+    chain = executor.registry.chain
+    assert OG_01 in chain.rules(Layer.OUTPUT)
+
+    from app.logic.grounding import ground_output
+
+    installed = [r for r in chain._rules[Layer.OUTPUT] if r.rule_id == OG_01][0]
+    assert installed.evaluate is ground_output
+
+
+async def test_the_research_skill_resolves(executor):
+    assert executor.registry.get(RESEARCH_SKILL) is not None
+
+
+# ── AC-2 · the brief survives the turn ───────────────────────────────
+
+
+async def test_a_brief_is_available_without_re_running_research(redis, executor):
+    """AC-2: "the same brief is available without re-running research"."""
+    tid, company = unique("t"), unique("Kalyani")
+    stored = {"company_name": company, "facts": [], "degraded": False}
+
+    await executor.store_brief(tid, company, stored)
+    got = await executor.cached_brief(tid, company)
+
+    assert got == stored
+
+
+async def test_the_second_turn_reads_the_cache(redis, executor):
+    tid, company = unique("t"), unique("Kalyani")
+    await executor.store_brief(
+        tid, company, {"company_name": company, "degraded": False}
+    )
+
+    _, from_cache = await executor.research(
+        tenant=tenant(tid),
+        input_context={"company_name": company},
+        input_prompt="again",
+    )
+
+    assert from_cache is True
+
+
+async def test_the_cache_key_normalises_the_company_name(redis, executor):
+    """The whole point of normalising: an operator retyping the name should
+    not pay for a fresh round of paid search."""
+    tid = unique("t")
+    slug = uuid.uuid4().hex[:8]
+    await executor.store_brief(tid, f"Kalyani {slug}", {"degraded": False, "n": 1})
+
+    got = await executor.cached_brief(tid, f"  kalyani   {slug} Pvt. Ltd.  ")
+
+    assert got == {"degraded": False, "n": 1}
+
+
+async def test_briefs_do_not_bleed_between_tenants(redis, executor):
+    company = unique("Shared")
+    await executor.store_brief(unique("t"), company, {"degraded": False, "secret": 1})
+
+    assert await executor.cached_brief(unique("t"), company) is None
+
+
+async def test_the_brief_key_carries_a_ttl(redis, executor):
+    """DB 2 is shared with ten other services (ERRATA-01); an untimed key is a
+    slow leak that evicts someone else's data."""
+    tid, company = unique("t"), unique("Kalyani")
+    await executor.store_brief(tid, company, {"degraded": False})
+
+    ttl = await redis.client.ttl(executor._brief_key(tid, company))
+
+    assert 0 < ttl <= TTL_BRIEF
+
+
+async def test_a_degraded_brief_is_never_cached(redis, executor):
+    """A degraded brief is the *absence* of research. Caching it would let a
+    one-minute Tavily outage suppress real research for the next hour, with
+    nothing to tell the operator why their questions stayed thin.
+    """
+    tid, company = unique("t"), unique("Kalyani")
+
+    await executor.store_brief(tid, company, {"degraded": True, "degraded_reason": "x"})
+
+    assert await executor.cached_brief(tid, company) is None
+
+
+async def test_a_degraded_research_run_leaves_the_cache_empty(redis, executor):
+    """The same property through the real path rather than the setter."""
+    tid, company = unique("t"), unique("Kalyani")
+
+    brief, _ = await executor.research(
+        tenant=tenant(tid),
+        input_context={"company_name": company},
+        input_prompt="prep",
+    )
+
+    assert brief["degraded"] is True
+    assert await executor.cached_brief(tid, company) is None
+
+
+async def test_a_corrupt_cache_entry_costs_a_rerun_not_the_turn(redis, executor):
+    tid, company = unique("t"), unique("Kalyani")
+    await redis.client.set(executor._brief_key(tid, company), "{not json")
+
+    assert await executor.cached_brief(tid, company) is None
+
+
+async def test_the_cache_can_be_bypassed(redis, executor):
+    """C-04 lets an operator ask for a re-run; the seam has to exist."""
+    tid, company = unique("t"), unique("Kalyani")
+    await executor.store_brief(tid, company, {"degraded": False})
+
+    _, from_cache = await executor.research(
+        tenant=tenant(tid),
+        input_context={"company_name": company},
+        input_prompt="again",
+        use_cache=False,
+    )
+
+    assert from_cache is False

--- a/onboarding-intelligence-agent-svc/tests/test_registry.py
+++ b/onboarding-intelligence-agent-svc/tests/test_registry.py
@@ -215,5 +215,8 @@ async def test_a_normal_skill_is_unaffected_by_origin(registry):
         tenant_context=TenantContext(tenant_id="t-1", role="ADMIN"),
         origin=Origin.EXTERNAL,
     )
+    # SKL-OIA-02, not 01: C-02 gave SKL-OIA-01 a body, and this test needs a
+    # skill whose NotImplementedError proves the call reached the body rather
+    # than being stopped by the origin gate.
     with pytest.raises(NotImplementedError):
-        await registry.execute("SKL-OIA-01", ctx)
+        await registry.execute("SKL-OIA-02", ctx)

--- a/onboarding-intelligence-agent-svc/tests/test_research_business.py
+++ b/onboarding-intelligence-agent-svc/tests/test_research_business.py
@@ -1,0 +1,403 @@
+"""C-02 · SKL-OIA-01, the research brief, and its degraded path.
+
+No mocks. The skill is driven through real providers pointed at local HTTP
+servers, so a real ``AsyncTavilyClient`` and a real breaker are in the path.
+The LLM is the one place a local server will not do — Gemini's SDK is not
+base-URL-configurable the way Tavily's is — so those cases use a tiny local
+stand-in object implementing the one method the provider calls. That is a
+seam, not a mock: nothing is patched, and the provider's own breaker,
+error-handling and text-extraction all still run.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+from hypothesis import given, settings as hyp_settings
+from hypothesis import strategies as st
+
+from app.circuit_breaker.breaker import BreakerConfig, CircuitBreaker
+from app.providers.llm import LLMProvider
+from app.providers.tavily import TavilyProvider
+from app.skills.models import SkillContext, SkillMeta, TenantContext
+from app.skills.research_brief import BusinessResearchBrief
+from app.skills.research_business import ResearchBusiness, normalise_company_name
+
+REAL_URL = "https://kalyani.example/about"
+
+
+def meta() -> SkillMeta:
+    return SkillMeta(
+        skill_id="SKL-OIA-01",
+        name="research_business",
+        description="research",
+        allowed_roles=["OWNER", "ADMIN", "EDITOR"],
+    )
+
+
+def context(**overrides) -> SkillContext:
+    input_context = {
+        "company_name": "Kalyani Roasters",
+        "website": "https://kalyani.example",
+        "industry": "speciality coffee",
+        "operator_notes": "Family run, wants to sell online.",
+    }
+    input_context.update(overrides.pop("input_context", {}))
+    return SkillContext(
+        input_prompt="prep the onboarding call",
+        tenant_context=TenantContext(tenant_id="t-1", user_id="u-1", role="ADMIN"),
+        input_context=input_context,
+        **overrides,
+    )
+
+
+def brk(name: str, **overrides) -> CircuitBreaker:
+    base = dict(
+        name=name,
+        failure_threshold=3,
+        window_seconds=60,
+        success_threshold=1,
+        half_open_max_calls=1,
+        reset_timeout_seconds=60,
+        degraded_mode="SKIP_RESEARCH" if name == "tavily" else "MANUAL_CHECKBOXES",
+        user_message="unavailable",
+    )
+    base.update(overrides)
+    return CircuitBreaker(BreakerConfig(**base))
+
+
+class StubModel:
+    """The one method LLMProvider calls on a Gemini model.
+
+    Not a mock framework and not a patch — a real object satisfying a
+    one-method interface, so the provider's breaker, exception handling and
+    empty-completion check all still execute for real.
+    """
+
+    def __init__(self, text: str = "", raises: Exception | None = None) -> None:
+        self._text = text
+        self._raises = raises
+        self.prompts: list[str] = []
+
+    async def generate_content_async(self, prompt, **kwargs):
+        self.prompts.append(prompt)
+        if self._raises:
+            raise self._raises
+
+        class Response:
+            text = self._text
+
+        return Response()
+
+
+@pytest.fixture
+def tavily_server():
+    state = {"status": 200, "body": {"results": []}}
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            self.rfile.read(int(self.headers.get("Content-Length") or 0))
+            payload = json.dumps(state["body"]).encode()
+            self.send_response(state["status"])
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *args):
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    state["url"] = f"http://127.0.0.1:{server.server_address[1]}"
+    try:
+        yield state
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def tavily_for(state, breaker=None) -> TavilyProvider:
+    from tavily import AsyncTavilyClient
+
+    return TavilyProvider(
+        "k",
+        breaker=breaker or brk("tavily"),
+        client=AsyncTavilyClient(api_key="k", api_base_url=state["url"]),
+    )
+
+
+def llm_for(model) -> LLMProvider:
+    return LLMProvider("k", breaker=brk("llm"), client=model)
+
+
+def one_result(state):
+    state["body"] = {
+        "results": [
+            {
+                "title": "Kalyani Roasters — About",
+                "url": REAL_URL,
+                "content": "A speciality coffee roaster in Pune, founded 2016.",
+            }
+        ]
+    }
+
+
+# ── AC-1 · a structured brief with sources ───────────────────────────
+
+
+@pytest.mark.integration
+async def test_a_sourced_fact_survives(tavily_server):
+    one_result(tavily_server)
+    model = StubModel(
+        json.dumps(
+            {
+                "facts": [
+                    {"statement": "Founded in 2016.", "source_url": REAL_URL},
+                ],
+                "competitors_seen": ["Blue Tokai"],
+                "digital_presence": {"website": "https://kalyani.example"},
+                "open_unknowns": ["What is their average order value?"],
+            }
+        )
+    )
+    skill = ResearchBusiness(
+        meta(), tavily=tavily_for(tavily_server), llm=llm_for(model)
+    )
+
+    result = await skill.run(context())
+    brief = BusinessResearchBrief.model_validate(result.output)
+
+    assert [f.statement for f in brief.facts] == ["Founded in 2016."]
+    assert brief.facts[0].source_url == REAL_URL
+    assert brief.competitors_seen == ["Blue Tokai"]
+    assert brief.open_unknowns == ["What is their average order value?"]
+    assert brief.degraded is False
+
+
+@pytest.mark.integration
+async def test_a_fact_citing_a_url_we_never_retrieved_becomes_an_unknown(tavily_server):
+    """The failure mode a URL-shape check misses.
+
+    A model that invents a plausible citation passes any rule that only asks
+    "is source_url present and http(s)". The only defence is checking it
+    against what search actually returned.
+    """
+    one_result(tavily_server)
+    model = StubModel(
+        json.dumps(
+            {
+                "facts": [
+                    {"statement": "Founded in 2016.", "source_url": REAL_URL},
+                    {
+                        "statement": "Revenue is 40 crore.",
+                        "source_url": "https://invented.example/financials",
+                    },
+                ],
+                "open_unknowns": [],
+            }
+        )
+    )
+    skill = ResearchBusiness(
+        meta(), tavily=tavily_for(tavily_server), llm=llm_for(model)
+    )
+
+    brief = BusinessResearchBrief.model_validate((await skill.run(context())).output)
+
+    assert [f.statement for f in brief.facts] == ["Founded in 2016."]
+    assert brief.open_unknowns == ["Unverified: Revenue is 40 crore."]
+
+
+@pytest.mark.integration
+async def test_the_prompt_carries_the_retrieved_sources(tavily_server):
+    """The model organises retrieved text; it does not research on its own.
+    If the sources never reach the prompt, every fact it produces is invented.
+    """
+    one_result(tavily_server)
+    model = StubModel(json.dumps({"facts": [], "open_unknowns": []}))
+    skill = ResearchBusiness(
+        meta(), tavily=tavily_for(tavily_server), llm=llm_for(model)
+    )
+
+    await skill.run(context())
+
+    assert REAL_URL in model.prompts[0]
+    assert "Kalyani Roasters" in model.prompts[0]
+
+
+@pytest.mark.integration
+async def test_an_unparseable_completion_yields_unknowns_not_an_error(tavily_server):
+    """The operator is better served by questions than by an error."""
+    one_result(tavily_server)
+    skill = ResearchBusiness(
+        meta(),
+        tavily=tavily_for(tavily_server),
+        llm=llm_for(StubModel("I'm afraid I can't do that.")),
+    )
+
+    brief = BusinessResearchBrief.model_validate((await skill.run(context())).output)
+
+    assert brief.facts == []
+    assert brief.degraded is False, "a bad completion is not a dependency outage"
+
+
+@pytest.mark.integration
+async def test_a_fenced_json_completion_is_still_read(tavily_server):
+    """Models add code fences despite instructions."""
+    one_result(tavily_server)
+    fenced = (
+        "```json\n"
+        + json.dumps(
+            {"facts": [{"statement": "Founded 2016.", "source_url": REAL_URL}]}
+        )
+        + "\n```"
+    )
+    skill = ResearchBusiness(
+        meta(), tavily=tavily_for(tavily_server), llm=llm_for(StubModel(fenced))
+    )
+
+    brief = BusinessResearchBrief.model_validate((await skill.run(context())).output)
+
+    assert len(brief.facts) == 1
+
+
+# ── AC-3 · degradation is flagged, never silent ──────────────────────
+
+
+@pytest.mark.integration
+async def test_an_open_tavily_breaker_produces_a_degraded_brief(tavily_server):
+    """The card's named case: test_tavily_open_produces_degraded_brief."""
+    breaker = brk("tavily", failure_threshold=1)
+    breaker.record_failure()
+    skill = ResearchBusiness(
+        meta(),
+        tavily=tavily_for(tavily_server, breaker),
+        llm=llm_for(StubModel("{}")),
+    )
+
+    brief = BusinessResearchBrief.model_validate((await skill.run(context())).output)
+
+    assert brief.degraded is True
+    assert brief.degraded_reason
+    assert brief.facts == [], "a degraded brief must assert nothing"
+    assert len(brief.open_unknowns) >= 5, "the operator still needs questions"
+
+
+@pytest.mark.integration
+async def test_a_degraded_brief_keeps_the_operators_own_information(tavily_server):
+    """AC-3: "a brief from the operator-provided information only"."""
+    breaker = brk("tavily", failure_threshold=1)
+    breaker.record_failure()
+    skill = ResearchBusiness(
+        meta(), tavily=tavily_for(tavily_server, breaker), llm=llm_for(StubModel("{}"))
+    )
+
+    brief = BusinessResearchBrief.model_validate((await skill.run(context())).output)
+
+    assert brief.company_name == "Kalyani Roasters"
+    assert brief.digital_presence.website == "https://kalyani.example"
+    assert "Family run" in brief.digital_presence.notes
+
+
+@pytest.mark.unit
+async def test_no_providers_at_all_still_produces_a_brief():
+    """A skill resolved by the registry with no providers wired — the state
+    of a deployment with no Tavily key. It must degrade, not raise."""
+    brief = BusinessResearchBrief.model_validate(
+        (await ResearchBusiness(meta()).run(context())).output
+    )
+
+    assert brief.degraded is True
+    assert brief.open_unknowns
+
+
+@pytest.mark.unit
+async def test_a_missing_company_name_degrades_rather_than_searching():
+    skill = ResearchBusiness(meta())
+
+    brief = BusinessResearchBrief.model_validate(
+        (await skill.run(context(input_context={"company_name": "  "}))).output
+    )
+
+    assert brief.degraded is True
+    assert "no company name" in brief.degraded_reason
+
+
+@pytest.mark.integration
+async def test_the_summary_line_leads_with_the_degradation(tavily_server):
+    """An operator skimming must not miss why their questions are thin."""
+    breaker = brk("tavily", failure_threshold=1)
+    breaker.record_failure()
+    skill = ResearchBusiness(
+        meta(), tavily=tavily_for(tavily_server, breaker), llm=llm_for(StubModel("{}"))
+    )
+
+    brief = BusinessResearchBrief.model_validate((await skill.run(context())).output)
+
+    assert brief.summary_line().startswith("Research unavailable")
+
+
+# ── Cache key normalisation ──────────────────────────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "written",
+    [
+        "Kalyani Roasters",
+        "kalyani roasters",
+        "  Kalyani   Roasters  ",
+        "Kalyani Roasters Pvt. Ltd.",
+        "KALYANI ROASTERS PRIVATE LIMITED",
+    ],
+)
+def test_the_same_business_normalises_to_one_key(written):
+    """Each variant otherwise costs a fresh round of paid search."""
+    assert normalise_company_name(written) == "kalyani roasters"
+
+
+@pytest.mark.unit
+def test_different_businesses_do_not_collide():
+    assert normalise_company_name("Kalyani Roasters") != normalise_company_name(
+        "Kalyani Textiles"
+    )
+
+
+# ── Property: nothing is asserted without a source ───────────────────
+
+
+@pytest.mark.property
+@hyp_settings(max_examples=60, deadline=None)
+@given(
+    statements=st.lists(st.text(min_size=1, max_size=40), max_size=6),
+    urls=st.lists(
+        st.sampled_from(
+            [REAL_URL, "https://other.example", "", "not-a-url", "ftp://x"]
+        ),
+        max_size=6,
+    ),
+)
+def test_every_surviving_fact_is_sourced_and_nothing_is_silently_lost(statements, urls):
+    """Two invariants over arbitrary model output.
+
+    Conservation is the one worth encoding: a claim is either kept with a real
+    source or demoted to an unknown, never dropped on the floor. A grounding
+    rule that silently deleted unsourced claims would satisfy "every fact is
+    sourced" perfectly while destroying the signal SKL-OIA-02 depends on.
+    """
+    pairs = list(zip(statements, urls))
+    raw = json.dumps({"facts": [{"statement": s, "source_url": u} for s, u in pairs]})
+    skill = ResearchBusiness(meta())
+
+    from app.providers.tavily import SearchResult
+
+    results = [SearchResult(title="t", url=REAL_URL, snippet="s")]
+    brief = skill._parse(raw, "Acme", results)
+
+    assert all(f.source_url == REAL_URL for f in brief.facts)
+    assert len(brief.facts) + len(brief.open_unknowns) == len(
+        [s for s, _ in pairs if s.strip()]
+    ), "a claim was neither kept nor demoted"

--- a/onboarding-intelligence-agent-svc/tests/test_research_business.py
+++ b/onboarding-intelligence-agent-svc/tests/test_research_business.py
@@ -69,12 +69,16 @@ def brk(name: str, **overrides) -> CircuitBreaker:
     return CircuitBreaker(BreakerConfig(**base))
 
 
-class StubModel:
-    """The one method LLMProvider calls on a Gemini model.
+class StubModels:
+    """Stands in for ``genai.Client(...).aio.models``.
 
-    Not a mock framework and not a patch — a real object satisfying a
-    one-method interface, so the provider's breaker, exception handling and
-    empty-completion check all still execute for real.
+    Not a mock framework and not a patch — a real object satisfying the
+    one-method surface the provider narrowed to, so the provider's breaker,
+    exception handling and empty-completion check all still execute for real.
+
+    The keyword-only signature mirrors google-genai's, so a drift in how the
+    provider calls it shows up here as a TypeError rather than being absorbed
+    by a permissive ``**kwargs``.
     """
 
     def __init__(self, text: str = "", raises: Exception | None = None) -> None:
@@ -82,8 +86,8 @@ class StubModel:
         self._raises = raises
         self.prompts: list[str] = []
 
-    async def generate_content_async(self, prompt, **kwargs):
-        self.prompts.append(prompt)
+    async def generate_content(self, *, model, contents, config=None):
+        self.prompts.append(contents)
         if self._raises:
             raise self._raises
 
@@ -152,7 +156,7 @@ def one_result(state):
 @pytest.mark.integration
 async def test_a_sourced_fact_survives(tavily_server):
     one_result(tavily_server)
-    model = StubModel(
+    model = StubModels(
         json.dumps(
             {
                 "facts": [
@@ -187,7 +191,7 @@ async def test_a_fact_citing_a_url_we_never_retrieved_becomes_an_unknown(tavily_
     against what search actually returned.
     """
     one_result(tavily_server)
-    model = StubModel(
+    model = StubModels(
         json.dumps(
             {
                 "facts": [
@@ -217,7 +221,7 @@ async def test_the_prompt_carries_the_retrieved_sources(tavily_server):
     If the sources never reach the prompt, every fact it produces is invented.
     """
     one_result(tavily_server)
-    model = StubModel(json.dumps({"facts": [], "open_unknowns": []}))
+    model = StubModels(json.dumps({"facts": [], "open_unknowns": []}))
     skill = ResearchBusiness(
         meta(), tavily=tavily_for(tavily_server), llm=llm_for(model)
     )
@@ -235,7 +239,7 @@ async def test_an_unparseable_completion_yields_unknowns_not_an_error(tavily_ser
     skill = ResearchBusiness(
         meta(),
         tavily=tavily_for(tavily_server),
-        llm=llm_for(StubModel("I'm afraid I can't do that.")),
+        llm=llm_for(StubModels("I'm afraid I can't do that.")),
     )
 
     brief = BusinessResearchBrief.model_validate((await skill.run(context())).output)
@@ -256,7 +260,7 @@ async def test_a_fenced_json_completion_is_still_read(tavily_server):
         + "\n```"
     )
     skill = ResearchBusiness(
-        meta(), tavily=tavily_for(tavily_server), llm=llm_for(StubModel(fenced))
+        meta(), tavily=tavily_for(tavily_server), llm=llm_for(StubModels(fenced))
     )
 
     brief = BusinessResearchBrief.model_validate((await skill.run(context())).output)
@@ -275,7 +279,7 @@ async def test_an_open_tavily_breaker_produces_a_degraded_brief(tavily_server):
     skill = ResearchBusiness(
         meta(),
         tavily=tavily_for(tavily_server, breaker),
-        llm=llm_for(StubModel("{}")),
+        llm=llm_for(StubModels("{}")),
     )
 
     brief = BusinessResearchBrief.model_validate((await skill.run(context())).output)
@@ -292,7 +296,7 @@ async def test_a_degraded_brief_keeps_the_operators_own_information(tavily_serve
     breaker = brk("tavily", failure_threshold=1)
     breaker.record_failure()
     skill = ResearchBusiness(
-        meta(), tavily=tavily_for(tavily_server, breaker), llm=llm_for(StubModel("{}"))
+        meta(), tavily=tavily_for(tavily_server, breaker), llm=llm_for(StubModels("{}"))
     )
 
     brief = BusinessResearchBrief.model_validate((await skill.run(context())).output)
@@ -332,7 +336,7 @@ async def test_the_summary_line_leads_with_the_degradation(tavily_server):
     breaker = brk("tavily", failure_threshold=1)
     breaker.record_failure()
     skill = ResearchBusiness(
-        meta(), tavily=tavily_for(tavily_server, breaker), llm=llm_for(StubModel("{}"))
+        meta(), tavily=tavily_for(tavily_server, breaker), llm=llm_for(StubModels("{}"))
     )
 
     brief = BusinessResearchBrief.model_validate((await skill.run(context())).output)

--- a/onboarding-intelligence-agent-svc/tests/test_research_business.py
+++ b/onboarding-intelligence-agent-svc/tests/test_research_business.py
@@ -401,3 +401,61 @@ def test_every_surviving_fact_is_sourced_and_nothing_is_silently_lost(statements
     assert len(brief.facts) + len(brief.open_unknowns) == len(
         [s for s, _ in pairs if s.strip()]
     ), "a claim was neither kept nor demoted"
+
+
+# ── Malformed model output must not take down the turn ───────────────
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "presence", [[1, 2], "a website", 42, None, True, {"website": None}]
+)
+def test_a_non_object_digital_presence_does_not_raise(presence):
+    """Review finding. ``(presence or {}).get(...)`` raised AttributeError on a
+    list, a string or a number — taking down the whole turn, which is exactly
+    what the degraded path exists to avoid.
+    """
+    skill = ResearchBusiness(meta())
+    raw = json.dumps({"facts": [], "digital_presence": presence})
+
+    brief = skill._parse(raw, "Acme", [])
+
+    assert brief.digital_presence.website is None
+
+
+@pytest.mark.unit
+def test_a_string_social_profiles_is_not_split_into_characters():
+    """The quieter half of the same finding, and the worse one.
+
+    Iterating a string yields single characters, so "twitter" became eight
+    one-letter "profiles" carried into the brief as if they were data. A crash
+    gets noticed; this would not have.
+    """
+    skill = ResearchBusiness(meta())
+    raw = json.dumps({"facts": [], "digital_presence": {"social_profiles": "twitter"}})
+
+    brief = skill._parse(raw, "Acme", [])
+
+    assert brief.digital_presence.social_profiles == []
+
+
+@pytest.mark.unit
+def test_a_well_formed_digital_presence_still_reads():
+    """The guard must not reject the shape it sits in front of."""
+    skill = ResearchBusiness(meta())
+    raw = json.dumps(
+        {
+            "facts": [],
+            "digital_presence": {
+                "website": "https://k.example",
+                "social_profiles": ["https://x.com/k", "  ", "https://ig.com/k"],
+                "notes": "active",
+            },
+        }
+    )
+
+    presence = skill._parse(raw, "Acme", []).digital_presence
+
+    assert presence.website == "https://k.example"
+    assert presence.social_profiles == ["https://x.com/k", "https://ig.com/k"]
+    assert presence.notes == "active"

--- a/onboarding-intelligence-agent-svc/tests/test_scaffold.py
+++ b/onboarding-intelligence-agent-svc/tests/test_scaffold.py
@@ -114,7 +114,11 @@ IMPLEMENTED |= {"app.api.deps", "app.api.schemas"}
 #: Implemented by C-02. §18.2 specified config/circuit_breakers.yaml and this
 #: module from the start, but no story owned building them — the scaffold
 #: docstring named A-06, whose acceptance criteria never mention breakers.
-IMPLEMENTED |= {"app.circuit_breaker.breaker", "app.providers.llm"}
+IMPLEMENTED |= {
+    "app.circuit_breaker.breaker",
+    "app.providers.llm",
+    "app.logic.prep_executor",
+}
 
 #: A-06 turned the sixteen skill modules into registry-resolvable classes.
 #: They are no longer bare stubs — the class is real and instantiable, and it
@@ -169,7 +173,15 @@ def test_skills_yaml_declares_all_sixteen_skills():
     assert len(parsed["skills"]) == 16
 
 
-@pytest.mark.parametrize("dotted", SKILL_MODULES)
+#: Skills whose bodies have landed. Named individually rather than removed
+#: from SKILL_MODULES, so the deferred-body check keeps covering the other
+#: fifteen and this list reads as a progress marker.
+IMPLEMENTED_BODIES = {"app.skills.research_business"}  # C-02
+
+
+@pytest.mark.parametrize(
+    "dotted", [m for m in SKILL_MODULES if m not in IMPLEMENTED_BODIES]
+)
 def test_skill_bodies_are_deferred(dotted):
     """The class resolves and instantiates; run/stream still refuse to run.
 
@@ -255,3 +267,27 @@ def test_each_spec_is_self_consistent():
 
     for code, spec in ERROR_SPECS.items():
         assert spec.code == code, f"{code} is keyed to a spec for {spec.code}"
+
+
+def test_the_implemented_body_list_stays_honest():
+    """A skill listed here but still raising would quietly lose its coverage —
+    the deferred check skips it and no other test would notice."""
+    import asyncio
+    import importlib
+
+    from app.skills.models import SkillContext, SkillMeta, TenantContext
+
+    for dotted in IMPLEMENTED_BODIES:
+        module = importlib.import_module(dotted)
+        name = dotted.rsplit(".", 1)[1]
+        cls = getattr(module, "".join(p.title() for p in name.split("_")))
+        skill = cls(SkillMeta(skill_id="SKL-OIA-00", name=name))
+
+        context = SkillContext(
+            input_prompt="p",
+            tenant_context=TenantContext(tenant_id="t-1", role="ADMIN"),
+            input_context={"company_name": "Acme"},
+        )
+        result = asyncio.run(skill.run(context))
+
+        assert result is not None, f"{dotted} is listed as implemented but returns None"


### PR DESCRIPTION
Second of two PRs for **C-02**. Stacked on **#556** (the §18.2 breakers and providers) — **merge #556 first**.

Gives SKL-OIA-01 a body and connects `/v1/execute` to it. C-01 wired the route straight to the conversation store and honestly returned `skill_id: "NONE"`; that is now `SKL-OIA-01`.

## AC-1 — grounding is checked twice, because once is not enough

| Layer | Catches |
|---|---|
| The skill | a fact whose `source_url` was **not in the set Tavily returned** |
| OG-01 | anything still unsourced, or not an http(s) URL |

A model that invents a plausible citation passes any rule that only asks *"is this field present and URL-shaped"*. The only defence is checking against what search actually retrieved.

**OG-01 is a real rule registered through `GuardrailChain.register`**, not logic hidden in the skill. That is the mechanism A-06 built for exactly this, the card puts its test in `tests/test_guardrails.py`, and M-01 should find a working rule to extend rather than a no-op plus a private copy it has no reason to look for.

**Unsourced claims are demoted to `open_unknowns`, never deleted.** The card is emphatic that unknowns are the highest-value output because SKL-OIA-02 turns them into questions. The property test encodes *conservation* for that reason: every claim is either kept with a real source or demoted — a rule that silently deleted them would satisfy "every fact is sourced" perfectly while destroying the signal.

## AC-3 — degradation, and one non-obvious consequence

A degraded brief is built from the operator's own hints and flagged with its reason. **It is deliberately never cached**: it is the *absence* of research, and caching it would let a one-minute Tavily outage suppress real research for the next hour with nothing to tell the operator why their questions stayed thin.

## Two things found while wiring — neither would have failed a test

**Django reads `output.detail`** and falls back to *"Preparation is under way."* when it's missing. My first version of the response dropped that key, which would have silently replaced every prep reply with the placeholder.

**OIA is absent from `10-redeploy-with-urls.sh`.** My plan recorded `OIA_BACKEND_BASE_URL=PLACEHOLDER` in `08-deploy-services.sh` as the bug. **That was wrong** — the placeholder is the fleet pattern, resolved by a second pass. The real bug is that OIA was never added to that pass, so it has held the literal string `"PLACEHOLDER"` since first deploy. Nothing had called the backend yet, so it cost nothing and stayed invisible. Now added.

## Changed tests

Three C-01/A-06 tests changed because behaviour deliberately changed — `skill_id` is no longer NONE, history now carries agent turns, and SKL-OIA-01 no longer raises `NotImplementedError`. Each was **rewritten to assert the new truth**, not relaxed. The scaffold now tracks implemented bodies explicitly, with a check that the list stays honest (a skill listed as implemented but still raising would quietly lose its coverage).

## Still outstanding for C-02

**D2's durable half.** AC-2 says *"or opens the Onboarding Interface"*. The Redis cache (1h TTL, tenant-scoped, normalised key) satisfies re-running within a session, but the approved plan also called for a Django `ResearchBrief` model. That is not in this PR — it needs a model, migration, endpoint and `backend_client`, and I would rather land it as a reviewed PR 3 than rush it in here.

**448 passed**, `mypy --strict` clean, `black`/`flake8` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)