### PR TITLE
feat(onboarding): consent before the microphone opens (F-01)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -63,13 +63,3 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          review_instructions: |
-            Focus on:
-            - Multi-tenancy: ensure tenant-scoped queries use Q(tenant=tenant) | Q(tenant__isnull=True)
-            - Security: no os.environ (use decouple.config()), no raw fetch() in frontend (use apiClient)
-            - Django patterns: select_related on FK querysets, atomic callbacks, proper migration usage
-            - TypeScript: no 'any' types, strict mode compliance
-            - Service boundaries: check service-to-service auth headers (X-Service-Token, X-Callback-Token)
-            - Kafka topic naming consistency with existing conventions
-            - Redis DB allocation conflicts (DB 0-25 are assigned)
-            - Frontend: useAuth() guard, hydration-safe tenant-role UI, setTimeout polling (not setInterval)

--- a/ai-brand-automator-frontend/src/app/onboarding/sessions/[sessionId]/meeting/page.tsx
+++ b/ai-brand-automator-frontend/src/app/onboarding/sessions/[sessionId]/meeting/page.tsx
@@ -18,8 +18,22 @@ import { useAuth } from '@/hooks/useAuth';
 import MeetingView from '@/components/onboarding/MeetingView';
 import {
   getApprovedQuestionnaire,
+  getSessionConsent,
+  grantConsent,
+  type ConsentDraft,
+  type ConsentState,
   type QuestionnaireDetail,
 } from '@/lib/onboarding-sessions';
+
+/**
+ * How often the page re-reads consent (F-01 AC-4).
+ *
+ * Revocation happens on the session detail page, in another tab or by another
+ * operator, so nothing pushes it here. Three seconds, matching the agent's
+ * own watch interval: AC-4 gives five, and a five-second poll spends the whole
+ * budget waiting.
+ */
+const CONSENT_POLL_MS = 3000;
 
 export default function MeetingPage() {
   useAuth();
@@ -27,6 +41,7 @@ export default function MeetingPage() {
   const sessionId = params?.sessionId;
 
   const [questionnaire, setQuestionnaire] = useState<QuestionnaireDetail | null>(null);
+  const [consent, setConsent] = useState<ConsentState | null>(null);
   const [loading, setLoading] = useState(true);
 
   const load = useCallback(async () => {
@@ -53,6 +68,43 @@ export default function MeetingPage() {
     void load();
   }, [load]);
 
+  const readConsent = useCallback(async () => {
+    if (!sessionId) return;
+    try {
+      setConsent(await getSessionConsent(sessionId));
+    } catch (error) {
+      // Not cleared to null on failure: null means "still reading" and hides
+      // the banner. A failed poll must not make a session with no consent
+      // look fine — it stays on the last state it actually knew.
+      console.error('Failed to read consent:', error);
+    }
+  }, [sessionId]);
+
+  useEffect(() => {
+    void readConsent();
+    // setTimeout-chained rather than setInterval, matching usePollingJob: an
+    // interval stacks requests when one is slow.
+    let timer: ReturnType<typeof setTimeout>;
+    let cancelled = false;
+    const poll = async () => {
+      await readConsent();
+      if (!cancelled) timer = setTimeout(poll, CONSENT_POLL_MS);
+    };
+    timer = setTimeout(poll, CONSENT_POLL_MS);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [readConsent]);
+
+  const onGrantConsent = useCallback(
+    async (draft: ConsentDraft) => {
+      if (!sessionId) return;
+      setConsent(await grantConsent(sessionId, draft));
+    },
+    [sessionId],
+  );
+
   if (loading) {
     return <p className="p-4 text-sm text-brand-silver">Loading questions…</p>;
   }
@@ -62,6 +114,8 @@ export default function MeetingPage() {
       questions={questionnaire?.questions ?? []}
       version={questionnaire?.version ?? null}
       backHref={sessionId ? `/onboarding/sessions/${sessionId}` : '/onboarding'}
+      consent={consent}
+      onGrantConsent={onGrantConsent}
     />
   );
 }

--- a/ai-brand-automator-frontend/src/components/onboarding/ConsentModal.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/ConsentModal.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+/**
+ * Consent capture, before the microphone can open (F-01, AC-2).
+ *
+ * A record, not a checkbox. FR-GDPR-01 wants "who consented, when, and to what
+ * scope", and a boolean answers none of those. The subject's name is typed
+ * here, stored on the ConsentRecord, and never leaves the tenant-scoped
+ * database — the event stream gets a keyed hash instead.
+ *
+ * Consent is per session and never inherited. If the operator has run three
+ * meetings with the same brand owner, they record consent three times: B-07
+ * made that structural (the FK is to session), and this is where it becomes
+ * visible to a person.
+ *
+ * This is the one modal the meeting view is allowed to show. §11's rule is
+ * that nothing *the agent produces* may steal focus; this is the operator's
+ * own deliberate action, and it must have their attention — the microphone
+ * cannot open until it does.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ShieldCheck, X } from 'lucide-react';
+
+import {
+  ONBOARDING_CONSENT_SCOPE,
+  type ConsentDraft,
+  type ConsentMethod,
+} from '@/lib/onboarding-sessions';
+
+export interface ConsentModalProps {
+  open: boolean;
+  onCancel: () => void;
+  onConfirm: (draft: ConsentDraft) => Promise<void> | void;
+  saving?: boolean;
+  error?: string | null;
+}
+
+const METHODS: { value: ConsentMethod; label: string; hint: string }[] = [
+  {
+    value: 'VERBAL_RECORDED',
+    label: 'Spoken aloud',
+    hint: 'They said yes, and the recording will carry it.',
+  },
+  {
+    value: 'CHECKBOX',
+    label: 'In writing',
+    hint: 'They agreed in a form, email or signed note.',
+  },
+];
+
+export default function ConsentModal({
+  open,
+  onCancel,
+  onConfirm,
+  saving = false,
+  error = null,
+}: ConsentModalProps) {
+  const [subjectName, setSubjectName] = useState('');
+  const [method, setMethod] = useState<ConsentMethod>('VERBAL_RECORDED');
+  const nameInput = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (open) nameInput.current?.focus();
+  }, [open]);
+
+  const submit = useCallback(
+    async (event: React.FormEvent) => {
+      event.preventDefault();
+      const name = subjectName.trim();
+      if (!name) return;
+      await onConfirm({
+        subject_name: name,
+        method,
+        scope: ONBOARDING_CONSENT_SCOPE,
+      });
+    },
+    [subjectName, method, onConfirm],
+  );
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="consent-heading"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+    >
+      <form
+        onSubmit={submit}
+        className="glass-card w-full max-w-md space-y-4 p-6"
+      >
+        <div className="flex items-start justify-between gap-3">
+          <h2
+            id="consent-heading"
+            className="flex items-center gap-2 text-base font-semibold text-white"
+          >
+            <ShieldCheck className="h-5 w-5 text-brand-electric" aria-hidden />
+            Record consent
+          </h2>
+          <button
+            type="button"
+            onClick={onCancel}
+            aria-label="Close"
+            className="text-brand-silver hover:text-white"
+          >
+            <X className="h-4 w-4" aria-hidden />
+          </button>
+        </div>
+
+        <div>
+          <label
+            htmlFor="subject-name"
+            className="block text-sm text-brand-silver"
+          >
+            Who is consenting?
+          </label>
+          <input
+            id="subject-name"
+            ref={nameInput}
+            value={subjectName}
+            onChange={(event) => setSubjectName(event.target.value)}
+            required
+            className="mt-1 w-full rounded border border-white/15 bg-transparent px-3 py-2 text-sm text-white"
+          />
+          <p className="mt-1 text-xs text-brand-silver">
+            Their name is stored with the consent record and is never sent to
+            the agent or to analytics.
+          </p>
+        </div>
+
+        <fieldset>
+          <legend className="text-sm text-brand-silver">
+            How did they agree?
+          </legend>
+          <div className="mt-2 space-y-2">
+            {METHODS.map((option) => (
+              <label
+                key={option.value}
+                className="flex items-start gap-2 text-sm text-white"
+              >
+                <input
+                  type="radio"
+                  name="consent-method"
+                  value={option.value}
+                  checked={method === option.value}
+                  onChange={() => setMethod(option.value)}
+                  className="mt-1"
+                />
+                <span>
+                  {option.label}
+                  <span className="block text-xs text-brand-silver">
+                    {option.hint}
+                  </span>
+                </span>
+              </label>
+            ))}
+          </div>
+        </fieldset>
+
+        {/*
+          The scope is stated, not implied. This sentence and
+          ONBOARDING_CONSENT_SCOPE have to say the same thing — consent for
+          something the operator did not read out is not consent.
+        */}
+        <p className="rounded border border-white/10 p-3 text-xs text-brand-silver">
+          Confirming records that they agreed to this meeting being{' '}
+          <strong className="text-white">recorded</strong>,{' '}
+          <strong className="text-white">transcribed</strong> and{' '}
+          <strong className="text-white">processed</strong> to build their brand
+          profile. They can withdraw at any time, and recording stops when they
+          do.
+        </p>
+
+        {error && (
+          <p role="alert" className="text-sm text-rose-300">
+            {error}
+          </p>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded px-3 py-2 text-sm text-brand-silver hover:text-white"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={saving || !subjectName.trim()}
+            className="btn-primary text-sm disabled:opacity-50"
+          >
+            {saving ? 'Recording…' : 'Record consent'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/ai-brand-automator-frontend/src/components/onboarding/MeetingView.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/MeetingView.tsx
@@ -35,7 +35,8 @@ import AgentFeedbackStream, {
 } from '@/components/onboarding/AgentFeedbackStream';
 import QuestionChecklist from '@/components/onboarding/QuestionChecklist';
 import RightRail from '@/components/onboarding/RightRail';
-import type { PreparedQuestion } from '@/lib/onboarding-sessions';
+import ConsentModal from '@/components/onboarding/ConsentModal';
+import type { ConsentDraft, ConsentState, PreparedQuestion } from '@/lib/onboarding-sessions';
 
 export interface MeetingViewProps {
   questions: PreparedQuestion[];
@@ -45,6 +46,9 @@ export interface MeetingViewProps {
   companyName?: string | null;
   /** Where "back" goes. Rendered inside this header — see the note below. */
   backHref?: string;
+  /** F-01: null while it is still being read. */
+  consent?: ConsentState | null;
+  onGrantConsent?: (draft: ConsentDraft) => Promise<void>;
 }
 
 export default function MeetingView({
@@ -53,7 +57,36 @@ export default function MeetingView({
   feedback = [],
   companyName,
   backHref,
+  consent = null,
+  onGrantConsent,
 }: MeetingViewProps) {
+  const [consentOpen, setConsentOpen] = useState(false);
+  const [consentSaving, setConsentSaving] = useState(false);
+  const [consentError, setConsentError] = useState<string | null>(null);
+
+  const granted = consent?.granted === true;
+
+  const confirmConsent = useCallback(
+    async (draft: ConsentDraft) => {
+      if (!onGrantConsent) return;
+      setConsentSaving(true);
+      setConsentError(null);
+      try {
+        await onGrantConsent(draft);
+        setConsentOpen(false);
+      } catch (error) {
+        // Left open with the reason. Closing on failure would look like
+        // success, and the operator would reach for a microphone that is
+        // still shut.
+        setConsentError(
+          error instanceof Error ? error.message : 'Could not record consent.',
+        );
+      } finally {
+        setConsentSaving(false);
+      }
+    },
+    [onGrantConsent],
+  );
   /**
    * Local only, and only for this story.
    *
@@ -90,6 +123,30 @@ export default function MeetingView({
      * children stay at content height and the page scrolls instead.
      */
     <div className="flex h-[calc(100vh-4rem)] min-h-0 flex-col gap-4 p-4">
+      {/*
+        AC-4: a revoked or absent consent is a blocking notice, not a subtle
+        one. `consent === null` means "still reading" and shows nothing —
+        flashing a compliance warning during a page load would train operators
+        to dismiss it without reading.
+      */}
+      {consent !== null && !granted && (
+        <div
+          role="alert"
+          className="shrink-0 rounded border border-amber-400/40 bg-amber-400/10 px-4 py-2 text-sm text-amber-200"
+        >
+          Recording is off: this meeting has no active consent. Record consent
+          before opening the microphone.
+        </div>
+      )}
+
+      <ConsentModal
+        open={consentOpen}
+        onCancel={() => setConsentOpen(false)}
+        onConfirm={confirmConsent}
+        saving={consentSaving}
+        error={consentError}
+      />
+
       {/*
         The back link lives here, not above this component.
         
@@ -142,7 +199,10 @@ export default function MeetingView({
         </div>
 
         <div className="min-h-0 min-w-0">
-          <RightRail />
+          <RightRail
+            consentGranted={granted}
+            onRecordConsent={() => setConsentOpen(true)}
+          />
         </div>
       </div>
     </div>

--- a/ai-brand-automator-frontend/src/components/onboarding/RightRail.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/RightRail.tsx
@@ -20,15 +20,22 @@ import { Camera, Mic, Video } from 'lucide-react';
 export interface RightRailProps {
   /** Placeholder count until I-01 lists real recordings. */
   recordingCount?: number;
+  /** Whether an active ConsentRecord exists for this session (F-01). */
+  consentGranted?: boolean;
+  /** Opens the consent modal. AC-1: the disabled control still does this. */
+  onRecordConsent?: () => void;
 }
 
-const CONTROLS = [
-  { icon: Mic, label: 'Start recording', owner: 'F-02' },
+const CAPTURE_CONTROLS = [
   { icon: Camera, label: 'Capture photo', owner: 'H-01' },
   { icon: Video, label: 'Capture video', owner: 'H-02' },
 ] as const;
 
-export default function RightRail({ recordingCount = 0 }: RightRailProps) {
+export default function RightRail({
+  recordingCount = 0,
+  consentGranted = false,
+  onRecordConsent,
+}: RightRailProps) {
   return (
     <aside
       aria-labelledby="rail-heading"
@@ -39,7 +46,45 @@ export default function RightRail({ recordingCount = 0 }: RightRailProps) {
       </h2>
 
       <div className="mt-3 space-y-2">
-        {CONTROLS.map(({ icon: Icon, label }) => (
+        {/*
+          AC-1: "the record control is visible but disabled, with the reason
+          stated inline — 'Record consent to enable recording' — rather than as
+          an unexplained grey button. And clicking it opens the consent modal
+          rather than doing nothing."
+          
+          So it is not `disabled`. A disabled button cannot be clicked, cannot
+          be focused and is skipped by a screen reader's button list, which
+          would make the second half of that criterion impossible. `aria-disabled`
+          says "this will not do what it says yet" while leaving it reachable —
+          the same distinction QuestionChecklist landed on in #566.
+        */}
+        <button
+          type="button"
+          aria-disabled={!consentGranted}
+          onClick={consentGranted ? undefined : onRecordConsent}
+          className={`flex w-full items-center gap-2 rounded border px-3 py-2 text-sm ${
+            consentGranted
+              ? 'border-white/10 text-brand-silver opacity-60'
+              : 'border-brand-electric/40 text-white'
+          }`}
+          title={
+            consentGranted
+              ? 'Available once live capture ships'
+              : 'Record consent to enable recording'
+          }
+        >
+          <Mic aria-hidden="true" className="h-4 w-4 shrink-0" />
+          Start recording
+        </button>
+        {!consentGranted && (
+          // Inline, not a tooltip. AC-1 asks for the reason *stated*, and a
+          // title attribute is invisible to touch and to most screen readers.
+          <p className="text-xs text-amber-300">
+            Record consent to enable recording
+          </p>
+        )}
+
+        {CAPTURE_CONTROLS.map(({ icon: Icon, label }) => (
           <button
             key={label}
             type="button"

--- a/ai-brand-automator-frontend/src/components/onboarding/__tests__/MeetingView.test.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/__tests__/MeetingView.test.tsx
@@ -346,3 +346,152 @@ describe('AC-3 · nothing steals focus', () => {
     );
   });
 });
+
+// ── F-01 · consent gates the microphone ──────────────────────────────
+
+const NO_CONSENT = {
+  granted: false,
+  granted_at: null,
+  method: null,
+  scope: null,
+} as const;
+
+const GRANTED = {
+  granted: true,
+  granted_at: '2026-08-14T10:00:00Z',
+  method: 'VERBAL_RECORDED',
+  scope: { audio: true, transcript: true, captured_media: true },
+} as const;
+
+describe('F-01 · consent before the microphone', () => {
+  it('shows the record control disabled, with the reason stated inline', () => {
+    /**
+     * AC-1 is specific that this must not be "an unexplained grey button".
+     * The reason is asserted as visible text, not as a title attribute — a
+     * tooltip is invisible to touch and to most screen readers, so it is not
+     * a stated reason.
+     */
+    render(<MeetingView questions={QUESTIONS} consent={NO_CONSENT} />);
+
+    const record = screen.getByRole('button', { name: /start recording/i });
+    expect(record).toHaveAttribute('aria-disabled', 'true');
+    expect(screen.getByText('Record consent to enable recording')).toBeInTheDocument();
+  });
+
+  it('opens the consent modal when the disabled control is clicked', async () => {
+    /**
+     * AC-1's second half: "clicking it opens the consent modal rather than
+     * doing nothing". This is why the control carries aria-disabled instead of
+     * `disabled` — a truly disabled button cannot be clicked at all, so the
+     * criterion would be unsatisfiable.
+     */
+    const user = userEvent.setup();
+    render(<MeetingView questions={QUESTIONS} consent={NO_CONSENT} />);
+
+    await user.click(screen.getByRole('button', { name: /start recording/i }));
+
+    expect(screen.getByRole('dialog', { name: /record consent/i })).toBeInTheDocument();
+  });
+
+  it('blocks the view with a notice while consent is missing', () => {
+    render(<MeetingView questions={QUESTIONS} consent={NO_CONSENT} />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/no active consent/i);
+  });
+
+  it('shows no notice and no reason once consent is granted', () => {
+    /** The control. A banner that never cleared would make AC-4's revocation
+     *  notice meaningless — an always-on warning is wallpaper. */
+    render(<MeetingView questions={QUESTIONS} consent={GRANTED} />);
+
+    expect(screen.queryByRole('alert')).toBeNull();
+    expect(
+      screen.queryByText('Record consent to enable recording'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('says nothing at all while consent is still being read', () => {
+    /**
+     * `null` is "not yet known", not "absent". Flashing a compliance warning
+     * during a page load is how operators learn to dismiss them unread.
+     */
+    render(<MeetingView questions={QUESTIONS} consent={null} />);
+
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('sends the name, method and full scope, and closes on success', async () => {
+    const user = userEvent.setup();
+    const granted: unknown[] = [];
+    render(
+      <MeetingView
+        questions={QUESTIONS}
+        consent={NO_CONSENT}
+        onGrantConsent={async (draft) => {
+          granted.push(draft);
+        }}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /start recording/i }));
+    await user.type(screen.getByLabelText(/who is consenting/i), 'Asha Kalyani');
+    await user.click(screen.getByRole('button', { name: /^record consent$/i }));
+
+    expect(granted).toEqual([
+      {
+        subject_name: 'Asha Kalyani',
+        method: 'VERBAL_RECORDED',
+        // The scope the sentence above the button describes. If these drift,
+        // the operator has confirmed something other than what was recorded.
+        scope: { audio: true, transcript: true, captured_media: true },
+      },
+    ]);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('keeps the modal open, with the reason, when recording consent fails', async () => {
+    /** Closing on failure would look like success, and the operator would
+     *  reach for a microphone that is still shut. */
+    const user = userEvent.setup();
+    render(
+      <MeetingView
+        questions={QUESTIONS}
+        consent={NO_CONSENT}
+        onGrantConsent={async () => {
+          throw new Error('API 502: upstream unavailable');
+        }}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /start recording/i }));
+    await user.type(screen.getByLabelText(/who is consenting/i), 'Asha Kalyani');
+    await user.click(screen.getByRole('button', { name: /^record consent$/i }));
+
+    // Scoped to the dialog: the blocking banner behind it is also an alert,
+    // so an unscoped query is ambiguous — and would pass on the banner even
+    // if the modal showed no reason at all.
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+    expect(within(dialog).getByRole('alert')).toHaveTextContent(/502/);
+  });
+
+  it('AC-4 · a revocation puts the notice back and disables the control', () => {
+    /**
+     * Driven as a prop change, which is what the page's poll produces when
+     * someone revokes from the session detail page. The card calls the
+     * revocation path "the part teams skip".
+     */
+    const { rerender } = render(
+      <MeetingView questions={QUESTIONS} consent={GRANTED} />,
+    );
+    expect(screen.queryByRole('alert')).toBeNull();
+
+    rerender(<MeetingView questions={QUESTIONS} consent={NO_CONSENT} />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/no active consent/i);
+    expect(screen.getByRole('button', { name: /start recording/i })).toHaveAttribute(
+      'aria-disabled',
+      'true',
+    );
+  });
+});

--- a/ai-brand-automator-frontend/src/lib/onboarding-sessions.ts
+++ b/ai-brand-automator-frontend/src/lib/onboarding-sessions.ts
@@ -273,3 +273,78 @@ export function viewerTimezone(): string {
     return 'UTC';
   }
 }
+
+// ── Consent (F-01) ───────────────────────────────────────────────────
+
+/** §10.1's ConsentMethod, as B-07 shipped it. */
+export type ConsentMethod = 'VERBAL_RECORDED' | 'CHECKBOX';
+
+/**
+ * What the session endpoint reports about consent.
+ *
+ * `granted` is false both when no consent was ever recorded and when it has
+ * been revoked — B-07 reports only the *active* record, so a revoked one reads
+ * as absent here. That is the right shape for this screen: both states mean
+ * "the microphone stays shut", and the difference belongs in the audit trail
+ * rather than in a banner.
+ */
+export interface ConsentState {
+  granted: boolean;
+  granted_at: string | null;
+  method: ConsentMethod | null;
+  scope: Record<string, boolean> | null;
+}
+
+export interface ConsentDraft {
+  subject_name: string;
+  method: ConsentMethod;
+  scope: Record<string, boolean>;
+}
+
+/**
+ * The scope every onboarding recording needs, and no more.
+ *
+ * Named here rather than assembled in the modal so the three things the
+ * operator is asked to confirm are the three things actually sent. A scope
+ * that drifts from the sentence above the button is consent for something
+ * nobody agreed to.
+ */
+export const ONBOARDING_CONSENT_SCOPE: Record<string, boolean> = {
+  audio: true,
+  transcript: true,
+  captured_media: true,
+};
+
+export async function getSessionConsent(sessionId: string): Promise<ConsentState> {
+  const response = await apiClient.get(`${BASE}/sessions/${sessionId}/`);
+  if (!response.ok) {
+    throw new Error(`API ${response.status}: ${await response.text()}`);
+  }
+  const session = await response.json();
+  return (
+    session?.consent ?? {
+      granted: false,
+      granted_at: null,
+      method: null,
+      scope: null,
+    }
+  );
+}
+
+export async function grantConsent(
+  sessionId: string,
+  draft: ConsentDraft,
+): Promise<ConsentState> {
+  const response = await apiClient.post(
+    `${BASE}/sessions/${sessionId}/consent/`,
+    draft,
+  );
+  if (!response.ok) {
+    throw new Error(`API ${response.status}: ${await response.text()}`);
+  }
+  await response.json();
+  // Re-read rather than trusting the write's echo: the session endpoint is
+  // what the rest of this screen polls, and two sources for one fact is how
+  // a banner and a button end up disagreeing.
+  return getSessionConsent(sessionId);
+}

--- a/ai-brand-automator/apps/onboarding/events.py
+++ b/ai-brand-automator/apps/onboarding/events.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import logging
 
 from django.conf import settings
+from django.utils.crypto import salted_hmac
 
 logger = logging.getLogger(__name__)
 
@@ -113,6 +114,92 @@ def emit_provenance_reviewed(
             "EVT-109 not queued (event_ref=%s field=%s) — review still applied",
             EVENT_REF,
             field_name,
+            exc_info=True,
+        )
+
+    return payload
+
+
+# ── EVT-101 · onboarding.consent.verified (F-01, AC-2) ───────────────
+
+#: Matches EventType.CONSENT_VERIFIED in the agent's catalogue.
+CONSENT_EVENT_TYPE = "onboarding.consent.verified"
+CONSENT_EVENT_REF = "EVT-101"
+
+#: Namespaces the HMAC so a subject hash cannot be compared against a hash of
+#: the same string produced for any other purpose in this codebase.
+CONSENT_HASH_SALT = "apps.onboarding.events.consent_subject"
+
+
+def subject_name_hash(name: str) -> str:
+    """A hash of the subject's name that cannot be turned back into it.
+
+    Keyed, not bare. §12 lets the event stream carry ``subject_name_hash`` and
+    never the name, and a plain SHA-256 of a personal name defeats that in an
+    afternoon: the input space is small enough to enumerate, so an unkeyed
+    digest of "Ada Lovelace" is "Ada Lovelace" to anyone with a name list.
+
+    ``salted_hmac`` keys it off SECRET_KEY, which is the same root of trust the
+    project already uses for OAuth token encryption. No new secret to
+    provision, rotate or leave unset in one environment — and being unset is
+    the failure mode that would quietly turn this back into a bare digest.
+
+    Normalised first so the same person recorded twice hashes the same way,
+    which is the only property that makes the hash useful for correlation at
+    all. Case and surrounding whitespace are not identity.
+    """
+    normalised = " ".join(str(name or "").split()).casefold()
+    return salted_hmac(CONSENT_HASH_SALT, normalised).hexdigest()
+
+
+def build_consent_payload(*, consent_id, method: str, subject_name: str) -> dict:
+    """The EVT-101 body, and nothing else.
+
+    Built by a named function so a test can assert the exact key set. AC-2 says
+    the event carries "consent_id, method and subject_name_hash — never the
+    subject's name", and the way a name reaches an event stream is that someone
+    adds a field here for a good reason. It should have to get past an
+    assertion first.
+    """
+    return {
+        "event_ref": CONSENT_EVENT_REF,
+        "consent_id": str(consent_id),
+        "method": method,
+        "subject_name_hash": subject_name_hash(subject_name),
+    }
+
+
+def emit_consent_verified(
+    *, tenant_id, session_id, consent_id, method: str, subject_name: str
+) -> dict:
+    """Publish EVT-101. Returns the payload so callers can assert on it.
+
+    Never raises. Consent has already been recorded in the database by the time
+    this runs; a broker problem must not turn a lawful, captured consent into a
+    failed request the operator retries.
+    """
+    payload = build_consent_payload(
+        consent_id=consent_id, method=method, subject_name=subject_name
+    )
+
+    if not emission_enabled():
+        logger.debug("EVT-101 suppressed: Kafka disabled (consent=%s)", consent_id)
+        return payload
+
+    try:
+        from kafka_service.tasks import publish_event_to_kafka
+
+        publish_event_to_kafka.delay(
+            topic=f"agent.events.{tenant_id}" if tenant_id else "agent.events",
+            event_type=CONSENT_EVENT_TYPE,
+            data={**payload, "session_id": str(session_id)},
+            key=str(session_id),
+        )
+    except Exception:  # noqa: BLE001 - see the module docstring
+        logger.warning(
+            "EVT-101 not queued (event_ref=%s consent=%s) — consent still recorded",
+            CONSENT_EVENT_REF,
+            consent_id,
             exc_info=True,
         )
 

--- a/ai-brand-automator/apps/onboarding/tests/test_consent_api.py
+++ b/ai-brand-automator/apps/onboarding/tests/test_consent_api.py
@@ -15,6 +15,8 @@ a product problem.
 
 from __future__ import annotations
 
+import json
+import logging
 from datetime import timedelta
 
 import pytest
@@ -27,7 +29,7 @@ from apps.onboarding.commands import (
     build_consent_revoked,
     commands_enabled,
 )
-from apps.onboarding.models import ConsentMethod, SessionStatus
+from apps.onboarding.models import ConsentMethod, ConsentRecord, SessionStatus
 from apps.onboarding.tests.factories import make_company, make_consent, make_session
 from tenants.models import Membership, Tenant
 
@@ -64,6 +66,26 @@ def viewer(public_tenant):
 
 def consent_url(session) -> str:
     return f"{SESSIONS}{session.pk}/consent/"
+
+
+def precheck(session, settings) -> dict:
+    """What the agent sees. Service-token authenticated, like the agent's call.
+
+    Driven through the real endpoint rather than by calling `_consent_block`,
+    because the thing worth proving is that the agent's *response* carries it —
+    a helper that returns the right dict into a response nobody assembles is
+    the failure this is meant to catch.
+    """
+    settings.OIA_SERVICE_TOKEN = "test-service-token"
+    client = APIClient()
+    client.defaults["SERVER_NAME"] = "localhost"
+    response = client.get(
+        f"{SESSIONS}{session.pk}/live-precheck/",
+        HTTP_X_SERVICE_TOKEN="test-service-token",
+        HTTP_X_TENANT_ID=str(session.tenant_id),
+    )
+    assert response.status_code == 200, response.data
+    return response.data
 
 
 VALID_BODY = {
@@ -480,3 +502,178 @@ def test_the_revocation_command_is_published_after_the_commit():
     source = inspect.getsource(OnboardingSessionViewSet._revoke_consent)
     assert "on_commit(" in source
     assert "\n        publish_consent_revoked(" not in source
+
+
+# ── F-01 AC-2 · EVT-101, and the precheck the agent reads ────────────
+
+
+def test_evt101_carries_hash_not_name(public_tenant, editor):
+    """AC-2: the event carries "consent_id, method and subject_name_hash —
+    never the subject's name".
+
+    The exact key set is asserted, not just the absence of one field. A name
+    reaches an event stream because somebody adds a key here for a good
+    reason, and it should have to get past an assertion first.
+    """
+    from apps.onboarding.events import build_consent_payload
+
+    payload = build_consent_payload(
+        consent_id=42, method=ConsentMethod.VERBAL_RECORDED, subject_name="Asha Kalyani"
+    )
+
+    assert set(payload) == {
+        "event_ref",
+        "consent_id",
+        "method",
+        "subject_name_hash",
+    }
+    assert payload["event_ref"] == "EVT-101"
+    serialised = json.dumps(payload)
+    assert "Asha" not in serialised
+    assert "Kalyani" not in serialised
+
+
+def test_the_subject_hash_is_keyed_not_a_bare_digest(public_tenant):
+    """A plain SHA-256 of a personal name is reversible with a name list.
+
+    The whole promise of `subject_name_hash` is that the event stream cannot
+    identify the subject, and an unkeyed digest of "Asha Kalyani" *is* "Asha
+    Kalyani" to anyone who thinks to try. Asserted against the bare digest
+    rather than by reading the implementation.
+    """
+    import hashlib
+
+    from apps.onboarding.events import subject_name_hash
+
+    bare = hashlib.sha256("asha kalyani".encode()).hexdigest()
+
+    assert subject_name_hash("Asha Kalyani") != bare
+
+
+def test_the_same_person_hashes_the_same_way(public_tenant):
+    """Correlation is the only reason to carry a hash at all, so casing and
+    stray whitespace must not produce two different subjects."""
+    from apps.onboarding.events import subject_name_hash
+
+    assert subject_name_hash("Asha Kalyani") == subject_name_hash("  asha   kalyani ")
+    assert subject_name_hash("Asha Kalyani") != subject_name_hash("Ada Lovelace")
+
+
+def test_granting_consent_emits_evt101(public_tenant, editor, settings):
+    """The emission is wired to the endpoint, not merely available.
+
+    Asserted through the real POST: a helper nobody calls is the commonest way
+    an event goes missing, and the payload builder passing its own unit test
+    would not notice.
+
+    A handler is attached to the emitter's own logger rather than using
+    `caplog`, because this project configures `apps.onboarding` with
+    propagation off — caplog's root handler never sees the record, so the
+    assertion would fail whether or not the emitter ran, which is the least
+    useful shape a test can have.
+    """
+    # Pinned, not inherited. This environment has ONBOARDING_KAFKA_ENABLED
+    # true, so the emitter took the publish branch and the suppression line
+    # never appeared — the first version of this test failed for a reason that
+    # had nothing to do with the wiring it was checking.
+    settings.ONBOARDING_KAFKA_ENABLED = False
+    session = make_session(tenant=public_tenant, status=SessionStatus.READY)
+
+    records: list[logging.LogRecord] = []
+
+    class Capture(logging.Handler):
+        def emit(self, record):
+            records.append(record)
+
+    emitter_log = logging.getLogger("apps.onboarding.events")
+    handler = Capture()
+    previous = emitter_log.level
+    emitter_log.addHandler(handler)
+    emitter_log.setLevel(logging.DEBUG)
+    try:
+        response = client_for(editor, public_tenant).post(
+            consent_url(session), VALID_BODY, format="json"
+        )
+    finally:
+        emitter_log.removeHandler(handler)
+        emitter_log.setLevel(previous)
+
+    assert response.status_code == 201, response.data
+    # Kafka is disabled in tests, so the suppression line is the observable
+    # trace that the emitter ran at all.
+    assert any(
+        "EVT-101" in record.getMessage() for record in records
+    ), "the consent endpoint did not reach the EVT-101 emitter"
+
+
+def test_a_broker_failure_does_not_fail_the_consent(public_tenant, editor, settings):
+    """Consent is already committed by the time EVT-101 is attempted. A broker
+    problem must not turn a lawful, captured consent into a 500 the operator
+    retries."""
+    settings.ONBOARDING_KAFKA_ENABLED = True  # forces the publish path
+
+    response = client_for(editor, public_tenant).post(
+        consent_url(make_session(tenant=public_tenant, status=SessionStatus.READY)),
+        VALID_BODY,
+        format="json",
+    )
+
+    assert response.status_code == 201, response.data
+    assert ConsentRecord.objects.count() == 1
+
+
+# ── F-01 AC-3 · what the agent reads ─────────────────────────────────
+
+
+def test_live_precheck_reports_no_consent(public_tenant, editor, settings):
+    session = make_session(tenant=public_tenant, status=SessionStatus.READY)
+
+    body = precheck(session, settings)
+
+    assert body["consent"] == {"present": False, "active": False, "consent_id": None}
+
+
+def test_live_precheck_reports_active_consent(public_tenant, editor, settings):
+    session = make_session(tenant=public_tenant, status=SessionStatus.READY)
+    client_for(editor, public_tenant).post(
+        consent_url(session), VALID_BODY, format="json"
+    )
+
+    body = precheck(session, settings)
+
+    assert body["consent"]["present"] is True
+    assert body["consent"]["active"] is True
+    # The name stays in the database, which is the subject-access-request
+    # surface. The agent needs to know whether there is consent, never whose.
+    assert "Asha" not in json.dumps(body)
+
+
+def test_live_precheck_reports_revoked_consent(public_tenant, editor, settings):
+    """The state IG-08 must refuse. A precheck that reported `present: true`
+    and stopped would let a revoked meeting back on air."""
+    session = make_session(tenant=public_tenant, status=SessionStatus.READY)
+    api = client_for(editor, public_tenant)
+    api.post(consent_url(session), VALID_BODY, format="json")
+    api.delete(consent_url(session))
+
+    body = precheck(session, settings)
+
+    assert body["consent"]["present"] is True
+    assert body["consent"]["active"] is False
+
+
+def test_consent_is_reported_even_when_the_questionnaire_refuses(
+    public_tenant, editor, settings
+):
+    """Every branch carries the block.
+
+    A caller that finds `consent` on one response and absent on another has to
+    guess, and the agent's safe guess — refuse — would show an unapproved
+    questionnaire to the operator as a consent error.
+    """
+    session = make_session(tenant=public_tenant, status=SessionStatus.READY)
+
+    body = precheck(session, settings)
+
+    assert body["approved"] is False, "fixture should have no approved questionnaire"
+    assert "consent" in body

--- a/ai-brand-automator/apps/onboarding/views.py
+++ b/ai-brand-automator/apps/onboarding/views.py
@@ -41,6 +41,7 @@ from apps.onboarding.field_map import all_mapped_fields, label_for, page_for
 from apps.onboarding.events import (
     ACTION_CONFIRM,
     ACTION_EDIT,
+    emit_consent_verified,
     emit_provenance_reviewed,
 )
 from apps.onboarding.models import (
@@ -322,6 +323,18 @@ class OnboardingSessionViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):
             session=session,
             tenant=session.tenant,
             granted_by=request.user if request.user.is_authenticated else None,
+        )
+
+        # F-01 AC-2. Emitted after the row exists, so the event can never
+        # describe a consent that failed to save — and never raises, so a
+        # broker problem cannot turn a lawful, captured consent into a failed
+        # request the operator retries against an idempotent endpoint.
+        emit_consent_verified(
+            tenant_id=session.tenant_id,
+            session_id=session.pk,
+            consent_id=record.pk,
+            method=record.method,
+            subject_name=record.subject_name,
         )
         return Response(
             ConsentRecordSerializer(record).data, status=http.HTTP_201_CREATED
@@ -1397,6 +1410,31 @@ def field_vocabulary(request):
     return Response({"fields": sorted(all_mapped_fields())}, status=http.HTTP_200_OK)
 
 
+def _consent_block(session) -> dict:
+    """One session's consent state, for IG-08 (F-01).
+
+    Reported on *every* branch of live-precheck, including the ones that refuse
+    for other reasons. A caller that finds `consent` present on one response
+    and absent on another has to guess, and the agent's safe guess — refuse —
+    would turn an unapproved questionnaire into a consent error on the
+    operator's screen.
+
+    The subject's name is deliberately absent. §19 and FR-GDPR-01 put it in the
+    tenant-scoped database, which is the subject-access-request surface; the
+    agent needs to know *whether* there is consent, never whose.
+    """
+    latest = (
+        ConsentRecord.objects.filter(session=session).order_by("-granted_at").first()
+    )
+    if latest is None:
+        return {"present": False, "active": False, "consent_id": None}
+    return {
+        "present": True,
+        "active": latest.is_active,
+        "consent_id": str(latest.pk),
+    }
+
+
 @api_view(["GET"])
 @permission_classes([AllowAny])
 def live_precheck(request, pk):
@@ -1444,6 +1482,7 @@ def live_precheck(request, pk):
                 "approved": False,
                 "session_status": session.status,
                 "questionnaire_status": None,
+                "consent": _consent_block(session),
                 "reason": (
                     "This session has no questionnaire yet. Prepare and approve "
                     "one before starting the meeting."
@@ -1458,6 +1497,7 @@ def live_precheck(request, pk):
             "session_status": session.status,
             "questionnaire_status": questionnaire.status,
             "questionnaire_id": questionnaire.pk,
+            "consent": _consent_block(session),
             "reason": (
                 ""
                 if approved

--- a/onboarding-intelligence-agent-svc/app/api/ws.py
+++ b/onboarding-intelligence-agent-svc/app/api/ws.py
@@ -36,6 +36,12 @@ from __future__ import annotations
 from fastapi import APIRouter, WebSocket
 
 from app.core.logging import get_logger
+from app.logic.consent_gate import (
+    CLOSE_FORBIDDEN,
+    consent_verdict,
+    emit_refusal,
+    fetch_consent_state,
+)
 from app.logic.live_gate import evaluate
 
 logger = get_logger(__name__)
@@ -65,9 +71,10 @@ def _tenant_of(websocket: WebSocket) -> str:
 
 @router.websocket("/v1/live/{session_id}")
 async def live_websocket(websocket: WebSocket, session_id: str) -> None:
-    """Refuse a live session whose questionnaire is not approved (IG-10)."""
+    """Refuse a live session without consent (IG-08) or approval (IG-10)."""
     tenant_id = _tenant_of(websocket)
     backend = getattr(websocket.app.state, "backend", None)
+    events = getattr(websocket.app.state, "events", None)
 
     if not tenant_id:
         # Decided before accept, delivered after — finding 1.
@@ -75,6 +82,25 @@ async def live_websocket(websocket: WebSocket, session_id: str) -> None:
         await websocket.close(
             code=CLOSE_UNAUTHORIZED, reason="A tenant is required to open a session."
         )
+        return
+
+    # IG-08 before IG-10, matching §5's own numbering — and the more
+    # fundamental question first. Whether we may record this person at all is
+    # not contingent on whether somebody approved a questionnaire.
+    #
+    # AC-3: this holds against a socket opened directly at /v1/live/{id},
+    # bypassing the UI entirely. The browser's disabled record button is a
+    # courtesy; this is the gate.
+    consent = await fetch_consent_state(
+        backend, tenant_id=tenant_id, session_id=session_id
+    )
+    consent_refusal = consent_verdict(consent)
+    if consent_refusal.blocked:
+        await emit_refusal(
+            events, consent_refusal, tenant_id=tenant_id, session_id=session_id
+        )
+        await websocket.accept()
+        await websocket.close(code=CLOSE_FORBIDDEN, reason=consent_refusal.detail[:120])
         return
 
     verdict = await evaluate(backend, tenant_id=tenant_id, session_id=session_id)

--- a/onboarding-intelligence-agent-svc/app/logic/consent_gate.py
+++ b/onboarding-intelligence-agent-svc/app/logic/consent_gate.py
@@ -123,7 +123,9 @@ def as_rule(state: ConsentState) -> Callable[[Any, Any], Verdict]:
     return _evaluate
 
 
-async def fetch_consent_state(backend: Any, *, tenant_id: str, session_id: str):
+async def fetch_consent_state(
+    backend: Any, *, tenant_id: str, session_id: str
+) -> ConsentState:
     """Read consent from Django's live-precheck.
 
     The same endpoint IG-10 uses, extended by this story rather than joined by

--- a/onboarding-intelligence-agent-svc/app/logic/consent_gate.py
+++ b/onboarding-intelligence-agent-svc/app/logic/consent_gate.py
@@ -1,0 +1,261 @@
+"""IG-08 — recording requires consent that is present and still valid.
+
+Design §5.1 IG-08, §10.1 ConsentRecord · story F-01 · FR-GDPR-01, FR-REC-01.
+
+Split into policy and I/O on purpose:
+
+- :func:`consent_verdict` is pure. Given a consent state it returns a Verdict.
+  Every branch — absent, revoked, unverifiable — is testable without a socket
+  or a server, and the branches are the part that has to be right.
+- :func:`fetch_consent_state` is the read from Django, service-token
+  authenticated. IG-08 says the record is "verified server-side against Django
+  — never trusted from the client", and this is where that holds.
+
+The card asks for "three places, one function": the WS accept path, POST
+/v1/process and every start control frame. Two of those do not exist yet —
+/v1/process is J-01's and control frames are F-04's — so today only the WS
+path calls it. The shape is what makes adding the other two a one-liner
+instead of a second implementation that drifts.
+
+The close code is **4403**, not the 4401 in §5.1's IG-08 row. The card's AC-3,
+the ERR-03 taxonomy row, FR-LIVE-01 and FR-GDPR-01 all say 4403, and 4401 is
+the code for an invalid JWT — reusing it here would make a consent failure
+indistinguishable from an auth failure to every client. Raised on #555.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable
+
+from app.logic.guardrails import Action, Verdict
+
+logger = logging.getLogger(__name__)
+
+RULE_ID = "IG-08"
+
+#: §10.2.3 and FR-LIVE-01: "4403 consent missing or revoked".
+CLOSE_FORBIDDEN = 4403
+
+#: The operator-facing reason. Short, because a WebSocket close reason is
+#: capped at 123 bytes and some clients silently drop a longer one.
+CONSENT_REQUIRED = "consent_required"
+
+#: How often an open session re-checks (AC-4: "within 5 seconds").
+#:
+#: Three, not five. A five-second poll cannot meet a five-second budget — a
+#: revocation landing one moment after a check waits most of a full interval
+#: before the next one, and then has to be acted on. Same arithmetic as D-03's
+#: sync cadence.
+WATCH_INTERVAL_S = 3.0
+
+
+@dataclass(frozen=True)
+class ConsentState:
+    """What Django says about one session's consent.
+
+    ``reachable`` is separate from ``present`` because "there is no consent"
+    and "we could not find out" are different facts with the same safe answer
+    but different operator-facing wording — and conflating them would make an
+    outage look like a compliance failure to whoever reads the logs.
+    """
+
+    present: bool
+    active: bool
+    reachable: bool = True
+    consent_id: str | None = None
+    #: Never sent to a client and never logged. Held only so a caller that has
+    #: it cannot accidentally be the one place it leaks — see the test.
+    subject_name: str = ""
+
+
+def consent_verdict(state: ConsentState) -> Verdict:
+    """IG-08's decision. Pure, and the only place the policy lives.
+
+    Fails closed on every uncertainty. §5: "on breach, fail closed and emit
+    EVT-004". An agent that recorded because it could not reach Django would
+    produce exactly the artefact FR-GDPR-01 exists to prevent, during an
+    outage, when nobody is reading logs.
+    """
+    if not state.reachable:
+        return Verdict(
+            rule_id=RULE_ID,
+            action=Action.BLOCK,
+            detail=(
+                f"{CONSENT_REQUIRED}: consent could not be verified with the "
+                "backend."
+            ),
+        )
+
+    if not state.present:
+        return Verdict(
+            rule_id=RULE_ID,
+            action=Action.BLOCK,
+            detail=f"{CONSENT_REQUIRED}: no consent has been recorded.",
+        )
+
+    if not state.active:
+        return Verdict(
+            rule_id=RULE_ID,
+            action=Action.BLOCK,
+            detail=f"{CONSENT_REQUIRED}: consent was revoked.",
+        )
+
+    return Verdict(rule_id=RULE_ID, action=Action.PASS)
+
+
+def as_rule(state: ConsentState) -> Callable[[Any, Any], Verdict]:
+    """Adapt the verdict to the chain's synchronous Rule signature.
+
+    The chain calls rules with (payload, context) and no I/O, which is right:
+    a guardrail that can block on a network read is a guardrail that can hang
+    the request it is protecting. The state is fetched by the caller and closed
+    over here, so the chain still emits EVT-004 through its own machinery
+    rather than this module hand-rolling an event.
+    """
+
+    def _evaluate(payload: Any, context: Any) -> Verdict:  # noqa: ARG001
+        return consent_verdict(state)
+
+    return _evaluate
+
+
+async def fetch_consent_state(backend: Any, *, tenant_id: str, session_id: str):
+    """Read consent from Django's live-precheck.
+
+    The same endpoint IG-10 uses, extended by this story rather than joined by
+    a second one — its own docstring makes the argument: "Two reads to decide
+    one thing is two chances to decide it on a stale half."
+    """
+    if backend is None or not getattr(backend, "configured", False):
+        return ConsentState(present=False, active=False, reachable=False)
+
+    try:
+        body = await backend.live_precheck(tenant_id=tenant_id, session_id=session_id)
+    except Exception as exc:  # noqa: BLE001 - fail closed on anything
+        logger.warning(
+            "consent_precheck_failed",
+            extra={"error": f"{type(exc).__name__}: {exc}"},
+        )
+        return ConsentState(present=False, active=False, reachable=False)
+
+    if not isinstance(body, dict):
+        return ConsentState(present=False, active=False, reachable=False)
+
+    consent = body.get("consent")
+    if not isinstance(consent, dict):
+        # An older backend that does not report consent yet. Refusing is the
+        # only safe reading: silently passing would mean a deploy-order
+        # mismatch turns the gate off without anyone choosing that.
+        logger.warning("consent_precheck_missing_consent_block")
+        return ConsentState(present=False, active=False, reachable=False)
+
+    return ConsentState(
+        present=bool(consent.get("present")),
+        active=bool(consent.get("active")),
+        reachable=True,
+        consent_id=consent.get("consent_id"),
+    )
+
+
+async def watch_consent(
+    poll: Callable[[], Awaitable[ConsentState]],
+    *,
+    on_revoked: Callable[[Verdict], Any],
+    interval_s: float = WATCH_INTERVAL_S,
+    stop_after: int | None = None,
+) -> None:
+    """Re-check consent for the life of an open session (AC-4).
+
+    A single evaluation on connect is not enough, and the card says so: B-07's
+    revocation path fires mid-session. Consent granted at the start of a
+    forty-five minute meeting is not consent at minute thirty.
+
+    F-04 mounts this on the socket it keeps open. It is a free function taking
+    a `poll` callable rather than a method on the socket handler so it can be
+    tested — and was tested — before that socket exists.
+
+    Returns when consent is revoked, when `stop_after` polls have run, or when
+    the task is cancelled.
+    """
+    polls = 0
+    while stop_after is None or polls < stop_after:
+        state = await poll()
+        polls += 1
+
+        verdict = consent_verdict(state)
+        if verdict.blocked:
+            logger.info(
+                "consent_revoked_mid_session",
+                extra={"rule_id": RULE_ID, "detail": verdict.detail},
+            )
+            on_revoked(verdict)
+            return
+
+        if interval_s:
+            await asyncio.sleep(interval_s)
+
+
+def _as_uuid(value: str) -> uuid.UUID | None:
+    try:
+        return uuid.UUID(str(value))
+    except (ValueError, AttributeError, TypeError):
+        return None
+
+
+async def emit_refusal(
+    events: Any,
+    verdict: Verdict,
+    *,
+    tenant_id: str,
+    session_id: str,
+    correlation_id: str = "",
+) -> None:
+    """EVT-004 for an IG-08 refusal (AC-3).
+
+    Lives here rather than at each call site so "three places, one function"
+    stays true of the *whole* refusal — the decision and the record of it —
+    and not only of the decision. A call site that closes the socket but
+    forgets the event leaves a compliance refusal invisible, which is the half
+    that matters after the fact.
+
+    Emitted here rather than left to GuardrailChain because the chain's
+    ``_emit_triggered`` only logs: its ``_emitter`` is stored and never used,
+    despite the docstring saying "every trigger is an event, not just a log
+    line". That gap predates this story and is reported separately; F-01 does
+    not fix it by quietly restructuring a synchronous path every rule shares.
+
+    Never raises. A refusal that failed to be recorded must still be a refusal.
+    """
+    if events is None:
+        return
+
+    try:
+        from app.events.catalog import EventType
+
+        await events.emit(
+            EventType.AGENT_GUARDRAIL_TRIGGERED,
+            tenant_id=tenant_id,
+            correlation_id=correlation_id or f"ig08-{session_id}",
+            # Omitted rather than passed through when it is not a UUID. The
+            # envelope validates both ids, and a non-UUID session id would
+            # raise inside build() and lose the *whole* event — the refusal
+            # would go unrecorded because an identifier was the wrong shape.
+            # Production ids are UUIDs; this only bites a hand-rolled caller.
+            session_id=_as_uuid(session_id),
+            outcome="FAILURE",
+            payload={
+                "rule_id": RULE_ID,
+                # §5's EVT-004 is "payload.rule_id and the action taken".
+                "action": verdict.action.value,
+                "detail": verdict.detail,
+            },
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "consent_refusal_event_failed",
+            extra={"error": f"{type(exc).__name__}: {exc}"},
+        )

--- a/onboarding-intelligence-agent-svc/tests/test_consent_gate.py
+++ b/onboarding-intelligence-agent-svc/tests/test_consent_gate.py
@@ -1,0 +1,151 @@
+"""F-01 · IG-08, the consent gate.
+
+Written in the order the card asks for: "The revocation path is the part teams
+skip. Write AC-4's test before AC-2's implementation if you want it to exist."
+So the revocation cases are first in this file and were first in the commit.
+
+The gate is split deliberately. `consent_verdict` is pure policy — it takes the
+consent state and returns a Verdict, so every branch is testable without a
+socket or a server. `fetch_consent_state` is the I/O that reads it from Django
+with a service token, which is what "verified server-side against Django, never
+trusted from the client" means. Combining them into one async rule would make
+the policy untestable except through HTTP, and the policy is the part that has
+to be right.
+"""
+
+from __future__ import annotations
+
+from app.logic.consent_gate import (
+    CONSENT_REQUIRED,
+    ConsentState,
+    RULE_ID,
+    consent_verdict,
+    watch_consent,
+)
+from app.logic.guardrails import Action
+
+# No module-level asyncio mark: pyproject sets `asyncio_mode = "auto"`, so the
+# async tests here run on their own and the mark would only be applied to the
+# synchronous ones — which pytest-asyncio warns about, correctly.
+
+
+# ── AC-4 · revocation, written first ─────────────────────────────────
+
+
+def test_revoked_consent_is_refused():
+    """The case the card says teams skip.
+
+    A ConsentRecord that exists is not consent — `revoked_at` being set means
+    the brand owner withdrew it, and a gate that only checks for existence
+    would keep recording someone who asked us to stop.
+    """
+    verdict = consent_verdict(ConsentState(present=True, active=False))
+
+    assert verdict.action is Action.BLOCK
+    assert verdict.rule_id == RULE_ID
+
+
+async def test_a_revocation_closes_the_watch():
+    """AC-4: an open socket closes "within 5 seconds" of revocation.
+
+    Driven through the watcher rather than a socket. F-04 owns the socket that
+    stays open; what F-01 owes it is a mechanism that notices, and a mechanism
+    nobody has run is a promise.
+    """
+    states = [
+        ConsentState(present=True, active=True),
+        ConsentState(present=True, active=True),
+        ConsentState(present=True, active=False),
+    ]
+    seen: list[ConsentState] = []
+
+    async def poll():
+        state = states[min(len(seen), len(states) - 1)]
+        seen.append(state)
+        return state
+
+    closed = []
+    await watch_consent(
+        poll,
+        on_revoked=lambda verdict: closed.append(verdict),
+        interval_s=0,
+        stop_after=len(states),
+    )
+
+    assert len(closed) == 1, "revocation was not noticed"
+    assert closed[0].action is Action.BLOCK
+    # It stopped at the revocation rather than polling on.
+    assert len(seen) == 3
+
+
+async def test_the_watch_interval_meets_the_five_second_budget():
+    """AC-4 says "within 5 seconds", so the interval is not a free parameter.
+
+    Asserted against the constant rather than by timing a real sleep: a test
+    that waits five seconds to prove a five-second budget is a test nobody
+    runs twice.
+    """
+    from app.logic.consent_gate import WATCH_INTERVAL_S
+
+    assert WATCH_INTERVAL_S <= 5.0
+
+
+async def test_a_watch_over_healthy_consent_never_fires():
+    """The control. A watcher that closed on everything would pass the
+    revocation test and end every meeting the moment it started."""
+    calls = 0
+
+    async def poll():
+        nonlocal calls
+        calls += 1
+        return ConsentState(present=True, active=True)
+
+    closed = []
+    await watch_consent(poll, on_revoked=closed.append, interval_s=0, stop_after=4)
+
+    assert closed == []
+    assert calls == 4
+
+
+# ── AC-3 · the gate refuses, server-side ─────────────────────────────
+
+
+def test_absent_consent_is_refused():
+    verdict = consent_verdict(ConsentState(present=False, active=False))
+
+    assert verdict.action is Action.BLOCK
+    assert CONSENT_REQUIRED in verdict.detail
+
+
+def test_active_consent_passes():
+    """The control that stops every other test here passing vacuously."""
+    verdict = consent_verdict(ConsentState(present=True, active=True))
+
+    assert verdict.action is Action.PASS
+
+
+def test_an_unreachable_backend_fails_closed():
+    """§5: "on breach, fail closed and emit EVT-004".
+
+    An agent that recorded because it could not reach Django would produce
+    exactly the artefact FR-GDPR-01 exists to prevent, and would do it during
+    an outage when nobody is reading logs.
+    """
+    verdict = consent_verdict(
+        ConsentState(present=False, active=False, reachable=False)
+    )
+
+    assert verdict.action is Action.BLOCK
+    assert "could not be verified" in verdict.detail.lower()
+
+
+def test_the_refusal_never_carries_the_subject_name():
+    """The verdict's detail reaches a close frame and a log line. A subject's
+    name in either is the leak FR-GDPR-01 and EVT-101's hashing both exist to
+    prevent."""
+    state = ConsentState(present=True, active=False, subject_name="Ada Lovelace")
+
+    verdict = consent_verdict(state)
+
+    assert "Ada" not in verdict.detail
+    assert "Lovelace" not in verdict.detail

--- a/onboarding-intelligence-agent-svc/tests/test_events_no_pii.py
+++ b/onboarding-intelligence-agent-svc/tests/test_events_no_pii.py
@@ -226,3 +226,32 @@ def test_emitter_joins_a_real_span_when_the_sdk_is_configured():
         )
 
     assert event.trace_id == expected
+
+
+# ── F-01 · EVT-101 ───────────────────────────────────────────────────
+
+
+def test_evt101_carries_hash_not_name():
+    """The card's named case, on the agent's side of the contract.
+
+    Django builds and emits EVT-101 (the consent endpoint is §10.2's), and its
+    own test asserts the payload it produces. This asserts the other half: that
+    the catalogue would *refuse* the name if a future caller attached it here.
+    Two teams, one contract, and the structural guard is what keeps them from
+    drifting apart quietly.
+    """
+    with pytest.raises(PIILeakError):
+        assert_no_pii(EventType.CONSENT_VERIFIED, {"subject_name": "Asha Kalyani"})
+
+
+def test_evt101_accepts_the_hashed_shape():
+    """The control. A guard that rejected everything would pass the test above
+    and block the event it exists to permit."""
+    assert_no_pii(
+        EventType.CONSENT_VERIFIED,
+        {
+            "consent_id": "c-1",
+            "method": "VERBAL_RECORDED",
+            "subject_name_hash": "9f" * 32,
+        },
+    )

--- a/onboarding-intelligence-agent-svc/tests/test_events_no_pii.py
+++ b/onboarding-intelligence-agent-svc/tests/test_events_no_pii.py
@@ -246,12 +246,23 @@ def test_evt101_carries_hash_not_name():
 
 def test_evt101_accepts_the_hashed_shape():
     """The control. A guard that rejected everything would pass the test above
-    and block the event it exists to permit."""
-    assert_no_pii(
-        EventType.CONSENT_VERIFIED,
-        {
-            "consent_id": "c-1",
-            "method": "VERBAL_RECORDED",
-            "subject_name_hash": "9f" * 32,
-        },
+    and block the event it exists to permit.
+
+    Built into a real envelope rather than stopping at "assert_no_pii did not
+    raise", following test_evt_103's shape in this file. Not raising is a
+    claim about the guard; surviving into an AgentEvent with the hash intact
+    and no name anywhere is the claim that matters.
+    """
+    payload = {
+        "consent_id": "c-1",
+        "method": "VERBAL_RECORDED",
+        "subject_name_hash": "9f" * 32,
+    }
+    assert_no_pii(EventType.CONSENT_VERIFIED, payload)
+
+    event = AgentEvent(
+        **envelope(event_type=EventType.CONSENT_VERIFIED, payload=payload)
     )
+
+    assert event.payload["subject_name_hash"] == "9f" * 32
+    assert "subject_name" not in event.payload

--- a/onboarding-intelligence-agent-svc/tests/test_ws_handshake.py
+++ b/onboarding-intelligence-agent-svc/tests/test_ws_handshake.py
@@ -32,14 +32,37 @@ CLOSE_UNAUTHORIZED = 4401
 @pytest.fixture
 def django_stub():
     """A local stand-in for Django's live-precheck endpoint."""
-    state = {"status": 200, "body": {"approved": True}, "requests": []}
+    # Consent present and active by default, so the IG-10 cases below keep
+    # testing IG-10. F-01 put IG-08 ahead of it in the same handler, and a
+    # stub that omitted consent would refuse every socket before the
+    # questionnaire was ever considered — turning this file green for the
+    # wrong reason on the approved-questionnaire case and red on the rest.
+    state = {
+        "status": 200,
+        "body": {
+            "approved": True,
+            "consent": {"present": True, "active": True, "consent_id": "c-1"},
+        },
+        "requests": [],
+    }
 
     class Handler(BaseHTTPRequestHandler):
         def do_GET(self):
             state["requests"].append(
                 {"path": self.path, "tenant": self.headers.get("X-Tenant-ID")}
             )
-            payload = json.dumps(state["body"]).encode()
+            # Consent defaults to present-and-active unless a test says
+            # otherwise. F-01 put IG-08 ahead of IG-10 in the same handler, so
+            # without this every test here would be refused for consent before
+            # its questionnaire was ever looked at — and the IG-10 cases would
+            # be passing on the wrong refusal. A test about consent sets the
+            # block explicitly and this leaves it alone.
+            body = dict(state["body"])
+            if not state.get("omit_consent_default"):
+                body.setdefault(
+                    "consent", {"present": True, "active": True, "consent_id": "c-1"}
+                )
+            payload = json.dumps(body).encode()
             self.send_response(state["status"])
             self.send_header("Content-Type", "application/json")
             self.send_header("Content-Length", str(len(payload)))
@@ -218,3 +241,105 @@ async def test_a_missing_backend_fails_closed():
     assert verdict.refused is True
     assert verdict.reason == UNREACHABLE_REASON
     assert verdict.close_code == CLOSE_FORBIDDEN
+
+
+# ── F-01 AC-3 · the consent gate, ahead of IG-10 ─────────────────────
+
+
+def test_close_4403_on_missing_consent(client, django_stub):
+    """The card's named case.
+
+    AC-3: a socket opened directly at /v1/live/{id}, bypassing the UI, is
+    refused server-side. The browser's disabled record button is a courtesy;
+    this is the gate — and this test is the only thing that proves the two are
+    not the same claim.
+    """
+    django_stub["body"] = {
+        "approved": True,
+        "consent": {"present": False, "active": False},
+    }
+
+    with pytest.raises(WebSocketDisconnect) as caught:
+        with open_socket(client) as socket:
+            socket.receive_text()
+
+    assert caught.value.code == 4403
+    assert "consent_required" in caught.value.reason
+
+
+def test_close_4403_on_revoked_consent(client, django_stub):
+    """A record that exists is not consent. `revoked_at` being set means the
+    brand owner withdrew it, and a gate that only checked existence would keep
+    a meeting on air for someone who asked us to stop."""
+    django_stub["body"] = {
+        "approved": True,
+        "consent": {"present": True, "active": False, "consent_id": "c-9"},
+    }
+
+    with pytest.raises(WebSocketDisconnect) as caught:
+        with open_socket(client) as socket:
+            socket.receive_text()
+
+    assert caught.value.code == 4403
+    assert "revoked" in caught.value.reason
+
+
+def test_consent_is_checked_before_the_questionnaire(client, django_stub):
+    """Ordering is observable, so it is asserted.
+
+    §5 numbers IG-08 before IG-10, and the question "may we record this
+    person at all" does not depend on whether somebody approved a
+    questionnaire. With both failing, the operator should be told the one that
+    matters first.
+    """
+    django_stub["body"] = {
+        "approved": False,
+        "reason": "Questionnaire 12 is still DRAFT.",
+        "consent": {"present": False, "active": False},
+    }
+
+    with pytest.raises(WebSocketDisconnect) as caught:
+        with open_socket(client) as socket:
+            socket.receive_text()
+
+    assert caught.value.code == 4403
+    assert "consent_required" in caught.value.reason
+    assert "Questionnaire" not in caught.value.reason
+
+
+def test_a_backend_that_omits_consent_is_refused(client, django_stub):
+    """A Django too old to report consent must not be read as consent given.
+
+    The deploy order is agent-then-backend as often as not, and a gate that
+    treated a missing block as "fine" would be switched off by a version skew
+    that nobody chose and nothing reports.
+    """
+    django_stub["body"] = {"approved": True}  # no consent key at all
+    django_stub["omit_consent_default"] = True
+
+    with pytest.raises(WebSocketDisconnect) as caught:
+        with open_socket(client) as socket:
+            socket.receive_text()
+
+    assert caught.value.code == 4403
+
+
+def test_the_refusal_never_carries_the_subject_name(client, django_stub):
+    """A close reason reaches browser consoles and gateway logs. The subject's
+    name belongs in the ConsentRecord and nowhere else."""
+    django_stub["body"] = {
+        "approved": True,
+        "consent": {
+            "present": True,
+            "active": False,
+            "consent_id": "c-9",
+            "subject_name": "Ada Lovelace",
+        },
+    }
+
+    with pytest.raises(WebSocketDisconnect) as caught:
+        with open_socket(client) as socket:
+            socket.receive_text()
+
+    assert "Ada" not in caught.value.reason
+    assert "Lovelace" not in caught.value.reason


### PR DESCRIPTION
**F-01 · IG-08**, across all three surfaces: the record control is inert without a `ConsentRecord`, the agent refuses a socket opened directly against `/v1/live/{id}`, and a revocation is noticed rather than waited on.

Written in the order the card asks for — *"the revocation path is the part teams skip; write AC-4's test before AC-2's implementation if you want it to exist."* `tests/test_consent_gate.py` was the first file in this branch and its revocation cases were the first tests in it.

## The gate

Policy and I/O are split. `consent_verdict` is pure — absent, revoked and unverifiable are each testable without a socket or a server. `fetch_consent_state` is the service-token read from Django, which is what *"verified server-side, never trusted from the client"* means. One async rule doing both would leave the policy testable only through HTTP, and the policy is the part that has to be right.

It fails closed on every uncertainty, including **a backend that answers without a consent block at all**. A Django too old to report consent must not read as consent given, or a deploy-order skew switches the gate off with nobody choosing that.

## Two of the three call sites do not exist yet

The card wants the gate at WS accept, `POST /v1/process` and every start control frame. `/v1/process` is J-01's; control frames are F-04's. Only the WS path calls it today, and the module says so.

`watch_consent` is the mechanism AC-4 needs — tested against a revoking backend, for F-04 to mount on the socket it keeps open. C-04 deliberately closes that socket immediately rather than hold one with nothing behind it, and I did not undo that reasoning to make a checkbox go green. **AC-4 is therefore demonstrably correct but not yet reachable through a live socket**; the browser half (banner, control back to disabled) does ship.

## Document conflicts → #555

- **4403, not the 4401 in §5.1's IG-08 row.** AC-3, the ERR-03 row, FR-LIVE-01 and FR-GDPR-01 all say 4403. 4401 is the invalid-JWT code — reusing it makes a consent failure indistinguishable from an auth failure to every client.
- **The card says `VERBAL or WRITTEN`;** §10.1 and the enum B-07 shipped both say `VERBAL_RECORDED / CHECKBOX`. Kept the shipped enum, labelled it in the modal.

## Two decisions worth review

**EVT-101 carries a keyed hash.** §12 permits `subject_name_hash` and never the name, and a bare SHA-256 of a personal name defeats that in an afternoon — the input space is small enough to enumerate. `salted_hmac` keys it off `SECRET_KEY`, the same root of trust used for OAuth tokens, so there is no new secret to provision or leave unset. No deployment change needed.

**The record control uses `aria-disabled`, not `disabled`.** AC-1 wants it "visible but disabled" *and* wants clicking it to open the modal. A `disabled` button cannot be clicked, focused, or found in a screen reader's button list, so the criterion would be unsatisfiable. Same distinction `QuestionChecklist` landed on in #566.

## Testing

527 Django (+9), 478 agent, 23 meeting-view (+8). Frontend baseline unchanged — same four wizard suites, same 36 failures.

Mutations verified: a missing consent block read as consent, presence checked without revocation, passing when the backend is unreachable, IG-10 ahead of IG-08, `disabled` in place of `aria-disabled`, and a banner that shows while consent is still loading.

Two of my own tests were wrong first and are worth naming. The ordering mutation initially *passed* — my mutant still returned on the consent branch first, so it proved nothing until I made IG-10 genuinely win. And `test_granting_consent_emits_evt101` asserted on a log line that never fires here, because this environment has `ONBOARDING_KAFKA_ENABLED` true and the emitter took the publish branch; the setting is pinned in the test now.

## Two findings, not fixed here

- **`GuardrailChain._emit_triggered` only logs.** Its `_emitter` is stored and never used, despite the docstring saying "every trigger is an event, not just a log line". EVT-004 is emitted by this gate directly rather than by restructuring a synchronous path every rule shares. Worth its own issue.
- I inserted a helper between `@api_view` and `live_precheck` and turned the helper into the view. Caught by a test, fixed, mentioned because the failure mode is silent under lint and typecheck.

## Not delivered

The microphone (F-02), the live protocol and the socket that stays open (F-04), `/v1/process` enforcement (J-01), the erasure workflow `revoked_at` triggers (Epic M), and `tests/e2e/test_live_meeting.py::test_revocation_closes_open_socket`, which needs F-04's socket to exist.