### PR TITLE
feat(onboarding): the meeting view's split layout (E-02)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -500,7 +500,36 @@ jobs:
         run: |
           cd ai-brand-automator-frontend
           npm test -- --coverage || echo "No tests configured yet"
-      
+
+      # Browser tests, added by E-02 for claims jsdom cannot make. Its AC-2 is
+      # about rendered geometry — no horizontal scrolling at a 13-inch
+      # viewport, question text not truncated — and jsdom reports every element
+      # as zero by zero.
+      #
+      # It earned its place immediately: it caught the checklist pane scrolling
+      # sideways by 665px on an unbroken reference code, and the page itself
+      # scrolling by 28px. Neither is visible to any jsdom test.
+      #
+      # Deliberately not suffixed with `|| echo`. The step above is (see #565)
+      # and cannot fail; a gate that cannot fail is not a gate.
+      - name: Install Playwright browsers
+        run: |
+          cd ai-brand-automator-frontend
+          npx playwright install --with-deps chromium
+
+      - name: Run browser tests
+        run: |
+          cd ai-brand-automator-frontend
+          npm run test:e2e
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: ai-brand-automator-frontend/playwright-report/
+          retention-days: 7
+
       - name: Upload coverage
         uses: codecov/codecov-action@v3
         with:

--- a/ai-brand-automator-frontend/.gitignore
+++ b/ai-brand-automator-frontend/.gitignore
@@ -39,3 +39,9 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Playwright (E-02)
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/ai-brand-automator-frontend/e2e/meeting-view.spec.ts
+++ b/ai-brand-automator-frontend/e2e/meeting-view.spec.ts
@@ -1,0 +1,200 @@
+/**
+ * E-02 AC-2 · "The layout survives a real laptop".
+ *
+ * The one criterion in this story that jsdom cannot speak to. It is entirely
+ * about rendered geometry: at a 13-inch viewport, with twenty questions and a
+ * running feedback stream, all three regions stay usable, nothing scrolls
+ * sideways, and question text is not squashed onto one line. jsdom reports
+ * every element as zero by zero, so the only jsdom version of this test would
+ * assert that the CSS classes I wrote are the CSS classes I wrote.
+ *
+ * The questionnaire is served by `page.route` rather than by Django. The
+ * subject under test is the layout: a real browser laying out the real
+ * component with the real stylesheet. Standing up Postgres, a tenant, a
+ * session and an approved questionnaire would not make the geometry any more
+ * real, and it would make a layout test fail for reasons that have nothing to
+ * do with layout. What must not be faked here — the browser and the CSS —
+ * is not.
+ */
+
+import { expect, test, type Page } from '@playwright/test';
+
+const SESSION_ID = 'e2e-session';
+const MEETING_URL = `/onboarding/sessions/${SESSION_ID}/meeting`;
+
+/** Long enough to need wrapping at this width, which is the case AC-2 names. */
+const QUESTIONS = Array.from({ length: 20 }, (_, i) => ({
+  id: `q-${i + 1}`,
+  text:
+    `Question ${i + 1}: what made you decide to roast in small batches rather ` +
+    `than scale the way the rest of the market did, and who told you it would ` +
+    `not work?`,
+  workflow_target: ['WF1', 'WF2', 'WF3'][i % 3],
+  status: 'PENDING',
+  order: i + 1,
+}));
+
+/**
+ * One question with a genuinely unbreakable run of characters.
+ *
+ * Two attempts were needed and the first was wrong, which is worth recording.
+ * Ordinary prose wraps on its own, so it can prove nothing about width. A URL
+ * looks unbreakable and is not — browsers take line breaks after `/`, `?` and
+ * `&`. Only an unbroken run has no break opportunity at all, and operators do
+ * paste those: a reference code, an order id, an API key.
+ *
+ * Without this question the whole suite stayed green while the checklist pane
+ * scrolled sideways by 665px.
+ */
+QUESTIONS[7].text = `Which system is this reference from? ${'X7QLMBTZ'.repeat(20)}`;
+
+async function openMeeting(page: Page) {
+  await page.addInitScript(() => {
+    // useAuth() only checks for a token's presence before rendering.
+    window.localStorage.setItem('access_token', 'e2e-token');
+    window.localStorage.setItem('refresh_token', 'e2e-refresh');
+  });
+
+  // Every API call, not only the questionnaire. The page also resolves tenant
+  // context on mount, and a 401 from *any* of them makes the api client clear
+  // the token and bounce to /auth/login — which is how the first version of
+  // this spec ended up asserting the layout of the login page.
+  await page.route('**/api/v1/**', async (route) => {
+    const url = route.request().url();
+    // A bare array for everything else. Tenant context calls `.find` on its
+    // response, so an object shaped like a paginated page throws inside the
+    // provider and the error boundary swallows the whole page.
+    const body: unknown = url.includes('/onboarding/')
+      // A *list*: getApprovedQuestionnaire fetches approved questionnaires and
+      // picks the highest version, so a single object yields zero questions —
+      // and a layout test with nothing to lay out passes the horizontal-scroll
+      // check while proving nothing.
+      ? [{ id: 'qn-1', version: 3, questions: QUESTIONS }]
+      : [];
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(body),
+    });
+  });
+
+  await page.goto(MEETING_URL);
+  await expect(page.getByRole('region', { name: /prepared questions/i })).toBeVisible();
+}
+
+test.describe('AC-2 · the layout survives a real laptop', () => {
+  test('nothing scrolls sideways at 1280×800 with twenty questions', async ({
+    page,
+  }) => {
+    await openMeeting(page);
+
+    const overflow = await page.evaluate(() => {
+      const measure = (node: Element | null) =>
+        node ? { sw: node.scrollWidth, cw: node.clientWidth } : null;
+      return {
+        document: measure(document.documentElement),
+        // Each region as well as the page. This is the correction that made
+        // the test real: the document stayed exactly 1280 wide while the
+        // checklist pane scrolled sideways by 665px, because the overflow was
+        // *inside* a region rather than on the page. AC-2 says the regions
+        // remain usable without horizontal scrolling, and only a per-region
+        // measurement can tell.
+        checklist: measure(document.querySelector('[data-testid="checklist-pane"]')),
+        feedback: measure(document.querySelector('[data-testid="feedback-scroller"]')),
+        rail: measure(document.querySelector('[data-testid="rail-scroller"]')),
+      };
+    });
+
+    for (const [name, box] of Object.entries(overflow)) {
+      expect(box, `${name} was not found`).not.toBeNull();
+      // A single pixel is the symptom of a child that refused to shrink — a
+      // missing min-w-0, or text with no break opportunity. Worth failing on
+      // exactly, because it never gets better on its own.
+      expect(box!.sw, `${name} scrolls horizontally`).toBeLessThanOrEqual(box!.cw);
+    }
+  });
+
+  test('the page itself does not scroll, so the panes are what move', async ({
+    page,
+  }) => {
+    /**
+     * AC-1's precondition. Three independently scrolling regions are only
+     * independent while the document does not scroll — an outer scrollbar
+     * moves all three together and the panes become decorative.
+     *
+     * This failed by 28px when it was first written: the back link sat above
+     * the fixed-height view rather than inside its header, so the box started
+     * 28px lower while still being sized `100vh - 4rem`. Small enough to look
+     * like nothing and to break the criterion completely.
+     */
+    await openMeeting(page);
+
+    const vertical = await page.evaluate(() => ({
+      scrollHeight: document.documentElement.scrollHeight,
+      clientHeight: document.documentElement.clientHeight,
+    }));
+
+    expect(vertical.scrollHeight).toBeLessThanOrEqual(vertical.clientHeight);
+  });
+
+  test('question text wraps instead of being truncated to one line', async ({
+    page,
+  }) => {
+    await openMeeting(page);
+
+    const question = page.getByText(/what made you decide to roast/).first();
+    const box = await question.boundingBox();
+    const lineHeight = await question.evaluate(
+      (node) => parseFloat(getComputedStyle(node).lineHeight) || 20,
+    );
+
+    expect(box).not.toBeNull();
+    // More than one line high is the observable form of "not truncated". The
+    // alternative check — that no `truncate` class is present — passes just as
+    // happily when a parent clips the text instead.
+    expect(box!.height).toBeGreaterThan(lineHeight * 1.5);
+  });
+
+  test('all three regions are visible and none is squeezed away', async ({
+    page,
+  }) => {
+    await openMeeting(page);
+
+    const regions = {
+      questions: page.getByRole('region', { name: /prepared questions/i }),
+      feedback: page.getByRole('region', { name: /agent feedback/i }),
+      rail: page.getByRole('complementary', { name: /recordings and captures/i }),
+    };
+
+    for (const [name, locator] of Object.entries(regions)) {
+      await expect(locator, `${name} region`).toBeVisible();
+      const box = await locator.boundingBox();
+      // "Usable" has to mean something measurable. A region collapsed to a
+      // sliver is technically visible and of no use to anybody.
+      expect(box!.width, `${name} width`).toBeGreaterThan(180);
+      expect(box!.height, `${name} height`).toBeGreaterThan(80);
+    }
+  });
+
+  test('the panes scroll independently of one another', async ({ page }) => {
+    /**
+     * AC-1's real form, which only a browser can show: scrolling the checklist
+     * must leave the feedback pane and the rail exactly where they were.
+     */
+    await openMeeting(page);
+
+    const checklist = page.getByTestId('checklist-pane');
+    const feedback = page.getByTestId('feedback-scroller');
+
+    const before = await feedback.evaluate((node) => node.scrollTop);
+    await checklist.evaluate((node) => {
+      node.scrollTop = 200;
+    });
+
+    expect(await checklist.evaluate((node) => node.scrollTop)).toBeGreaterThan(0);
+    expect(await feedback.evaluate((node) => node.scrollTop)).toBe(before);
+    // And the page itself never scrolled, which is what makes the panes the
+    // things that move.
+    expect(await page.evaluate(() => window.scrollY)).toBe(0);
+  });
+});

--- a/ai-brand-automator-frontend/package-lock.json
+++ b/ai-brand-automator-frontend/package-lock.json
@@ -21,6 +21,7 @@
         "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.62.1",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.1",
@@ -2282,6 +2283,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -10290,6 +10307,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/ai-brand-automator-frontend/package.json
+++ b/ai-brand-automator-frontend/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "jest"
+    "test": "jest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@xyflow/react": "^12.10.1",
@@ -23,6 +24,7 @@
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",

--- a/ai-brand-automator-frontend/playwright.config.ts
+++ b/ai-brand-automator-frontend/playwright.config.ts
@@ -1,0 +1,62 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Browser tests, for claims jsdom cannot make.
+ *
+ * Added by E-02. Its AC-2 is a layout claim — a 13-inch screen, twenty
+ * questions, no horizontal scrolling, question text not truncated to a single
+ * line — and jsdom has no layout engine: every element reports zero width and
+ * height. A jsdom test could only assert that I wrote the CSS classes I meant
+ * to write, which is the implementation reading itself back.
+ *
+ * `e2e/file-browser.spec.ts` is deliberately excluded. It predates this config
+ * and has never run — its own header says "npm install -D @playwright/test",
+ * which had not been done — and it needs a logged-in user against a seeded
+ * backend. Reviving it is real work and belongs to whoever owns that feature,
+ * not to a layout story that happened to install the runner.
+ */
+export default defineConfig({
+  testDir: './e2e',
+  testMatch: ['**/meeting-view.spec.ts'],
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? 'github' : 'list',
+
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+
+  projects: [
+    {
+      name: 'laptop-13in',
+      use: {
+        ...devices['Desktop Chrome'],
+        // AC-2's "real laptop". 1280×800 is the 13-inch MacBook's default
+        // logical resolution, and the browser chrome eats the rest — which is
+        // the point of naming a size rather than testing at 1920 and calling
+        // it responsive.
+        viewport: { width: 1280, height: 800 },
+      },
+    },
+  ],
+
+  // `next dev`, not `next build && next start`.
+  //
+  // This project sets `output: "standalone"` for the Docker image, and Next
+  // warns that `next start` "does not work" with it — it served pages here,
+  // but unreliably: a stale instance answered 404 for routes that were in the
+  // build. Depending on behaviour the framework disclaims is how a layout
+  // suite starts failing for reasons that have nothing to do with layout.
+  //
+  // The alternative would be running the standalone server, which needs its
+  // static assets copied into place by hand. Dev mode emits the same Tailwind
+  // utilities, so the geometry under test is the same.
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 300_000,
+  },
+});

--- a/ai-brand-automator-frontend/src/app/onboarding/sessions/[sessionId]/meeting/page.tsx
+++ b/ai-brand-automator-frontend/src/app/onboarding/sessions/[sessionId]/meeting/page.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+/**
+ * /onboarding/sessions/[sessionId]/meeting — the live meeting view (E-02).
+ *
+ * Nested under the session because a meeting is always a meeting *for* one,
+ * and the session page is already where its approved questions live.
+ *
+ * The questions are real — C-05's endpoint serves them. Everything else on
+ * this page is a placeholder with an owner: the feedback stream is F-04's to
+ * fill, the rail's controls are F-02's and H-01's. E-02 delivers the shape.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+
+import { useAuth } from '@/hooks/useAuth';
+import MeetingView from '@/components/onboarding/MeetingView';
+import {
+  getApprovedQuestionnaire,
+  type QuestionnaireDetail,
+} from '@/lib/onboarding-sessions';
+
+export default function MeetingPage() {
+  useAuth();
+  const params = useParams<{ sessionId: string }>();
+  const sessionId = params?.sessionId;
+
+  const [questionnaire, setQuestionnaire] = useState<QuestionnaireDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    if (!sessionId) {
+      // Same shape as the session page, and for the same reason: returning
+      // early with `loading` still true leaves "Loading questions…" on screen
+      // for ever.
+      setQuestionnaire(null);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    try {
+      setQuestionnaire(await getApprovedQuestionnaire(sessionId));
+    } catch (error) {
+      setQuestionnaire(null);
+      console.error('Failed to load the approved questionnaire:', error);
+    } finally {
+      setLoading(false);
+    }
+  }, [sessionId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  if (loading) {
+    return <p className="p-4 text-sm text-brand-silver">Loading questions…</p>;
+  }
+
+  return (
+    <MeetingView
+      questions={questionnaire?.questions ?? []}
+      version={questionnaire?.version ?? null}
+      backHref={sessionId ? `/onboarding/sessions/${sessionId}` : '/onboarding'}
+    />
+  );
+}

--- a/ai-brand-automator-frontend/src/app/onboarding/sessions/[sessionId]/page.tsx
+++ b/ai-brand-automator-frontend/src/app/onboarding/sessions/[sessionId]/page.tsx
@@ -12,7 +12,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, Radio } from 'lucide-react';
 
 import { useAuth } from '@/hooks/useAuth';
 import QuestionChecklist from '@/components/onboarding/QuestionChecklist';
@@ -67,7 +67,24 @@ export default function SessionPage() {
         Onboarding
       </Link>
 
-      <h1 className="text-2xl font-semibold text-white">Session</h1>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h1 className="text-2xl font-semibold text-white">Session</h1>
+        {/*
+          §11 gives OnboardingHome an "entry point to the meeting view" and
+          E-01 shipped without one. It sits here rather than on the home list
+          so the link is next to the questions it opens with, and so it is
+          never rendered for a session id that does not resolve.
+        */}
+        {sessionId && (
+          <Link
+            href={`/onboarding/sessions/${sessionId}/meeting`}
+            className="btn-primary inline-flex items-center gap-2 text-sm"
+          >
+            <Radio className="h-4 w-4" aria-hidden />
+            Open meeting view
+          </Link>
+        )}
+      </div>
 
       {loading ? (
         <p className="text-sm text-brand-silver">Loading questions…</p>

--- a/ai-brand-automator-frontend/src/components/onboarding/AgentFeedbackStream.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/AgentFeedbackStream.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+/**
+ * The lower pane of the meeting view (E-02, Design §11 AgentFeedbackStream).
+ *
+ * "Append-only feed of follow-up suggestions, notable facts, coverage changes
+ * and gap warnings. Deliberately not a chat box — the operator is talking to a
+ * person and cannot type. Everything here is glanceable in under two seconds."
+ *
+ * E-02 renders it with placeholder items; G-02 through G-06 supply real ones.
+ * The scroll behaviour is built now rather than retrofitted, because by the
+ * time four stories are pushing updates into this pane the wrong behaviour is
+ * load-bearing.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { AlertTriangle, Lightbulb, Sparkles, TrendingUp } from 'lucide-react';
+
+export type FeedbackKind = 'follow_up' | 'fact' | 'coverage' | 'gap';
+
+export interface FeedbackItem {
+  id: string;
+  kind: FeedbackKind;
+  text: string;
+  /** ISO-8601. Rendered in the viewer's zone. */
+  at: string;
+}
+
+export interface AgentFeedbackStreamProps {
+  items: FeedbackItem[];
+}
+
+const ICONS = {
+  follow_up: Lightbulb,
+  fact: Sparkles,
+  coverage: TrendingUp,
+  gap: AlertTriangle,
+} as const;
+
+const KIND_LABELS: Record<FeedbackKind, string> = {
+  follow_up: 'Follow-up',
+  fact: 'Noted',
+  coverage: 'Coverage',
+  gap: 'Gap',
+};
+
+const KIND_STYLES: Record<FeedbackKind, string> = {
+  follow_up: 'text-brand-electric',
+  fact: 'text-brand-silver',
+  coverage: 'text-emerald-300',
+  gap: 'text-amber-300',
+};
+
+/**
+ * How close to the bottom still counts as "at the bottom".
+ *
+ * Not zero. Sub-pixel rounding and a partially visible last row mean an
+ * operator who has scrolled all the way down often sits a pixel or two short,
+ * and a strict comparison would decide they had scrolled away and then stop
+ * following the stream for the rest of the meeting.
+ */
+const BOTTOM_THRESHOLD_PX = 24;
+
+export default function AgentFeedbackStream({ items }: AgentFeedbackStreamProps) {
+  const scroller = useRef<HTMLDivElement | null>(null);
+
+  /**
+   * Whether new items should pull the view down.
+   *
+   * True until the operator scrolls up, and true again the moment they return
+   * to the bottom. §11's hard rule is that nothing the agent produces may
+   * steal focus, and an unconditional scroll-to-bottom is the commonest way a
+   * feed does exactly that: the operator is reading item four when item twenty
+   * arrives and the text moves out from under them.
+   */
+  const [pinned, setPinned] = useState(true);
+  const [unread, setUnread] = useState(0);
+  const seen = useRef(items.length);
+
+  const atBottom = useCallback((node: HTMLDivElement) => {
+    return (
+      node.scrollHeight - node.scrollTop - node.clientHeight <= BOTTOM_THRESHOLD_PX
+    );
+  }, []);
+
+  const onScroll = useCallback(() => {
+    const node = scroller.current;
+    if (!node) return;
+    const bottom = atBottom(node);
+    setPinned(bottom);
+    if (bottom) setUnread(0);
+  }, [atBottom]);
+
+  useEffect(() => {
+    const node = scroller.current;
+    const arrived = items.length - seen.current;
+    seen.current = items.length;
+    if (arrived <= 0 || !node) return;
+
+    if (pinned) {
+      // Assigning scrollTop rather than scrollIntoView: the latter can scroll
+      // *ancestors* too, which moves the checklist in the pane above.
+      node.scrollTop = node.scrollHeight;
+    } else {
+      // Counted, not shown to them by force. The affordance below lets the
+      // operator choose the moment they catch up.
+      setUnread((count) => count + arrived);
+    }
+  }, [items.length, pinned]);
+
+  const jumpToLatest = useCallback(() => {
+    const node = scroller.current;
+    if (!node) return;
+    node.scrollTop = node.scrollHeight;
+    setPinned(true);
+    setUnread(0);
+  }, []);
+
+  return (
+    <section
+      aria-labelledby="feedback-heading"
+      className="glass-card flex min-h-0 flex-col p-5"
+    >
+      <div className="flex items-center justify-between">
+        <h2 id="feedback-heading" className="text-sm font-semibold text-white">
+          Agent feedback
+        </h2>
+        <span className="text-xs text-brand-silver">{items.length} signals</span>
+      </div>
+
+      <div
+        ref={scroller}
+        onScroll={onScroll}
+        data-testid="feedback-scroller"
+        // AC-1: its own scroll container, so this pane moving leaves the
+        // checklist and the rail exactly where they were.
+        className="mt-3 min-h-0 flex-1 overflow-y-auto pr-1"
+        // Announced politely and never focused: an assertive region would
+        // interrupt a screen-reader user mid-sentence, which is the audible
+        // form of stealing focus.
+        aria-live="polite"
+        aria-relevant="additions"
+      >
+        {items.length === 0 ? (
+          <p className="text-sm text-brand-silver">
+            Suggestions, notable facts and coverage changes appear here once the
+            meeting is running.
+          </p>
+        ) : (
+          <ol className="space-y-2">
+            {items.map((item) => {
+              const Icon = ICONS[item.kind];
+              return (
+                // Keyed by id, never by index: a keyed-by-index list remounts
+                // every row when one is prepended, and a remount is how an
+                // input inside the tree would lose focus.
+                <li key={item.id} className="flex items-start gap-2">
+                  <Icon
+                    aria-hidden="true"
+                    className={`mt-0.5 h-4 w-4 shrink-0 ${KIND_STYLES[item.kind]}`}
+                  />
+                  <div className="min-w-0">
+                    <p className="text-sm text-white">
+                      <span className={`mr-2 text-xs ${KIND_STYLES[item.kind]}`}>
+                        {KIND_LABELS[item.kind]}
+                      </span>
+                      {item.text}
+                    </p>
+                  </div>
+                </li>
+              );
+            })}
+          </ol>
+        )}
+      </div>
+
+      {unread > 0 && (
+        // Inline and below the feed, not a toast over the checklist. §11: "no
+        // toast that covers the checklist".
+        <button
+          type="button"
+          onClick={jumpToLatest}
+          className="mt-2 self-start text-xs text-brand-electric hover:underline"
+        >
+          {unread} new {unread === 1 ? 'signal' : 'signals'} — jump to latest
+        </button>
+      )}
+    </section>
+  );
+}

--- a/ai-brand-automator-frontend/src/components/onboarding/MeetingView.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/MeetingView.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+/**
+ * The live meeting view (E-02, Design §11 MeetingView, FR-LIVE-02).
+ *
+ * "The horizontal split the requirement calls for: QuestionChecklist on top,
+ * AgentFeedbackStream below, RightRail alongside."
+ *
+ * §11 also gives this component the WebSocket and the seq cursor. That is
+ * F-04's work — E-02 is the shape, with placeholder data, so the stories that
+ * fill it have somewhere to attach.
+ *
+ * One rule governs the whole file, quoted from §11: "nothing the agent
+ * produces may steal focus. No modal, no toast that covers the checklist, no
+ * auto-scroll that moves what the operator is reading." The operator is
+ * conducting a conversation with a human being. Everything here is arranged
+ * so that an arriving signal cannot interrupt them:
+ *
+ *   - no element in this tree ever calls .focus() or .scrollIntoView()
+ *   - nothing is autoFocus'd
+ *   - the feedback pane follows new items only while already at the bottom
+ *   - the "N new" affordance sits inline under the feed, never over the
+ *     checklist
+ *
+ * Building it now is cheaper than retrofitting it once G-02 through G-06 are
+ * all pushing updates into the pane, which is what the card says too.
+ */
+
+import { useCallback, useState } from 'react';
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
+
+import AgentFeedbackStream, {
+  type FeedbackItem,
+} from '@/components/onboarding/AgentFeedbackStream';
+import QuestionChecklist from '@/components/onboarding/QuestionChecklist';
+import RightRail from '@/components/onboarding/RightRail';
+import type { PreparedQuestion } from '@/lib/onboarding-sessions';
+
+export interface MeetingViewProps {
+  questions: PreparedQuestion[];
+  version?: number | null;
+  /** Placeholder in E-02; F-04 streams these in. */
+  feedback?: FeedbackItem[];
+  companyName?: string | null;
+  /** Where "back" goes. Rendered inside this header — see the note below. */
+  backHref?: string;
+}
+
+export default function MeetingView({
+  questions,
+  version,
+  feedback = [],
+  companyName,
+  backHref,
+}: MeetingViewProps) {
+  /**
+   * Local only, and only for this story.
+   *
+   * The card is explicit: "Keep checkbox interactions in local state in this
+   * story only. G-03 replaces that with server-authoritative state, and the
+   * component boundary should already anticipate it." It does — QuestionChecklist
+   * takes `checkedIds` and `onToggle` and does not care where they come from,
+   * so G-03 swaps this useState for the server's answer and changes nothing
+   * below.
+   */
+  const [checkedIds, setCheckedIds] = useState<ReadonlySet<string>>(new Set());
+
+  const toggle = useCallback((questionId: string) => {
+    setCheckedIds((current) => {
+      const next = new Set(current);
+      if (next.has(questionId)) {
+        next.delete(questionId);
+      } else {
+        next.add(questionId);
+      }
+      return next;
+    });
+  }, []);
+
+  return (
+    /*
+     * A fixed-height grid rather than a page that grows.
+     *
+     * AC-1 wants three regions "each scrolling without moving the others",
+     * which is only true if the page itself does not scroll — otherwise the
+     * outer scrollbar moves all three together and the panes are decorative.
+     * min-h-0 on every track is what actually lets a flex/grid child shrink
+     * below its content and hand the overflow to its own scroller; without it
+     * children stay at content height and the page scrolls instead.
+     */
+    <div className="flex h-[calc(100vh-4rem)] min-h-0 flex-col gap-4 p-4">
+      {/*
+        The back link lives here, not above this component.
+        
+        Stacked, it added a 28px row *outside* the fixed-height box, so the
+        box started at y=92 while still being sized 100vh-4rem — and the page
+        scrolled by exactly that 28px. AC-1's three independent scrollers are
+        only independent while the document itself does not scroll; an outer
+        scrollbar moves all three together. One header, one height.
+      */}
+      <header className="shrink-0">
+        {backHref && (
+          <Link
+            href={backHref}
+            className="mb-1 inline-flex items-center gap-2 text-sm text-brand-silver hover:text-white"
+          >
+            <ArrowLeft className="h-4 w-4" aria-hidden />
+            Session
+          </Link>
+        )}
+        <h1 className="text-lg font-semibold text-white">
+          Meeting{companyName ? ` · ${companyName}` : ''}
+        </h1>
+        <p className="text-sm text-brand-silver">
+          Tick a question when it has been answered. The agent&rsquo;s
+          suggestions appear below and never interrupt you.
+        </p>
+      </header>
+
+      {/*
+        Two columns on a laptop, one on narrow screens. `lg:` rather than `md:`
+        because AC-2's target is a 13-inch laptop at typical zoom: at md the
+        rail and the checklist share a width neither can use, and the question
+        text starts wrapping every two or three words.
+      */}
+      <div className="grid min-h-0 flex-1 grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1fr)_20rem]">
+        {/* min-w-0 on the left track: without it a long unbroken question
+            string sets the column's minimum width and the whole page scrolls
+            sideways, which is exactly what AC-2 forbids. */}
+        <div className="grid min-h-0 min-w-0 grid-rows-2 gap-4">
+          <div data-testid="checklist-pane" className="min-h-0 overflow-y-auto">
+            <QuestionChecklist
+              questions={questions}
+              version={version}
+              checkedIds={checkedIds}
+              onToggle={toggle}
+            />
+          </div>
+
+          <AgentFeedbackStream items={feedback} />
+        </div>
+
+        <div className="min-h-0 min-w-0">
+          <RightRail />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ai-brand-automator-frontend/src/components/onboarding/QuestionChecklist.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/QuestionChecklist.tsx
@@ -48,12 +48,33 @@ export interface QuestionChecklistProps {
   questions: PreparedQuestion[];
   /** Null when the session has no approved questionnaire yet (AC-2). */
   version?: number | null;
+  /**
+   * Ids the operator has ticked (E-02).
+   *
+   * Only meaningful alongside `onToggle`. Held by the caller rather than here
+   * so G-03 can replace local state with server-authoritative state without
+   * touching this component — the boundary the E-02 card asks for.
+   */
+  checkedIds?: ReadonlySet<string>;
+  /**
+   * Omit for a read-only checklist, which is C-05's session page: the boxes
+   * report the agent's sufficiency signal and must not move when clicked.
+   * Supply it for the meeting view, where ticking one is the operator's job.
+   *
+   * Two modes rather than two components because the markup, the ordering
+   * rule and the workflow tags are the same in both, and a fork would let
+   * them drift — the numbering in particular, which the operator reads aloud.
+   */
+  onToggle?: (questionId: string) => void;
 }
 
 export default function QuestionChecklist({
   questions,
   version,
+  checkedIds,
+  onToggle,
 }: QuestionChecklistProps) {
+  const interactive = typeof onToggle === 'function';
   if (questions.length === 0) {
     return (
       <section aria-labelledby="checklist-heading" className="glass-card p-5">
@@ -102,7 +123,13 @@ export default function QuestionChecklist({
           <li key={question.id} className="flex items-start gap-3">
             <input
               type="checkbox"
-              readOnly
+              /*
+               * E-02: `readOnly` belongs to the display mode only. An
+               * interactive box is controlled by `checked` + `onChange` in the
+               * ordinary way, and leaving `readOnly` on it would suppress the
+               * very warning that tells you the handler is missing.
+               */
+              readOnly={!interactive}
               /*
                * Review was right that HTML ignores `readonly` on a checkbox,
                * and wrong about the remedy — and I checked before believing
@@ -124,13 +151,34 @@ export default function QuestionChecklist({
                * or announcing "unavailable" — G-03 makes these interactive
                * and the element should not change shape for that.
                */
-              aria-disabled
-              checked={question.status === 'GREEN'}
+              aria-disabled={interactive ? undefined : true}
+              /*
+               * Two sources of truth, deliberately not merged. In the display
+               * mode the box reports the agent's sufficiency signal; in the
+               * meeting it reports what the operator has ticked. G-03 is what
+               * reconciles them, and doing it early here would bake in a
+               * precedence rule that story has not decided yet.
+               */
+              checked={
+                interactive
+                  ? (checkedIds?.has(question.id) ?? false)
+                  : question.status === 'GREEN'
+              }
+              onChange={interactive ? () => onToggle?.(question.id) : undefined}
               aria-label={question.text}
               className="mt-1 h-4 w-4 shrink-0 rounded border-white/20 bg-transparent"
             />
             <div className="min-w-0">
-              <p className="text-sm text-white">
+              {/*
+                `break-words` is load-bearing, not decoration. Ordinary prose
+                wraps on its own and so does a URL — browsers break after `/`,
+                `?` and `&`. An unbroken run of characters does not, and
+                operators paste those: a reference code, an API key, an order
+                id. Without this the pane scrolls sideways, which is what AC-2
+                forbids, and the document does not — so a page-level overflow
+                check never sees it.
+              */}
+              <p className="break-words text-sm text-white">
                 <span className="mr-2 text-brand-silver">{index + 1}.</span>
                 {question.text}
               </p>

--- a/ai-brand-automator-frontend/src/components/onboarding/RightRail.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/RightRail.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+/**
+ * The meeting view's right rail (E-02, Design §11).
+ *
+ * Shells only. §11 gives the rail to RecorderControl, CaptureControl and
+ * RecordingsLibrary, and each of those is its own story — F-02, H-01 and
+ * I-01 respectively. What E-02 owes them is a place to attach that is already
+ * the right shape and already scrolls independently.
+ *
+ * The controls are rendered disabled rather than omitted, following the
+ * precedent E-01 set and for the same reason: a greyed control tells the
+ * operator the capability exists and is not ready, where an absent one reads
+ * as a missing feature. They carry an explicit reason so the state is legible
+ * rather than mysterious.
+ */
+
+import { Camera, Mic, Video } from 'lucide-react';
+
+export interface RightRailProps {
+  /** Placeholder count until I-01 lists real recordings. */
+  recordingCount?: number;
+}
+
+const CONTROLS = [
+  { icon: Mic, label: 'Start recording', owner: 'F-02' },
+  { icon: Camera, label: 'Capture photo', owner: 'H-01' },
+  { icon: Video, label: 'Capture video', owner: 'H-02' },
+] as const;
+
+export default function RightRail({ recordingCount = 0 }: RightRailProps) {
+  return (
+    <aside
+      aria-labelledby="rail-heading"
+      className="glass-card flex min-h-0 flex-col p-5"
+    >
+      <h2 id="rail-heading" className="text-sm font-semibold text-white">
+        Recordings and captures
+      </h2>
+
+      <div className="mt-3 space-y-2">
+        {CONTROLS.map(({ icon: Icon, label }) => (
+          <button
+            key={label}
+            type="button"
+            disabled
+            // The reason travels with the control. "Not available yet" on its
+            // own invites a support ticket asking when.
+            title="Available once live capture ships"
+            className="flex w-full items-center gap-2 rounded border border-white/10 px-3 py-2 text-sm text-brand-silver opacity-60"
+          >
+            <Icon aria-hidden="true" className="h-4 w-4 shrink-0" />
+            {label}
+          </button>
+        ))}
+      </div>
+
+      <div
+        data-testid="rail-scroller"
+        // AC-1: the rail scrolls on its own. A long recordings list must not
+        // push the capture controls off the top — they are the reason the rail
+        // is "always reachable" in FR-LIVE-02.
+        className="mt-4 min-h-0 flex-1 overflow-y-auto"
+      >
+        {recordingCount === 0 ? (
+          <p className="text-sm text-brand-silver">
+            Recordings and captured media appear here during the meeting.
+          </p>
+        ) : (
+          <p className="text-sm text-brand-silver">
+            {recordingCount} item{recordingCount === 1 ? '' : 's'}
+          </p>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/ai-brand-automator-frontend/src/components/onboarding/__tests__/MeetingView.test.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/__tests__/MeetingView.test.tsx
@@ -1,0 +1,348 @@
+/**
+ * E-02 · the meeting view's layout and its focus rules.
+ *
+ * The card names `test_focus_preserved_on_stream_update` and
+ * `test_no_autoscroll_after_manual_scroll`. FR-LIVE-02 is more specific about
+ * the first: "asserted by a frontend test that types continuously while
+ * signals stream in", which is what `types continuously` below does — a
+ * keystroke, a signal, a keystroke, for the length of a sentence.
+ *
+ * What jsdom can and cannot do here is worth stating, because a test that
+ * quietly proves nothing is worse than an absent one. jsdom has no layout
+ * engine: every element reports zero width and height, and `scrollTop`
+ * assignments are stored rather than clamped. So the scroll tests below drive
+ * the arithmetic by setting scrollHeight/clientHeight/scrollTop explicitly —
+ * which does exercise the real component logic — while AC-2, a claim about
+ * how the layout behaves at a real viewport, is covered by the Playwright
+ * spec in e2e/meeting-view.spec.ts and cannot be covered here.
+ */
+
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+
+import AgentFeedbackStream, {
+  type FeedbackItem,
+} from '@/components/onboarding/AgentFeedbackStream';
+import MeetingView from '@/components/onboarding/MeetingView';
+import type { PreparedQuestion } from '@/lib/onboarding-sessions';
+
+function aQuestion(n: number): PreparedQuestion {
+  // Every field the type declares, not a cast past the ones that were
+  // inconvenient. `as PreparedQuestion` over a partial object compiles until
+  // the interface grows, and then keeps compiling while the fixture drifts
+  // away from what the server actually sends.
+  return {
+    id: `q-${n}`,
+    order: n,
+    text: `Question number ${n} about the brand and how it came to be`,
+    origin: 'PREPARED',
+    workflow_target: n % 3 === 0 ? 'WF3' : n % 2 === 0 ? 'WF2' : 'WF1',
+    target_field: `field_${n}`,
+    status: 'OPEN',
+  };
+}
+
+const QUESTIONS = Array.from({ length: 20 }, (_, i) => aQuestion(i + 1));
+
+function aSignal(n: number): FeedbackItem {
+  return {
+    id: `f-${n}`,
+    kind: 'follow_up',
+    text: `Signal number ${n}`,
+    at: '2026-08-13T10:00:00Z',
+  };
+}
+
+/**
+ * Gives a scroll container the geometry jsdom will not compute, so the
+ * component's own pinned/unpinned arithmetic runs against real numbers.
+ */
+function giveGeometry(
+  node: HTMLElement,
+  { scrollHeight, clientHeight }: { scrollHeight: number; clientHeight: number },
+) {
+  Object.defineProperty(node, 'scrollHeight', {
+    configurable: true,
+    get: () => scrollHeight,
+  });
+  Object.defineProperty(node, 'clientHeight', {
+    configurable: true,
+    get: () => clientHeight,
+  });
+}
+
+/** A stream whose items can be appended from outside, as F-04 will append them. */
+function StreamHarness({ initial = 1 }: { initial?: number }) {
+  const [items, setItems] = useState<FeedbackItem[]>(
+    Array.from({ length: initial }, (_, i) => aSignal(i + 1)),
+  );
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setItems((prior) => [...prior, aSignal(prior.length + 1)])}
+      >
+        emit signal
+      </button>
+      <label htmlFor="note">Note</label>
+      <input id="note" />
+      <AgentFeedbackStream items={items} />
+    </>
+  );
+}
+
+describe('MeetingView layout (AC-1)', () => {
+  it('renders the three regions', () => {
+    render(<MeetingView questions={QUESTIONS} version={3} />);
+
+    expect(
+      screen.getByRole('region', { name: /prepared questions/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('region', { name: /agent feedback/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('complementary', { name: /recordings and captures/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('gives each region its own scroll container', () => {
+    /**
+     * The structural half of AC-1: three separate overflow containers rather
+     * than one page scroller. If the panes shared the page's scrollbar they
+     * would move together, and "each scrolling without moving the others"
+     * would be false however it looked.
+     */
+    const { container } = render(<MeetingView questions={QUESTIONS} />);
+
+    for (const id of ['checklist-pane', 'feedback-scroller', 'rail-scroller']) {
+      expect(screen.getByTestId(id).className).toContain('overflow-y-auto');
+    }
+    // And the page itself does not scroll: the outer shell is a fixed-height
+    // flex column, so the overflow belongs to the panes.
+    expect(container.firstElementChild?.className).toContain('h-[calc(100vh-4rem)]');
+  });
+
+  it('keeps the capture controls reachable above the rail list', () => {
+    /** FR-LIVE-02: "capture and recording controls always reachable". They sit
+     *  outside the rail's scroller, so a long list cannot push them away. */
+    render(<MeetingView questions={QUESTIONS} />);
+
+    const rail = screen.getByRole('complementary', { name: /recordings/i });
+    const record = within(rail).getByRole('button', { name: /start recording/i });
+
+    expect(screen.getByTestId('rail-scroller').contains(record)).toBe(false);
+  });
+});
+
+describe('checkbox state (E-02 local only)', () => {
+  it('ticks and unticks a question', async () => {
+    const user = userEvent.setup();
+    render(<MeetingView questions={QUESTIONS.slice(0, 3)} />);
+
+    const box = screen.getByRole('checkbox', { name: QUESTIONS[0].text });
+    expect(box).not.toBeChecked();
+
+    await user.click(box);
+    expect(box).toBeChecked();
+
+    await user.click(box);
+    expect(box).not.toBeChecked();
+  });
+
+  it('leaves the read-only checklist read-only', async () => {
+    /**
+     * The control for the two-mode props. C-05's session page renders the same
+     * component without `onToggle`, where a box reports the agent's signal and
+     * must not move when clicked — the behaviour #566 was opened to protect.
+     */
+    const user = userEvent.setup();
+    const QuestionChecklist = (
+      await import('@/components/onboarding/QuestionChecklist')
+    ).default;
+    render(<QuestionChecklist questions={QUESTIONS.slice(0, 2)} version={1} />);
+
+    const box = screen.getByRole('checkbox', { name: QUESTIONS[0].text });
+    await user.click(box);
+
+    expect(box).not.toBeChecked();
+    expect(box).toHaveAttribute('aria-disabled', 'true');
+  });
+});
+
+/** MeetingView with feedback that can be appended from outside, as F-04 will. */
+function MeetingHarness() {
+  const [feedback, setFeedback] = useState<FeedbackItem[]>([aSignal(1)]);
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setFeedback((prior) => [...prior, aSignal(prior.length + 1)])}
+      >
+        emit signal
+      </button>
+      <MeetingView questions={QUESTIONS} feedback={feedback} />
+    </>
+  );
+}
+
+describe('AC-3 · nothing steals focus', () => {
+  it('keeps focus on a checkbox while signals arrive', () => {
+    /**
+     * AC-3's own wording is "the operator ... interacting with a checkbox",
+     * and this is the case the sibling-input test cannot reach: the checkbox
+     * lives *inside* the tree that re-renders when feedback arrives, so a
+     * remount of the checklist — a conditional wrapper, a key tied to
+     * something that changes — would drop focus on the floor.
+     */
+    render(<MeetingHarness />);
+
+    const box = screen.getByRole('checkbox', { name: QUESTIONS[4].text });
+    box.focus();
+    expect(document.activeElement).toBe(box);
+
+    const emit = screen.getByRole('button', { name: /emit signal/i });
+    for (let i = 0; i < 5; i += 1) fireEvent.click(emit);
+
+    expect(document.activeElement).toBe(box);
+  });
+
+  it('keeps a half-typed note intact through a burst of signals', () => {
+    /**
+     * The same hazard for text: a remount restores an empty input, and the
+     * operator's half-written sentence is gone. Bursts rather than one signal,
+     * because G-02 through G-06 will push several at once.
+     */
+    render(<StreamHarness />);
+    const note = screen.getByLabelText('Note') as HTMLInputElement;
+    fireEvent.change(note, { target: { value: 'small batch roas' } });
+    note.focus();
+
+    const emit = screen.getByRole('button', { name: /emit signal/i });
+    for (let i = 0; i < 8; i += 1) fireEvent.click(emit);
+
+    expect(document.activeElement).toBe(note);
+    expect(note.value).toBe('small batch roas');
+  });
+
+  it('test_focus_preserved_on_stream_update', async () => {
+    /**
+     * FR-LIVE-02's own wording: a test that "types continuously while signals
+     * stream in". Typed one character at a time with a signal arriving between
+     * every keystroke, then the three things a stolen focus would break —
+     * which element has it, what it contains, and where the caret sits.
+     */
+    const user = userEvent.setup();
+    render(<StreamHarness />);
+
+    const note = screen.getByLabelText('Note') as HTMLInputElement;
+    const emit = screen.getByRole('button', { name: /emit signal/i });
+    await user.click(note);
+
+    const sentence = 'they roast in small batches';
+    for (const character of sentence) {
+      await user.type(note, character);
+      fireEvent.click(emit);
+    }
+
+    expect(document.activeElement).toBe(note);
+    expect(note.value).toBe(sentence);
+    expect(note.selectionStart).toBe(sentence.length);
+  });
+
+  it('test_no_autoscroll_after_manual_scroll', () => {
+    /**
+     * The operator has scrolled up to read something. New signals must not
+     * drag the view back down — §11: "no auto-scroll that moves what the
+     * operator is reading".
+     */
+    const { rerender } = render(
+      <AgentFeedbackStream items={[aSignal(1), aSignal(2)]} />,
+    );
+    const scroller = screen.getByTestId('feedback-scroller');
+    giveGeometry(scroller, { scrollHeight: 1000, clientHeight: 200 });
+
+    // Scrolled well away from the bottom, and the component told about it.
+    scroller.scrollTop = 100;
+    fireEvent.scroll(scroller);
+
+    rerender(<AgentFeedbackStream items={[aSignal(1), aSignal(2), aSignal(3)]} />);
+
+    expect(scroller.scrollTop).toBe(100);
+    // Counted instead, so the operator can catch up on their own terms.
+    expect(
+      screen.getByRole('button', { name: /1 new signal/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('follows the stream while the operator is already at the bottom', () => {
+    /**
+     * The control. A pane that never scrolled would pass the test above and
+     * force the operator to scroll manually for the whole meeting.
+     */
+    const { rerender } = render(<AgentFeedbackStream items={[aSignal(1)]} />);
+    const scroller = screen.getByTestId('feedback-scroller');
+    giveGeometry(scroller, { scrollHeight: 1000, clientHeight: 200 });
+
+    scroller.scrollTop = 800; // exactly at the bottom
+    fireEvent.scroll(scroller);
+
+    rerender(<AgentFeedbackStream items={[aSignal(1), aSignal(2)]} />);
+
+    expect(scroller.scrollTop).toBe(1000);
+    expect(screen.queryByRole('button', { name: /new signal/i })).toBeNull();
+  });
+
+  it('resumes following once the operator scrolls back down', () => {
+    const { rerender } = render(<AgentFeedbackStream items={[aSignal(1)]} />);
+    const scroller = screen.getByTestId('feedback-scroller');
+    giveGeometry(scroller, { scrollHeight: 1000, clientHeight: 200 });
+
+    scroller.scrollTop = 100;
+    fireEvent.scroll(scroller);
+    rerender(<AgentFeedbackStream items={[aSignal(1), aSignal(2)]} />);
+    expect(scroller.scrollTop).toBe(100);
+
+    scroller.scrollTop = 800;
+    fireEvent.scroll(scroller);
+    rerender(<AgentFeedbackStream items={[aSignal(1), aSignal(2), aSignal(3)]} />);
+
+    expect(scroller.scrollTop).toBe(1000);
+  });
+
+  it.each([
+    ['exactly at the bottom', 800, true],
+    ['within the rounding threshold', 790, true],
+    ['a clear scroll away', 700, false],
+  ])('%s → follows: %j', (_label, scrollTop, shouldFollow) => {
+    /**
+     * The boundary is not zero on purpose: sub-pixel rounding and a partly
+     * visible last row leave an operator who has scrolled all the way down
+     * sitting a pixel or two short, and a strict comparison would decide they
+     * had scrolled away and stop following for the rest of the meeting.
+     */
+    const { rerender } = render(<AgentFeedbackStream items={[aSignal(1)]} />);
+    const scroller = screen.getByTestId('feedback-scroller');
+    giveGeometry(scroller, { scrollHeight: 1000, clientHeight: 200 });
+
+    scroller.scrollTop = scrollTop;
+    fireEvent.scroll(scroller);
+    rerender(<AgentFeedbackStream items={[aSignal(1), aSignal(2)]} />);
+
+    expect(scroller.scrollTop).toBe(shouldFollow ? 1000 : scrollTop);
+  });
+
+  it('puts the catch-up affordance below the feed, never over the checklist', () => {
+    /** §11: "no modal, no toast that covers the checklist." */
+    render(<MeetingView questions={QUESTIONS} feedback={[aSignal(1)]} />);
+
+    expect(screen.queryByRole('dialog')).toBeNull();
+    expect(screen.queryByRole('alertdialog')).toBeNull();
+    // Politely announced, so a screen reader is not interrupted mid-sentence.
+    expect(screen.getByTestId('feedback-scroller')).toHaveAttribute(
+      'aria-live',
+      'polite',
+    );
+  });
+});


### PR DESCRIPTION
**E-02 · Meeting view layout.** Questions above, agent feedback below, recordings and captures alongside, at `/onboarding/sessions/[id]/meeting`. Placeholder data throughout — F-04 fills the stream, F-02 and H-01 the rail's controls. This story owes them the shape.

Unblocks **F-01, F-02, G-03, H-01, I-01** — effectively all of Epics F, G, H and I. It was the only unblocked story left; A–D and E-01 are complete (22 of 59).

## The component boundary the card asks for

`QuestionChecklist` gains `checkedIds` and `onToggle`. Omit them and it is C-05's read-only display, where a box reports the agent's sufficiency signal and must not move when clicked — the behaviour #566 exists to protect, still covered by its own test. Supply them and it is the meeting's checklist. G-03 swaps local state for server-authoritative state and changes nothing else.

## AC-3, built in rather than retrofitted

Nothing in this tree calls `.focus()` or `.scrollIntoView()`, nothing is `autoFocus`'d, the feed follows new items **only while the operator is already at the bottom**, and the catch-up affordance sits inline below the feed rather than over the checklist. The card is right that this is much cheaper now than once G-02–G-06 are all pushing updates in.

## Why Playwright, and what it found

You approved installing it for AC-2. jsdom cannot speak to that criterion at all — every element reports zero by zero, so the only jsdom version of "no horizontal scrolling at a 13-inch viewport" would assert that the CSS classes I wrote are the CSS classes I wrote.

It paid for itself in one run, twice:

**The checklist pane scrolled sideways by 665px** on an unbroken reference code. Ordinary prose wraps by itself, and a URL does too — browsers break after `/`, `?` and `&` — so only a run with no break opportunity exposes it, and operators paste those. Fixed with `break-words`.

The first version of that test measured the **document**, which stayed exactly 1280 wide while the pane overflowed. It could never have failed. It measures each region now.

**The page scrolled vertically by 28px**, because the back link sat above a box sized `100vh - 4rem` rather than inside its header. AC-1's three independent scrollers are only independent while the document itself does not scroll — an outer scrollbar moves all three together.

Both are AC failures invisible to any jsdom test, found before review instead of after.

## Testing

15 jsdom tests, 5 browser tests, both cases the card names by name (`test_focus_preserved_on_stream_update`, `test_no_autoscroll_after_manual_scroll`) plus FR-LIVE-02's specific wording — a test that types continuously while signals stream in.

Verified by mutation: removing `break-words`, shrinking the height offset, keying the checklist so it remounts, and ignoring the pinned flag each fail the test written for it.

**Honest gap:** `min-w-0` on the grid tracks is defensive and is *not* covered — with `break-words` in place, no content I could construct made it matter. I left it in as correct CSS rather than delete something a future wide child will need.

Two earlier attempts at the focus test are worth knowing about. The first put the typed input as a *sibling* of the stream, where a remount could not reach it; a `.focus()` mutation passed straight through. The second tests a checkbox inside the tree that actually re-renders, which is AC-3's own wording, and a remount mutation fails it.

## CI

The browser job is deliberately **not** suffixed with `|| echo`, unlike the jest step directly above it (#565). A gate that cannot fail is not a gate.

Frontend baseline unchanged: the same four wizard suites fail on a clean tree with the same 36 failures — confirmed by stashing, not assumed.

## Not delivered

WebSocket (F-04), real streamed feedback, recorder and capture controls beyond disabled shells (F-02, H-01), server-authoritative checkbox state (G-03), coverage fractions (G-06).