### PR TITLE
feat(frontend): the Onboarding Interface landing view (E-01)

### DIFF
--- a/ai-brand-automator-frontend/src/app/onboarding/page.tsx
+++ b/ai-brand-automator-frontend/src/app/onboarding/page.tsx
@@ -1,21 +1,27 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+/**
+ * /onboarding — the Onboarding Interface (E-01, FR-UI-01).
+ *
+ * This route used to be a redirect: editors to wizard step 1, viewers to
+ * /chat. FR-UI-01 changes that — "the onboarding icon opens the Onboarding
+ * Interface rather than wizard step 1, and the interface offers both the
+ * meeting-driven path and a direct link into the unchanged manual wizard".
+ *
+ * The wizard itself is untouched. /onboarding/step-1 through step-5 still
+ * render and still work with no session and no meeting, which is NFR-COMPAT
+ * and is asserted in __tests__/OnboardingHome.test.tsx rather than left to
+ * inspection.
+ *
+ * No role redirect either. A Viewer now lands here and sees a read-only
+ * variant (AC-3); previously they were bounced to /chat and could not reach
+ * onboarding at all.
+ */
+
 import { useAuth } from '@/hooks/useAuth';
-import { useTenantRole } from '@/hooks/useTenantRole';
-import { useEffect } from 'react';
+import OnboardingHome from '@/components/onboarding/OnboardingHome';
 
 export default function OnboardingPage() {
-  useAuth(); // Protect this route
-  const router = useRouter();
-  const { canEdit } = useTenantRole();
-  
-  useEffect(() => {
-    if (canEdit) {
-      router.push('/onboarding/step-1');
-    } else {
-      // Viewers cannot access onboarding
-      router.push('/chat');
-    }
-  }, [router, canEdit]);
+  useAuth();
+  return <OnboardingHome />;
 }

--- a/ai-brand-automator-frontend/src/components/common/Navigation.tsx
+++ b/ai-brand-automator-frontend/src/components/common/Navigation.tsx
@@ -126,9 +126,10 @@ export function Navigation({ children }: { children: React.ReactNode }) {
       ? [{ href: '/chat', label: 'AI Chat', icon: <MessageSquare className={iconCls} />, active: pathname === '/chat' }]
       : []),
     { href: '/dashboard', label: 'Dashboard', icon: <LayoutDashboard className={iconCls} />, active: pathname === '/dashboard' },
-    ...(canEdit
-      ? [{ href: '/onboarding', label: 'Onboarding', icon: <Compass className={iconCls} />, active: pathname?.startsWith('/onboarding') ?? false }]
-      : []),
+    // Not gated on canEdit. E-01 AC-3 gives a Viewer a real read-only
+    // Onboarding Interface, and a link they cannot see is an interface
+    // they cannot reach — the page itself decides what they may do.
+    { href: '/onboarding', label: 'Onboarding', icon: <Compass className={iconCls} />, active: pathname?.startsWith('/onboarding') ?? false },
     { href: '/files', label: 'Files', icon: <FolderOpen className={iconCls} />, active: pathname === '/files' },
     { href: '/automation', label: 'Automation', icon: <Zap className={iconCls} />, active: pathname === '/automation' },
     { href: '/dashboard/pipelines', label: 'Pipelines', icon: <GitBranch className={iconCls} />, active: pathname?.startsWith('/dashboard/pipelines') ?? false },

--- a/ai-brand-automator-frontend/src/components/onboarding/OnboardingHome.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/OnboardingHome.tsx
@@ -1,0 +1,259 @@
+'use client';
+
+/**
+ * OnboardingHome — the landing view at /onboarding (E-01, Design §11).
+ *
+ * Replaces a redirect. Until now `/onboarding` bounced editors to wizard step
+ * 1 and viewers to /chat, so there was no interface at all and a Viewer could
+ * not reach onboarding by any route.
+ *
+ * FR-UI-01: the icon opens this, and this *offers* the manual wizard rather
+ * than being it. NFR-COMPAT is the other half — the wizard routes are
+ * untouched and still work directly, which E-01 AC-2 requires be asserted by
+ * a test rather than by inspection.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import {
+  CalendarDays,
+  ClipboardList,
+  FileText,
+  MessageSquare,
+  Video,
+} from 'lucide-react';
+
+import { useTenantRole } from '@/hooks/useTenantRole';
+import {
+  listRecordings,
+  listSessions,
+  wizardDeepLink,
+  type MeetingRecordingSummary,
+  type OnboardingSessionSummary,
+  type SessionStatus,
+} from '@/lib/onboarding-sessions';
+
+/**
+ * §9.4's states, as chips. Colour carries the same information as the label
+ * rather than replacing it — a status a colourblind operator cannot read is
+ * not a status.
+ */
+const STATUS_STYLES: Record<SessionStatus, string> = {
+  DRAFT: 'bg-slate-700/60 text-brand-silver',
+  PREPARING: 'bg-amber-500/15 text-amber-300',
+  READY: 'bg-emerald-500/15 text-emerald-300',
+  MEETING_LIVE: 'bg-brand-electric/20 text-brand-electric',
+  PROCESSING: 'bg-sky-500/15 text-sky-300',
+  REVIEW: 'bg-violet-500/15 text-violet-300',
+  COMPLETE: 'bg-emerald-600/15 text-emerald-400',
+  ESCALATED: 'bg-rose-500/15 text-rose-300',
+  ARCHIVED: 'bg-slate-800/60 text-slate-400',
+};
+
+function StatusChip({ status }: { status: SessionStatus }) {
+  return (
+    <span
+      className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${
+        STATUS_STYLES[status] ?? STATUS_STYLES.DRAFT
+      }`}
+    >
+      {status.replace('_', ' ').toLowerCase()}
+    </span>
+  );
+}
+
+/**
+ * The calendar pane, before there is a calendar.
+ *
+ * §11 lists it and AC-1 expects it to render, but scheduling is D-01 — which
+ * this story *blocks*, so there is no data source yet and cannot be. A
+ * labelled placeholder is the honest shape: leaving the region out would make
+ * the page look finished when a quarter of it is not, and stubbing a fake
+ * calendar would be worse.
+ */
+function CalendarPane() {
+  return (
+    <section
+      aria-labelledby="onboarding-calendar-heading"
+      className="glass-card p-5"
+    >
+      <div className="flex items-center gap-2">
+        <CalendarDays className="h-4 w-4 text-brand-electric" aria-hidden />
+        <h2
+          id="onboarding-calendar-heading"
+          className="text-sm font-semibold text-white"
+        >
+          Schedule
+        </h2>
+      </div>
+      <p className="mt-3 text-sm text-brand-silver">
+        Booking and calendar sync arrive with the scheduling story. Sessions
+        you create here will appear on this pane once it does.
+      </p>
+    </section>
+  );
+}
+
+export default function OnboardingHome() {
+  const { canEdit } = useTenantRole();
+  const [sessions, setSessions] = useState<OnboardingSessionSummary[]>([]);
+  const [recordings, setRecordings] = useState<MeetingRecordingSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [nextSessions, nextRecordings] = await Promise.all([
+        listSessions(),
+        listRecordings(),
+      ]);
+      setSessions(nextSessions);
+      setRecordings(nextRecordings);
+    } catch (error) {
+      // Clear rather than keep stale rows: a list that silently stops
+      // updating is worse than an empty one, because it looks current.
+      setSessions([]);
+      setRecordings([]);
+      console.error('Failed to load onboarding sessions:', error);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold text-white">Onboarding</h1>
+          <p className="mt-1 text-sm text-brand-silver">
+            Prepare a meeting, run it, and let the answers fill the brand
+            profile — or go straight to the forms.
+          </p>
+        </div>
+
+        {/*
+          Absent for a Viewer, not disabled. AC-3 is explicit that a hidden
+          working endpoint behind a greyed-out button does not count, so the
+          affordances are not rendered at all.
+        */}
+        {canEdit && (
+          <div className="flex flex-wrap gap-2">
+            <Link href="/chat" className="btn-primary inline-flex items-center gap-2">
+              <MessageSquare className="h-4 w-4" aria-hidden />
+              Prepare in chat
+            </Link>
+            <Link
+              href={wizardDeepLink(sessions[0])}
+              className="inline-flex items-center gap-2 rounded-lg border border-white/10 px-4 py-2 text-sm text-brand-silver hover:bg-white/5"
+            >
+              <FileText className="h-4 w-4" aria-hidden />
+              Go to onboarding forms
+            </Link>
+          </div>
+        )}
+      </header>
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        <div className="lg:col-span-2 space-y-6">
+          <section aria-labelledby="onboarding-sessions-heading" className="glass-card p-5">
+            <div className="flex items-center gap-2">
+              <ClipboardList className="h-4 w-4 text-brand-electric" aria-hidden />
+              <h2
+                id="onboarding-sessions-heading"
+                className="text-sm font-semibold text-white"
+              >
+                Sessions
+              </h2>
+            </div>
+
+            {loading ? (
+              <p className="mt-3 text-sm text-brand-silver">Loading sessions…</p>
+            ) : sessions.length === 0 ? (
+              <div className="mt-3 space-y-3">
+                <p className="text-sm text-brand-silver">
+                  No onboarding sessions yet.
+                </p>
+                {canEdit && (
+                  <Link
+                    href="/chat"
+                    className="inline-flex items-center gap-2 text-sm text-brand-electric hover:underline"
+                  >
+                    <MessageSquare className="h-4 w-4" aria-hidden />
+                    Prepare your first meeting in chat
+                  </Link>
+                )}
+              </div>
+            ) : (
+              <ul className="mt-3 divide-y divide-white/5">
+                {sessions.map((session) => (
+                  <li
+                    key={session.id}
+                    className="flex items-center justify-between gap-3 py-3"
+                  >
+                    <div className="min-w-0">
+                      <p className="truncate text-sm text-white">
+                        {session.company ?? 'Unassigned company'}
+                      </p>
+                      <p className="text-xs text-brand-silver">
+                        Updated {new Date(session.updated_at).toLocaleString()}
+                      </p>
+                    </div>
+                    <div className="flex shrink-0 items-center gap-3">
+                      <StatusChip status={session.status} />
+                      {canEdit && (
+                        <Link
+                          href={`/onboarding/sessions/${session.id}`}
+                          className="text-sm text-brand-electric hover:underline"
+                        >
+                          Open
+                        </Link>
+                      )}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+
+          <section aria-labelledby="onboarding-recordings-heading" className="glass-card p-5">
+            <div className="flex items-center gap-2">
+              <Video className="h-4 w-4 text-brand-electric" aria-hidden />
+              <h2
+                id="onboarding-recordings-heading"
+                className="text-sm font-semibold text-white"
+              >
+                Recordings
+              </h2>
+            </div>
+            {loading ? (
+              <p className="mt-3 text-sm text-brand-silver">Loading recordings…</p>
+            ) : recordings.length === 0 ? (
+              <p className="mt-3 text-sm text-brand-silver">
+                Recordings appear here after a meeting.
+              </p>
+            ) : (
+              <ul className="mt-3 divide-y divide-white/5">
+                {recordings.map((recording) => (
+                  <li key={recording.id} className="flex items-center justify-between py-3">
+                    <span className="text-sm text-white">{recording.status}</span>
+                    <span className="text-xs text-brand-silver">
+                      {recording.duration_s
+                        ? `${Math.round(recording.duration_s / 60)} min`
+                        : '—'}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        </div>
+
+        <CalendarPane />
+      </div>
+    </div>
+  );
+}

--- a/ai-brand-automator-frontend/src/components/onboarding/OnboardingHome.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/OnboardingHome.tsx
@@ -95,7 +95,21 @@ function CalendarPane() {
 }
 
 export default function OnboardingHome() {
-  const { canEdit } = useTenantRole();
+  const { canEdit: canEditRole } = useTenantRole();
+  /**
+   * useTenantRole reads TenantContext, which is localStorage-backed, so the
+   * server render and the first client render disagree about the role and
+   * React reports a hydration mismatch. The project's own rule covers this —
+   * "Guard hydration for tenant-role-dependent UI" — and Navigation.tsx
+   * already does it. I wrote the role-gated markup without it.
+   *
+   * Treating an unmounted render as "cannot edit" is the safe direction: the
+   * affordances appear a beat late rather than flashing for a Viewer who
+   * should never see them.
+   */
+  const [hasMounted, setHasMounted] = useState(false);
+  useEffect(() => setHasMounted(true), []);
+  const canEdit = hasMounted && canEditRole;
   const [sessions, setSessions] = useState<OnboardingSessionSummary[]>([]);
   const [recordings, setRecordings] = useState<MeetingRecordingSummary[]>([]);
   const [loading, setLoading] = useState(true);

--- a/ai-brand-automator-frontend/src/components/onboarding/__tests__/OnboardingHome.test.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/__tests__/OnboardingHome.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * E-01 · the Onboarding Interface landing view.
+ *
+ * The card names `test_viewer_affordances_absent` here, and AC-3 is explicit
+ * about what "absent" means: "the buttons are absent, not merely disabled with
+ * a hidden working endpoint behind them". A test that only asserted a button
+ * was disabled would pass on exactly the implementation the AC rules out, so
+ * these assert absence by query and then assert the read-only page still shows
+ * the data a Viewer is entitled to.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+
+import OnboardingHome from '@/components/onboarding/OnboardingHome';
+import { listRecordings, listSessions } from '@/lib/onboarding-sessions';
+import { useTenantRole } from '@/hooks/useTenantRole';
+
+jest.mock('@/lib/onboarding-sessions', () => ({
+  ...jest.requireActual('@/lib/onboarding-sessions'),
+  listSessions: jest.fn(),
+  listRecordings: jest.fn(),
+}));
+jest.mock('@/hooks/useTenantRole');
+
+const mockedSessions = listSessions as jest.MockedFunction<typeof listSessions>;
+const mockedRecordings = listRecordings as jest.MockedFunction<typeof listRecordings>;
+const mockedRole = useTenantRole as jest.MockedFunction<typeof useTenantRole>;
+
+function asRole(role: 'admin' | 'editor' | 'viewer') {
+  mockedRole.mockReturnValue({
+    role,
+    isOwner: false,
+    isAdmin: role === 'admin',
+    canEdit: role === 'admin' || role === 'editor',
+    canManageTeam: role === 'admin',
+    canManageBilling: false,
+  } as ReturnType<typeof useTenantRole>);
+}
+
+const SESSION = {
+  id: 'sess-1',
+  company: 'company-1',
+  status: 'READY' as const,
+  questionnaire: 'q-1',
+  created_at: '2026-08-09T10:00:00Z',
+  updated_at: '2026-08-09T11:00:00Z',
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedSessions.mockResolvedValue([SESSION]);
+  mockedRecordings.mockResolvedValue([]);
+  asRole('admin');
+});
+
+describe('OnboardingHome', () => {
+  it('renders the landing composition', async () => {
+    render(<OnboardingHome />);
+
+    // AC-1: the calendar pane, the sessions list and clear entry points.
+    expect(await screen.findByRole('heading', { name: /schedule/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /sessions/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /prepare in chat/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /go to onboarding forms/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows a session with its §9.4 status chip', async () => {
+    render(<OnboardingHome />);
+
+    expect(await screen.findByText('company-1')).toBeInTheDocument();
+    expect(screen.getByText('ready')).toBeInTheDocument();
+  });
+
+  it('test_viewer_affordances_absent', async () => {
+    /**
+     * The card's named case. Absent, not disabled — AC-3 rules out a greyed
+     * button with a working endpoint behind it, so absence is asserted by
+     * query rather than by checking a `disabled` attribute.
+     */
+    asRole('viewer');
+    render(<OnboardingHome />);
+
+    await screen.findByRole('heading', { name: /sessions/i });
+
+    expect(screen.queryByRole('link', { name: /prepare in chat/i })).toBeNull();
+    expect(screen.queryByRole('link', { name: /go to onboarding forms/i })).toBeNull();
+    expect(screen.queryByRole('link', { name: /^open$/i })).toBeNull();
+  });
+
+  it('still shows a viewer the data they are entitled to', async () => {
+    /**
+     * The control. A page that rendered nothing for a Viewer would pass the
+     * test above while failing AC-3, which says they "see sessions and
+     * recordings".
+     */
+    asRole('viewer');
+    render(<OnboardingHome />);
+
+    expect(await screen.findByText('company-1')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /recordings/i })).toBeInTheDocument();
+  });
+
+  it('leads somewhere useful when there are no sessions', async () => {
+    mockedSessions.mockResolvedValue([]);
+    render(<OnboardingHome />);
+
+    expect(await screen.findByText(/no onboarding sessions yet/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /prepare your first meeting in chat/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('clears the list rather than keeping stale rows when loading fails', async () => {
+    mockedSessions.mockRejectedValue(new Error('network'));
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(<OnboardingHome />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/no onboarding sessions yet/i)).toBeInTheDocument(),
+    );
+    expect(screen.queryByText('company-1')).toBeNull();
+  });
+});

--- a/ai-brand-automator-frontend/src/lib/__tests__/onboarding-sessions.test.ts
+++ b/ai-brand-automator-frontend/src/lib/__tests__/onboarding-sessions.test.ts
@@ -1,0 +1,74 @@
+/**
+ * E-01 · NFR-COMPAT and the wizard deep link.
+ *
+ * The card puts NFR-COMPAT's assertion in `tests/e2e/test_process_to_review.py`
+ * "from this story onward". That file does not exist, and it is a Python e2e
+ * suite while this is a Next.js route — there is no browser-level e2e tooling
+ * in this repo to put it in. Rather than claim an e2e I cannot run, the
+ * guarantee is asserted here at the level the repo actually supports, and the
+ * gap is stated in the PR.
+ *
+ * What is checked: the wizard routes still exist as their own pages, and the
+ * deep link into page 1 carries what K-01 needs to send an operator back.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { wizardDeepLink } from '@/lib/onboarding-sessions';
+
+const APP = path.join(process.cwd(), 'src', 'app', 'onboarding');
+
+describe('NFR-COMPAT · the manual wizard survives', () => {
+  it.each(['step-1', 'step-2', 'step-3', 'step-4', 'step-5'])(
+    'keeps %s as its own route',
+    (step) => {
+      /**
+       * E-01 replaced /onboarding — previously a redirect into step 1 — with
+       * a landing view. The wizard pages are separate routes and must be
+       * untouched by that: AC-2 requires an existing bookmark to keep working
+       * "with no meeting required at any point".
+       */
+      expect(fs.existsSync(path.join(APP, step, 'page.tsx'))).toBe(true);
+    },
+  );
+
+  it('no longer redirects away from /onboarding', () => {
+    /**
+     * The behaviour E-01 changes, asserted so a future refactor cannot
+     * quietly restore it. The old page pushed editors to step-1 and viewers
+     * to /chat, which is why a Viewer could not reach onboarding at all.
+     */
+    const source = fs.readFileSync(path.join(APP, 'page.tsx'), 'utf8');
+
+    expect(source).not.toMatch(/router\.push/);
+    expect(source).toContain('OnboardingHome');
+  });
+});
+
+describe('wizardDeepLink', () => {
+  it('carries the company and session so K-01 can return the operator', () => {
+    const link = wizardDeepLink({ id: 'sess-1', company: 'company-1' });
+
+    expect(link).toContain('/onboarding/step-1?');
+    expect(link).toContain('companyId=company-1');
+    expect(link).toContain('sessionId=sess-1');
+  });
+
+  it('falls back to the bare wizard when there is no session', () => {
+    /**
+     * The manual path has to work for someone who has never held a meeting —
+     * that is the whole of NFR-COMPAT. A link that required a session id
+     * would break exactly that person.
+     */
+    expect(wizardDeepLink(null)).toBe('/onboarding/step-1');
+    expect(wizardDeepLink(undefined)).toBe('/onboarding/step-1');
+  });
+
+  it('omits the company when a session has none', () => {
+    const link = wizardDeepLink({ id: 'sess-2', company: null });
+
+    expect(link).toContain('sessionId=sess-2');
+    expect(link).not.toContain('companyId');
+  });
+});

--- a/ai-brand-automator-frontend/src/lib/__tests__/onboarding-sessions.test.ts
+++ b/ai-brand-automator-frontend/src/lib/__tests__/onboarding-sessions.test.ts
@@ -15,7 +15,25 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { wizardDeepLink } from '@/lib/onboarding-sessions';
+import { apiClient } from '@/lib/api';
+import {
+  listRecordings,
+  listSessions,
+  wizardDeepLink,
+} from '@/lib/onboarding-sessions';
+
+jest.mock('@/lib/api', () => ({ apiClient: { get: jest.fn() } }));
+
+const mockedGet = apiClient.get as jest.MockedFunction<typeof apiClient.get>;
+
+function responseOf(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
 
 const APP = path.join(process.cwd(), 'src', 'app', 'onboarding');
 
@@ -70,5 +88,53 @@ describe('wizardDeepLink', () => {
 
     expect(link).toContain('sessionId=sess-2');
     expect(link).not.toContain('companyId');
+  });
+});
+
+
+describe('the list clients actually read the response', () => {
+  /**
+   * These exist because review found two bugs that made every call return an
+   * empty list, and nothing caught them: the component tests mocked
+   * `listSessions` and `listRecordings` themselves, which is to say they
+   * mocked the two functions that contained the bugs.
+   *
+   * Mocking `apiClient` instead leaves the code under test in the path.
+   */
+  beforeEach(() => jest.clearAllMocks());
+
+  it('parses the body rather than returning the Response', async () => {
+    // apiClient.get resolves to a Response. Passing it straight to a parser
+    // that expects a body matched nothing and yielded [] on every call.
+    mockedGet.mockResolvedValue(responseOf([{ id: 'sess-1' }]));
+
+    await expect(listSessions()).resolves.toHaveLength(1);
+  });
+
+  it('unwraps a paginated body too', async () => {
+    mockedGet.mockResolvedValue(responseOf({ count: 1, results: [{ id: 'sess-1' }] }));
+
+    await expect(listSessions()).resolves.toHaveLength(1);
+  });
+
+  it('does not double-prefix the api version', async () => {
+    // env.getApiUrl already prepends /api/v1, so a full path produced
+    // /api/v1/api/v1/onboarding/... — a 404 that surfaced as an empty list.
+    mockedGet.mockResolvedValue(responseOf([]));
+
+    await listSessions();
+    await listRecordings();
+
+    for (const [path] of mockedGet.mock.calls) {
+      expect(path).not.toContain('/api/v1');
+      expect(path).toMatch(/^\/onboarding\//);
+    }
+  });
+
+  it('throws on a non-ok response instead of reporting no sessions', async () => {
+    // A 500 that returns [] is indistinguishable from a tenant with none.
+    mockedGet.mockResolvedValue(responseOf({ detail: 'boom' }, false, 500));
+
+    await expect(listSessions()).rejects.toThrow('API 500');
   });
 });

--- a/ai-brand-automator-frontend/src/lib/onboarding-sessions.ts
+++ b/ai-brand-automator-frontend/src/lib/onboarding-sessions.ts
@@ -45,11 +45,20 @@ export interface MeetingRecordingSummary {
 }
 
 /**
+ * Paths are relative to `/api/v1`, which `env.getApiUrl()` already prepends.
+ *
+ * Writing them in full produced `/api/v1/api/v1/onboarding/...` — every call
+ * 404ing while the UI showed an ordinary empty list. `workspace.ts` sets the
+ * same precedent with `const BASE = '/workspace'`.
+ */
+const BASE = '/onboarding';
+
+/**
  * A page of results, or a bare array.
  *
  * DRF returns `{count, results}` when pagination is on and a plain array when
- * it is not, and this project configures it per-view. Handling both here means
- * a pagination change in Django cannot turn a working list into an empty one
+ * it is not, and this project configures it per-view. Handling both means a
+ * pagination change in Django cannot turn a working list into an empty one
  * with no error.
  */
 function itemsOf<T>(body: unknown): T[] {
@@ -60,16 +69,29 @@ function itemsOf<T>(body: unknown): T[] {
   return [];
 }
 
+/**
+ * Read a list endpoint.
+ *
+ * `apiClient.get()` resolves to a `Response`, not to parsed JSON. Passing that
+ * object straight into `itemsOf` matched none of its branches and returned an
+ * empty array on every call, success or failure — the list looked empty rather
+ * than broken. Throwing on a non-ok status is the other half: a 500 that
+ * returns `[]` is indistinguishable from a tenant with no sessions.
+ */
+async function getList<T>(path: string): Promise<T[]> {
+  const response = await apiClient.get(path);
+  if (!response.ok) {
+    throw new Error(`API ${response.status}: ${await response.text()}`);
+  }
+  return itemsOf<T>(await response.json());
+}
+
 export async function listSessions(): Promise<OnboardingSessionSummary[]> {
-  return itemsOf<OnboardingSessionSummary>(
-    await apiClient.get('/api/v1/onboarding/sessions/'),
-  );
+  return getList<OnboardingSessionSummary>(`${BASE}/sessions/`);
 }
 
 export async function listRecordings(): Promise<MeetingRecordingSummary[]> {
-  return itemsOf<MeetingRecordingSummary>(
-    await apiClient.get('/api/v1/onboarding/recordings/'),
-  );
+  return getList<MeetingRecordingSummary>(`${BASE}/recordings/`);
 }
 
 /**

--- a/ai-brand-automator-frontend/src/lib/onboarding-sessions.ts
+++ b/ai-brand-automator-frontend/src/lib/onboarding-sessions.ts
@@ -1,0 +1,93 @@
+/**
+ * Onboarding session API helpers (E-01).
+ *
+ * Named `onboarding-sessions` rather than `onboarding` because the original
+ * `onboarding` app already owns companies, assets and wizard progress, and a
+ * second module with the same name would be a coin flip every time someone
+ * imports one. This wraps the `apps.onboarding` endpoints — Django label
+ * `onboarding_sessions`, mounted at /api/v1/onboarding/ — which are the
+ * meeting-driven half.
+ *
+ * Every call goes through apiClient, never raw fetch: it carries the JWT and
+ * refreshes it, and a bare fetch would silently 401 the moment a token turned
+ * over mid-session.
+ */
+
+import { apiClient } from '@/lib/api';
+
+/** §9.4's session states. */
+export type SessionStatus =
+  | 'DRAFT'
+  | 'PREPARING'
+  | 'READY'
+  | 'MEETING_LIVE'
+  | 'PROCESSING'
+  | 'REVIEW'
+  | 'COMPLETE'
+  | 'ESCALATED'
+  | 'ARCHIVED';
+
+export interface OnboardingSessionSummary {
+  id: string;
+  company: string | null;
+  status: SessionStatus;
+  questionnaire: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface MeetingRecordingSummary {
+  id: string;
+  session: string;
+  status: string;
+  duration_s: number | null;
+  created_at: string;
+}
+
+/**
+ * A page of results, or a bare array.
+ *
+ * DRF returns `{count, results}` when pagination is on and a plain array when
+ * it is not, and this project configures it per-view. Handling both here means
+ * a pagination change in Django cannot turn a working list into an empty one
+ * with no error.
+ */
+function itemsOf<T>(body: unknown): T[] {
+  if (Array.isArray(body)) return body as T[];
+  if (body && typeof body === 'object' && Array.isArray((body as { results?: unknown }).results)) {
+    return (body as { results: T[] }).results;
+  }
+  return [];
+}
+
+export async function listSessions(): Promise<OnboardingSessionSummary[]> {
+  return itemsOf<OnboardingSessionSummary>(
+    await apiClient.get('/api/v1/onboarding/sessions/'),
+  );
+}
+
+export async function listRecordings(): Promise<MeetingRecordingSummary[]> {
+  return itemsOf<MeetingRecordingSummary>(
+    await apiClient.get('/api/v1/onboarding/recordings/'),
+  );
+}
+
+/**
+ * The deep link into wizard page 1 for a session's company.
+ *
+ * Carries both ids because the technical note requires it: K-01's review
+ * links have to return the operator to where they were, and a wizard page
+ * that does not know which session sent it there cannot do that.
+ *
+ * Built here rather than inline so the query shape lives in one place — the
+ * wizard, the review links and any future caller have to agree on it.
+ */
+export function wizardDeepLink(
+  session?: Pick<OnboardingSessionSummary, 'id' | 'company'> | null,
+): string {
+  if (!session) return '/onboarding/step-1';
+  const params = new URLSearchParams();
+  if (session.company) params.set('companyId', session.company);
+  params.set('sessionId', session.id);
+  return `/onboarding/step-1?${params.toString()}`;
+}


### PR DESCRIPTION
**E-01**, built first because **C-05 depends on it** — `/onboarding` was still the five-step wizard, so C-05's "operator opens the Onboarding Interface" had no interface to open.

## Two findings shaped this

**A Viewer could not reach onboarding at all.** The route bounced them to `/chat` and the nav item was gated on `canEdit`, so AC-3's *"real read-only variant"* was unreachable by any path. Both changed.

AC-3 is explicit that *"the buttons are absent, not merely disabled with a hidden working endpoint behind them"*, so affordances aren't rendered rather than greyed out — and **the test asserts absence by query**, because a test checking a `disabled` attribute would pass on exactly the implementation the AC rules out. Verified: rendering them for everyone fails `test_viewer_affordances_absent`.

**There is no calendar and cannot be one.** D-01 is the scheduling story and E-01 *blocks* it. AC-1 lists a calendar pane, so it ships as a **labelled placeholder** naming where scheduling arrives. Leaving the region out would make the page look finished when a quarter of it isn't; stubbing a fake calendar would be worse.

## NFR-COMPAT

Asserted, not inspected: the wizard routes still exist as their own pages, `/onboarding` no longer redirects, and the deep link carries the company and session id K-01 needs to send an operator back.

The card puts this in `tests/e2e/test_process_to_review.py` "from this story onward". **That file doesn't exist**, and it's a Python e2e suite while this is a Next.js route — there's no browser-level e2e tooling in this repo. I asserted the guarantee at the level the repo supports and am flagging the gap rather than claiming an e2e I can't run.

## Naming

`onboarding-sessions.ts`, not `onboarding.ts` — the original `onboarding` app already owns companies, assets and wizard progress, and two modules with that name would be a coin flip on every import. It also tolerates both DRF list shapes, so turning pagination on in Django can't quietly empty the list.

## ⚠️ Pre-existing frontend breakage

**15 new tests pass**, `tsc --noEmit` clean.

The full suite is **112 failed / 106 passed**. Measured against the same baseline with these changes stashed: **112 failed / 91 passed** — so every one of those failures already exists on `development_main` and this PR adds 15 passes and breaks nothing.

Most look like missing providers in the test harness, e.g. `useBrandContext must be used within a BrandContextProvider`. Not this story's to fix, but worth someone's — it means the frontend job gives no signal today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)