### PR TITLE
feat(frontend): the in-app calendar pane (D-01, PR 2)

### DIFF
--- a/ai-brand-automator-frontend/src/components/onboarding/CalendarPane.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/CalendarPane.tsx
@@ -1,0 +1,357 @@
+'use client';
+
+/**
+ * CalendarPane — onboarding meetings, month or week (D-01, Design §11).
+ *
+ * Replaces the placeholder E-01 left. Deliberately not a general-purpose
+ * calendar: the card warns that "scope creep here is unbounded", so this shows
+ * onboarding meetings, in two views, and nothing else. No library, for the
+ * same reason — a calendar package brings its own 90% and an invitation to
+ * use it.
+ *
+ * Everything renders in the *viewer's* zone. The server stores a UTC instant
+ * plus the IANA zone it was booked in; this formats the instant locally and
+ * shows the booking zone alongside when they differ, because "09:00 in
+ * Europe/London" is what the operator agreed with the brand owner and a
+ * colleague in Sydney needs both halves.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { CalendarDays, ChevronLeft, ChevronRight } from 'lucide-react';
+
+import { useTenantRole } from '@/hooks/useTenantRole';
+import {
+  cancelMeeting,
+  createMeeting,
+  listMeetings,
+  listSessions,
+  viewerTimezone,
+  type OnboardingSessionSummary,
+  type ScheduledMeeting,
+} from '@/lib/onboarding-sessions';
+
+type View = 'month' | 'week';
+
+function startOfDay(date: Date): Date {
+  const copy = new Date(date);
+  copy.setHours(0, 0, 0, 0);
+  return copy;
+}
+
+/** Monday-first, which is what the rest of the product assumes. */
+function startOfWeek(date: Date): Date {
+  const copy = startOfDay(date);
+  const weekday = (copy.getDay() + 6) % 7;
+  copy.setDate(copy.getDate() - weekday);
+  return copy;
+}
+
+function startOfMonthGrid(date: Date): Date {
+  return startOfWeek(new Date(date.getFullYear(), date.getMonth(), 1));
+}
+
+function addDays(date: Date, days: number): Date {
+  const copy = new Date(date);
+  copy.setDate(copy.getDate() + days);
+  return copy;
+}
+
+/**
+ * The window a view covers.
+ *
+ * Computed in local time and sent as UTC instants, which is the only
+ * conversion in this component — the server does the filtering, so a week
+ * boundary that lands mid-afternoon UTC still selects the right meetings.
+ */
+function windowFor(view: View, anchor: Date): { from: Date; to: Date; days: Date[] } {
+  const from = view === 'month' ? startOfMonthGrid(anchor) : startOfWeek(anchor);
+  const length = view === 'month' ? 42 : 7;
+  const days = Array.from({ length }, (_, index) => addDays(from, index));
+  return { from, to: addDays(from, length), days };
+}
+
+function sameDay(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+export interface CalendarPaneProps {
+  /** Fixed "today" for tests; the component is otherwise clock-dependent. */
+  now?: Date;
+}
+
+export default function CalendarPane({ now }: CalendarPaneProps) {
+  const { canEdit: canEditRole } = useTenantRole();
+  // Hydration guard, per the project rule and E-01's review: useTenantRole
+  // reads a localStorage-backed context, so the server and first client
+  // renders otherwise disagree.
+  const [hasMounted, setHasMounted] = useState(false);
+  useEffect(() => setHasMounted(true), []);
+  const canEdit = hasMounted && canEditRole;
+
+  const today = useMemo(() => now ?? new Date(), [now]);
+  const [view, setView] = useState<View>('month');
+  const [anchor, setAnchor] = useState<Date>(() => startOfDay(now ?? new Date()));
+  const [meetings, setMeetings] = useState<ScheduledMeeting[]>([]);
+  const [sessions, setSessions] = useState<OnboardingSessionSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const { from, to, days } = useMemo(() => windowFor(view, anchor), [view, anchor]);
+  const zone = useMemo(() => viewerTimezone(), []);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      setMeetings(await listMeetings(from, to));
+    } catch (error) {
+      // Cleared, not stale: a calendar showing last month's meetings as if
+      // they were this month's is worse than one showing none.
+      setMeetings([]);
+      console.error('Failed to load meetings:', error);
+    } finally {
+      setLoading(false);
+    }
+  }, [from, to]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    // A meeting belongs to a session, so the form needs the list. Loaded once
+    // rather than per window change — the sessions do not move when the
+    // operator pages to next month.
+    listSessions()
+      .then(setSessions)
+      .catch((problem) => console.error('Failed to load sessions:', problem));
+  }, []);
+
+  async function onSchedule(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const form = new FormData(event.currentTarget);
+    const starts = String(form.get('starts') || '');
+    const minutes = Number(form.get('minutes') || 60);
+    if (!starts) return;
+
+    // datetime-local gives a *local* wall-clock string with no zone. Reading
+    // it through Date interprets it in the browser's zone, which is exactly
+    // what the operator meant, and toISOString then hands the server the UTC
+    // instant. The zone name travels separately so the booking's own zone
+    // survives a DST change (D-01 AC-2).
+    const startsAt = new Date(starts);
+    const endsAt = new Date(startsAt.getTime() + minutes * 60_000);
+
+    setSaving(true);
+    setError(null);
+    try {
+      await createMeeting({
+        session: String(form.get('session')),
+        starts_at: startsAt.toISOString(),
+        ends_at: endsAt.toISOString(),
+        timezone: zone,
+      });
+      await load();
+      event.currentTarget.reset();
+    } catch (problem) {
+      setError(problem instanceof Error ? problem.message : 'Could not schedule.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const byDay = useMemo(() => {
+    const map = new Map<string, ScheduledMeeting[]>();
+    for (const meeting of meetings) {
+      if (meeting.status === 'CANCELLED') continue;
+      // Grouped by the *viewer's* local day. A meeting at 23:00 UTC belongs to
+      // tomorrow for someone in Sydney, and putting it on the UTC day would
+      // show it on the wrong square.
+      const local = new Date(meeting.starts_at);
+      const key = startOfDay(local).toDateString();
+      map.set(key, [...(map.get(key) ?? []), meeting]);
+    }
+    return map;
+  }, [meetings]);
+
+  const shift = (direction: 1 | -1) =>
+    setAnchor((current) =>
+      view === 'month'
+        ? new Date(current.getFullYear(), current.getMonth() + direction, 1)
+        : addDays(current, direction * 7),
+    );
+
+  async function onCancel(meeting: ScheduledMeeting) {
+    try {
+      await cancelMeeting(meeting.id);
+      await load();
+    } catch (error) {
+      console.error('Failed to cancel the meeting:', error);
+    }
+  }
+
+  return (
+    <section aria-labelledby="calendar-heading" className="glass-card p-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <CalendarDays className="h-4 w-4 text-brand-electric" aria-hidden />
+          <h2 id="calendar-heading" className="text-sm font-semibold text-white">
+            {anchor.toLocaleString(undefined, { month: 'long', year: 'numeric' })}
+          </h2>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <div className="flex rounded-lg border border-white/10 p-0.5" role="group" aria-label="Calendar view">
+            {(['month', 'week'] as const).map((option) => (
+              <button
+                key={option}
+                type="button"
+                onClick={() => setView(option)}
+                aria-pressed={view === option}
+                className={`rounded px-2 py-1 text-xs capitalize ${
+                  view === option ? 'bg-white/10 text-white' : 'text-brand-silver'
+                }`}
+              >
+                {option}
+              </button>
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={() => shift(-1)}
+            aria-label="Previous"
+            className="rounded p-1 text-brand-silver hover:bg-white/5"
+          >
+            <ChevronLeft className="h-4 w-4" aria-hidden />
+          </button>
+          <button
+            type="button"
+            onClick={() => shift(1)}
+            aria-label="Next"
+            className="rounded p-1 text-brand-silver hover:bg-white/5"
+          >
+            <ChevronRight className="h-4 w-4" aria-hidden />
+          </button>
+        </div>
+      </div>
+
+      <p className="mt-2 text-xs text-brand-silver">
+        Times shown in {zone}
+      </p>
+
+      {loading ? (
+        <p className="mt-3 text-sm text-brand-silver">Loading meetings…</p>
+      ) : (
+        <div
+          className={`mt-3 grid gap-1 ${view === 'month' ? 'grid-cols-7' : 'grid-cols-7'}`}
+          role="grid"
+          aria-label={`Onboarding meetings, ${view} view`}
+        >
+          {days.map((day) => {
+            const dayMeetings = byDay.get(day.toDateString()) ?? [];
+            const outside = view === 'month' && day.getMonth() !== anchor.getMonth();
+            return (
+              <div
+                key={day.toISOString()}
+                role="gridcell"
+                aria-label={day.toDateString()}
+                className={`min-h-16 rounded border border-white/5 p-1 ${
+                  outside ? 'opacity-40' : ''
+                } ${sameDay(day, today) ? 'ring-1 ring-brand-electric/40' : ''}`}
+              >
+                <span className="text-[10px] text-brand-silver">{day.getDate()}</span>
+                {dayMeetings.map((meeting) => (
+                  <div key={meeting.id} className="mt-1 rounded bg-brand-electric/15 p-1">
+                    <p className="truncate text-[11px] text-white">
+                      {new Date(meeting.starts_at).toLocaleTimeString(undefined, {
+                        hour: '2-digit',
+                        minute: '2-digit',
+                      })}{' '}
+                      {meeting.title || 'Onboarding meeting'}
+                    </p>
+                    {meeting.timezone !== zone && (
+                      // Both halves. The operator agreed a local time with the
+                      // brand owner; a colleague elsewhere needs to know which.
+                      <p className="truncate text-[10px] text-brand-silver">
+                        booked {meeting.timezone}
+                      </p>
+                    )}
+                    {canEdit && (
+                      <button
+                        type="button"
+                        onClick={() => onCancel(meeting)}
+                        className="mt-0.5 text-[10px] text-rose-300 hover:underline"
+                      >
+                        Cancel
+                      </button>
+                    )}
+                  </div>
+                ))}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/*
+        AC-3: a Viewer gets a read-only calendar. Absent, not disabled — the
+        precedent E-01 set, and for the same reason: a greyed button with a
+        live endpoint behind it is not read-only.
+
+        AC-1 requires creation to work, so this is a real form rather than a
+        button that opens nothing. An affordance that does not do what it says
+        is worse than one that is missing.
+      */}
+      {canEdit && (
+        <form onSubmit={onSchedule} className="mt-4 flex flex-wrap items-end gap-2">
+          <label className="text-xs text-brand-silver">
+            Session
+            <select
+              name="session"
+              required
+              className="mt-1 block rounded border border-white/10 bg-transparent px-2 py-1 text-sm text-white"
+            >
+              {sessions.map((session) => (
+                <option key={session.id} value={session.id} className="bg-brand-midnight">
+                  {session.company ?? 'Unassigned'}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="text-xs text-brand-silver">
+            Starts
+            <input
+              type="datetime-local"
+              name="starts"
+              required
+              className="mt-1 block rounded border border-white/10 bg-transparent px-2 py-1 text-sm text-white"
+            />
+          </label>
+          <label className="text-xs text-brand-silver">
+            Minutes
+            <input
+              type="number"
+              name="minutes"
+              defaultValue={60}
+              min={5}
+              step={5}
+              className="mt-1 block w-20 rounded border border-white/10 bg-transparent px-2 py-1 text-sm text-white"
+            />
+          </label>
+          <button type="submit" className="btn-primary text-sm" disabled={saving}>
+            {saving ? 'Scheduling…' : 'Schedule a meeting'}
+          </button>
+          {error && (
+            <p role="alert" className="w-full text-xs text-rose-300">
+              {error}
+            </p>
+          )}
+        </form>
+      )}
+    </section>
+  );
+}

--- a/ai-brand-automator-frontend/src/components/onboarding/OnboardingHome.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/OnboardingHome.tsx
@@ -16,13 +16,13 @@
 import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import {
-  CalendarDays,
   ClipboardList,
   FileText,
   MessageSquare,
   Video,
 } from 'lucide-react';
 
+import CalendarPane from '@/components/onboarding/CalendarPane';
 import { useTenantRole } from '@/hooks/useTenantRole';
 import {
   listRecordings,
@@ -59,38 +59,6 @@ function StatusChip({ status }: { status: SessionStatus }) {
     >
       {status.replace('_', ' ').toLowerCase()}
     </span>
-  );
-}
-
-/**
- * The calendar pane, before there is a calendar.
- *
- * §11 lists it and AC-1 expects it to render, but scheduling is D-01 — which
- * this story *blocks*, so there is no data source yet and cannot be. A
- * labelled placeholder is the honest shape: leaving the region out would make
- * the page look finished when a quarter of it is not, and stubbing a fake
- * calendar would be worse.
- */
-function CalendarPane() {
-  return (
-    <section
-      aria-labelledby="onboarding-calendar-heading"
-      className="glass-card p-5"
-    >
-      <div className="flex items-center gap-2">
-        <CalendarDays className="h-4 w-4 text-brand-electric" aria-hidden />
-        <h2
-          id="onboarding-calendar-heading"
-          className="text-sm font-semibold text-white"
-        >
-          Schedule
-        </h2>
-      </div>
-      <p className="mt-3 text-sm text-brand-silver">
-        Booking and calendar sync arrive with the scheduling story. Sessions
-        you create here will appear on this pane once it does.
-      </p>
-    </section>
   );
 }
 

--- a/ai-brand-automator-frontend/src/components/onboarding/__tests__/CalendarPane.test.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/__tests__/CalendarPane.test.tsx
@@ -1,0 +1,241 @@
+/**
+ * D-01 · the in-app calendar pane.
+ *
+ * The card names `test_viewer_readonly` here — RBAC at the component level.
+ *
+ * `now` is injected so the grid is not clock-dependent; a calendar test that
+ * passes in January and fails in February is worse than no test, because the
+ * failure looks like a regression.
+ */
+
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+
+import CalendarPane from '@/components/onboarding/CalendarPane';
+import {
+  cancelMeeting,
+  createMeeting,
+  listMeetings,
+  listSessions,
+  type ScheduledMeeting,
+} from '@/lib/onboarding-sessions';
+import { useTenantRole } from '@/hooks/useTenantRole';
+
+jest.mock('@/lib/onboarding-sessions', () => ({
+  ...jest.requireActual('@/lib/onboarding-sessions'),
+  listMeetings: jest.fn(),
+  listSessions: jest.fn(),
+  createMeeting: jest.fn(),
+  cancelMeeting: jest.fn(),
+}));
+jest.mock('@/hooks/useTenantRole');
+
+const mockedMeetings = listMeetings as jest.MockedFunction<typeof listMeetings>;
+const mockedSessions = listSessions as jest.MockedFunction<typeof listSessions>;
+const mockedCreate = createMeeting as jest.MockedFunction<typeof createMeeting>;
+const mockedCancel = cancelMeeting as jest.MockedFunction<typeof cancelMeeting>;
+const mockedRole = useTenantRole as jest.MockedFunction<typeof useTenantRole>;
+
+/** A Tuesday, mid-month, well away from any DST boundary. */
+const NOW = new Date('2024-06-11T09:00:00Z');
+
+const MEETING: ScheduledMeeting = {
+  id: 'm-1',
+  session: 'sess-1',
+  company: 'Kalyani Roasters',
+  title: 'Kickoff',
+  starts_at: '2024-06-12T13:00:00Z',
+  ends_at: '2024-06-12T14:00:00Z',
+  timezone: 'Europe/London',
+  status: 'SCHEDULED',
+};
+
+function asRole(role: 'admin' | 'editor' | 'viewer') {
+  mockedRole.mockReturnValue({
+    role,
+    isOwner: false,
+    isAdmin: role === 'admin',
+    canEdit: role === 'admin' || role === 'editor',
+    canManageTeam: role === 'admin',
+    canManageBilling: false,
+  } as ReturnType<typeof useTenantRole>);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedMeetings.mockResolvedValue([MEETING]);
+  mockedSessions.mockResolvedValue([
+    {
+      id: 'sess-1',
+      company: 'Kalyani Roasters',
+      status: 'PREPARING',
+      questionnaire: null,
+      created_at: '2024-06-01T00:00:00Z',
+      updated_at: '2024-06-01T00:00:00Z',
+    },
+  ]);
+});
+
+describe('CalendarPane', () => {
+  it('renders a month grid with the meeting on it', async () => {
+    asRole('admin');
+    render(<CalendarPane now={NOW} />);
+
+    expect(await screen.findByText(/Kickoff/)).toBeInTheDocument();
+    // Six weeks of squares, so the grid shape does not move month to month.
+    expect(screen.getAllByRole('gridcell')).toHaveLength(42);
+  });
+
+  it('switches to a week view', async () => {
+    asRole('admin');
+    render(<CalendarPane now={NOW} />);
+    await screen.findByText(/Kickoff/);
+
+    fireEvent.click(screen.getByRole('button', { name: /week/i }));
+
+    await waitFor(() => expect(screen.getAllByRole('gridcell')).toHaveLength(7));
+  });
+
+  it('asks the server for the window it is showing', async () => {
+    /**
+     * The narrowing is server-side (D-01 PR 1). A component that fetched
+     * everything and filtered here would work until the tenant had a year of
+     * meetings.
+     */
+    asRole('admin');
+    render(<CalendarPane now={NOW} />);
+
+    await waitFor(() => expect(mockedMeetings).toHaveBeenCalled());
+    const [from, to] = mockedMeetings.mock.calls[0];
+    expect(from.getTime()).toBeLessThan(NOW.getTime());
+    expect(to.getTime()).toBeGreaterThan(NOW.getTime());
+  });
+
+  it('shows the booking zone when it differs from the viewer’s', async () => {
+    /**
+     * AC-2's human half. The operator agreed "14:00 in London" with the brand
+     * owner; a colleague reading this in another zone needs both that and
+     * their own local time, or they will quote the wrong one back.
+     */
+    asRole('admin');
+    render(<CalendarPane now={NOW} />);
+
+    expect(await screen.findByText(/booked Europe\/London/)).toBeInTheDocument();
+  });
+
+  it('does not render a cancelled meeting', async () => {
+    asRole('admin');
+    mockedMeetings.mockResolvedValue([{ ...MEETING, status: 'CANCELLED' }]);
+
+    render(<CalendarPane now={NOW} />);
+
+    await waitFor(() => expect(mockedMeetings).toHaveBeenCalled());
+    expect(screen.queryByText(/Kickoff/)).toBeNull();
+  });
+
+  it('test_viewer_readonly', async () => {
+    /**
+     * The card's named case. Absent, not disabled — E-01's precedent, and for
+     * the same reason: a greyed control with a live endpoint behind it is not
+     * read-only.
+     */
+    asRole('viewer');
+    render(<CalendarPane now={NOW} />);
+
+    await screen.findByText(/Kickoff/);
+
+    expect(screen.queryByRole('button', { name: /schedule a meeting/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /^cancel$/i })).toBeNull();
+    expect(screen.queryByRole('combobox')).toBeNull();
+  });
+
+  it('still shows a viewer the calendar itself', async () => {
+    /**
+     * The control. A pane that rendered nothing for a Viewer would pass the
+     * test above while failing AC-3, which grants "a read-only calendar".
+     */
+    asRole('viewer');
+    render(<CalendarPane now={NOW} />);
+
+    expect(await screen.findByText(/Kickoff/)).toBeInTheDocument();
+    expect(screen.getByRole('grid')).toBeInTheDocument();
+  });
+
+  it('lets an editor schedule a meeting', async () => {
+    /**
+     * AC-1. The form is real rather than a button that opens nothing — an
+     * affordance that does not do what it says is worse than a missing one.
+     */
+    asRole('editor');
+    mockedCreate.mockResolvedValue(MEETING);
+    render(<CalendarPane now={NOW} />);
+    await screen.findByText(/Kickoff/);
+
+    fireEvent.change(screen.getByLabelText(/starts/i), {
+      target: { value: '2024-06-20T14:00' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /schedule a meeting/i }));
+
+    await waitFor(() => expect(mockedCreate).toHaveBeenCalled());
+    const draft = mockedCreate.mock.calls[0][0];
+    expect(draft.session).toBe('sess-1');
+    // Sent as a UTC instant, with the zone alongside — never an offset.
+    expect(draft.starts_at).toMatch(/Z$/);
+    expect(draft.timezone).toBeTruthy();
+    expect(draft.timezone).not.toMatch(/^[+-]\d/);
+  });
+
+  it('reports a scheduling failure instead of silently doing nothing', async () => {
+    asRole('editor');
+    mockedCreate.mockRejectedValue(new Error('API 400: overlaps'));
+    render(<CalendarPane now={NOW} />);
+    await screen.findByText(/Kickoff/);
+
+    fireEvent.change(screen.getByLabelText(/starts/i), {
+      target: { value: '2024-06-20T14:00' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /schedule a meeting/i }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('overlaps');
+  });
+
+  it('cancels a meeting and reloads', async () => {
+    asRole('editor');
+    mockedCancel.mockResolvedValue({ ...MEETING, status: 'CANCELLED' });
+    render(<CalendarPane now={NOW} />);
+    await screen.findByText(/Kickoff/);
+
+    fireEvent.click(screen.getByRole('button', { name: /^cancel$/i }));
+
+    await waitFor(() => expect(mockedCancel).toHaveBeenCalledWith('m-1'));
+    expect(mockedMeetings).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears the grid rather than showing last month’s meetings', async () => {
+    asRole('admin');
+    mockedMeetings.mockRejectedValue(new Error('network'));
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(<CalendarPane now={NOW} />);
+
+    await waitFor(() => expect(screen.queryByText(/Kickoff/)).toBeNull());
+    expect(screen.getByRole('grid')).toBeInTheDocument();
+  });
+
+  it('places a meeting on the viewer’s local day, not the UTC one', async () => {
+    /**
+     * A meeting at 23:00 UTC belongs to the next day for anyone east of
+     * Greenwich. Grouping by the UTC date would put it on the wrong square —
+     * visible to a user, invisible to a test that only checks it rendered.
+     */
+    asRole('admin');
+    const late = { ...MEETING, id: 'm-2', starts_at: '2024-06-12T23:30:00Z' };
+    mockedMeetings.mockResolvedValue([late]);
+
+    render(<CalendarPane now={NOW} />);
+    await screen.findByText(/Kickoff/);
+
+    const local = new Date(late.starts_at);
+    const cell = screen.getByRole('gridcell', { name: local.toDateString() });
+    expect(within(cell).getByText(/Kickoff/)).toBeInTheDocument();
+  });
+});

--- a/ai-brand-automator-frontend/src/components/onboarding/__tests__/CalendarPane.test.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/__tests__/CalendarPane.test.tsx
@@ -26,6 +26,14 @@ jest.mock('@/lib/onboarding-sessions', () => ({
   listSessions: jest.fn(),
   createMeeting: jest.fn(),
   cancelMeeting: jest.fn(),
+  /**
+   * Pinned to UTC. The real implementation reads the machine's Intl zone, so
+   * "booked Europe/London" only renders when the viewer's zone differs from
+   * the booking's — and the suite would have failed for anyone running it in
+   * London, including a CI runner configured that way. A test whose result
+   * depends on where it runs reports geography, not correctness.
+   */
+  viewerTimezone: () => 'UTC',
 }));
 jest.mock('@/hooks/useTenantRole');
 

--- a/ai-brand-automator-frontend/src/components/onboarding/__tests__/OnboardingHome.test.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/__tests__/OnboardingHome.test.tsx
@@ -21,6 +21,17 @@ jest.mock('@/lib/onboarding-sessions', () => ({
   listRecordings: jest.fn(),
 }));
 jest.mock('@/hooks/useTenantRole');
+/**
+ * The real CalendarPane arrived with D-01 and does its own fetching. Stubbed
+ * here because this suite is about the landing *composition* — that the pane
+ * is present and in the right place — while the calendar's own behaviour has
+ * a dedicated suite. Rendering the real one would make these tests fail on a
+ * change to the calendar, which is the wrong place to hear about it.
+ */
+jest.mock('@/components/onboarding/CalendarPane', () => ({
+  __esModule: true,
+  default: () => <section aria-label="Calendar" />,
+}));
 
 const mockedSessions = listSessions as jest.MockedFunction<typeof listSessions>;
 const mockedRecordings = listRecordings as jest.MockedFunction<typeof listRecordings>;
@@ -58,7 +69,10 @@ describe('OnboardingHome', () => {
     render(<OnboardingHome />);
 
     // AC-1: the calendar pane, the sessions list and clear entry points.
-    expect(await screen.findByRole('heading', { name: /schedule/i })).toBeInTheDocument();
+    // The pane is asserted by presence, not by its wording — E-01 shipped a
+    // placeholder that said "Schedule" and D-01 replaced it with a real
+    // calendar headed by the month, and this test should survive that.
+    expect(await screen.findByRole('region', { name: /calendar/i })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: /sessions/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /prepare in chat/i })).toBeInTheDocument();
     expect(

--- a/ai-brand-automator-frontend/src/lib/onboarding-sessions.ts
+++ b/ai-brand-automator-frontend/src/lib/onboarding-sessions.ts
@@ -66,6 +66,28 @@ export interface QuestionnaireDetail {
   coverage: Record<WorkflowTarget, number>;
 }
 
+export type MeetingStatus = 'SCHEDULED' | 'CANCELLED';
+
+export interface ScheduledMeeting {
+  id: string;
+  session: string;
+  company: string | null;
+  title: string;
+  /** UTC instant, ISO-8601. Rendered in the *viewer's* zone, never this one. */
+  starts_at: string;
+  ends_at: string;
+  /**
+   * The IANA zone the meeting was scheduled in.
+   *
+   * Carried for display — "09:00 in Europe/London" is what the operator
+   * agreed with the brand owner, and a viewer in Sydney wants to know that as
+   * well as their own 20:00. It is never used to compute an instant; the
+   * instant is already in starts_at.
+   */
+  timezone: string;
+  status: MeetingStatus;
+}
+
 export interface MeetingRecordingSummary {
   id: string;
   session: string;
@@ -164,4 +186,69 @@ export async function getApprovedQuestionnaire(
   // (C-04 AC-3), so more than one approved row can exist over a session's
   // life and the newest is the one the operator just approved.
   return rows.sort((a, b) => b.version - a.version)[0] ?? null;
+}
+
+/** Meetings overlapping a window. The server narrows; see the D-01 viewset. */
+export async function listMeetings(
+  from: Date,
+  to: Date,
+): Promise<ScheduledMeeting[]> {
+  const params = new URLSearchParams({
+    from: from.toISOString(),
+    to: to.toISOString(),
+  });
+  return getList<ScheduledMeeting>(`${BASE}/calendar/events/?${params.toString()}`);
+}
+
+async function sendMeeting(
+  path: string,
+  method: 'post' | 'patch',
+  payload: unknown,
+): Promise<ScheduledMeeting> {
+  const response = await apiClient[method](path, payload);
+  if (!response.ok) {
+    throw new Error(`API ${response.status}: ${await response.text()}`);
+  }
+  return (await response.json()) as ScheduledMeeting;
+}
+
+export interface MeetingDraft {
+  session: string;
+  title?: string;
+  starts_at: string;
+  ends_at: string;
+  timezone: string;
+}
+
+export async function createMeeting(draft: MeetingDraft): Promise<ScheduledMeeting> {
+  return sendMeeting(`${BASE}/calendar/events/`, 'post', draft);
+}
+
+export async function updateMeeting(
+  id: string,
+  changes: Partial<MeetingDraft>,
+): Promise<ScheduledMeeting> {
+  return sendMeeting(`${BASE}/calendar/events/${id}/`, 'patch', changes);
+}
+
+export async function cancelMeeting(id: string): Promise<ScheduledMeeting> {
+  // A POST, not a DELETE: cancelling releases the session and keeps the
+  // record (D-01 AC-1), so the row survives and DELETE would misdescribe it.
+  return sendMeeting(`${BASE}/calendar/events/${id}/cancel/`, 'post', {});
+}
+
+/**
+ * The viewer's own IANA zone, from the browser.
+ *
+ * AC-2 wants "the same instant rendered in the viewer's local zone", and the
+ * browser is the only thing that knows what that is. Falls back to UTC rather
+ * than guessing an offset — a wrong zone name is recoverable, a fabricated
+ * offset is the bug this story exists to avoid.
+ */
+export function viewerTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+  } catch {
+    return 'UTC';
+  }
 }

--- a/ai-brand-automator/apps/onboarding/tests/test_calendar.py
+++ b/ai-brand-automator/apps/onboarding/tests/test_calendar.py
@@ -553,3 +553,65 @@ def test_a_non_zone_is_refused_by_the_serializer(
 
     assert response.status_code == 400, response.content
     assert not ScheduledMeeting.objects.exists()
+
+
+def test_the_window_end_is_exclusive(api_client, tenant, session, editor):
+    """Review finding. The pane sends `to` as the day after the last square,
+    so an inclusive bound fetched a meeting it would never draw — a row paid
+    for, counted in the response, and invisible on screen.
+    """
+    boundary = datetime(2024, 7, 1, 0, 0, tzinfo=UTC)
+    a_meeting(session, tenant, starts=boundary)
+
+    # "Z", not isoformat(). isoformat() emits "+00:00" and a bare + in a query
+    # string decodes as a space, so the server saw "2024-07-01T00:00:00 00:00"
+    # and answered 400 — which the rows helper below would have swallowed as
+    # an empty list, passing this test for entirely the wrong reason. The pane
+    # sends toISOString(), which is already Z-suffixed.
+    response = api_client.get(
+        f"{EVENTS}?from=2024-06-01T00:00:00Z&to=2024-07-01T00:00:00Z"
+    )
+
+    assert response.status_code == 200, response.content
+    body = response.json()
+    rows = body["results"] if "results" in body else body
+    assert rows == [], "a meeting starting on the exclusive bound was returned"
+
+
+def test_a_meeting_just_inside_the_window_is_returned(
+    api_client, tenant, session, editor
+):
+    """The control. An exclusive bound that excluded the last minute too would
+    pass the test above while hiding real meetings."""
+    a_meeting(session, tenant, starts=datetime(2024, 6, 30, 23, 59, tzinfo=UTC))
+
+    body = api_client.get(
+        f"{EVENTS}?from=2024-06-01T00:00:00Z&to=2024-07-01T00:00:00Z"
+    ).json()
+
+    rows = body["results"] if isinstance(body, dict) else body
+    assert len(rows) == 1
+
+
+def test_the_already_cancelled_message_reads_as_a_sentence(
+    api_client, tenant, session, editor
+):
+    """It is user-facing API output; a client should be able to show it."""
+    created = api_client.post(
+        EVENTS,
+        {
+            "session": session.pk,
+            "starts_at": "2024-06-15T12:00:00Z",
+            "ends_at": "2024-06-15T13:00:00Z",
+            "timezone": "UTC",
+        },
+        format="json",
+    ).json()
+    api_client.post(f"{EVENTS}{created['id']}/cancel/", format="json")
+
+    message = api_client.post(f"{EVENTS}{created['id']}/cancel/", format="json").json()[
+        "error"
+    ]
+
+    assert message[0].isupper()
+    assert message.endswith(".")

--- a/ai-brand-automator/apps/onboarding/views.py
+++ b/ai-brand-automator/apps/onboarding/views.py
@@ -1528,7 +1528,11 @@ class ScheduledMeetingViewSet(
         # became a 500 on an ordinary GET; a naive value also compares against
         # aware columns unpredictably. An unparseable window is a client bug,
         # so it is a 400 rather than a silent full-range read.
-        for param, lookup in (("from", "ends_at__gte"), ("to", "starts_at__lte")):
+        # `to` is exclusive. The pane sends the day *after* the last square in
+        # the grid, so an inclusive lte fetched a meeting starting exactly on
+        # that boundary and then never rendered it — a row paid for, counted,
+        # and invisible. `from` stays inclusive: it is the first square.
+        for param, lookup in (("from", "ends_at__gte"), ("to", "starts_at__lt")):
             raw = self.request.query_params.get(param)
             if not raw:
                 continue
@@ -1570,7 +1574,7 @@ class ScheduledMeetingViewSet(
                 raise Http404
             if meeting.status == MeetingStatus.CANCELLED:
                 return Response(
-                    {"error": "this meeting is already cancelled"},
+                    {"error": "This meeting is already cancelled."},
                     status=http.HTTP_409_CONFLICT,
                 )
 


### PR DESCRIPTION
Second of two PRs for **D-01**. Stacked on **#567** — merge that first. Fills the placeholder E-01 left.

## Hand-built, deliberately

The card warns "scope creep here is unbounded". A calendar library brings its own ninety percent and an invitation to use it; this shows onboarding meetings in two views and nothing else.

## Time

Everything renders from the UTC instant **in the viewer's zone**, with the booking zone shown alongside when they differ. Both halves matter — *"14:00 in London"* is what the operator agreed with the brand owner, and a colleague in Sydney seeing only their own 23:00 will quote the wrong one back.

Meetings are grouped by the viewer's **local day**. A meeting at 23:30 UTC belongs to tomorrow for anyone east of Greenwich; grouping by the UTC date puts it on the wrong square — visible to a user, invisible to a test that only checks it rendered. So there's a test that checks the square.

## A mistake worth recording

I wrote a "Schedule a meeting" button with an **empty handler**, then replaced it with a real form. AC-1 requires creation to work, and an affordance that doesn't do what it says is worse than a missing one — the same defect I've been flagging in reviews all week.

`datetime-local` gives a local wall-clock string; reading it through `Date` interprets it in the browser's zone, which is what the operator meant, and the zone name travels separately so the booking survives a DST change.

## AC-3

`test_viewer_readonly` asserts **absence, not disablement** — E-01's precedent, and for the same reason: a greyed control with a live endpoint behind it is not read-only. Verified: rendering the form for everyone fails it.

## Two E-01 tests changed

Replacing the placeholder broke them, and both had the stub's fingerprints — one asserted the placeholder's "Schedule" heading. That suite now stubs `CalendarPane` and asserts the pane **by presence**: it's about the landing composition and shouldn't fail when the calendar changes.

**12 new tests pass**, `tsc` clean.

The four failing suites under `components/onboarding` are the **pre-existing wizard form tests** from #565, not these — all four of my suites pass. That issue also means the frontend CI job still can't fail, so its green here tells you nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)