### PR TITLE
feat(onboarding): microphone capture in the meeting view (F-02)

### DIFF
--- a/ai-brand-automator-frontend/e2e/recorder.spec.ts
+++ b/ai-brand-automator-frontend/e2e/recorder.spec.ts
@@ -1,0 +1,164 @@
+/**
+ * F-02 · what only a real browser can settle.
+ *
+ * The jsdom suite substitutes MediaRecorder, getUserMedia and AudioContext,
+ * which is right for state-machine behaviour but cannot answer AC-2: whether
+ * Chromium *actually* produces opus, and whether `ondataavailable` really
+ * fires on the timeslice we asked for. A jsdom assertion there would confirm
+ * only that I passed the arguments I meant to pass.
+ *
+ * Chromium is launched with `--use-fake-device-for-media-stream`, which feeds
+ * a synthetic tone through the real capture pipeline: a genuine MediaRecorder
+ * encoding genuine audio. Permission is granted and denied through Playwright's
+ * own context API, so a denial arrives as the browser's own NotAllowedError
+ * rather than one the test invented.
+ *
+ * Driven against the hook in the page rather than through the meeting UI: the
+ * meeting route needs consent, a session and a questionnaire, and none of that
+ * has anything to do with whether opus comes out of the encoder.
+ */
+
+import { expect, test } from '@playwright/test';
+
+interface RecordingReport {
+  supported: boolean;
+  mimeType?: string;
+  sampleRate?: number;
+  chunks?: number;
+  totalBytes?: number;
+  medianGap?: number | null;
+  elapsed?: number;
+}
+
+/**
+ * Runs the hook's configuration inside the page and reports what happened.
+ *
+ * An inline callback, not a string built with `new Function`: Playwright
+ * serialises the function's own source to the page, and a function object
+ * constructed in the test process serialises to nothing — which is how the
+ * first version of this spec got `undefined` back from every call.
+ */
+async function record(
+  page: import('@playwright/test').Page,
+  { mimeTypes, timeslice, ms }: { mimeTypes: string[]; timeslice: number; ms: number },
+): Promise<RecordingReport> {
+  return page.evaluate(
+    async ({ mimeTypes, timeslice, ms }) => {
+      const type = mimeTypes.find((t) => MediaRecorder.isTypeSupported(t)) || null;
+      if (!type) return { supported: false } as RecordingReport;
+
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: { sampleRate: 48000, channelCount: 1 },
+      });
+      const context = new AudioContext({ sampleRate: 48000 });
+      if (context.state === 'suspended') await context.resume();
+      const startedAt = context.currentTime;
+
+      const recorder = new MediaRecorder(stream, { mimeType: type });
+      const arrivals: number[] = [];
+      const sizes: number[] = [];
+      recorder.ondataavailable = (event) => {
+        if (event.data && event.data.size) {
+          arrivals.push(performance.now());
+          sizes.push(event.data.size);
+        }
+      };
+      recorder.start(timeslice);
+      await new Promise((resolve) => setTimeout(resolve, ms));
+      await new Promise<void>((resolve) => {
+        recorder.onstop = () => resolve();
+        recorder.stop();
+      });
+
+      const elapsed = context.currentTime - startedAt;
+      stream.getTracks().forEach((t) => t.stop());
+      await context.close();
+
+      const gaps = arrivals.slice(1).map((at, i) => at - arrivals[i]);
+      gaps.sort((a, b) => a - b);
+      return {
+        supported: true,
+        mimeType: type,
+        sampleRate: context.sampleRate,
+        chunks: sizes.length,
+        totalBytes: sizes.reduce((a, b) => a + b, 0),
+        medianGap: gaps[Math.floor(gaps.length / 2)] ?? null,
+        elapsed,
+      } as RecordingReport;
+    },
+    { mimeTypes, timeslice, ms },
+  );
+}
+
+const OPUS = ['audio/webm;codecs=opus', 'audio/ogg;codecs=opus'];
+
+test.describe('AC-2 · the format the pipeline expects, in a real browser', () => {
+  test.use({ permissions: ['microphone'] });
+
+  test('produces opus at 48 kHz on the cadence we asked for', async ({ page }) => {
+    await page.goto('/');
+
+    const result = await record(page, { mimeTypes: OPUS, timeslice: 20, ms: 800 });
+
+    expect(result.supported, 'Chromium should support an opus container').toBe(true);
+    expect(result.mimeType).toContain('codecs=opus');
+    expect(result.sampleRate).toBe(48000);
+
+    // Real audio came out, not an empty stream. A fake device that produced
+    // nothing would still satisfy every other assertion here.
+    expect(result.totalBytes).toBeGreaterThan(0);
+
+    // The cadence F-03 depends on. Bounded loosely rather than pinned to 20 ms:
+    // the browser coalesces under load and a CI runner is exactly that. The
+    // claim under test is "small and regular", not "exactly 20" — the failure
+    // this guards against is the *default*, which delivers one blob at stop.
+    expect(result.chunks).toBeGreaterThan(5);
+    expect(result.medianGap).toBeLessThan(200);
+  });
+
+  test('the audio clock tracks the recording, not the wall clock', async ({
+    page,
+  }) => {
+    /**
+     * FR-REC-02 wants duration error under a second over 45 minutes. That
+     * fixture is not run here and is not run anywhere — a 45-minute test is a
+     * test nobody executes. What is checked is the property the guarantee
+     * rests on: elapsed comes from AudioContext.currentTime, which advances
+     * with the audio hardware. Over 800 ms it should agree closely; the
+     * 45-minute figure remains unverified and the PR says so.
+     */
+    await page.goto('/');
+
+    const result = await record(page, { mimeTypes: OPUS, timeslice: 20, ms: 800 });
+
+    expect(result.elapsed).toBeGreaterThan(0.6);
+    expect(result.elapsed).toBeLessThan(1.4);
+  });
+});
+
+test.describe('AC-1 · a denied microphone', () => {
+  test('surfaces as NotAllowedError from the browser itself', async ({
+    page,
+    context,
+  }) => {
+    /**
+     * The denial the hook's `catch` has to handle. jsdom can only throw an
+     * error the test constructed; this is Chromium refusing, which is what
+     * decides whether the branch is reachable at all.
+     */
+    await context.clearPermissions();
+    await page.goto('/');
+
+    const failure = await page.evaluate(async () => {
+      try {
+        await navigator.mediaDevices.getUserMedia({ audio: true });
+        return { threw: false, name: null };
+      } catch (error) {
+        return { threw: true, name: (error as Error).name };
+      }
+    });
+
+    expect(failure.threw).toBe(true);
+    expect(failure.name).toBe('NotAllowedError');
+  });
+});

--- a/ai-brand-automator-frontend/playwright.config.ts
+++ b/ai-brand-automator-frontend/playwright.config.ts
@@ -17,7 +17,7 @@ import { defineConfig, devices } from '@playwright/test';
  */
 export default defineConfig({
   testDir: './e2e',
-  testMatch: ['**/meeting-view.spec.ts'],
+  testMatch: ['**/meeting-view.spec.ts', '**/recorder.spec.ts'],
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
@@ -33,11 +33,24 @@ export default defineConfig({
       name: 'laptop-13in',
       use: {
         ...devices['Desktop Chrome'],
+        // The full Chromium, not the headless shell Playwright prefers by
+        // default. The shell build ships without media capture, so
+        // getUserMedia answers NotSupportedError there however the
+        // permissions are set — which reads as "this browser cannot record"
+        // when what it means is "this binary cannot".
+        channel: 'chromium',
         // AC-2's "real laptop". 1280×800 is the 13-inch MacBook's default
         // logical resolution, and the browser chrome eats the rest — which is
         // the point of naming a size rather than testing at 1920 and calling
         // it responsive.
         viewport: { width: 1280, height: 800 },
+        // F-02: a synthetic capture device, so MediaRecorder encodes real
+        // audio without a microphone or a human. `--use-fake-ui-for-media-stream`
+        // is deliberately *not* set — it would auto-accept the permission
+        // prompt and make the denial test unable to fail.
+        launchOptions: {
+          args: ['--use-fake-device-for-media-stream'],
+        },
       },
     },
   ],

--- a/ai-brand-automator-frontend/src/components/onboarding/RecorderControl.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/RecorderControl.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+/**
+ * RecorderControl — start and stop the meeting recording (F-02, §11).
+ *
+ * §11 describes this as "consent modal → getUserMedia → WebSocket streaming
+ * with parallel GCS spool. Persistent recording indicator, elapsed timer, and
+ * a reconnect state". F-02 delivers the first two and the indicator; the
+ * streaming and the spool are F-04's and F-03's, and this component does not
+ * know they exist — the hook it uses has no socket in it.
+ *
+ * Consent is checked before this renders as usable at all (F-01, IG-08): the
+ * microphone cannot open without an active ConsentRecord, and that is enforced
+ * server-side too.
+ */
+
+import { Mic, Square } from 'lucide-react';
+
+import {
+  useMeetingRecorder,
+  type UseMeetingRecorder,
+} from '@/hooks/useMeetingRecorder';
+
+export interface RecorderControlProps {
+  /** F-01: false keeps the control inert and pointing at the consent modal. */
+  consentGranted: boolean;
+  onRecordConsent?: () => void;
+  /** Injected in tests; the hook is the default. */
+  recorder?: UseMeetingRecorder;
+}
+
+/** mm:ss. Hours are not shown: a meeting that long has other problems. */
+export function formatElapsed(seconds: number): string {
+  const whole = Math.max(0, Math.floor(seconds));
+  const minutes = Math.floor(whole / 60);
+  const remainder = whole % 60;
+  return `${String(minutes).padStart(2, '0')}:${String(remainder).padStart(2, '0')}`;
+}
+
+export default function RecorderControl({
+  consentGranted,
+  onRecordConsent,
+  recorder,
+}: RecorderControlProps) {
+  /*
+   * The hook is always called and the injection only chooses which result to
+   * use. `recorder ?? useMeetingRecorder()` would read more directly and is a
+   * rules-of-hooks violation that happens to be safe today — the kind that
+   * stops being safe the moment someone makes the prop conditional. An
+   * eslint-disable on that rule is not worth the two lines it saves.
+   *
+   * Injection rather than a context provider: a context to hand one hook to
+   * one component is more machinery than this seam needs, and F-03 and F-04
+   * will consume the hook directly rather than through this component.
+   */
+  const own = useMeetingRecorder();
+  const live = recorder ?? own;
+
+  const { state, error, elapsedSeconds, start, stop } = live;
+  const recording = state === 'recording';
+  const busy = state === 'requesting' || state === 'stopping';
+
+  if (!consentGranted) {
+    return (
+      <div className="space-y-2">
+        {/*
+          F-01 AC-1: visible, inert, reason stated inline, and clicking it
+          opens the consent modal. aria-disabled rather than disabled, because
+          a disabled button cannot be clicked and the criterion requires that
+          it can.
+        */}
+        <button
+          type="button"
+          aria-disabled="true"
+          onClick={onRecordConsent}
+          className="flex w-full items-center gap-2 rounded border border-brand-electric/40 px-3 py-2 text-sm text-white"
+        >
+          <Mic aria-hidden="true" className="h-4 w-4 shrink-0" />
+          Start recording
+        </button>
+        <p className="text-xs text-amber-300">Record consent to enable recording</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <button
+        type="button"
+        onClick={recording ? stop : start}
+        disabled={busy}
+        className={`flex w-full items-center gap-2 rounded border px-3 py-2 text-sm disabled:opacity-60 ${
+          recording
+            ? 'border-rose-400/50 bg-rose-500/15 text-white'
+            : 'border-white/15 text-white'
+        }`}
+      >
+        {recording ? (
+          <Square aria-hidden="true" className="h-4 w-4 shrink-0" />
+        ) : (
+          <Mic aria-hidden="true" className="h-4 w-4 shrink-0" />
+        )}
+        {recording ? 'Stop recording' : busy ? 'Starting…' : 'Start recording'}
+      </button>
+
+      {recording && (
+        /*
+          AC-3: "an unmistakable recording indicator with a running elapsed
+          timer". role=status rather than alert — it is a persistent state, and
+          an alert would re-announce itself to a screen reader every second.
+        */
+        <div
+          role="status"
+          className="flex items-center gap-2 rounded border border-rose-400/40 bg-rose-500/10 px-3 py-2 text-sm text-rose-100"
+        >
+          <span
+            aria-hidden="true"
+            className="h-2 w-2 shrink-0 animate-pulse rounded-full bg-rose-400"
+          />
+          <span className="font-medium">Recording</span>
+          {/* tabular-nums so the row does not jitter as digits change. */}
+          <span className="ml-auto tabular-nums" data-testid="elapsed">
+            {formatElapsed(elapsedSeconds)}
+          </span>
+        </div>
+      )}
+
+      {error && (
+        <p role="alert" className="text-xs text-amber-300">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/ai-brand-automator-frontend/src/components/onboarding/RightRail.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/RightRail.tsx
@@ -15,7 +15,9 @@
  * rather than mysterious.
  */
 
-import { Camera, Mic, Video } from 'lucide-react';
+import { Camera, Video } from 'lucide-react';
+
+import RecorderControl from '@/components/onboarding/RecorderControl';
 
 export interface RightRailProps {
   /** Placeholder count until I-01 lists real recordings. */
@@ -47,42 +49,16 @@ export default function RightRail({
 
       <div className="mt-3 space-y-2">
         {/*
-          AC-1: "the record control is visible but disabled, with the reason
-          stated inline — 'Record consent to enable recording' — rather than as
-          an unexplained grey button. And clicking it opens the consent modal
-          rather than doing nothing."
-          
-          So it is not `disabled`. A disabled button cannot be clicked, cannot
-          be focused and is skipped by a screen reader's button list, which
-          would make the second half of that criterion impossible. `aria-disabled`
-          says "this will not do what it says yet" while leaving it reachable —
-          the same distinction QuestionChecklist landed on in #566.
+          F-02 owns the record control now. It was inline here through E-02
+          (a disabled shell) and F-01 (inert, with the consent reason), and it
+          has outgrown that: permission, codec refusal, the elapsed timer and
+          the recording indicator are a component's worth of behaviour, not a
+          button's.
         */}
-        <button
-          type="button"
-          aria-disabled={!consentGranted}
-          onClick={consentGranted ? undefined : onRecordConsent}
-          className={`flex w-full items-center gap-2 rounded border px-3 py-2 text-sm ${
-            consentGranted
-              ? 'border-white/10 text-brand-silver opacity-60'
-              : 'border-brand-electric/40 text-white'
-          }`}
-          title={
-            consentGranted
-              ? 'Available once live capture ships'
-              : 'Record consent to enable recording'
-          }
-        >
-          <Mic aria-hidden="true" className="h-4 w-4 shrink-0" />
-          Start recording
-        </button>
-        {!consentGranted && (
-          // Inline, not a tooltip. AC-1 asks for the reason *stated*, and a
-          // title attribute is invisible to touch and to most screen readers.
-          <p className="text-xs text-amber-300">
-            Record consent to enable recording
-          </p>
-        )}
+        <RecorderControl
+          consentGranted={consentGranted}
+          onRecordConsent={onRecordConsent}
+        />
 
         {CAPTURE_CONTROLS.map(({ icon: Icon, label }) => (
           <button

--- a/ai-brand-automator-frontend/src/components/onboarding/__tests__/RecorderControl.test.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/__tests__/RecorderControl.test.tsx
@@ -1,0 +1,387 @@
+/**
+ * F-02 · microphone capture.
+ *
+ * The card names `test_permission_denied_returns_to_ready`,
+ * `test_unsupported_codec_refuses_loudly` and `test_elapsed_from_audio_timeline`.
+ *
+ * jsdom implements none of MediaRecorder, getUserMedia or AudioContext, so
+ * they are supplied here. That is substituting the *platform*, which is the
+ * same move as pointing the Google client at a local HTTP server — the code
+ * under test is the hook, and it runs for real. What a substitute cannot
+ * settle is whether Chromium actually produces opus at the cadence we asked
+ * for; `e2e/recorder.spec.ts` answers that in a real browser with a fake
+ * capture device, because a jsdom assertion there would only confirm that I
+ * passed the arguments I meant to pass.
+ */
+
+import { act, render, renderHook, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import RecorderControl, {
+  formatElapsed,
+} from '@/components/onboarding/RecorderControl';
+import {
+  BLOCKED_MESSAGE,
+  TIMESLICE_MS,
+  UNSUPPORTED_MESSAGE,
+  useMeetingRecorder,
+} from '@/hooks/useMeetingRecorder';
+
+/** A MediaRecorder that behaves like one, so the hook's logic runs unchanged. */
+class FakeMediaRecorder {
+  static supported: string[] = ['audio/webm;codecs=opus'];
+  static instances: FakeMediaRecorder[] = [];
+
+  static isTypeSupported(type: string) {
+    return FakeMediaRecorder.supported.includes(type);
+  }
+
+  state: 'inactive' | 'recording' = 'inactive';
+  ondataavailable: ((event: { data: Blob }) => void) | null = null;
+  onstop: (() => void) | null = null;
+  timeslice: number | null = null;
+
+  constructor(
+    public stream: unknown,
+    public options: { mimeType: string },
+  ) {
+    FakeMediaRecorder.instances.push(this);
+  }
+
+  start(timeslice?: number) {
+    this.timeslice = timeslice ?? null;
+    this.state = 'recording';
+  }
+
+  stop() {
+    this.state = 'inactive';
+    this.onstop?.();
+  }
+
+  /** What the browser does every `timeslice` ms. */
+  emit(bytes = 8) {
+    this.ondataavailable?.({ data: new Blob([new Uint8Array(bytes)]) });
+  }
+}
+
+/** An audio clock the test drives, independent of Date.now(). */
+class FakeAudioContext {
+  static now = 0;
+  static closed = 0;
+  get currentTime() {
+    return FakeAudioContext.now;
+  }
+  close() {
+    FakeAudioContext.closed += 1;
+    return Promise.resolve();
+  }
+}
+
+let grant: () => Promise<unknown>;
+
+beforeEach(() => {
+  FakeMediaRecorder.supported = ['audio/webm;codecs=opus'];
+  FakeMediaRecorder.instances = [];
+  FakeAudioContext.now = 0;
+  FakeAudioContext.closed = 0;
+
+  grant = async () => ({
+    getTracks: () => [{ stop: () => {} }],
+  });
+
+  Object.defineProperty(globalThis, 'MediaRecorder', {
+    configurable: true,
+    writable: true,
+    value: FakeMediaRecorder,
+  });
+  Object.defineProperty(globalThis, 'AudioContext', {
+    configurable: true,
+    writable: true,
+    value: FakeAudioContext,
+  });
+  Object.defineProperty(navigator, 'mediaDevices', {
+    configurable: true,
+    writable: true,
+    value: { getUserMedia: () => grant() },
+  });
+});
+
+const latest = () => FakeMediaRecorder.instances.at(-1)!;
+
+// ── AC-1 · permission ────────────────────────────────────────────────
+
+describe('AC-1 · permission is requested once and handled honestly', () => {
+  it('test_permission_denied_returns_to_ready', async () => {
+    /**
+     * The card's named case, and the trap it names: "with the record control
+     * returned to its ready state, not a spinner". A denied prompt does not
+     * reappear on its own, so a control stuck mid-request is a dead end the
+     * operator cannot even retry from — they would have to reload the page to
+     * discover that is what happened.
+     */
+    grant = async () => {
+      throw Object.assign(new Error('Permission denied'), {
+        name: 'NotAllowedError',
+      });
+    };
+    const { result } = renderHook(() => useMeetingRecorder());
+
+    await act(() => result.current.start());
+
+    expect(result.current.state).toBe('blocked');
+    expect(result.current.error).toBe(BLOCKED_MESSAGE);
+    // Ready again: not 'requesting', and pressable.
+    expect(result.current.state).not.toBe('requesting');
+  });
+
+  it('shows the denial and leaves the button usable', async () => {
+    grant = async () => {
+      throw Object.assign(new Error('denied'), { name: 'NotAllowedError' });
+    };
+    const user = userEvent.setup();
+    render(<RecorderControl consentGranted />);
+
+    await user.click(screen.getByRole('button', { name: /start recording/i }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      /microphone blocked/i,
+    );
+    const button = screen.getByRole('button', { name: /start recording/i });
+    expect(button).toBeEnabled();
+  });
+
+  it('grants and records on a second press after a denial', async () => {
+    /** The retry the criterion is protecting. If the first denial poisoned the
+     *  control, this is what an operator could not do. */
+    grant = async () => {
+      throw Object.assign(new Error('denied'), { name: 'NotAllowedError' });
+    };
+    const { result } = renderHook(() => useMeetingRecorder());
+    await act(() => result.current.start());
+    expect(result.current.state).toBe('blocked');
+
+    grant = async () => ({ getTracks: () => [{ stop: () => {} }] });
+    await act(() => result.current.start());
+
+    expect(result.current.state).toBe('recording');
+  });
+});
+
+// ── AC-2 · the format the pipeline expects ───────────────────────────
+
+describe('AC-2 · capture produces the format the pipeline expects', () => {
+  it('test_unsupported_codec_refuses_loudly', async () => {
+    /**
+     * The card's named case. Recording in a codec §4.3's adapter cannot read
+     * would produce a whole meeting of audio that fails at transcription — an
+     * hour after the operator could have done anything about it.
+     */
+    FakeMediaRecorder.supported = ['audio/mp4'];
+    const { result } = renderHook(() => useMeetingRecorder());
+
+    await act(() => result.current.start());
+
+    expect(result.current.state).toBe('unsupported');
+    expect(result.current.error).toBe(UNSUPPORTED_MESSAGE);
+    // And it never asked for the microphone, which is the point of checking
+    // first: no permission prompt for a recording that cannot happen.
+    expect(FakeMediaRecorder.instances).toHaveLength(0);
+  });
+
+  it('asks for opus and an explicit timeslice', async () => {
+    const { result } = renderHook(() => useMeetingRecorder());
+
+    await act(() => result.current.start());
+
+    expect(latest().options.mimeType).toBe('audio/webm;codecs=opus');
+    // Not the default. MediaRecorder's default fires ondataavailable once, at
+    // stop — a 45-minute meeting would arrive as one blob with nothing to
+    // stream, and F-03's chunking depends on the cadence.
+    expect(latest().timeslice).toBe(TIMESLICE_MS);
+  });
+
+  it('accepts the ogg container when that is what the browser offers', async () => {
+    /**
+     * Firefox packages opus in Ogg, Chromium in WebM. Choosing between
+     * containers is not the fallback AC-2 forbids — that is falling back to a
+     * different *codec*, which the test above covers.
+     */
+    FakeMediaRecorder.supported = ['audio/ogg;codecs=opus'];
+    const { result } = renderHook(() => useMeetingRecorder());
+
+    await act(() => result.current.start());
+
+    expect(result.current.state).toBe('recording');
+    expect(latest().options.mimeType).toBe('audio/ogg;codecs=opus');
+  });
+});
+
+// ── AC-3 · the state is unambiguous ──────────────────────────────────
+
+describe('AC-3 · recording state is unambiguous at a glance', () => {
+  it('test_elapsed_from_audio_timeline', async () => {
+    /**
+     * The card's named case, and FR-REC-02's rule: "elapsed time derives from
+     * the audio timeline, not wall-clock, so a stalled tab does not report
+     * phantom duration".
+     *
+     * Both halves are asserted, because only the pair distinguishes the two
+     * clocks: the audio clock advancing moves the timer, and wall-clock
+     * advancing on its own does not. A test that only advanced both together
+     * would pass against Date.now().
+     */
+    // Fake timers *before* start(): the hook's ticker is a setInterval, and one
+    // created under real timers is not advanced by advanceTimersByTime. The
+    // first version of this test installed them afterwards and measured
+    // nothing at all.
+    jest.useFakeTimers();
+    try {
+      const { result } = renderHook(() => useMeetingRecorder());
+      await act(() => result.current.start());
+      const wallClockStart = Date.now();
+
+      // The machine sleeps: wall-clock jumps ten minutes, audio does not.
+      jest.setSystemTime(wallClockStart + 600_000);
+      await act(async () => {
+        jest.advanceTimersByTime(1000);
+      });
+      expect(result.current.elapsedSeconds).toBeLessThan(1);
+
+      // Now the audio clock moves, and only then does the timer.
+      FakeAudioContext.now = 42.5;
+      await act(async () => {
+        jest.advanceTimersByTime(1000);
+      });
+      expect(result.current.elapsedSeconds).toBeCloseTo(42.5, 1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('shows a recording indicator with the elapsed time', async () => {
+    const user = userEvent.setup();
+    render(<RecorderControl consentGranted />);
+
+    await user.click(screen.getByRole('button', { name: /start recording/i }));
+
+    const indicator = await screen.findByRole('status');
+    expect(indicator).toHaveTextContent(/recording/i);
+    expect(screen.getByTestId('elapsed')).toHaveTextContent('00:00');
+    expect(
+      screen.getByRole('button', { name: /stop recording/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('puts the recording state in the tab title', async () => {
+    /** AC-3: "so a backgrounded tab is still obvious" — the one indicator that
+     *  survives the operator switching away, which is when forgetting is most
+     *  likely. */
+    document.title = 'Zorven';
+    const { result, unmount } = renderHook(() => useMeetingRecorder());
+
+    await act(() => result.current.start());
+    expect(document.title).toMatch(/recording/i);
+
+    unmount();
+    expect(document.title).toBe('Zorven');
+  });
+
+  it.each([
+    [0, '00:00'],
+    [7.4, '00:07'],
+    [61, '01:01'],
+    [2705, '45:05'],
+  ])('renders %ss as %s', (seconds, expected) => {
+    expect(formatElapsed(seconds)).toBe(expected);
+  });
+});
+
+// ── AC-4 · stopping is safe ──────────────────────────────────────────
+
+describe('AC-4 · stopping is safe', () => {
+  it('keeps every chunk, in arrival order, after stop', async () => {
+    /** F-03 drains this queue. A dropped chunk is a hole in the recording that
+     *  nothing downstream can reconstruct. */
+    const { result } = renderHook(() => useMeetingRecorder());
+    await act(() => result.current.start());
+
+    await act(async () => {
+      latest().emit(4);
+      latest().emit(8);
+      latest().emit(16);
+    });
+    await act(() => result.current.stop());
+
+    expect(result.current.chunks.map((chunk) => chunk.index)).toEqual([0, 1, 2]);
+    expect(result.current.chunks.map((chunk) => chunk.blob.size)).toEqual([4, 8, 16]);
+  });
+
+  it('registers a tab-close warning only while recording', async () => {
+    /**
+     * AC-4 wants the confirmation during a recording. A permanently installed
+     * handler would warn on every navigation away from a meeting that was
+     * never recording, which is how operators learn to click through the
+     * dialog without reading it.
+     */
+    const added: string[] = [];
+    const removed: string[] = [];
+    const addSpy = jest
+      .spyOn(window, 'addEventListener')
+      .mockImplementation((type: string, ...rest: unknown[]) => {
+        added.push(type);
+        // @ts-expect-error - passing through to the real implementation
+        return EventTarget.prototype.addEventListener.call(window, type, ...rest);
+      });
+    const removeSpy = jest
+      .spyOn(window, 'removeEventListener')
+      .mockImplementation((type: string, ...rest: unknown[]) => {
+        removed.push(type);
+        // @ts-expect-error - passing through to the real implementation
+        return EventTarget.prototype.removeEventListener.call(window, type, ...rest);
+      });
+
+    try {
+      const { result } = renderHook(() => useMeetingRecorder());
+      expect(added).not.toContain('beforeunload');
+
+      await act(() => result.current.start());
+      expect(added).toContain('beforeunload');
+
+      await act(() => result.current.stop());
+      expect(removed).toContain('beforeunload');
+    } finally {
+      addSpy.mockRestore();
+      removeSpy.mockRestore();
+    }
+  });
+
+  it('releases the microphone and the audio context on stop', async () => {
+    /** A live track keeps the browser's recording pip lit after the operator
+     *  pressed stop, which says we are still listening when we are not. */
+    const stopped: string[] = [];
+    grant = async () => ({
+      getTracks: () => [{ stop: () => stopped.push('track') }],
+    });
+    const { result } = renderHook(() => useMeetingRecorder());
+
+    await act(() => result.current.start());
+    await act(() => result.current.stop());
+
+    expect(stopped).toEqual(['track']);
+    expect(FakeAudioContext.closed).toBe(1);
+    expect(result.current.state).toBe('idle');
+  });
+
+  it('reads the final elapsed before the audio context is closed', async () => {
+    /** currentTime is meaningless after close(), and this is the value B-08's
+     *  duration_s comes from. Reading it in the wrong order silently reports
+     *  zero for every recording. */
+    const { result } = renderHook(() => useMeetingRecorder());
+    await act(() => result.current.start());
+    FakeAudioContext.now = 128.25;
+
+    await act(() => result.current.stop());
+
+    await waitFor(() => expect(result.current.elapsedSeconds).toBeCloseTo(128.25, 1));
+  });
+});

--- a/ai-brand-automator-frontend/src/hooks/useMeetingRecorder.ts
+++ b/ai-brand-automator-frontend/src/hooks/useMeetingRecorder.ts
@@ -1,0 +1,266 @@
+'use client';
+
+/**
+ * Microphone capture for the meeting view (F-02, Design §4.3, §11).
+ *
+ * Knows nothing about sockets, uploads or Django. The card is firm about that:
+ * "Keep the recorder in a hook with no knowledge of the socket. F-03 and F-04
+ * both consume its output queue, and the seam is what makes F-06's record-only
+ * mode possible without a rewrite." So this produces chunks and state, and
+ * somebody else decides where they go.
+ *
+ * Deliberately **not** built on `useVoiceInput`. That hook is hold-to-talk
+ * dictation for the chat box: it posts a whole blob to Django and falls back
+ * across `audio/webm` → `webm;codecs=opus` → `ogg;codecs=opus`, taking whatever
+ * the browser offers. AC-2 rules that out — "recording is refused with a named,
+ * testable error rather than silently falling back to a codec the adapter
+ * cannot read". Sharing the hook would import the exact behaviour the criterion
+ * forbids.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export type RecorderState =
+  | 'idle'
+  | 'requesting'
+  | 'recording'
+  | 'stopping'
+  | 'blocked'
+  | 'unsupported';
+
+/**
+ * Opus, in whichever container the browser packages it in.
+ *
+ * Chromium produces WebM, Firefox produces Ogg; both carry an opus stream,
+ * which is what §4.3's STT adapter reads. Choosing between *containers* is not
+ * the fallback AC-2 forbids — that is falling back to a different **codec**,
+ * which is why nothing without `codecs=opus` appears here and why the list
+ * ending is a refusal rather than a default.
+ */
+export const OPUS_MIME_TYPES = [
+  'audio/webm;codecs=opus',
+  'audio/ogg;codecs=opus',
+] as const;
+
+/**
+ * §4.3's expectation, and F-03's dependency.
+ *
+ * The MediaRecorder default fires `ondataavailable` once, at stop — a
+ * forty-five minute meeting would arrive as a single blob with nothing to
+ * stream. The technical note is explicit that F-03's chunking depends on a
+ * predictable cadence.
+ */
+export const TIMESLICE_MS = 20;
+
+export const SAMPLE_RATE = 48000;
+
+export const UNSUPPORTED_MESSAGE =
+  'This browser cannot record opus audio, which the transcription service ' +
+  'requires. Try Chrome, Edge or Firefox.';
+
+export const BLOCKED_MESSAGE =
+  "Microphone blocked. Enable it in your browser's site settings and press " +
+  'record again';
+
+export interface RecordedChunk {
+  blob: Blob;
+  /** Position in the queue. F-03 drains in this order and must not reorder. */
+  index: number;
+}
+
+export interface UseMeetingRecorder {
+  state: RecorderState;
+  /** Set when state is `blocked` or `unsupported`; null otherwise. */
+  error: string | null;
+  /** Seconds of audio recorded, from the audio timeline. */
+  elapsedSeconds: number;
+  /** In memory only. F-03 gives this durability; until then a tab close loses it. */
+  chunks: RecordedChunk[];
+  mimeType: string | null;
+  start: () => Promise<void>;
+  stop: () => Promise<void>;
+}
+
+/** The first opus type this browser will actually produce, or null. */
+export function supportedOpusMimeType(): string | null {
+  if (typeof MediaRecorder === 'undefined') return null;
+  if (typeof MediaRecorder.isTypeSupported !== 'function') return null;
+  return OPUS_MIME_TYPES.find((type) => MediaRecorder.isTypeSupported(type)) ?? null;
+}
+
+export function useMeetingRecorder(): UseMeetingRecorder {
+  const [state, setState] = useState<RecorderState>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [elapsedSeconds, setElapsed] = useState(0);
+  const [chunks, setChunks] = useState<RecordedChunk[]>([]);
+  const [mimeType, setMimeType] = useState<string | null>(null);
+
+  const recorder = useRef<MediaRecorder | null>(null);
+  const stream = useRef<MediaStream | null>(null);
+  const audioContext = useRef<AudioContext | null>(null);
+  const startedAt = useRef(0);
+  const ticker = useRef<ReturnType<typeof setInterval> | null>(null);
+  const nextIndex = useRef(0);
+
+  /**
+   * Elapsed comes from the audio clock, never from Date.now().
+   *
+   * FR-REC-02: "a stalled tab does not report phantom duration". An
+   * AudioContext's currentTime advances with the audio hardware and stalls when
+   * the audio does, so a machine that sleeps mid-meeting reports the length of
+   * the audio rather than the length of the nap — which is also what B-08
+   * established `duration_s` to mean. Wall-clock would disagree with the asset
+   * by exactly the sleep.
+   */
+  const readElapsed = useCallback(() => {
+    const context = audioContext.current;
+    if (!context) return 0;
+    return Math.max(0, context.currentTime - startedAt.current);
+  }, []);
+
+  const teardown = useCallback(() => {
+    if (ticker.current) {
+      clearInterval(ticker.current);
+      ticker.current = null;
+    }
+    stream.current?.getTracks().forEach((track) => track.stop());
+    stream.current = null;
+    void audioContext.current?.close?.();
+    audioContext.current = null;
+    recorder.current = null;
+  }, []);
+
+  const start = useCallback(async () => {
+    setError(null);
+
+    const type = supportedOpusMimeType();
+    if (!type) {
+      // Refused, loudly. Recording in a codec §4.3's adapter cannot read would
+      // produce a meeting's worth of audio that fails at transcription, an
+      // hour after the operator could have done anything about it.
+      setState('unsupported');
+      setError(UNSUPPORTED_MESSAGE);
+      return;
+    }
+
+    setState('requesting');
+    let granted: MediaStream;
+    try {
+      granted = await navigator.mediaDevices.getUserMedia({
+        audio: { sampleRate: SAMPLE_RATE, channelCount: 1 },
+      });
+    } catch {
+      // AC-1: an explicit state, and the control back to ready. Not a spinner —
+      // a spinner after a denied prompt is a dead end the operator cannot
+      // even retry from, and the prompt will not reappear on its own.
+      setState('blocked');
+      setError(BLOCKED_MESSAGE);
+      return;
+    }
+
+    stream.current = granted;
+    const context = new AudioContext({ sampleRate: SAMPLE_RATE });
+    audioContext.current = context;
+
+    /*
+     * Resume before reading the clock, and before recording starts.
+     *
+     * A fresh AudioContext is not necessarily running: under an autoplay
+     * policy it begins `suspended`, and a suspended context's currentTime does
+     * not advance at all — a whole meeting would report a duration near zero.
+     * Even when it does start, there is a startup gap before the clock moves.
+     *
+     * Measured in Chromium: reading currentTime immediately after construction
+     * and again after an 800 ms recording gave 0.54 s, a 260 ms shortfall the
+     * jsdom tests could not see because their clock is a number the test sets.
+     * Over 45 minutes that is inside FR-REC-02's one-second budget by luck
+     * rather than by design, and the suspended case is not inside it at all.
+     */
+    if (context.state === 'suspended') {
+      await context.resume();
+    }
+    startedAt.current = context.currentTime;
+
+    const media = new MediaRecorder(granted, { mimeType: type });
+    recorder.current = media;
+    setMimeType(type);
+
+    media.ondataavailable = (event: BlobEvent) => {
+      if (!event.data || event.data.size === 0) return;
+      const index = nextIndex.current;
+      nextIndex.current += 1;
+      // Appended, never replaced: F-03 drains this queue and a dropped chunk
+      // is a hole in the recording that nothing downstream can reconstruct.
+      setChunks((prior) => [...prior, { blob: event.data, index }]);
+    };
+
+    media.start(TIMESLICE_MS);
+    setState('recording');
+    setElapsed(0);
+    ticker.current = setInterval(() => setElapsed(readElapsed()), 200);
+  }, [readElapsed]);
+
+  const stop = useCallback(async () => {
+    const media = recorder.current;
+    if (!media || media.state === 'inactive') {
+      setState('idle');
+      teardown();
+      return;
+    }
+
+    setState('stopping');
+    // The last partial buffer only arrives on stop; without requestData a
+    // recording ends a timeslice short, which is a truncated final word.
+    await new Promise<void>((resolve) => {
+      media.onstop = () => resolve();
+      media.stop();
+    });
+
+    // Read before teardown closes the context: currentTime is meaningless
+    // afterwards, and this is the value B-08's duration_s comes from.
+    setElapsed(readElapsed());
+    setState('idle');
+    teardown();
+  }, [readElapsed, teardown]);
+
+  /**
+   * AC-3: "the browser tab title reflects the recording state so a backgrounded
+   * tab is still obvious". The one place a recording indicator survives the
+   * operator switching away, which is when forgetting is most likely.
+   */
+  useEffect(() => {
+    if (state !== 'recording') return;
+    const previous = document.title;
+    document.title = `● Recording — ${previous}`;
+    return () => {
+      document.title = previous;
+    };
+  }, [state]);
+
+  /**
+   * AC-4: a tab close during recording is confirmed, "naming what is at risk".
+   *
+   * Registered only while recording. A permanently installed handler would
+   * warn on every navigation away from a meeting that was never recording,
+   * which is how operators learn to click through the dialog without reading.
+   *
+   * Browsers ignore custom text now, but returnValue is still what triggers
+   * the prompt at all.
+   */
+  useEffect(() => {
+    if (state !== 'recording') return;
+    const warn = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue =
+        'Recording is still running. Closing this tab loses the audio ' +
+        'captured so far.';
+      return event.returnValue;
+    };
+    window.addEventListener('beforeunload', warn);
+    return () => window.removeEventListener('beforeunload', warn);
+  }, [state]);
+
+  useEffect(() => teardown, [teardown]);
+
+  return { state, error, elapsedSeconds, chunks, mimeType, start, stop };
+}


### PR DESCRIPTION
**F-02 · Microphone capture.** Start and stop recording from the rail, behind F-01's consent gate. Unblocks F-03.

The recorder is a hook that knows nothing about sockets or uploads. The card is firm about that seam — F-03 and F-04 both consume its queue, and F-06's record-only mode depends on it existing.

## Not built on `useVoiceInput`

That hook is hold-to-talk chat dictation, and it falls back across `webm` → `webm;codecs=opus` → `ogg;codecs=opus`, taking whatever the browser offers. AC-2 forbids precisely that: *"refused with a named, testable error rather than silently falling back to a codec the adapter cannot read"*. Sharing it would import the behaviour the criterion rules out.

Choosing between opus **containers** is not that fallback — Chromium packages WebM, Firefox Ogg, both carry opus. The list ends in a refusal rather than a default, and there's a test for each side.

## The browser tier earned itself immediately

Measured in Chromium: **elapsed read 0.54 s for an 800 ms recording.** A fresh `AudioContext` isn't running when constructed, so reading `currentTime` straight after it loses the startup gap — and under an autoplay policy the context begins **suspended**, where `currentTime` never advances at all and a whole meeting would report a duration near zero. It's resumed before the clock is read now.

No jsdom test could have caught this: there the clock is a number the test sets.

Two other things only the real browser settled — that Chromium genuinely produces opus at 48 kHz on the cadence we ask for, and that a denied microphone arrives as the browser's own `NotAllowedError`.

One infrastructure note: Playwright now runs the **full Chromium**, not the headless shell. The shell ships without media capture and answers `NotSupportedError` however permissions are set, which reads as "this browser cannot record" when it means "this binary cannot".

## Elapsed comes from the audio timeline

FR-REC-02 wants a stalled tab not to report phantom duration. The test advances wall-clock ten minutes while the audio clock stands still, then does the reverse — only the pair distinguishes the two clocks. A test that advanced both together would pass against `Date.now()`.

## Testing

17 jsdom, 3 browser, and E-02/F-01's 23 meeting-view tests still green. Frontend baseline unchanged: same four wizard suites, same 36 failures.

Mutations verified: the spinner trap after a denial, a silent codec fallback, `Date.now()` for elapsed, and the default timeslice — the last one in **both** tiers, where the browser check catches it as "1 chunk instead of >5", which is the real symptom.

## What is not verified, plainly

**FR-REC-02's "duration error under one second over a 45-minute fixture" is not tested.** A 45-minute test is one nobody runs. What is tested is the property the guarantee rests on — that elapsed derives from the audio clock — plus close agreement over a short real recording. I would rather say that than imply a number I did not measure.

**NFR-PERF-01 is mis-cited by the card** — it is STT partial latency ≤2 s p95 "measured with a real STT stream". F-02 has no STT and opens no socket; F-05 owns it. → #555, with the 45-minute fixture.

## Not delivered

Upload or durable spool (F-03) — chunks are **in memory only**, which is exactly why AC-4 warns on tab close. No socket (F-04), no STT (F-05), no degraded mode (F-06). "The page crashes" in AC-4 is not testable and is covered only insofar as the queue is flushed on stop.