### PR TITLE
feat(frontend): show approved questions in the Onboarding Interface (C-05)

### DIFF
--- a/ai-brand-automator-frontend/src/app/onboarding/sessions/[sessionId]/page.tsx
+++ b/ai-brand-automator-frontend/src/app/onboarding/sessions/[sessionId]/page.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+/**
+ * /onboarding/sessions/[sessionId] — one session, with its approved questions.
+ *
+ * This route is also the fix for a dangling link: E-01 rendered an "Open"
+ * action pointing here before the page existed, so it 404'd from the moment
+ * that PR merged. C-05 needs the page anyway — it is where QuestionChecklist
+ * lives — but the link should not have shipped ahead of it.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
+
+import { useAuth } from '@/hooks/useAuth';
+import QuestionChecklist from '@/components/onboarding/QuestionChecklist';
+import {
+  getApprovedQuestionnaire,
+  type QuestionnaireDetail,
+} from '@/lib/onboarding-sessions';
+
+export default function SessionPage() {
+  useAuth();
+  const params = useParams<{ sessionId: string }>();
+  const sessionId = params?.sessionId;
+
+  const [questionnaire, setQuestionnaire] = useState<QuestionnaireDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    if (!sessionId) return;
+    setLoading(true);
+    try {
+      setQuestionnaire(await getApprovedQuestionnaire(sessionId));
+    } catch (error) {
+      // Cleared, not left stale. AC-3 wants a re-approved version to replace
+      // what is on screen; showing the previous set after a failed refresh
+      // would be the same defect with a slower fuse.
+      setQuestionnaire(null);
+      console.error('Failed to load the approved questionnaire:', error);
+    } finally {
+      setLoading(false);
+    }
+  }, [sessionId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return (
+    <div className="space-y-6">
+      <Link
+        href="/onboarding"
+        className="inline-flex items-center gap-2 text-sm text-brand-silver hover:text-white"
+      >
+        <ArrowLeft className="h-4 w-4" aria-hidden />
+        Onboarding
+      </Link>
+
+      <h1 className="text-2xl font-semibold text-white">Session</h1>
+
+      {loading ? (
+        <p className="text-sm text-brand-silver">Loading questions…</p>
+      ) : (
+        <QuestionChecklist
+          questions={questionnaire?.questions ?? []}
+          version={questionnaire?.version ?? null}
+        />
+      )}
+    </div>
+  );
+}

--- a/ai-brand-automator-frontend/src/app/onboarding/sessions/[sessionId]/page.tsx
+++ b/ai-brand-automator-frontend/src/app/onboarding/sessions/[sessionId]/page.tsx
@@ -30,7 +30,15 @@ export default function SessionPage() {
   const [loading, setLoading] = useState(true);
 
   const load = useCallback(async () => {
-    if (!sessionId) return;
+    if (!sessionId) {
+      // Not `return` on its own: that leaves loading true forever, so a
+      // moment without params — or a mis-mounted route — shows "Loading
+      // questions…" and never anything else. The empty state is the honest
+      // answer when there is no session to load.
+      setQuestionnaire(null);
+      setLoading(false);
+      return;
+    }
     setLoading(true);
     try {
       setQuestionnaire(await getApprovedQuestionnaire(sessionId));

--- a/ai-brand-automator-frontend/src/components/onboarding/QuestionChecklist.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/QuestionChecklist.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+/**
+ * QuestionChecklist — the approved questions, ready for the meeting (C-05).
+ *
+ * Design §11 places this inside MeetingView, where G-03 will tick boxes from
+ * the agent's sufficiency signals. C-05 renders the same component in the
+ * Onboarding Interface so the operator sees the set before the meeting starts.
+ * One component, two homes — which is why the card is firm that checkbox state
+ * stays server-authoritative: "a component built around local state has to be
+ * rewritten" once the signals arrive.
+ *
+ * So there is no local state here at all. A question is ticked because the
+ * server says GREEN, and nothing in this component can change that. The toggle
+ * belongs to G-03, along with the endpoint to record an operator's override —
+ * which §11 notes is "a training signal, not just UI state" and therefore
+ * cannot be a checkbox that only the browser knows about.
+ *
+ * That also settles AC-3 by construction: re-approval replaces the rendered
+ * set wholesale, so there is no per-question client state for a question that
+ * no longer exists to survive in.
+ */
+
+import Link from 'next/link';
+import { MessageSquare } from 'lucide-react';
+
+import type { PreparedQuestion, WorkflowTarget } from '@/lib/onboarding-sessions';
+
+/**
+ * Quiet on purpose. The card: workflow tags "matter to the operator's sense of
+ * coverage but they must not compete with the question text during a live
+ * conversation." So they are small, low-contrast, and not part of the row's
+ * accessible name.
+ */
+const TAG_STYLES: Record<WorkflowTarget, string> = {
+  WF1: 'text-sky-300/70',
+  WF2: 'text-violet-300/70',
+  WF3: 'text-amber-300/70',
+};
+
+const TAG_LABELS: Record<WorkflowTarget, string> = {
+  WF1: 'discovery',
+  WF2: 'strategy',
+  WF3: 'campaigns',
+};
+
+export interface QuestionChecklistProps {
+  questions: PreparedQuestion[];
+  /** Null when the session has no approved questionnaire yet (AC-2). */
+  version?: number | null;
+}
+
+export default function QuestionChecklist({
+  questions,
+  version,
+}: QuestionChecklistProps) {
+  if (questions.length === 0) {
+    return (
+      <section aria-labelledby="checklist-heading" className="glass-card p-5">
+        <h2 id="checklist-heading" className="text-sm font-semibold text-white">
+          Prepared questions
+        </h2>
+        {/*
+          AC-2: "an empty state linking directly into the chat prep flow,
+          rather than an empty box". A dead end here is an operator who has to
+          work out on their own where preparation happens.
+        */}
+        <p className="mt-3 text-sm text-brand-silver">
+          No approved questionnaire for this session yet. Questions you prepare
+          and approve in chat appear here, ready for the meeting.
+        </p>
+        <Link
+          href="/chat"
+          className="mt-3 inline-flex items-center gap-2 text-sm text-brand-electric hover:underline"
+        >
+          <MessageSquare className="h-4 w-4" aria-hidden />
+          Prepare questions in chat
+        </Link>
+      </section>
+    );
+  }
+
+  return (
+    <section aria-labelledby="checklist-heading" className="glass-card p-5">
+      <div className="flex items-baseline justify-between gap-3">
+        <h2 id="checklist-heading" className="text-sm font-semibold text-white">
+          Prepared questions
+        </h2>
+        {version != null && (
+          <span className="text-xs text-brand-silver">version {version}</span>
+        )}
+      </div>
+
+      <ol className="mt-3 space-y-2">
+        {/*
+          Rendered in the order the server sent, which C-04 renumbers to be
+          contiguous after every edit. Sorting here would let the component and
+          the approved record disagree about what "question 4" means, and the
+          operator says that number out loud.
+        */}
+        {questions.map((question, index) => (
+          <li key={question.id} className="flex items-start gap-3">
+            <input
+              type="checkbox"
+              readOnly
+              checked={question.status === 'GREEN'}
+              aria-label={question.text}
+              className="mt-1 h-4 w-4 shrink-0 rounded border-white/20 bg-transparent"
+            />
+            <div className="min-w-0">
+              <p className="text-sm text-white">
+                <span className="mr-2 text-brand-silver">{index + 1}.</span>
+                {question.text}
+              </p>
+              <span
+                className={`text-xs ${TAG_STYLES[question.workflow_target]}`}
+                // Not part of the accessible name: a screen reader announcing
+                // "campaigns" before every question would be the audible
+                // version of a tag competing with the text.
+                aria-hidden
+              >
+                {TAG_LABELS[question.workflow_target]}
+              </span>
+            </div>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/ai-brand-automator-frontend/src/components/onboarding/QuestionChecklist.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/QuestionChecklist.tsx
@@ -103,6 +103,28 @@ export default function QuestionChecklist({
             <input
               type="checkbox"
               readOnly
+              /*
+               * Review was right that HTML ignores `readonly` on a checkbox,
+               * and wrong about the remedy — and I checked before believing
+               * either. A *controlled* checkbox is held by React: with
+               * `checked` bound to server state and no onChange, React
+               * restores the DOM after a click and the box does not move.
+               * `readOnly` is there to suppress React's warning about
+               * exactly that arrangement.
+               *
+               * Adding onClick={preventDefault} — the suggested fix — broke
+               * it. Preventing the default interferes with React's own
+               * restoration, and the box then really did toggle. The test
+               * that clicks it caught that immediately, which is the whole
+               * reason it clicks instead of reading an attribute.
+               *
+               * aria-disabled stays: the semantics were the sound half of the
+               * finding. It says "this reflects a value, do not try to change
+               * it" without `disabled` dropping the box out of the tab order
+               * or announcing "unavailable" — G-03 makes these interactive
+               * and the element should not change shape for that.
+               */
+              aria-disabled
               checked={question.status === 'GREEN'}
               aria-label={question.text}
               className="mt-1 h-4 w-4 shrink-0 rounded border-white/20 bg-transparent"

--- a/ai-brand-automator-frontend/src/components/onboarding/__tests__/QuestionChecklist.test.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/__tests__/QuestionChecklist.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * C-05 · the prepared-question checklist.
+ *
+ * The card names two cases here — `test_renders_approved_set` and
+ * `test_empty_state_links_to_prep`.
+ */
+
+import { render, screen, within } from '@testing-library/react';
+
+import QuestionChecklist from '@/components/onboarding/QuestionChecklist';
+import type { PreparedQuestion } from '@/lib/onboarding-sessions';
+
+function question(overrides: Partial<PreparedQuestion> = {}): PreparedQuestion {
+  return {
+    id: 'q-1',
+    order: 0,
+    text: 'What do you sell?',
+    origin: 'PREPARED',
+    workflow_target: 'WF1',
+    target_field: '',
+    status: 'OPEN',
+    ...overrides,
+  };
+}
+
+const APPROVED_SET: PreparedQuestion[] = [
+  question({ id: 'q-1', order: 0, text: 'What do you sell?', workflow_target: 'WF1' }),
+  question({
+    id: 'q-2',
+    order: 1,
+    text: 'What makes you different?',
+    workflow_target: 'WF2',
+  }),
+  question({
+    id: 'q-3',
+    order: 2,
+    text: 'Do you have previous ads we could reuse?',
+    workflow_target: 'WF3',
+  }),
+];
+
+describe('QuestionChecklist', () => {
+  it('test_renders_approved_set', () => {
+    /** The card's named case: order and tags correct. */
+    render(<QuestionChecklist questions={APPROVED_SET} version={2} />);
+
+    const items = screen.getAllByRole('listitem');
+    expect(items).toHaveLength(3);
+
+    // In the server's order, not sorted here. The operator says "question 4"
+    // out loud, and the component and the approved record have to agree.
+    expect(items[0]).toHaveTextContent('What do you sell?');
+    expect(items[2]).toHaveTextContent('Do you have previous ads we could reuse?');
+
+    expect(items[0]).toHaveTextContent('discovery');
+    expect(items[1]).toHaveTextContent('strategy');
+    expect(items[2]).toHaveTextContent('campaigns');
+
+    expect(screen.getByText('version 2')).toBeInTheDocument();
+  });
+
+  it('renders every box unchecked when nothing has been answered', () => {
+    render(<QuestionChecklist questions={APPROVED_SET} />);
+
+    for (const box of screen.getAllByRole('checkbox')) {
+      expect(box).not.toBeChecked();
+    }
+  });
+
+  it('ticks a box because the server says GREEN, not because of a click', () => {
+    /**
+     * Checkbox state is server-authoritative — G-03 drives it from sufficiency
+     * signals, and the card warns that a component built around local state
+     * has to be rewritten. Rendering from `status` is what makes that true.
+     */
+    render(
+      <QuestionChecklist
+        questions={[question({ id: 'q-1', status: 'GREEN' }), question({ id: 'q-2' })]}
+      />,
+    );
+
+    const [first, second] = screen.getAllByRole('checkbox');
+    expect(first).toBeChecked();
+    expect(second).not.toBeChecked();
+  });
+
+  it('does not let the operator toggle a box', () => {
+    /**
+     * The control for the test above. A writable checkbox would look correct
+     * on first render and then drift from the server the moment anyone
+     * clicked it — the exact rewrite the card is trying to prevent.
+     */
+    render(<QuestionChecklist questions={[question()]} />);
+
+    expect(screen.getByRole('checkbox')).toHaveAttribute('readonly');
+  });
+
+  it('keeps the workflow tag out of the row’s accessible name', () => {
+    /**
+     * "Visually quiet" has an audible counterpart: a screen reader announcing
+     * "campaigns" before every question would be a tag competing with the
+     * text, which is what the card rules out.
+     */
+    render(<QuestionChecklist questions={[question({ workflow_target: 'WF3' })]} />);
+
+    expect(screen.getByRole('checkbox')).toHaveAccessibleName('What do you sell?');
+    const item = screen.getByRole('listitem');
+    expect(within(item).getByText('campaigns')).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('test_empty_state_links_to_prep', () => {
+    /** The card's named case: the dead end is not a dead end. */
+    render(<QuestionChecklist questions={[]} />);
+
+    expect(screen.getByText(/no approved questionnaire/i)).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: /prepare questions in chat/i });
+    expect(link).toHaveAttribute('href', '/chat');
+  });
+
+  it('shows no version and no checkboxes when the set is empty', () => {
+    render(<QuestionChecklist questions={[]} version={3} />);
+
+    expect(screen.queryByRole('checkbox')).toBeNull();
+    expect(screen.queryByText(/version/i)).toBeNull();
+  });
+
+  it('replaces the whole set when a new version is rendered', () => {
+    /**
+     * AC-3, satisfied by construction. There is no per-question client state,
+     * so a question that no longer exists cannot leave anything behind — this
+     * asserts the property rather than trusting the absence.
+     */
+    const { rerender } = render(
+      <QuestionChecklist questions={APPROVED_SET} version={1} />,
+    );
+    expect(screen.getAllByRole('listitem')).toHaveLength(3);
+
+    rerender(
+      <QuestionChecklist
+        questions={[question({ id: 'q-9', text: 'Only question in v2?' })]}
+        version={2}
+      />,
+    );
+
+    const items = screen.getAllByRole('listitem');
+    expect(items).toHaveLength(1);
+    expect(items[0]).toHaveTextContent('Only question in v2?');
+    expect(screen.queryByText('What do you sell?')).toBeNull();
+    expect(screen.getByText('version 2')).toBeInTheDocument();
+  });
+});

--- a/ai-brand-automator-frontend/src/components/onboarding/__tests__/QuestionChecklist.test.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/__tests__/QuestionChecklist.test.tsx
@@ -5,7 +5,7 @@
  * `test_empty_state_links_to_prep`.
  */
 
-import { render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 
 import QuestionChecklist from '@/components/onboarding/QuestionChecklist';
 import type { PreparedQuestion } from '@/lib/onboarding-sessions';
@@ -89,10 +89,34 @@ describe('QuestionChecklist', () => {
      * The control for the test above. A writable checkbox would look correct
      * on first render and then drift from the server the moment anyone
      * clicked it — the exact rewrite the card is trying to prevent.
+     *
+     * This asserted `toHaveAttribute('readonly')`, which review pointed out
+     * proves nothing: HTML does not honour readonly on a checkbox at all. The
+     * assertion passed while the guarantee did not hold. Clicking it is the
+     * only assertion that means anything.
+     *
+     * Honest limit: jsdom does not reproduce the transient flip a real
+     * browser shows before React re-renders, so this proves the state is
+     * stable, not that no pixel ever changes.
      */
-    render(<QuestionChecklist questions={[question()]} />);
+    render(<QuestionChecklist questions={[question({ status: 'OPEN' })]} />);
+    const box = screen.getByRole('checkbox');
 
-    expect(screen.getByRole('checkbox')).toHaveAttribute('readonly');
+    fireEvent.click(box);
+    fireEvent.keyDown(box, { key: ' ' });
+
+    expect(box).not.toBeChecked();
+    expect(box).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('stays checked when a GREEN box is clicked', () => {
+    /** The other direction — an operator cannot untick the agent either. */
+    render(<QuestionChecklist questions={[question({ status: 'GREEN' })]} />);
+    const box = screen.getByRole('checkbox');
+
+    fireEvent.click(box);
+
+    expect(box).toBeChecked();
   });
 
   it('keeps the workflow tag out of the row’s accessible name', () => {

--- a/ai-brand-automator-frontend/src/lib/__tests__/onboarding-sessions.test.ts
+++ b/ai-brand-automator-frontend/src/lib/__tests__/onboarding-sessions.test.ts
@@ -17,6 +17,7 @@ import path from 'node:path';
 
 import { apiClient } from '@/lib/api';
 import {
+  getApprovedQuestionnaire,
   listRecordings,
   listSessions,
   wizardDeepLink,
@@ -136,5 +137,57 @@ describe('the list clients actually read the response', () => {
     mockedGet.mockResolvedValue(responseOf({ detail: 'boom' }, false, 500));
 
     await expect(listSessions()).rejects.toThrow('API 500');
+  });
+});
+
+
+describe('getApprovedQuestionnaire', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('asks the server for one session\'s approved set', () => {
+    /**
+     * Filtered server-side. Fetching everything and picking in the browser is
+     * correct only until the list paginates, and then it silently shows
+     * nothing — a failure indistinguishable from "not approved yet".
+     */
+    mockedGet.mockResolvedValue(responseOf([]));
+
+    return getApprovedQuestionnaire('sess-1').then(() => {
+      const [path] = mockedGet.mock.calls[0];
+      expect(path).toContain('session=sess-1');
+      expect(path).toContain('status=APPROVED');
+    });
+  });
+
+  it('returns the newest version when a session has been re-approved', async () => {
+    // C-04 AC-3 supersedes rather than replacing, so more than one approved
+    // row can exist over a session's life. The operator means the last one.
+    mockedGet.mockResolvedValue(
+      responseOf([
+        { id: 'q-v1', version: 1, questions: [] },
+        { id: 'q-v3', version: 3, questions: [] },
+        { id: 'q-v2', version: 2, questions: [] },
+      ]),
+    );
+
+    await expect(getApprovedQuestionnaire('sess-1')).resolves.toMatchObject({
+      id: 'q-v3',
+    });
+  });
+
+  it('returns null when nothing is approved, rather than throwing', async () => {
+    // An unapproved session is an ordinary state with its own empty view
+    // (AC-2), not an error.
+    mockedGet.mockResolvedValue(responseOf([]));
+
+    await expect(getApprovedQuestionnaire('sess-1')).resolves.toBeNull();
+  });
+
+  it('escapes the session id', async () => {
+    mockedGet.mockResolvedValue(responseOf([]));
+
+    await getApprovedQuestionnaire('a b&c');
+
+    expect(mockedGet.mock.calls[0][0]).toContain('session=a%20b%26c');
   });
 });

--- a/ai-brand-automator-frontend/src/lib/onboarding-sessions.ts
+++ b/ai-brand-automator-frontend/src/lib/onboarding-sessions.ts
@@ -36,6 +36,36 @@ export interface OnboardingSessionSummary {
   updated_at: string;
 }
 
+/** §9.4's three workflows, as tagged on a question. */
+export type WorkflowTarget = 'WF1' | 'WF2' | 'WF3';
+
+export interface PreparedQuestion {
+  id: string;
+  order: number;
+  text: string;
+  origin: string;
+  workflow_target: WorkflowTarget;
+  target_field: string;
+  /**
+   * Server-authoritative checkbox state. OPEN is unchecked, GREEN is ticked.
+   *
+   * The C-05 card is explicit that this must not become client state: G-03
+   * drives it from the agent's sufficiency signals during the meeting, and
+   * "a component built around local state has to be rewritten".
+   */
+  status: 'OPEN' | 'GREEN' | 'SKIPPED';
+}
+
+export interface QuestionnaireDetail {
+  id: string;
+  session: string | null;
+  status: 'DRAFT' | 'APPROVED' | 'SUPERSEDED';
+  version: number;
+  question_count: number;
+  questions: PreparedQuestion[];
+  coverage: Record<WorkflowTarget, number>;
+}
+
 export interface MeetingRecordingSummary {
   id: string;
   session: string;
@@ -112,4 +142,26 @@ export function wizardDeepLink(
   if (session.company) params.set('companyId', session.company);
   params.set('sessionId', session.id);
   return `/onboarding/step-1?${params.toString()}`;
+}
+
+/**
+ * The approved questionnaire for a session, or null.
+ *
+ * Filtered server-side. Fetching every questionnaire and picking one in the
+ * browser is correct only until the list paginates, and then it silently
+ * shows nothing — the failure looks identical to "not approved yet".
+ *
+ * Null rather than throwing when there is none: an unapproved session is an
+ * ordinary state with its own empty view (AC-2), not an error.
+ */
+export async function getApprovedQuestionnaire(
+  sessionId: string,
+): Promise<QuestionnaireDetail | null> {
+  const rows = await getList<QuestionnaireDetail>(
+    `${BASE}/questionnaires/?session=${encodeURIComponent(sessionId)}&status=APPROVED`,
+  );
+  // Highest version wins. Re-approval supersedes rather than replacing
+  // (C-04 AC-3), so more than one approved row can exist over a session's
+  // life and the newest is the one the operator just approved.
+  return rows.sort((a, b) => b.version - a.version)[0] ?? null;
 }

--- a/ai-brand-automator/apps/onboarding/tests/test_questionnaire.py
+++ b/ai-brand-automator/apps/onboarding/tests/test_questionnaire.py
@@ -894,3 +894,51 @@ def test_a_template_cannot_be_cloned_onto_another_tenants_company(
 
     assert response.status_code == 400
     assert not Questionnaire.objects.filter(company=theirs).exists()
+
+
+# ── C-05 · the Interface asks for one session's approved set ─────────
+
+
+def test_questionnaires_can_be_filtered_by_session(api_client, tenant, admin):
+    """Server-side, because the client filtering a paginated list is correct
+    only until page 2 and then silently shows nothing."""
+    from apps.onboarding.models import OnboardingSession
+
+    company = Company.objects.create(tenant=tenant, name="Kalyani")
+    session = OnboardingSession.objects.create(tenant=tenant, company=company)
+    mine = a_draft(api_client, tenant)
+    Questionnaire.objects.filter(pk=mine).update(session=session)
+    a_draft(api_client, tenant)  # a second, unattached
+
+    body = api_client.get(
+        f"/api/v1/onboarding/questionnaires/?session={session.pk}"
+    ).json()
+
+    rows = body["results"] if isinstance(body, dict) else body
+    assert [r["id"] for r in rows] == [mine]
+
+
+def test_questionnaires_can_be_filtered_by_status(api_client, tenant, admin):
+    approved_id = a_draft(api_client, tenant)
+    api_client.post(
+        f"/api/v1/onboarding/questionnaires/{approved_id}/approve/", format="json"
+    )
+    a_draft(api_client, tenant)  # stays DRAFT
+
+    body = api_client.get("/api/v1/onboarding/questionnaires/?status=approved").json()
+
+    rows = body["results"] if isinstance(body, dict) else body
+    assert [r["id"] for r in rows] == [approved_id]
+
+
+def test_a_malformed_session_filter_returns_nothing_not_a_500(
+    api_client, tenant, admin
+):
+    """The session pk is a bigint; a non-numeric filter would otherwise raise
+    out of the queryset on a plain GET."""
+    response = api_client.get("/api/v1/onboarding/questionnaires/?session=not-a-number")
+
+    assert response.status_code == 200
+    body = response.json()
+    rows = body["results"] if isinstance(body, dict) else body
+    assert rows == []

--- a/ai-brand-automator/apps/onboarding/views.py
+++ b/ai-brand-automator/apps/onboarding/views.py
@@ -870,11 +870,28 @@ class QuestionnaireViewSet(
         tenant = getattr(self.request, "tenant", None)
         # Prefetch the children: the serializer nests them, and without this
         # a list of N questionnaires is N+1 queries.
-        return (
+        queryset = (
             Questionnaire.objects.select_related("company", "session")
             .prefetch_related("questions")
             .filter(tenant_scope_q(tenant))
         )
+
+        # Filtered server-side (C-05). The Onboarding Interface wants "the
+        # approved questionnaire for this session"; without these the client
+        # would fetch the list and filter it, which is correct only until the
+        # list is long enough to paginate and then silently shows nothing.
+        session = self.request.query_params.get("session")
+        if session:
+            try:
+                queryset = queryset.filter(session_id=session)
+            except (ValueError, TypeError):
+                queryset = queryset.none()
+
+        status = self.request.query_params.get("status")
+        if status:
+            queryset = queryset.filter(status=status.upper())
+
+        return queryset
 
     # ── AC-1 · refinement, per question and per set ──────────────────
 


### PR DESCRIPTION
`QuestionChecklist` renders a session's approved set; `/onboarding/sessions/[sessionId]` hosts it.

## That page is also a fix

**E-01 shipped an "Open" link pointing at this route before it existed**, so it 404'd from the moment #564 merged. My defect. C-05 needed the page anyway, but the link should not have gone out ahead of it.

## No local checkbox state, at all

The card is firm: state stays server-authoritative because G-03 drives ticks from the agent's sufficiency signals, and *"a component built around local state has to be rewritten"*.

So a box is checked because the server says `GREEN`, the input is `readOnly`, and there is **no toggle**. §11 notes an operator's override is *"a training signal, not just UI state"* — it needs an endpoint that doesn't exist yet, not a click the browser keeps to itself.

**This settles AC-3 by construction.** Re-approval replaces the rendered set wholesale, so there's no per-question client state for a vanished question to survive in. Asserted rather than assumed: a rerender with a new version drops the old rows entirely.

## Quiet tags, in both senses

Small and low-contrast, and `aria-hidden` — otherwise a screen reader announces "campaigns" before every question, which is the audible form of the tag competing with the text the card rules out. The checkbox's accessible name is the question.

## Server-side filtering

`?session=` and `?status=` on the questionnaire list. Fetching everything and picking in the browser is correct only until the list paginates, and then it **silently shows nothing** — a failure indistinguishable from "not approved yet".

The session filter is guarded because the pk is a bigint and a non-numeric value raises out of the queryset on a plain GET. Verified load-bearing: removing the guard fails that test.

`getApprovedQuestionnaire` returns the **highest version**, because C-04 supersedes rather than replaces and a session accumulates approved rows over its life.

## Tests

Both cases the card names — `test_renders_approved_set`, `test_empty_state_links_to_prep` — plus tag-quietness, the readOnly control, and version replacement. Client tests mock `apiClient`, **not** the module under test; that was the lesson from #564, where mocking the module hid two bugs that made every call return an empty list.

**31 frontend tests pass**, `tsc` clean, 3 new Django tests for the filters.

Note the frontend CI job still cannot fail (#565), so its green tells you nothing here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)