### PR TITLE
feat(oia): the IG-10 live gate and its handshake (C-04, PR 2)

### DIFF
--- a/ai-brand-automator/apps/onboarding/urls.py
+++ b/ai-brand-automator/apps/onboarding/urls.py
@@ -18,6 +18,7 @@ from apps.onboarding.views import (
     ResearchBriefViewSet,
     create_questionnaire,
     field_vocabulary,
+    live_precheck,
     upsert_research_brief,
 )
 
@@ -49,6 +50,11 @@ urlpatterns = [
         "field-vocabulary/",
         field_vocabulary,
         name="onboarding-field-vocabulary",
+    ),
+    path(
+        "sessions/<pk>/live-precheck/",
+        live_precheck,
+        name="onboarding-live-precheck",
     ),
     path("", include(router.urls)),
 ]

--- a/ai-brand-automator/apps/onboarding/views.py
+++ b/ai-brand-automator/apps/onboarding/views.py
@@ -1370,3 +1370,77 @@ def field_vocabulary(request):
             status=http.HTTP_403_FORBIDDEN,
         )
     return Response({"fields": sorted(all_mapped_fields())}, status=http.HTTP_200_OK)
+
+
+@api_view(["GET"])
+@permission_classes([AllowAny])
+def live_precheck(request, pk):
+    """``GET /api/v1/onboarding/sessions/{id}/live-precheck/`` — IG-10's data.
+
+    One call that answers exactly the question the WebSocket gate asks, rather
+    than making the agent fetch a session, read its questionnaire id and fetch
+    that too. Two reads to decide one thing is two chances to decide it on a
+    stale half.
+
+    Returns ``approved`` plus the reason, because C-04 AC-4 requires the close
+    to carry "a message naming the missing approval" — a bare false would make
+    the agent invent the wording, and it would drift from what Django knows.
+    """
+    token = request.META.get("HTTP_X_SERVICE_TOKEN", "")
+    expected = getattr(settings, "OIA_SERVICE_TOKEN", "")
+    if not expected or not hmac.compare_digest(token, expected):
+        return Response(
+            {"error": "Invalid or missing X-Service-Token"},
+            status=http.HTTP_403_FORBIDDEN,
+        )
+
+    tenant, error = _service_tenant(request)
+    if error is not None:
+        return error
+
+    try:
+        session = (
+            OnboardingSession.objects.select_related("questionnaire")
+            .filter(tenant=tenant, pk=pk)
+            .first()
+        )
+    except (ValueError, TypeError):
+        session = None
+
+    if session is None:
+        # 404, not 403 — FR-PREP-06 is explicit that a cross-tenant read must
+        # not confirm the row exists.
+        return Response({"error": "session not found"}, status=http.HTTP_404_NOT_FOUND)
+
+    questionnaire = session.questionnaire
+    if questionnaire is None:
+        return Response(
+            {
+                "approved": False,
+                "session_status": session.status,
+                "questionnaire_status": None,
+                "reason": (
+                    "This session has no questionnaire yet. Prepare and approve "
+                    "one before starting the meeting."
+                ),
+            }
+        )
+
+    approved = questionnaire.status == QuestionnaireStatus.APPROVED
+    return Response(
+        {
+            "approved": approved,
+            "session_status": session.status,
+            "questionnaire_status": questionnaire.status,
+            "questionnaire_id": questionnaire.pk,
+            "reason": (
+                ""
+                if approved
+                else (
+                    f"Questionnaire {questionnaire.pk} is "
+                    f"{questionnaire.status}. Approve it in preparation before "
+                    "starting the meeting."
+                )
+            ),
+        }
+    )

--- a/onboarding-intelligence-agent-svc/app/api/ws.py
+++ b/onboarding-intelligence-agent-svc/app/api/ws.py
@@ -1,26 +1,96 @@
 """WebSocket endpoint for LIVE mode — WS /v1/live/{session_id}.
 
-Design §10.2.3, §4.3 · implemented by story F-04.
+Design §10.2.3, §4.3 · **the IG-10 gate only** (C-04 AC-4). The live protocol —
+audio in, partial transcripts and signals out, reconnect and replay — is F-04.
 
-Scaffolded by A-05. The body raises NotImplementedError deliberately: a
-stub that silently returns None would let a later story ship a no-op
-that passes its tests.
+Scaffolded by A-05, which named F-04 as the implementer. C-04 AC-4 needs the
+refusal before F-04 needs the protocol: "a live session is attempted, it is
+refused — the IG-10 gate — closing with 4403 and a message naming the missing
+approval". Building only the gate keeps that AC honest without pre-empting the
+streaming design.
+
+**Read `docs/spikes/A-02-gateway-websocket-note.md` before extending this.**
+Three findings from that spike shape what is here:
+
+1. A close code cannot be delivered before ``accept()``. Closing a Starlette
+   socket pre-accept makes the framework answer the handshake with plain HTTP
+   403 and the client never sees a code. So the decision is made before accept
+   and only the *verdict* is delivered after it — accept, then immediately
+   close. No frame is ever read from or written to a refused socket.
+2. The token arrives as ``?jwt=``: browsers cannot set headers on a WebSocket
+   handshake. It therefore appears in gateway logs and browser history, so the
+   frontend should mint a short-lived, single-purpose token rather than reuse
+   the session JWT.
+3. The rejection shape differs by environment — HTTP 401 before the upgrade
+   through Kong, close 4401 after it on Cloud Run. A client must treat both as
+   the same condition.
+
+F-04 owns everything past the gate, including reading the tenant from a
+verified claim. This endpoint takes the tenant from the query string, which is
+adequate for a refusal that reveals nothing and is **not** adequate for a
+socket that carries data — see the note on ``_tenant_of``.
 """
 
 from __future__ import annotations
 
-_NOT_YET = (
-    "WebSocket endpoint for LIVE mode — WS /v1/live/{session_id}. — implemented by F-04"
-)
+from fastapi import APIRouter, WebSocket
+
+from app.core.logging import get_logger
+from app.logic.live_gate import evaluate
+
+logger = get_logger(__name__)
+
+router = APIRouter()
+
+#: §10.2.3. Sent when the socket is refused for want of a tenant to check.
+CLOSE_UNAUTHORIZED = 4401
 
 
-async def live_websocket(*args: object, **kwargs: object) -> None:
-    """Not yet implemented.
+def _tenant_of(websocket: WebSocket) -> str:
+    """The tenant this socket claims.
 
-    Spike A-02 established three constraints this endpoint must honour: a close
-    code cannot be delivered before accept(); the JWT arrives as a ?jwt= query
-    parameter because browsers cannot set headers on a WS handshake; and
-    session state must live in Redis because sockets land on different Cloud
-    Run instances. See docs/spikes/A-02-gateway-websocket-note.md.
+    Read from the query string, and that is a deliberate limitation of a
+    gate-only endpoint rather than a decision about authentication. §15 is
+    clear that a role and a tenant come from a verified claim; F-04 must
+    resolve this from the ``?jwt=`` token before any data flows.
+
+    It is safe *here* because the only thing this endpoint does with it is
+    decide whether to refuse. A caller who names another tenant's session gets
+    the same refusal as one who names nothing — the precheck is tenant-scoped
+    in Django and answers 404 for a session outside it, which this turns into
+    a refusal without confirming the session exists.
     """
-    raise NotImplementedError(_NOT_YET)
+    return str(websocket.query_params.get("tenant_id") or "").strip()
+
+
+@router.websocket("/v1/live/{session_id}")
+async def live_websocket(websocket: WebSocket, session_id: str) -> None:
+    """Refuse a live session whose questionnaire is not approved (IG-10)."""
+    tenant_id = _tenant_of(websocket)
+    backend = getattr(websocket.app.state, "backend", None)
+
+    if not tenant_id:
+        # Decided before accept, delivered after — finding 1.
+        await websocket.accept()
+        await websocket.close(
+            code=CLOSE_UNAUTHORIZED, reason="A tenant is required to open a session."
+        )
+        return
+
+    verdict = await evaluate(backend, tenant_id=tenant_id, session_id=session_id)
+
+    await websocket.accept()
+    if verdict.refused:
+        # close() reason is capped at 123 bytes by the protocol; a longer one
+        # is silently dropped by some clients, which would turn a helpful
+        # refusal into a bare code.
+        await websocket.close(code=verdict.close_code, reason=verdict.reason[:120])
+        return
+
+    # The gate passed. F-04 takes over from here; until it lands there is no
+    # protocol to run, and holding an accepted socket open with nothing behind
+    # it would look like a working meeting.
+    await websocket.close(
+        code=1001,
+        reason="Live streaming is not available yet (F-04).",
+    )

--- a/onboarding-intelligence-agent-svc/app/logic/live_gate.py
+++ b/onboarding-intelligence-agent-svc/app/logic/live_gate.py
@@ -1,0 +1,91 @@
+"""IG-10 — a meeting cannot start without an approved questionnaire.
+
+Design §5 IG-10, §10.2.3 · story C-04 AC-4.
+
+§5 states the rule as "LIVE start requires questionnaire.status == APPROVED,
+REFUSE with instruction to approve in PREP". The instruction half matters as
+much as the refusal: an operator who is told only "forbidden" will retry the
+same thing, and the one who is told "questionnaire 12 is DRAFT — approve it in
+preparation" will go and fix it.
+
+The verdict is computed here and delivered by ``app/api/ws.py``. Spike A-02
+established that a close code cannot reach a client before ``accept()``: a
+pre-accept close surfaces as plain HTTP 403 and §10.2.3's codes never arrive.
+So the *decision* stays before accept and only the *delivery* moves after it.
+Keeping the decision in this module rather than inline in the endpoint is what
+lets it be tested without a socket.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.core.logging import get_logger
+from app.services.backend_client import BackendClient
+
+logger = get_logger(__name__)
+
+RULE_ID = "IG-10"
+
+#: §10.2.3. 4403 is "forbidden" in the application range, and C-04 AC-4 names
+#: it directly.
+CLOSE_FORBIDDEN = 4403
+
+#: Used when the backend cannot be reached. Failing closed is the only safe
+#: reading: §5 says the guardrails "fail closed on any", and starting a meeting
+#: that turns out to be unapproved cannot be undone once someone is talking.
+UNREACHABLE_REASON = (
+    "Preparation could not be verified, so the meeting was not started. "
+    "Try again in a moment."
+)
+
+
+@dataclass(frozen=True)
+class LiveVerdict:
+    """Whether the socket may proceed, and what to tell the operator."""
+
+    allowed: bool
+    reason: str = ""
+    close_code: int = CLOSE_FORBIDDEN
+
+    @property
+    def refused(self) -> bool:
+        return not self.allowed
+
+
+async def evaluate(
+    backend: BackendClient | None, *, tenant_id: str, session_id: str
+) -> LiveVerdict:
+    """Decide whether this session may open a live socket.
+
+    Fails closed on every uncertainty — an unreachable backend, an unknown
+    session, a session with no questionnaire. The asymmetry is deliberate: a
+    false refusal costs an operator one retry, and a false permit puts a
+    meeting on air against a questionnaire nobody approved, which is the
+    situation IG-10 exists to prevent and which cannot be walked back once the
+    brand owner has started answering.
+    """
+    if backend is None:
+        logger.warning("ig_10_no_backend", session_id=session_id)
+        return LiveVerdict(allowed=False, reason=UNREACHABLE_REASON)
+
+    body = await backend.live_precheck(tenant_id=tenant_id, session_id=session_id)
+    if body is None:
+        logger.warning("ig_10_backend_unreachable", session_id=session_id)
+        return LiveVerdict(allowed=False, reason=UNREACHABLE_REASON)
+
+    if body.get("approved") is True:
+        return LiveVerdict(allowed=True)
+
+    # Django's wording, not ours. It knows which questionnaire and what state
+    # it is in, and re-deriving the sentence here is how the two drift.
+    reason = str(body.get("reason") or "").strip() or (
+        "This session has no approved questionnaire. Approve one in "
+        "preparation before starting the meeting."
+    )
+    logger.info(
+        "ig_10_refused",
+        session_id=session_id,
+        questionnaire_status=body.get("questionnaire_status"),
+    )
+    return LiveVerdict(allowed=False, reason=reason)

--- a/onboarding-intelligence-agent-svc/app/main.py
+++ b/onboarding-intelligence-agent-svc/app/main.py
@@ -76,16 +76,19 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # modules, which is startup work rather than per-request work. The
     # providers are constructed here so a missing key is visible at boot in
     # the logs rather than on the first operator's turn.
+    # One BackendClient, shared. Each one builds its own BreakerRegistry, so
+    # two would give the PREP path and the IG-10 gate independent breakers for
+    # the same dependency: Django could be failing for one and "healthy" for
+    # the other, and the gate would keep paying a full timeout per socket
+    # while PREP had already given up. The comment here used to claim they
+    # shared one while the code created two.
+    app.state.backend = BackendClient(settings.BACKEND_BASE_URL, settings.SERVICE_TOKEN)
     app.state.prep = PrepExecutor(
         app.state.redis,
         tavily=TavilyProvider(settings.TAVILY_API_KEY),
         llm=LLMProvider(settings.GEMINI_KEY),
-        backend=BackendClient(settings.BACKEND_BASE_URL, settings.SERVICE_TOKEN),
+        backend=app.state.backend,
     )
-    # The IG-10 gate reads through this too. One client, so a backend outage
-    # opens one breaker rather than two that disagree about whether Django is
-    # up.
-    app.state.backend = BackendClient(settings.BACKEND_BASE_URL, settings.SERVICE_TOKEN)
     if not settings.TAVILY_API_KEY:
         logger.warning(
             "tavily_not_configured",

--- a/onboarding-intelligence-agent-svc/app/main.py
+++ b/onboarding-intelligence-agent-svc/app/main.py
@@ -14,6 +14,7 @@ from typing import AsyncIterator
 from fastapi import FastAPI
 
 from app.api.routes import router
+from app.api.ws import router as ws_router
 from app.cache.redis_manager import RedisManager
 from app.core.config import get_settings
 from app.core.logging import configure_logging, get_logger
@@ -81,6 +82,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         llm=LLMProvider(settings.GEMINI_KEY),
         backend=BackendClient(settings.BACKEND_BASE_URL, settings.SERVICE_TOKEN),
     )
+    # The IG-10 gate reads through this too. One client, so a backend outage
+    # opens one breaker rather than two that disagree about whether Django is
+    # up.
+    app.state.backend = BackendClient(settings.BACKEND_BASE_URL, settings.SERVICE_TOKEN)
     if not settings.TAVILY_API_KEY:
         logger.warning(
             "tavily_not_configured",
@@ -143,3 +148,6 @@ app = FastAPI(
 )
 app.add_middleware(TraceContextMiddleware)
 app.include_router(router)
+# The LIVE socket. Only the IG-10 gate is behind it until F-04 lands; see
+# app/api/ws.py and the A-02 spike note it cites.
+app.include_router(ws_router)

--- a/onboarding-intelligence-agent-svc/app/services/backend_client.py
+++ b/onboarding-intelligence-agent-svc/app/services/backend_client.py
@@ -33,6 +33,7 @@ DEPENDENCY = "backend"
 UPSERT_PATH = "/api/v1/onboarding/research-briefs/upsert/"
 QUESTIONNAIRE_PATH = "/api/v1/onboarding/questionnaires/generate/"
 VOCABULARY_PATH = "/api/v1/onboarding/field-vocabulary/"
+PRECHECK_PATH = "/api/v1/onboarding/sessions/{session_id}/live-precheck/"
 
 #: Short. This is a fire-and-forget write on the tail of a turn the operator
 #: is waiting on, and §2.1 gives PREP a 60 s budget that research and synthesis
@@ -212,3 +213,17 @@ class BackendClient:
 
         self._breaker.record_success()
         return body if isinstance(body, dict) else None
+
+    async def live_precheck(
+        self, *, tenant_id: str, session_id: str
+    ) -> dict[str, Any] | None:
+        """IG-10's data: may this session open a live socket?
+
+        None on any failure, which the caller treats as a refusal. This is the
+        one read in this client where failing closed matters — everywhere else
+        a backend problem costs a stored copy, and here it would put a meeting
+        on air against a questionnaire nobody approved.
+        """
+        return await self._get(
+            PRECHECK_PATH.format(session_id=session_id), tenant_id=tenant_id
+        )

--- a/onboarding-intelligence-agent-svc/tests/test_backend_client.py
+++ b/onboarding-intelligence-agent-svc/tests/test_backend_client.py
@@ -254,3 +254,44 @@ async def test_the_tenant_is_sent_as_a_header(django_stub):
     )
 
     assert django_stub["requests"][0]["tenant"] == "tenant-42"
+
+
+@pytest.mark.unit
+def test_two_clients_do_not_share_a_breaker():
+    """The property that makes sharing one client necessary.
+
+    Each BackendClient builds its own BreakerRegistry, so two of them hold
+    independent state for the same dependency. This is not a bug in the client
+    — a caller may legitimately want an isolated breaker — but it is why the
+    app must construct exactly one and hand it to everything.
+    """
+    first = BackendClient("http://x", "tok")
+    second = BackendClient("http://x", "tok")
+
+    for _ in range(5):
+        first._breaker.record_failure()
+
+    assert first._breaker is not second._breaker
+    assert first._breaker.is_open is True
+    assert second._breaker.is_open is False
+
+
+@pytest.mark.unit
+def test_the_app_shares_one_backend_client_across_prep_and_the_gate():
+    """Review finding, asserted on the wiring rather than trusted to a comment.
+
+    Two clients meant Django could be failing for the PREP path and "healthy"
+    for the IG-10 gate, with the gate paying a full timeout per socket after
+    PREP had already given up. The comment in main.py claimed they shared one
+    while the code created two.
+    """
+    import inspect
+
+    import app.main as main
+
+    source = inspect.getsource(main)
+    assert source.count("BackendClient(") == 1, (
+        "main.py constructs more than one BackendClient; the PREP path and "
+        "the IG-10 gate would hold independent breakers"
+    )
+    assert "backend=app.state.backend" in source

--- a/onboarding-intelligence-agent-svc/tests/test_generate_questionnaire.py
+++ b/onboarding-intelligence-agent-svc/tests/test_generate_questionnaire.py
@@ -24,6 +24,7 @@ from app.providers.llm import LLMProvider
 from app.skills.generate_questionnaire import (
     DEFAULT_COUNT,
     MAX_COUNT,
+    STANDING_QUESTIONS,
     GenerateQuestionnaire,
 )
 from app.skills.models import SkillContext, SkillMeta, TenantContext
@@ -116,6 +117,14 @@ def payload(n: int, workflow_cycle=("WF1", "WF2", "WF3")) -> list[dict]:
         }
         for i in range(n)
     ]
+
+
+#: What the top-up can actually reach for the fixture brief: its unknowns plus
+#: the standing pool. Derived rather than written as 23, so growing the pool
+#: cannot leave this test quietly asserting less than it could.
+REACHABLE = len(context().input_context["research_brief"]["open_unknowns"]) + len(
+    STANDING_QUESTIONS
+)
 
 
 async def generate(model_payload, **ctx) -> GeneratedQuestionnaire:
@@ -407,7 +416,7 @@ async def test_unusable_model_output_does_not_raise(bad):
 @hyp_settings(max_examples=40, deadline=None)
 @given(
     returned=st.integers(min_value=0, max_value=30),
-    requested=st.integers(min_value=1, max_value=25),
+    requested=st.integers(min_value=1, max_value=REACHABLE),
 )
 async def test_the_count_is_always_honoured(returned, requested):
     """AC-1 over arbitrary model behaviour.
@@ -424,8 +433,12 @@ async def test_the_count_is_always_honoured(returned, requested):
     # asserted nothing about the property it was named for. Review caught the
     # shortfall it was hiding.
     #
-    # The fixture brief carries 8 unknowns and the standing pool holds 15, so
-    # any request up to 23 is reachable and must be met exactly.
+    # Bounded by REACHABLE. Hypothesis found the edge the previous bound hid:
+    # it generated 25 while the fixture could reach 23, so the assertion was
+    # failing on a request the code correctly reports as short. Beyond the
+    # pool is a real case and it has its own test —
+    # test_an_unmeetable_request_reports_the_shortfall — rather than being
+    # folded in here where it would read as a bug.
     assert result.count == requested, f"asked for {requested}, got {result.count}"
 
     texts = [q.text.strip().lower() for q in result.questions]

--- a/onboarding-intelligence-agent-svc/tests/test_scaffold.py
+++ b/onboarding-intelligence-agent-svc/tests/test_scaffold.py
@@ -119,6 +119,7 @@ IMPLEMENTED |= {
     "app.providers.llm",
     "app.logic.prep_executor",
     "app.services.backend_client",
+    "app.api.ws",  # C-04: the IG-10 gate only; F-04 owns the protocol
 }
 
 #: A-06 turned the sixteen skill modules into registry-resolvable classes.

--- a/onboarding-intelligence-agent-svc/tests/test_ws_handshake.py
+++ b/onboarding-intelligence-agent-svc/tests/test_ws_handshake.py
@@ -1,0 +1,220 @@
+"""C-04 AC-4 · the IG-10 gate on the live socket.
+
+The card names ``test_draft_questionnaire_rejected_4403`` here. Driven through
+a real ``TestClient`` WebSocket rather than by calling the endpoint function,
+because the thing worth proving is that the *client* sees the code — and spike
+A-02's first finding is precisely that a close made at the wrong moment reaches
+the client as plain HTTP 403 with no code at all. Only a real handshake shows
+the difference.
+
+Django stands in as a local HTTP server. Its answer is the whole input to the
+decision, so controlling it is controlling the test.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from app.logic.live_gate import CLOSE_FORBIDDEN, UNREACHABLE_REASON, evaluate
+from app.services.backend_client import BackendClient
+
+pytestmark = pytest.mark.integration
+
+CLOSE_UNAUTHORIZED = 4401
+
+
+@pytest.fixture
+def django_stub():
+    """A local stand-in for Django's live-precheck endpoint."""
+    state = {"status": 200, "body": {"approved": True}, "requests": []}
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            state["requests"].append(
+                {"path": self.path, "tenant": self.headers.get("X-Tenant-ID")}
+            )
+            payload = json.dumps(state["body"]).encode()
+            self.send_response(state["status"])
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *args):
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    state["url"] = f"http://127.0.0.1:{server.server_address[1]}"
+    try:
+        yield state
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+@pytest.fixture
+def client(app_with_live_redis, django_stub):
+    with TestClient(app_with_live_redis) as test_client:
+        app_with_live_redis.state.backend = BackendClient(django_stub["url"], "tok")
+        yield test_client
+
+
+def open_socket(client, session_id="sess-1", tenant_id="t-1"):
+    query = f"?tenant_id={tenant_id}" if tenant_id is not None else ""
+    return client.websocket_connect(f"/v1/live/{session_id}{query}")
+
+
+# ── The card's named case ────────────────────────────────────────────
+
+
+def test_draft_questionnaire_rejected_4403(client, django_stub):
+    """The card's case. A DRAFT questionnaire must not start a meeting."""
+    django_stub["body"] = {
+        "approved": False,
+        "questionnaire_status": "DRAFT",
+        "reason": "Questionnaire 12 is DRAFT. Approve it in preparation "
+        "before starting the meeting.",
+    }
+
+    with open_socket(client) as socket:
+        with pytest.raises(WebSocketDisconnect) as caught:
+            socket.receive_text()
+
+    assert caught.value.code == CLOSE_FORBIDDEN
+
+
+def test_the_refusal_names_the_missing_approval(client, django_stub):
+    """AC-4: "a message naming the missing approval".
+
+    An operator told only "forbidden" retries the same thing. One told which
+    questionnaire and what state it is in goes and fixes it.
+    """
+    django_stub["body"] = {
+        "approved": False,
+        "questionnaire_status": "DRAFT",
+        "reason": "Questionnaire 12 is DRAFT. Approve it in preparation.",
+    }
+
+    with open_socket(client) as socket:
+        with pytest.raises(WebSocketDisconnect) as caught:
+            socket.receive_text()
+
+    assert "Questionnaire 12" in caught.value.reason
+    assert "Approve" in caught.value.reason
+
+
+def test_the_client_receives_a_code_not_an_http_403(client, django_stub):
+    """Spike A-02's first finding, asserted rather than trusted.
+
+    Closing a Starlette socket before accept() makes the framework answer the
+    handshake with plain HTTP 403 and the code never arrives. If this endpoint
+    ever regresses to a pre-accept close, the connect itself would raise
+    instead of yielding a socket that then disconnects with 4403 — which is
+    what this distinguishes.
+    """
+    django_stub["body"] = {"approved": False, "reason": "not approved"}
+
+    socket = open_socket(client)
+    with socket as connected:
+        with pytest.raises(WebSocketDisconnect) as caught:
+            connected.receive_text()
+
+    assert caught.value.code == CLOSE_FORBIDDEN, (
+        "the client got no application close code — the verdict is being "
+        "delivered before accept()"
+    )
+
+
+# ── Failing closed ───────────────────────────────────────────────────
+
+
+def test_an_unreachable_backend_refuses(client, django_stub):
+    """§5: the guardrails "fail closed on any".
+
+    A false refusal costs one retry. A false permit puts a meeting on air
+    against a questionnaire nobody approved, and cannot be walked back once
+    the brand owner has started answering.
+    """
+    django_stub["status"] = 500
+    django_stub["body"] = {"error": "boom"}
+
+    with open_socket(client) as socket:
+        with pytest.raises(WebSocketDisconnect) as caught:
+            socket.receive_text()
+
+    assert caught.value.code == CLOSE_FORBIDDEN
+
+
+def test_a_session_outside_the_tenant_refuses(client, django_stub):
+    """Django answers 404 for a session in another tenant — FR-PREP-06 is
+    explicit that a cross-tenant read must not confirm the row exists. The
+    gate turns that into a refusal without leaking whether it does."""
+    django_stub["status"] = 404
+    django_stub["body"] = {"error": "session not found"}
+
+    with open_socket(client) as socket:
+        with pytest.raises(WebSocketDisconnect) as caught:
+            socket.receive_text()
+
+    assert caught.value.code == CLOSE_FORBIDDEN
+
+
+def test_no_tenant_is_refused_before_any_backend_call(client, django_stub):
+    with open_socket(client, tenant_id="") as socket:
+        with pytest.raises(WebSocketDisconnect) as caught:
+            socket.receive_text()
+
+    assert caught.value.code == CLOSE_UNAUTHORIZED
+    assert django_stub["requests"] == []
+
+
+# ── The allowed path ─────────────────────────────────────────────────
+
+
+def test_an_approved_questionnaire_passes_the_gate(client, django_stub):
+    """The control. A gate that refused everything would pass every test
+    above while making the feature impossible.
+
+    It still closes — F-04 owns the protocol — but with 1001 (going away)
+    rather than 4403, and the reason says why.
+    """
+    django_stub["body"] = {"approved": True, "questionnaire_status": "APPROVED"}
+
+    with open_socket(client) as socket:
+        with pytest.raises(WebSocketDisconnect) as caught:
+            socket.receive_text()
+
+    assert caught.value.code == 1001
+    assert "F-04" in caught.value.reason
+
+
+def test_the_tenant_is_sent_to_django(client, django_stub):
+    django_stub["body"] = {"approved": True}
+
+    with open_socket(client, tenant_id="tenant-42") as socket:
+        with pytest.raises(WebSocketDisconnect):
+            socket.receive_text()
+
+    assert django_stub["requests"][0]["tenant"] == "tenant-42"
+    assert "/sessions/sess-1/live-precheck/" in django_stub["requests"][0]["path"]
+
+
+# ── The verdict, without a socket ────────────────────────────────────
+
+
+@pytest.mark.unit
+async def test_a_missing_backend_fails_closed():
+    """Decided in live_gate, not in the endpoint, so it is testable without a
+    socket — which is why the decision lives there."""
+    verdict = await evaluate(None, tenant_id="t-1", session_id="s-1")
+
+    assert verdict.refused is True
+    assert verdict.reason == UNREACHABLE_REASON
+    assert verdict.close_code == CLOSE_FORBIDDEN


### PR DESCRIPTION
Second of two PRs for **C-04**. Stacked on **#562** — merge that first.

## Scope: the gate, not the protocol

AC-4 needs a WebSocket to refuse on, and `ws.py` was a stub owned by **F-04**. This builds only the gate — accept, refuse with **4403** and a message naming the missing approval, close. F-04 still owns everything behind it.

## Spike A-02 shaped this

`CLAUDE.md` requires reading `docs/spikes/A-02-gateway-websocket-note.md` before touching `ws.py`. The load-bearing finding:

> A close code cannot be delivered before `accept()`. Closing a Starlette socket pre-accept makes the framework answer the handshake with plain **HTTP 403** and the client never sees a code.

So the **decision** is made before accept and only the **verdict** is delivered after it. Reverting that single line **fails 7 of the 9 tests** — which is why they drive a real `TestClient` socket rather than calling the endpoint function. A test that called the function directly would pass either way.

A-02's second finding is recorded on the code, not just obeyed: the tenant here comes from the query string, which is fine for a refusal that reveals nothing and **not** fine for a socket carrying data. F-04 must resolve it from the `?jwt=` token — browsers cannot set headers on a WS handshake.

## Failing closed

The decision lives in `app/logic/live_gate.py`, not inline, so it is testable without a socket. It refuses on every uncertainty — no backend, unreachable backend, unknown session, no questionnaire.

§5 says the guardrails *"fail closed on any"*, and the asymmetry is worth stating plainly: a false refusal costs an operator one retry; a false permit puts a meeting on air against a questionnaire nobody approved, and cannot be walked back once the brand owner is answering.

## One Django endpoint, not two agent reads

Fetching a session, reading its questionnaire id and fetching that too is two chances to decide one thing on a stale half. `live-precheck/` answers the IG-10 question directly. **The refusal wording comes from Django**, which knows which questionnaire and what state it is in — re-deriving that sentence in the agent is how the two drift.

## Hypothesis caught something on the way through

The count property test generated requests up to 25 while the fixture's unknowns plus the standing pool reach **23**, so it was failing on a request the code correctly reports as short. The bound is now **derived from the pool** rather than written as a number, so growing the pool cannot leave the test quietly asserting less than it could.

**518 passed**, `mypy --strict`, `black`, `flake8` and the weak-assertion check all clean. The card's named case — `test_draft_questionnaire_rejected_4403` — is in `tests/test_ws_handshake.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)