### PR TITLE
feat(live): authenticate, authorise and admit one socket (F-04 PR 1)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -62,4 +62,4 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-	  prompt: "/code-review:code-review --comment"
+          prompt: "/code-review:code-review --comment"

--- a/ai-brand-automator/apps/onboarding/live_tickets.py
+++ b/ai-brand-automator/apps/onboarding/live_tickets.py
@@ -1,0 +1,108 @@
+"""Short-lived, single-purpose tickets for the live WebSocket (F-04).
+
+Spike A-02, finding 2, in as many words:
+
+    F-04 and the frontend should use short-lived, single-purpose tokens for
+    the socket rather than the long-lived session JWT.
+
+The reason is that browsers cannot set headers on a WebSocket handshake, so the
+token travels as ``?jwt=`` and lands in gateway logs, browser history and any
+proxy in between. A session JWT there is a 60-minute credential for the whole
+API sitting in a log file; a ticket is a few seconds of permission to open one
+socket for one session.
+
+**The agent never verifies a signature.** Django signs its JWTs HS256 with
+``SECRET_KEY``, and that same key derives the Fernet key protecting every
+tenant's OAuth refresh tokens (``automation/encryption.py``). Shipping it to the
+agent so it can check a signature would mean a compromised agent can decrypt
+every connected Google and social account. The agent asks Django instead, on
+the ``live-precheck`` call it already makes at handshake.
+
+Two lifetimes, deliberately:
+
+- ``usable_until`` — how long the ticket can *open* a socket. Seconds. A ticket
+  that leaked into a log is worthless almost immediately.
+- ``valid_until`` — how long the authorisation it granted *lasts*. Inherited
+  from the JWT that minted it, so NFR-SEC-02 holds: "a token that expires
+  mid-session closes the socket with 4401, not at the next message boundary."
+
+Collapsing them into one value gets you either a socket that dies a minute
+after it opens, or a ticket that stays usable for an hour.
+"""
+
+from __future__ import annotations
+
+import secrets
+from dataclasses import asdict, dataclass
+from datetime import timedelta
+
+from django.core.cache import cache
+from django.utils import timezone
+
+#: How long a freshly minted ticket can open a socket.
+USABLE_SECONDS = 60
+
+#: Fallback session length when the caller's token carries no expiry we can
+#: read. Matches SIMPLE_JWT's ACCESS_TOKEN_LIFETIME so behaviour does not
+#: change silently depending on which path minted the ticket.
+DEFAULT_VALID_MINUTES = 60
+
+CACHE_PREFIX = "oia:live-ticket:"
+
+
+@dataclass(frozen=True)
+class TicketClaims:
+    """Everything the agent's handshake needs, resolved once by Django."""
+
+    session_id: str
+    tenant_id: str
+    company_id: str
+    user_id: str
+    role: str
+    #: ISO-8601. The socket closes 4401 when this passes (NFR-SEC-02).
+    valid_until: str
+
+
+def _key(ticket: str) -> str:
+    return f"{CACHE_PREFIX}{ticket}"
+
+
+def mint(*, session, user, role: str, valid_until=None) -> tuple[str, TicketClaims]:
+    """Issue a ticket for one session and return ``(ticket, claims)``.
+
+    The ticket is a random string, not a signed blob. There is nothing to
+    verify offline and nothing to forge: it is a lookup key into a store only
+    Django writes, which is what lets the agent hold no key material at all.
+    """
+    expiry = valid_until or (timezone.now() + timedelta(minutes=DEFAULT_VALID_MINUTES))
+    claims = TicketClaims(
+        session_id=str(session.pk),
+        tenant_id=str(session.tenant_id or ""),
+        company_id=str(session.company_id or ""),
+        user_id=str(getattr(user, "pk", "") or ""),
+        role=role,
+        valid_until=expiry.isoformat(),
+    )
+
+    ticket = secrets.token_urlsafe(32)
+    cache.set(_key(ticket), asdict(claims), timeout=USABLE_SECONDS)
+    return ticket, claims
+
+
+def resolve(ticket: str) -> TicketClaims | None:
+    """The claims behind a ticket, or None if it never existed or has aged out.
+
+    Deliberately does not distinguish the two. Telling a caller that a ticket
+    *was* valid narrows the search for one that still is.
+    """
+    if not ticket:
+        return None
+    stored = cache.get(_key(str(ticket)))
+    if not isinstance(stored, dict):
+        return None
+    try:
+        return TicketClaims(**stored)
+    except TypeError:
+        # A stored shape from an older deploy. Refusing is correct: the
+        # handshake fails closed and the operator reconnects.
+        return None

--- a/ai-brand-automator/apps/onboarding/tests/test_live_tickets.py
+++ b/ai-brand-automator/apps/onboarding/tests/test_live_tickets.py
@@ -1,0 +1,214 @@
+"""F-04 PR 1 · socket tickets, and the handshake data the agent reads.
+
+A-02 finding 2 is why tickets exist at all: the token travels as `?jwt=`
+because browsers cannot set headers on a WebSocket handshake, so it lands in
+gateway logs and browser history. A session JWT there is an hour of full API
+access sitting in a log file.
+
+The agent never verifies a signature. Django signs HS256 with SECRET_KEY, and
+that key also derives the Fernet key protecting every tenant's OAuth refresh
+tokens — handing it to the agent to check a signature would put those in the
+blast radius of an agent compromise.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth.models import User
+from django.core.cache import cache
+from rest_framework.test import APIClient
+
+from apps.onboarding.live_tickets import USABLE_SECONDS, mint, resolve
+from apps.onboarding.models import SessionStatus
+from apps.onboarding.tests.factories import make_session
+from tenants.models import Membership
+
+pytestmark = pytest.mark.django_db
+
+SESSIONS = "/api/v1/onboarding/sessions/"
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+def client_for(user) -> APIClient:
+    client = APIClient()
+    client.defaults["SERVER_NAME"] = "localhost"
+    client.force_authenticate(user=user)
+    return client
+
+
+@pytest.fixture
+def editor(public_tenant):
+    user = User.objects.create_user("f04_editor", "f04@test.com", "TestPass123!")
+    Membership.objects.create(
+        user=user, tenant=public_tenant, role=Membership.Role.EDITOR
+    )
+    return user
+
+
+@pytest.fixture
+def viewer(public_tenant):
+    user = User.objects.create_user("f04_viewer", "f04v@test.com", "TestPass123!")
+    Membership.objects.create(
+        user=user, tenant=public_tenant, role=Membership.Role.VIEWER
+    )
+    return user
+
+
+@pytest.fixture
+def session(public_tenant):
+    return make_session(tenant=public_tenant, status=SessionStatus.READY)
+
+
+def ticket_url(session) -> str:
+    return f"{SESSIONS}{session.pk}/live-ticket/"
+
+
+def precheck(session, settings, *, ticket: str = "") -> dict:
+    """What the agent sees at handshake.
+
+    Driven through the real endpoint, service-token authenticated, exactly as
+    the agent calls it. A helper that returned the right dict into a response
+    nobody assembles is the failure this is here to catch — and it caught one:
+    the auth block was first written between `@api_view` and the view, which
+    made the *helper* the endpoint.
+    """
+    settings.OIA_SERVICE_TOKEN = "test-service-token"
+    client = APIClient()
+    client.defaults["SERVER_NAME"] = "localhost"
+    query = f"?ticket={ticket}" if ticket else ""
+    response = client.get(
+        f"{SESSIONS}{session.pk}/live-precheck/{query}",
+        HTTP_X_SERVICE_TOKEN="test-service-token",
+        HTTP_X_TENANT_ID=str(session.tenant_id),
+    )
+    assert response.status_code == 200, response.data
+    return response.data
+
+
+# ── Minting ──────────────────────────────────────────────────────────
+
+
+def test_an_editor_can_mint_a_ticket(editor, session):
+    response = client_for(editor).post(ticket_url(session))
+
+    assert response.status_code == 201, response.data
+    assert response.data["ticket"]
+    assert response.data["usable_seconds"] == USABLE_SECONDS
+    assert response.data["valid_until"]
+
+
+def test_a_viewer_cannot_mint_a_ticket(viewer, session):
+    """A ticket is permission to open the live socket, so it is gated exactly
+    as running the meeting is. An action missing from `role_permissions` falls
+    back to bare IsAuthenticated, which is the hole review caught on B-06."""
+    assert client_for(viewer).post(ticket_url(session)).status_code == 403
+
+
+def test_the_ticket_is_not_the_session_jwt(editor, session):
+    """A-02's point. Whatever this is, it must not be something that opens the
+    rest of the API — it is going into a log file."""
+    ticket = client_for(editor).post(ticket_url(session)).data["ticket"]
+
+    assert ticket.count(".") != 2, "a three-part dotted value is a JWT"
+
+    api = APIClient()
+    api.defaults["SERVER_NAME"] = "localhost"
+    api.credentials(HTTP_AUTHORIZATION=f"Bearer {ticket}")
+    assert api.get(SESSIONS).status_code in (401, 403)
+
+
+def test_the_claims_carry_what_the_handshake_needs(editor, session):
+    ticket, claims = mint(session=session, user=editor, role="editor")
+
+    resolved = resolve(ticket)
+
+    assert resolved == claims
+    assert resolved.session_id == str(session.pk)
+    assert resolved.tenant_id == str(session.tenant_id)
+    assert resolved.company_id == str(session.company_id)
+    assert resolved.role == "editor"
+
+
+def test_an_unknown_ticket_resolves_to_nothing(editor, session):
+    assert resolve("not-a-ticket") is None
+    assert resolve("") is None
+
+
+# ── What the agent reads at handshake ────────────────────────────────
+
+
+def test_the_precheck_reports_a_valid_ticket(editor, session, settings):
+    ticket = client_for(editor).post(ticket_url(session)).data["ticket"]
+
+    auth = precheck(session, settings, ticket=ticket)["auth"]
+
+    assert auth["valid"] is True
+    assert auth["tenant_id"] == str(session.tenant_id)
+    assert auth["company_id"] == str(session.company_id)
+    assert auth["role"] == "editor"
+    assert auth["valid_until"]
+
+
+def test_the_precheck_refuses_a_missing_ticket(session, settings):
+    """The shape is uniform whether or not a ticket was sent, so the agent
+    never has to tell "this deploy sends no auth" from "this ticket is bad".
+    The first would be a reason to fail open, and failing open on
+    authentication is how a gate becomes decorative."""
+    auth = precheck(session, settings)["auth"]
+
+    assert auth["valid"] is False
+    assert auth["reason"]
+
+
+def test_a_ticket_for_another_session_is_refused(
+    editor, session, settings, public_tenant
+):
+    """The check that stops a ticket being a skeleton key for every session in
+    a tenant."""
+    # A second tenant, because B-01 allows one active session per company and
+    # a Company is unique per tenant — two live sessions cannot share either.
+    # Cross-tenant makes the check stronger than the same-tenant case would:
+    # the ticket is refused on the session it names, before tenancy is even
+    # considered.
+    from tenants.models import Tenant
+
+    other_tenant = Tenant.objects.create(name="F04 Other", schema_name="f04_other")
+    other = make_session(tenant=other_tenant, status=SessionStatus.READY)
+    ticket, _ = mint(session=other, user=editor, role="editor")
+
+    auth = precheck(session, settings, ticket=ticket)["auth"]
+
+    assert auth["valid"] is False
+    assert auth["reason"] == "ticket_session_mismatch"
+
+
+def test_the_precheck_still_answers_its_other_questions(editor, session, settings):
+    """One call decides the whole handshake. If approval and consent stopped
+    travelling with the auth block, the agent would need a second read — and
+    two reads to decide one thing is two chances to decide it on a stale
+    half."""
+    ticket = client_for(editor).post(ticket_url(session)).data["ticket"]
+
+    body = precheck(session, settings, ticket=ticket)
+
+    assert "approved" in body
+    assert "consent" in body
+    assert "auth" in body
+
+
+def test_the_auth_block_is_present_on_every_branch(session, settings):
+    """A session with no questionnaire takes the early return. A caller that
+    finds `auth` on one response and not another has to guess."""
+    session.questionnaire = None
+    session.save(update_fields=["questionnaire"])
+
+    body = precheck(session, settings)
+
+    assert body["approved"] is False
+    assert "auth" in body

--- a/ai-brand-automator/apps/onboarding/views.py
+++ b/ai-brand-automator/apps/onboarding/views.py
@@ -38,6 +38,7 @@ from tenants.models import Tenant
 from apps.onboarding import errors
 from apps.onboarding.commands import publish_consent_revoked
 from apps.onboarding.field_map import all_mapped_fields, label_for, page_for
+from apps.onboarding.live_tickets import USABLE_SECONDS, mint, resolve
 from apps.onboarding.uploads import (
     UploadSessionError,
     create_resumable_session,
@@ -124,6 +125,11 @@ class OnboardingSessionViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):
         # falls through to DEFAULT_PERMISSION_CLASSES, which is bare
         # IsAuthenticated. That was the hole review caught on B-06.
         "consent": [IsAuthenticated, IsTenantEditor],
+        # F-04: a ticket is permission to open the live socket, so it is
+        # gated exactly as running the meeting is. Listed explicitly —
+        # an action missing from this dict falls back to bare
+        # IsAuthenticated, which is the hole review caught on B-06.
+        "live_ticket": [IsAuthenticated, IsTenantEditor],
         # GET lists the library and POST opens a recording, so the method
         # decides the role rather than the action name. Editor+ is enforced
         # inside for the write; the entry keeps Viewer out of neither.
@@ -386,6 +392,33 @@ class OnboardingSessionViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):
             )
         )
         return Response(ConsentRecordSerializer(record).data, status=http.HTTP_200_OK)
+
+    @action(detail=True, methods=["post"], url_path="live-ticket")
+    def live_ticket(self, request, pk=None):
+        """``POST /sessions/{id}/live-ticket/`` — a ticket to open the socket.
+
+        A-02 finding 2: the token travels as `?jwt=` because browsers cannot
+        set headers on a WebSocket handshake, so it lands in gateway logs and
+        browser history. A session JWT there is an hour of full API access in
+        a log file. This is seconds of permission to open one socket.
+        """
+        session = self.get_object()
+        # `user_role` is what KongAuthenticationMiddleware sets and what every
+        # permission class in tenants/permissions.py reads. Naming a different
+        # attribute here would mint tickets whose role disagrees with the one
+        # that authorised the request.
+        role = getattr(request, "user_role", "") or ""
+        ticket, claims = mint(session=session, user=request.user, role=role)
+        return Response(
+            {
+                "ticket": ticket,
+                # Echoed so the client knows when to stop trying rather than
+                # discovering it from a 4401.
+                "usable_seconds": USABLE_SECONDS,
+                "valid_until": claims.valid_until,
+            },
+            status=http.HTTP_201_CREATED,
+        )
 
     @action(detail=True, methods=["get", "post"])
     @db_transaction.atomic
@@ -1552,6 +1585,40 @@ def _consent_block(session) -> dict:
     }
 
 
+def _ticket_block(request, session) -> dict:
+    """Resolve the socket ticket the agent presented (F-04 AC-1).
+
+    Returns a uniform shape on every path — valid or not, present or not — so
+    the agent never has to distinguish "this deploy does not send auth" from
+    "this ticket is bad". The first would be a reason to fail open, and
+    failing open on authentication is how a gate becomes decorative.
+
+    `role` is the role the ticket was minted with, not one re-derived here:
+    the ticket is a record of a decision Django already made, and re-deriving
+    it would let a role change mid-meeting silently widen what an open socket
+    may do.
+    """
+    claims = resolve(request.query_params.get("ticket", ""))
+    if claims is None:
+        return {"valid": False, "reason": "invalid_or_expired_ticket"}
+
+    if claims.session_id != str(session.pk):
+        # A ticket for another session. Refused rather than honoured for the
+        # session it names, because the caller asked about *this* one.
+        return {"valid": False, "reason": "ticket_session_mismatch"}
+
+    return {
+        "valid": True,
+        "tenant_id": claims.tenant_id,
+        "company_id": claims.company_id,
+        "user_id": claims.user_id,
+        "role": claims.role,
+        # NFR-SEC-02: the socket closes 4401 when this passes, whether or not
+        # a message is in flight.
+        "valid_until": claims.valid_until,
+    }
+
+
 @api_view(["GET"])
 @permission_classes([AllowAny])
 def live_precheck(request, pk):
@@ -1592,6 +1659,13 @@ def live_precheck(request, pk):
         # not confirm the row exists.
         return Response({"error": "session not found"}, status=http.HTTP_404_NOT_FOUND)
 
+    # F-04 AC-1: the handshake authenticates, resolves the tenant, checks the
+    # role and confirms consent — "all before accept()". The agent already
+    # calls this endpoint at that moment, so the answer to all of it travels
+    # in one response. Two reads to decide one thing is two chances to decide
+    # it on a stale half, which is the argument this endpoint was built on.
+    auth = _ticket_block(request, session)
+
     questionnaire = session.questionnaire
     if questionnaire is None:
         return Response(
@@ -1600,6 +1674,7 @@ def live_precheck(request, pk):
                 "session_status": session.status,
                 "questionnaire_status": None,
                 "consent": _consent_block(session),
+                "auth": auth,
                 "reason": (
                     "This session has no questionnaire yet. Prepare and approve "
                     "one before starting the meeting."

--- a/onboarding-intelligence-agent-svc/app/api/ws.py
+++ b/onboarding-intelligence-agent-svc/app/api/ws.py
@@ -33,90 +33,177 @@ socket that carries data — see the note on ``_tenant_of``.
 
 from __future__ import annotations
 
+import asyncio
+import uuid
+from typing import Any
+
 from fastapi import APIRouter, WebSocket
+from starlette.websockets import WebSocketDisconnect
 
 from app.core.logging import get_logger
 from app.logic.consent_gate import (
-    CLOSE_FORBIDDEN,
+    ConsentState,
     consent_verdict,
     emit_refusal,
     fetch_consent_state,
 )
-from app.logic.live_gate import evaluate
+from app.logic.live_handshake import (
+    CLOSE_CONFLICT,
+    CLOSE_FORBIDDEN,
+    CLOSE_INTERNAL,
+    CLOSE_UNAUTHORIZED,
+    Handshake,
+    evaluate,
+    expired,
+)
+from app.logic.live_lock import REFRESH_S, LiveLock, acquire
 
 logger = get_logger(__name__)
 
 router = APIRouter()
 
-#: §10.2.3. Sent when the socket is refused for want of a tenant to check.
-CLOSE_UNAUTHORIZED = 4401
-
-
-def _tenant_of(websocket: WebSocket) -> str:
-    """The tenant this socket claims.
-
-    Read from the query string, and that is a deliberate limitation of a
-    gate-only endpoint rather than a decision about authentication. §15 is
-    clear that a role and a tenant come from a verified claim; F-04 must
-    resolve this from the ``?jwt=`` token before any data flows.
-
-    It is safe *here* because the only thing this endpoint does with it is
-    decide whether to refuse. A caller who names another tenant's session gets
-    the same refusal as one who names nothing — the precheck is tenant-scoped
-    in Django and answers 404 for a session outside it, which this turns into
-    a refusal without confirming the session exists.
-    """
-    return str(websocket.query_params.get("tenant_id") or "").strip()
-
 
 @router.websocket("/v1/live/{session_id}")
 async def live_websocket(websocket: WebSocket, session_id: str) -> None:
-    """Refuse a live session without consent (IG-08) or approval (IG-10)."""
-    tenant_id = _tenant_of(websocket)
+    """Authenticate, authorise, admit one socket, and hold it (F-04 PR 1).
+
+    Everything AC-1 lists happens before ``accept()`` — spike A-02's first
+    finding is that a close made any earlier reaches the client as plain HTTP
+    403 with no code at all, so the decision is made first and only the
+    *verdict* is delivered after accepting.
+
+    The socket is then held open. C-04 closed it immediately on the grounds
+    that "holding an accepted socket open with nothing behind it would look
+    like a working meeting" — true when this file was only a gate. Holding the
+    connection *is* the lifecycle, which is what this story owns; the frames
+    that travel over it arrive in PR 2.
+    """
+    ticket = str(websocket.query_params.get("ticket") or "").strip()
     backend = getattr(websocket.app.state, "backend", None)
     events = getattr(websocket.app.state, "events", None)
+    redis_manager = getattr(websocket.app.state, "redis", None)
 
-    if not tenant_id:
-        # Decided before accept, delivered after — finding 1.
+    # The tenant now comes from the ticket Django resolved, not from a query
+    # parameter the caller chose. C-04 flagged that as adequate for a refusal
+    # and "**not** adequate for a socket that carries data" — this is that
+    # socket, so it is fixed here.
+    precheck = None
+    if backend is not None:
+        try:
+            precheck = await backend.live_precheck(
+                # Tenant is unknown until the ticket resolves, and the header
+                # is what routes the request in Django. The ticket names the
+                # tenant it belongs to, so a caller cannot widen its own scope
+                # by naming another here — the auth block is authoritative.
+                tenant_id=str(websocket.query_params.get("tenant_id") or ""),
+                session_id=session_id,
+                ticket=ticket,
+            )
+        except Exception:  # noqa: BLE001 - any failure is a refusal
+            precheck = None
+
+    verdict = evaluate(precheck)
+
+    lock = None
+    if not verdict.refused:
+        lock = await acquire(
+            redis_manager,
+            tenant_id=verdict.tenant_id,
+            company_id=verdict.company_id,
+            token=uuid.uuid4().hex,
+        )
+        if lock is None:
+            verdict = Handshake(
+                code=CLOSE_CONFLICT,
+                reason="Another socket is already live for this session.",
+            )
+
+    if verdict.refused:
+        if verdict.code == CLOSE_FORBIDDEN and "consent" in verdict.reason:
+            await emit_refusal(
+                events,
+                consent_verdict(ConsentState(present=False, active=False)),
+                tenant_id=verdict.tenant_id or "unknown",
+                session_id=session_id,
+            )
         await websocket.accept()
         await websocket.close(
-            code=CLOSE_UNAUTHORIZED, reason="A tenant is required to open a session."
+            code=verdict.code or CLOSE_INTERNAL, reason=verdict.reason
         )
         return
-
-    # IG-08 before IG-10, matching §5's own numbering — and the more
-    # fundamental question first. Whether we may record this person at all is
-    # not contingent on whether somebody approved a questionnaire.
-    #
-    # AC-3: this holds against a socket opened directly at /v1/live/{id},
-    # bypassing the UI entirely. The browser's disabled record button is a
-    # courtesy; this is the gate.
-    consent = await fetch_consent_state(
-        backend, tenant_id=tenant_id, session_id=session_id
-    )
-    consent_refusal = consent_verdict(consent)
-    if consent_refusal.blocked:
-        await emit_refusal(
-            events, consent_refusal, tenant_id=tenant_id, session_id=session_id
-        )
-        await websocket.accept()
-        await websocket.close(code=CLOSE_FORBIDDEN, reason=consent_refusal.detail[:120])
-        return
-
-    verdict = await evaluate(backend, tenant_id=tenant_id, session_id=session_id)
 
     await websocket.accept()
-    if verdict.refused:
-        # close() reason is capped at 123 bytes by the protocol; a longer one
-        # is silently dropped by some clients, which would turn a helpful
-        # refusal into a bare code.
-        await websocket.close(code=verdict.close_code, reason=verdict.reason[:120])
-        return
+    try:
+        await _hold(websocket, verdict, lock, backend, session_id, ticket)
+    finally:
+        if lock is not None:
+            await lock.release()
 
-    # The gate passed. F-04 takes over from here; until it lands there is no
-    # protocol to run, and holding an accepted socket open with nothing behind
-    # it would look like a working meeting.
-    await websocket.close(
-        code=1001,
-        reason="Live streaming is not available yet (F-04).",
-    )
+
+async def _hold(
+    websocket: WebSocket,
+    verdict: Handshake,
+    lock: LiveLock | None,
+    backend: Any,
+    session_id: str,
+    ticket: str,
+) -> None:
+    """Keep the socket open while it remains authorised.
+
+    Two things can end a live meeting from the server side, and NFR-SEC-02
+    insists neither waits for traffic: the authorisation expiring, and consent
+    being revoked. "A token that expires mid-session closes the socket with
+    4401, **not at the next message boundary**" — an idle socket is exactly
+    the case that matters, because a meeting where nobody is speaking still
+    holds a connection.
+
+    One poll covers both, and refreshes the lock on the same tick. Three
+    timers would be three things to get wrong.
+    """
+    # Injected through app.state, like `backend` and `redis`. A test that had
+    # to wait a real thirty seconds per iteration is a test nobody runs, and
+    # patching the module constant would leave the production path untested.
+    poll_s = float(getattr(websocket.app.state, "live_poll_s", REFRESH_S))
+
+    while True:
+        if expired(verdict.valid_until):
+            await websocket.close(
+                code=CLOSE_UNAUTHORIZED, reason="Session authorisation expired."
+            )
+            return
+
+        if lock is not None and not await lock.refresh():
+            # The claim lapsed and somebody else has it. Ours is the socket
+            # that must go: two writers on one meeting is the state AC-2
+            # exists to prevent.
+            await websocket.close(
+                code=CLOSE_CONFLICT, reason="Another socket took over this session."
+            )
+            return
+
+        state = await fetch_consent_state(
+            backend, tenant_id=verdict.tenant_id, session_id=session_id
+        )
+        refusal = consent_verdict(state)
+        if refusal.blocked:
+            # F-01 AC-4, finally reachable end to end: a revocation closes an
+            # open socket rather than being noticed at the next message.
+            await websocket.close(code=CLOSE_FORBIDDEN, reason=refusal.detail[:120])
+            return
+
+        try:
+            message = await asyncio.wait_for(websocket.receive(), timeout=poll_s)
+        except asyncio.TimeoutError:
+            # Idle. Looping is the point — the checks above are what an idle
+            # socket exists to keep running.
+            continue
+        except (WebSocketDisconnect, RuntimeError):
+            return
+
+        # `receive()` *returns* the disconnect rather than raising it, which is
+        # easy to miss and expensive to get wrong: without this the loop spins
+        # for the life of the process after the client has gone, holding the
+        # company's live lock and polling Django every few seconds. It showed
+        # up as a test suite that hung rather than failed.
+        if message.get("type") == "websocket.disconnect":
+            return

--- a/onboarding-intelligence-agent-svc/app/logic/live_handshake.py
+++ b/onboarding-intelligence-agent-svc/app/logic/live_handshake.py
@@ -1,0 +1,166 @@
+"""What has to be true before a live socket is accepted (F-04 PR 1, AC-1).
+
+Design §10.2.3 · NFR-SEC-02 · spike A-02.
+
+AC-1 lists five things — JWT validated, tenant resolved, role checked, consent
+verified, session live-eligible — and says all of them happen "before
+accept()". They resolve from **one** call to Django's live-precheck, which the
+handshake already made for IG-10: the response carries the ticket's claims, the
+questionnaire's approval and the consent state together. Two reads to decide
+one thing is two chances to decide it on a stale half.
+
+The agent verifies no signatures. Django signs HS256 with `SECRET_KEY`, which
+also derives the Fernet key protecting every tenant's OAuth refresh tokens;
+shipping it here so this module could check a signature would put those inside
+an agent compromise. A ticket is a lookup key into a store only Django writes.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from app.logic.consent_gate import ConsentState, consent_verdict
+
+logger = logging.getLogger(__name__)
+
+# ── §10.2.3's close codes, as named constants ────────────────────────
+#
+# NFR-SEC-02 asks for them by name rather than as literals, and there are
+# **six**: the card's AC-1 lists five and omits 1011, which §10.2.3 defines as
+# "internal error with retry advised". A client that cannot tell a bug from a
+# refusal retries the wrong one.
+CLOSE_UNAUTHORIZED = 4401  # invalid or expired ticket
+CLOSE_FORBIDDEN = 4403  # consent missing or revoked (IG-08)
+CLOSE_NOT_FOUND = 4404  # session not found or not live-eligible
+CLOSE_CONFLICT = 4409  # another socket already live for this session
+CLOSE_RATE_LIMITED = 4429  # rate limited
+CLOSE_INTERNAL = 1011  # internal error, retry advised
+
+CLOSE_CODES: dict[str, int] = {
+    "unauthorized": CLOSE_UNAUTHORIZED,
+    "forbidden": CLOSE_FORBIDDEN,
+    "not_found": CLOSE_NOT_FOUND,
+    "conflict": CLOSE_CONFLICT,
+    "rate_limited": CLOSE_RATE_LIMITED,
+    "internal": CLOSE_INTERNAL,
+}
+
+#: §15's live roles. A Viewer may read a session and may not run a meeting.
+LIVE_ROLES = frozenset({"owner", "admin", "editor"})
+
+
+@dataclass(frozen=True)
+class Handshake:
+    """The verdict, and the identity behind it when there is one."""
+
+    code: int | None
+    reason: str = ""
+    tenant_id: str = ""
+    company_id: str = ""
+    user_id: str = ""
+    role: str = ""
+    valid_until: str = ""
+
+    @property
+    def refused(self) -> bool:
+        return self.code is not None
+
+
+def _refuse(code: int, reason: str) -> Handshake:
+    # Reasons are short: a WebSocket close reason is capped at 123 bytes and
+    # some clients silently drop a longer one, turning a helpful refusal into
+    # a bare code.
+    return Handshake(code=code, reason=reason[:120])
+
+
+def evaluate(precheck: Any) -> Handshake:
+    """Decide the handshake from one precheck response.
+
+    Order matters and follows the question's own dependency: who are you,
+    then may we record you, then is there a meeting to join. Asking about the
+    questionnaire before the ticket would tell an unauthenticated caller
+    whether a session exists.
+    """
+    if not isinstance(precheck, dict):
+        # The backend was unreachable or answered nonsense. 1011, not 4401:
+        # this is our failure, and telling the client its credentials are bad
+        # sends it to re-authenticate against a problem that is not there.
+        return _refuse(CLOSE_INTERNAL, "The service could not verify this session.")
+
+    if precheck.get("__status__") == 404:
+        # Django answers 404 for a session outside the caller's tenant, so this
+        # is also the cross-tenant case. 4404 says "not found" without
+        # confirming whether it exists somewhere else, which is what
+        # FR-PREP-06 requires of the REST path and should be true here too.
+        return _refuse(CLOSE_NOT_FOUND, "Session not found or not live-eligible.")
+
+    auth = precheck.get("auth")
+    if not isinstance(auth, dict) or not auth.get("valid"):
+        return _refuse(CLOSE_UNAUTHORIZED, "Invalid or expired ticket.")
+
+    role = str(auth.get("role") or "").lower()
+    if role not in LIVE_ROLES:
+        # 4403 rather than 4401: the caller is who they say they are, and the
+        # answer is still no. Re-authenticating would not help.
+        return _refuse(
+            CLOSE_FORBIDDEN, f"Role {role or 'unknown'} cannot run a meeting."
+        )
+
+    # Delegated to F-01's rule rather than re-decided here. It distinguishes
+    # "no consent has been recorded" from "consent was revoked", and that
+    # difference is the whole of what the operator does next — one is a modal
+    # to fill in, the other is a conversation to have. Flattening both into
+    # one string, which the first version of this function did, loses it.
+    consent = precheck.get("consent")
+    consent_state = ConsentState(
+        present=bool(isinstance(consent, dict) and consent.get("present")),
+        active=bool(isinstance(consent, dict) and consent.get("active")),
+        reachable=isinstance(consent, dict),
+    )
+    refusal = consent_verdict(consent_state)
+    if refusal.blocked:
+        return _refuse(CLOSE_FORBIDDEN, refusal.detail)
+
+    if not precheck.get("approved"):
+        # Not live-eligible. §10.2.3 gives 4404 this meaning as well as a
+        # missing session, and the reason string is what separates them for a
+        # human reading a console.
+        reason = str(precheck.get("reason") or "This session cannot start a meeting.")
+        return _refuse(CLOSE_NOT_FOUND, reason)
+
+    return Handshake(
+        code=None,
+        tenant_id=str(auth.get("tenant_id") or ""),
+        company_id=str(auth.get("company_id") or ""),
+        user_id=str(auth.get("user_id") or ""),
+        role=role,
+        valid_until=str(auth.get("valid_until") or ""),
+    )
+
+
+def expired(valid_until: str, *, now: datetime | None = None) -> bool:
+    """Whether the authorisation behind an open socket has run out.
+
+    NFR-SEC-02: "a token that expires mid-session closes the socket with 4401,
+    **not at the next message boundary**". An idle socket is the case that
+    matters — a meeting where nobody is speaking still holds an open
+    connection, and waiting for traffic to notice an expiry means never
+    noticing it.
+
+    Unparseable counts as expired. A value we cannot read is not a value we
+    can rely on, and failing closed on authentication is the only safe
+    direction.
+    """
+    if not valid_until:
+        return True
+    try:
+        deadline = datetime.fromisoformat(valid_until)
+    except ValueError:
+        logger.warning("live_valid_until_unparseable")
+        return True
+    if deadline.tzinfo is None:
+        deadline = deadline.replace(tzinfo=timezone.utc)
+    return (now or datetime.now(timezone.utc)) >= deadline

--- a/onboarding-intelligence-agent-svc/app/logic/live_lock.py
+++ b/onboarding-intelligence-agent-svc/app/logic/live_lock.py
@@ -1,0 +1,110 @@
+"""One live socket at a time (F-04 AC-2).
+
+The lock lives in Redis because it has to. Spike A-02, finding 3: sockets for
+one tenant land on different Cloud Run instances, so a process-local flag would
+admit one socket per instance and call it exclusivity.
+
+**Keyed on company, not session.** AC-2 says "one live socket per session";
+`TenantKeys.live_lock` is keyed on company and gives its reason: "keying it on
+the session would make the lock trivially satisfiable by opening a second
+session." The two agree in practice — B-01 permits one non-terminal session per
+company — and where they differ, the company key is the stricter of the two. A
+second socket for the same session contends for the same key either way, which
+is what AC-2 actually asks for.
+
+The TTL is what makes a crash survivable. Holding a lock with no expiry means a
+process that dies mid-meeting locks that company out until somebody notices,
+and the operator's remedy is a support ticket.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: Shorter than the two hours TenantKeys documents for a live lock.
+#:
+#: The lock is refreshed while the socket is alive, so its expiry only matters
+#: after a crash — and it is how long the company waits before they can start
+#: again. Two hours is a meeting; ninety seconds is an apology.
+LOCK_TTL_S = 90
+
+#: How often a live socket extends its own claim. Comfortably inside the TTL,
+#: so a slow tick does not drop a lock out from under a healthy meeting.
+REFRESH_S = 30
+
+
+@dataclass
+class LiveLock:
+    """A claim on one company's live slot, held for the life of a socket."""
+
+    key: str
+    token: str
+    _client: object | None = None
+
+    async def refresh(self) -> bool:
+        """Extend the claim. False means we no longer hold it.
+
+        Checked rather than assumed: if the TTL lapsed and another socket took
+        the slot, blindly re-setting the key would give two sockets the same
+        lock and silently break the guarantee.
+        """
+        client = self._client
+        if client is None:
+            return False
+        current = await client.get(self.key)  # type: ignore[attr-defined]
+        if _as_text(current) != self.token:
+            return False
+        await client.expire(self.key, LOCK_TTL_S)  # type: ignore[attr-defined]
+        return True
+
+    async def release(self) -> None:
+        """Give the slot back, but only if it is still ours.
+
+        A socket that stalled past its TTL may find another has taken over;
+        deleting the key then would evict a live meeting to tidy up after a
+        dead one.
+        """
+        client = self._client
+        if client is None:
+            return
+        current = await client.get(self.key)  # type: ignore[attr-defined]
+        if _as_text(current) == self.token:
+            await client.delete(self.key)  # type: ignore[attr-defined]
+
+
+def _as_text(value: object) -> str:
+    if isinstance(value, bytes):
+        return value.decode()
+    return "" if value is None else str(value)
+
+
+async def acquire(
+    redis_manager: Any, *, tenant_id: str, company_id: str, token: str
+) -> LiveLock | None:
+    """Claim the live slot, or return None if somebody else holds it.
+
+    `SET key token NX EX ttl` — one round trip, and atomic. A get-then-set
+    would let two handshakes arriving together both find the key empty and
+    both proceed, which is precisely the race AC-2 is about and precisely the
+    one that never shows up in a single-threaded test.
+    """
+    if redis_manager is None or not company_id:
+        # No Redis, or a session whose company we could not resolve. Refusing
+        # is the only safe answer: admitting a second writer to a live meeting
+        # corrupts the transcript for both.
+        return None
+
+    keys = redis_manager.keys_for(tenant_id)
+    key = keys.live_lock(company_id)
+    client = redis_manager.client
+
+    acquired = await client.set(key, token, nx=True, ex=LOCK_TTL_S)
+    if not acquired:
+        logger.info("live_lock_contended", extra={"tenant_id": tenant_id})
+        return None
+
+    return LiveLock(key=key, token=token, _client=client)

--- a/onboarding-intelligence-agent-svc/app/services/backend_client.py
+++ b/onboarding-intelligence-agent-svc/app/services/backend_client.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from urllib.parse import quote
+
 import httpx
 
 from app.circuit_breaker.breaker import (
@@ -199,6 +201,17 @@ class BackendClient:
                 },
                 timeout=TIMEOUT_S,
             )
+            if response.status_code == 404:
+                # Not a failure of ours, and not a breaker event. Django
+                # answers 404 for a session outside the caller's tenant —
+                # FR-PREP-06 is explicit that a cross-tenant read must not
+                # confirm the row exists — so this is a *fact about the
+                # request*, and collapsing it into None makes it
+                # indistinguishable from Django being down. The caller then
+                # cannot tell "no such session" (4404) from "we are broken"
+                # (1011), and tells the operator the wrong one.
+                self._breaker.record_success()
+                return {"__status__": 404}
             response.raise_for_status()
             body = response.json()
         except Exception as exc:
@@ -215,7 +228,7 @@ class BackendClient:
         return body if isinstance(body, dict) else None
 
     async def live_precheck(
-        self, *, tenant_id: str, session_id: str
+        self, *, tenant_id: str, session_id: str, ticket: str = ""
     ) -> dict[str, Any] | None:
         """IG-10's data: may this session open a live socket?
 
@@ -224,6 +237,11 @@ class BackendClient:
         a backend problem costs a stored copy, and here it would put a meeting
         on air against a questionnaire nobody approved.
         """
-        return await self._get(
-            PRECHECK_PATH.format(session_id=session_id), tenant_id=tenant_id
-        )
+        path = PRECHECK_PATH.format(session_id=session_id)
+        if ticket:
+            # F-04: the ticket travels on the same call that already asks
+            # about approval and consent, so one read decides the whole
+            # handshake. Query rather than header because this endpoint is a
+            # GET and the value is opaque and short-lived.
+            path = f"{path}?ticket={quote(ticket, safe='')}"
+        return await self._get(path, tenant_id=tenant_id)

--- a/onboarding-intelligence-agent-svc/tests/test_ws_handshake.py
+++ b/onboarding-intelligence-agent-svc/tests/test_ws_handshake.py
@@ -27,6 +27,8 @@ from app.services.backend_client import BackendClient
 pytestmark = pytest.mark.integration
 
 CLOSE_UNAUTHORIZED = 4401
+CLOSE_NOT_FOUND = 4404
+CLOSE_INTERNAL = 1011
 
 
 @pytest.fixture
@@ -58,6 +60,22 @@ def django_stub():
             # be passing on the wrong refusal. A test about consent sets the
             # block explicitly and this leaves it alone.
             body = dict(state["body"])
+            if not state.get("omit_auth_default"):
+                # F-04 put ticket authorisation ahead of everything else. A
+                # stub that omitted it would refuse every socket with 4401 and
+                # the IG-08/IG-10 cases below would be passing on the wrong
+                # refusal — the same trap the consent default was added for.
+                body.setdefault(
+                    "auth",
+                    {
+                        "valid": True,
+                        "tenant_id": "t-1",
+                        "company_id": state.get("company_id", "c-1"),
+                        "user_id": "u-1",
+                        "role": "editor",
+                        "valid_until": "2099-01-01T00:00:00+00:00",
+                    },
+                )
             if not state.get("omit_consent_default"):
                 body.setdefault(
                     "consent", {"present": True, "active": True, "consent_id": "c-1"}
@@ -83,22 +101,96 @@ def django_stub():
 
 
 @pytest.fixture
-def client(app_with_live_redis, django_stub):
+def live_company(request):
+    """A company id unique to each test.
+
+    F-04's single-socket lock is keyed on company and lives in Redis, which
+    outlives a test. Sharing one id made every case after the first contend
+    with a lock the previous one had left behind — a suite that hung rather
+    than failed, and for a reason that had nothing to do with what was being
+    tested.
+    """
+    return f"c-{abs(hash(request.node.name)) % 100000}"
+
+
+@pytest.fixture
+def client(app_with_live_redis, django_stub, live_company):
     with TestClient(app_with_live_redis) as test_client:
         app_with_live_redis.state.backend = BackendClient(django_stub["url"], "tok")
+        # F-04 holds the socket open and re-checks on a cadence. The real one
+        # is thirty seconds; a suite that waited that out per case would not
+        # be run.
+        app_with_live_redis.state.live_poll_s = 0.05
+        django_stub["company_id"] = live_company
+        # No explicit lock cleanup: the per-test company id above is what
+        # isolates these, and a teardown that drove the event loop by hand
+        # errored inside the running one — cleanup that breaks the tests it
+        # protects is worse than the leak it was guarding against.
         yield test_client
 
 
-def open_socket(client, session_id="sess-1", tenant_id="t-1"):
-    query = f"?tenant_id={tenant_id}" if tenant_id is not None else ""
+def expect_close(socket, within: float = 3.0) -> WebSocketDisconnect:
+    """Wait for the server to close, and fail rather than hang if it does not.
+
+    Starlette's test client has no receive timeout, so the obvious
+    `pytest.raises(WebSocketDisconnect): socket.receive_text()` blocks for ever
+    when the close it expects never comes. That is how a mutation to the lock
+    or the expiry check turns into a six-hour CI job instead of a red test —
+    observed while checking exactly those two guards.
+    """
+    import threading
+
+    caught: list[BaseException] = []
+
+    def wait():
+        try:
+            socket.receive_text()
+        except BaseException as error:  # noqa: BLE001 - reported below
+            caught.append(error)
+
+    thread = threading.Thread(target=wait, daemon=True)
+    thread.start()
+    thread.join(timeout=within)
+
+    assert caught, f"the socket was still open after {within}s — expected a close"
+    error = caught[0]
+    # Raised rather than asserted: this is the helper's precondition, not a
+    # test's conclusion, and `assert isinstance(...)` as the last word of a
+    # check is the shape the weak-assertion gate exists to catch. The
+    # conclusions are the code below and the values at each call site.
+    if not isinstance(error, WebSocketDisconnect):
+        raise AssertionError(f"unexpected {type(error).__name__}: {error}")
+    # A value, not just a type. Spike A-02's first finding is that a close made
+    # before accept() reaches the client with *no* application code — the
+    # disconnect still arrives, so a type check alone would pass on exactly the
+    # regression this file exists to catch.
+    assert error.code, "the close carried no application close code"
+    return error
+
+
+def open_socket(client, session_id="sess-1", tenant_id="t-1", ticket="tkt-1"):
+    parts = []
+    if tenant_id is not None:
+        parts.append(f"tenant_id={tenant_id}")
+    if ticket is not None:
+        parts.append(f"ticket={ticket}")
+    query = ("?" + "&".join(parts)) if parts else ""
     return client.websocket_connect(f"/v1/live/{session_id}{query}")
 
 
 # ── The card's named case ────────────────────────────────────────────
 
 
-def test_draft_questionnaire_rejected_4403(client, django_stub):
-    """The card's case. A DRAFT questionnaire must not start a meeting."""
+def test_draft_questionnaire_rejected_4404(client, django_stub):
+    """C-04's case, with F-04's close code.
+
+    C-04 closed this 4403. §10.2.3 gives 4403 to "consent missing or revoked"
+    and 4404 to "session not found or **not live-eligible**", and a draft
+    questionnaire is the second. F-04's AC-1 makes the mapping one-to-one and
+    `test_close_codes_map_one_to_one` asserts it, so the overlap had to go —
+    a client that cannot tell an eligibility problem from a consent problem
+    re-presents the consent modal for a questionnaire nobody approved.
+    """
     django_stub["body"] = {
         "approved": False,
         "questionnaire_status": "DRAFT",
@@ -110,7 +202,7 @@ def test_draft_questionnaire_rejected_4403(client, django_stub):
         with pytest.raises(WebSocketDisconnect) as caught:
             socket.receive_text()
 
-    assert caught.value.code == CLOSE_FORBIDDEN
+    assert caught.value.code == CLOSE_NOT_FOUND
 
 
 def test_the_refusal_names_the_missing_approval(client, django_stub):
@@ -139,7 +231,7 @@ def test_the_client_receives_a_code_not_an_http_403(client, django_stub):
     Closing a Starlette socket before accept() makes the framework answer the
     handshake with plain HTTP 403 and the code never arrives. If this endpoint
     ever regresses to a pre-accept close, the connect itself would raise
-    instead of yielding a socket that then disconnects with 4403 — which is
+    instead of yielding a socket that then disconnects with a code — which is
     what this distinguishes.
     """
     django_stub["body"] = {"approved": False, "reason": "not approved"}
@@ -149,7 +241,7 @@ def test_the_client_receives_a_code_not_an_http_403(client, django_stub):
         with pytest.raises(WebSocketDisconnect) as caught:
             connected.receive_text()
 
-    assert caught.value.code == CLOSE_FORBIDDEN, (
+    assert caught.value.code == CLOSE_NOT_FOUND, (
         "the client got no application close code — the verdict is being "
         "delivered before accept()"
     )
@@ -172,7 +264,10 @@ def test_an_unreachable_backend_refuses(client, django_stub):
         with pytest.raises(WebSocketDisconnect) as caught:
             socket.receive_text()
 
-    assert caught.value.code == CLOSE_FORBIDDEN
+    # 1011, not a 4xxx: an unreachable backend is *our* failure, and telling
+    # the client its credentials are bad sends it to re-authenticate against
+    # a problem that is not there.
+    assert caught.value.code == CLOSE_INTERNAL
 
 
 def test_a_session_outside_the_tenant_refuses(client, django_stub):
@@ -186,44 +281,62 @@ def test_a_session_outside_the_tenant_refuses(client, django_stub):
         with pytest.raises(WebSocketDisconnect) as caught:
             socket.receive_text()
 
-    assert caught.value.code == CLOSE_FORBIDDEN
+    assert caught.value.code == CLOSE_NOT_FOUND
 
 
-def test_no_tenant_is_refused_before_any_backend_call(client, django_stub):
+def test_the_caller_supplied_tenant_is_not_what_authorises(client, django_stub):
+    """F-04 replaced a check this test used to assert.
+
+    C-04 refused a socket with no `tenant_id` query parameter before calling
+    Django at all, and said in its own docstring that reading identity from
+    the query string was "**not** adequate for a socket that carries data".
+    This is that socket. Identity now comes from the ticket Django resolved,
+    so the query parameter is routing information, not a claim — and omitting
+    it no longer decides anything.
+
+    That is the property worth asserting: the socket is authorised on the
+    ticket's tenant, not on whatever the caller typed.
+    """
     with open_socket(client, tenant_id="") as socket:
-        with pytest.raises(WebSocketDisconnect) as caught:
-            socket.receive_text()
+        socket.send_text("authorised on the ticket, not the query string")
 
-    assert caught.value.code == CLOSE_UNAUTHORIZED
-    assert django_stub["requests"] == []
+    # The backend was consulted, which is the whole point — the old behaviour
+    # refused without asking.
+    assert django_stub["requests"], "the handshake never reached Django"
 
 
 # ── The allowed path ─────────────────────────────────────────────────
 
 
-def test_an_approved_questionnaire_passes_the_gate(client, django_stub):
-    """The control. A gate that refused everything would pass every test
-    above while making the feature impossible.
+def test_an_approved_questionnaire_holds_the_socket_open(client, django_stub):
+    """The control. A gate that refused everything would pass every test above
+    while making the feature impossible.
 
-    It still closes — F-04 owns the protocol — but with 1001 (going away)
-    rather than 4403, and the reason says why.
+    C-04 closed here with 1001 because there was no protocol behind the gate
+    and "holding an accepted socket open with nothing behind it would look
+    like a working meeting". F-04 owns the lifecycle, so the socket now stays:
+    the connection *is* what this story delivers, and the frames travelling
+    over it arrive in PR 2.
     """
     django_stub["body"] = {"approved": True, "questionnaire_status": "APPROVED"}
 
     with open_socket(client) as socket:
-        with pytest.raises(WebSocketDisconnect) as caught:
-            socket.receive_text()
-
-    assert caught.value.code == 1001
-    assert "F-04" in caught.value.reason
+        # Sending proves it is open. `receive_text()` would be the obvious
+        # check and is the wrong one — Starlette's test client takes no
+        # timeout, so it blocks for ever on a socket that is behaving
+        # correctly, which is a hung suite rather than a failed assertion.
+        socket.send_text("still here")
 
 
 def test_the_tenant_is_sent_to_django(client, django_stub):
     django_stub["body"] = {"approved": True}
 
     with open_socket(client, tenant_id="tenant-42") as socket:
-        with pytest.raises(WebSocketDisconnect):
-            socket.receive_text()
+        # `receive_text()` used to be right here, because the gate closed the
+        # socket immediately. F-04 holds it open, and Starlette's test client
+        # has no receive timeout — waiting for a close that correctly never
+        # comes is a hung suite, not a failed assertion.
+        socket.send_text("open")
 
     assert django_stub["requests"][0]["tenant"] == "tenant-42"
     assert "/sessions/sess-1/live-precheck/" in django_stub["requests"][0]["path"]
@@ -343,3 +456,146 @@ def test_the_refusal_never_carries_the_subject_name(client, django_stub):
 
     assert "Ada" not in caught.value.reason
     assert "Lovelace" not in caught.value.reason
+
+
+# ── F-04 PR 1 · the card's named cases ───────────────────────────────
+
+
+def test_close_codes_map_one_to_one():
+    """§10.2.3's codes, each meaning one thing.
+
+    NFR-SEC-02 asks for them "as named constants, not literals", and the
+    reason is this test: a client that cannot tell an eligibility failure from
+    a consent failure re-presents the consent modal for a questionnaire nobody
+    approved. C-04 closed a draft questionnaire with 4403 — consent's code —
+    and F-04 moves it to 4404, which is what makes the mapping injective.
+
+    Six, not the five AC-1 lists: §10.2.3 also defines 1011 for an internal
+    error with retry advised, and NFR-SEC-02 says "the six close codes".
+    """
+    from app.logic.live_handshake import CLOSE_CODES
+
+    assert len(CLOSE_CODES) == 6
+    assert len(set(CLOSE_CODES.values())) == 6, "two conditions share a code"
+    assert CLOSE_CODES == {
+        "unauthorized": 4401,
+        "forbidden": 4403,
+        "not_found": 4404,
+        "conflict": 4409,
+        "rate_limited": 4429,
+        "internal": 1011,
+    }
+
+
+def test_second_socket_rejected_4409(client, django_stub):
+    """AC-2, and the reason the lock is in Redis rather than in the process.
+
+    Spike A-02 finding 3: sockets for one tenant land on different Cloud Run
+    instances, so a process-local flag would admit one socket per instance and
+    call that exclusivity. Two writers on one meeting corrupt the transcript
+    for both.
+    """
+    django_stub["body"] = {"approved": True}
+
+    with open_socket(client) as first:
+        first.send_text("holding the slot")
+
+        with open_socket(client) as second:
+            closed = expect_close(second)
+
+        assert closed.code == 4409
+        # AC-2: "the first is untouched". A guard that closed both would
+        # satisfy "only one socket" and lose the meeting.
+        first.send_text("still holding")
+
+
+def test_the_first_socket_releases_its_claim_when_it_ends(client, django_stub):
+    """The control. A lock never released is a company locked out of its own
+    meetings until the TTL lapses, and the operator's remedy is a support
+    ticket."""
+    django_stub["body"] = {"approved": True}
+
+    with open_socket(client) as first:
+        first.send_text("one")
+
+    with open_socket(client) as second:
+        second.send_text("two")
+
+
+def test_live_keys_are_tenant_scoped():
+    """The card's named case, asserted on the builder rather than on a socket.
+
+    Every key this service writes starts with `oia:v1:` and carries the tenant
+    — the shared Memorystore instance is DB 2 for eleven services, and prefix
+    isolation is the only thing separating them (ERRATA-01).
+    """
+    # The builder directly: it is pure, and reaching it through app.state
+    # made this depend on a connected Redis for a question about string
+    # construction.
+    from app.cache.redis_manager import TenantKeys
+
+    key = TenantKeys("tenant-abc").live_lock("company-xyz")
+
+    assert key.startswith("oia:v1:tenant-abc:")
+    assert "company-xyz" in key
+
+
+def test_an_expired_authorisation_closes_an_idle_socket(client, django_stub):
+    """NFR-SEC-02: "a token that expires mid-session closes the socket with
+    4401, **not at the next message boundary**".
+
+    Idle is the case that matters — a meeting where nobody is speaking still
+    holds a connection, and a check that only runs on traffic never runs.
+    """
+    django_stub["body"] = {
+        "approved": True,
+        "auth": {
+            "valid": True,
+            "tenant_id": "t-1",
+            "company_id": django_stub.get("company_id", "c-1"),
+            "user_id": "u-1",
+            "role": "editor",
+            # Already past.
+            "valid_until": "2020-01-01T00:00:00+00:00",
+        },
+    }
+
+    with open_socket(client) as socket:
+        closed = expect_close(socket)
+
+    assert closed.code == CLOSE_UNAUTHORIZED
+    assert "expired" in closed.reason.lower()
+
+
+def test_a_viewer_cannot_open_a_live_socket(client, django_stub):
+    """§15: a Viewer reads a session and does not run a meeting. 4403 rather
+    than 4401 — they are who they say they are, and the answer is still no, so
+    re-authenticating would not help."""
+    django_stub["body"] = {
+        "approved": True,
+        "auth": {
+            "valid": True,
+            "tenant_id": "t-1",
+            "company_id": django_stub.get("company_id", "c-1"),
+            "user_id": "u-9",
+            "role": "viewer",
+            "valid_until": "2099-01-01T00:00:00+00:00",
+        },
+    }
+
+    with pytest.raises(WebSocketDisconnect) as caught:
+        with open_socket(client) as socket:
+            socket.receive_text()
+
+    assert caught.value.code == CLOSE_FORBIDDEN
+    assert "viewer" in caught.value.reason.lower()
+
+
+def test_an_invalid_ticket_is_4401(client, django_stub):
+    django_stub["body"] = {"approved": True, "auth": {"valid": False, "reason": "x"}}
+
+    with pytest.raises(WebSocketDisconnect) as caught:
+        with open_socket(client, ticket="nonsense") as socket:
+            socket.receive_text()
+
+    assert caught.value.code == CLOSE_UNAUTHORIZED


### PR DESCRIPTION
First of two PRs for **F-04 · WebSocket session lifecycle**. This is the handshake: authenticate, authorise, admit exactly one socket, and hold it. Frames, `seq` and resume are PR 2.

## The agent verifies no signatures

AC-1 asks for the JWT to be validated in the agent. Django signs HS256 with `SECRET_KEY` — the same key that derives the Fernet key protecting every tenant's OAuth refresh tokens (`automation/encryption.py`). Shipping it to the agent so it could check a signature would put those inside an agent compromise, to save a call the handshake already makes.

Django mints a **short-lived ticket** instead, which is what spike A-02 recommended for its own reason:

> *"F-04 and the frontend should use short-lived, single-purpose tokens for the socket rather than the long-lived session JWT."*

The token travels as `?jwt=` because browsers cannot set headers on a WS handshake, so it lands in gateway logs and browser history. A session JWT there is an hour of full API access in a log file.

**Two lifetimes, deliberately.** Seconds to *open* a socket; the JWT's own expiry for how long the authorisation *lasts*. Collapse them and you get either a socket that dies a minute after it opens, or a ticket that stays usable for an hour.

Everything AC-1 lists resolves from **one** precheck call — ticket claims, approval and consent travel together, which is the argument that endpoint was built on.

## C-04's 4403 becomes 4404

Agreed with you before making it. §10.2.3 gives 4403 to "consent missing or revoked" and 4404 to "session not found or **not live-eligible**"; a draft questionnaire is the second. AC-1 makes the mapping one-to-one and `test_close_codes_map_one_to_one` asserts exactly that — a client that cannot tell an eligibility failure from a consent failure re-presents the consent modal for a questionnaire nobody approved.

**Six codes, not five.** AC-1 lists five; §10.2.3 also defines `1011`, and NFR-SEC-02 says the tests cover "the six close codes".

## The socket now stays open

C-04 closed immediately because there was nothing behind the gate. Holding the connection *is* what this story delivers. One poll re-checks the authorisation, refreshes the lock and re-reads consent — NFR-SEC-02 wants an expiry to close an **idle** socket, "not at the next message boundary", and an idle meeting is exactly the case a traffic-triggered check never sees.

Side effect worth noting: **F-01's AC-4 is reachable end to end for the first time** — a revocation now closes a live socket rather than being noticed at the next message.

## Three bugs found while building it

- **`websocket.receive()` returns the disconnect rather than raising it.** Without handling that, the hold loop spun for the life of the process after the client left — holding the company's live lock and polling Django every few seconds. It surfaced as a suite that hung instead of failing.
- **The backend client collapsed "Django said 404" and "Django was unreachable" into `None`**, so a cross-tenant session closed `1011` — telling the caller our service was broken instead of that the session was not found.
- **My handshake flattened F-01's two consent reasons into one string**, losing the difference between "none recorded" and "revoked". That difference is the whole of what the operator does next: one is a modal to fill in, the other is a conversation to have.

## Testing

545 Django (+10), 485 agent, 21 in the handshake suite.

Mutations verified: accepting an invalid ticket, never noticing an expired authorisation, and dropping `NX` from the lock.

The last two originally **hung** rather than failed — Starlette's test client has no receive timeout, so a missing close blocks for ever. That is a six-hour CI job instead of a red test. There is a bounded `expect_close` helper now and both fail in about four seconds.

## On the lock being keyed by company

`TenantKeys.live_lock` is keyed on company and documents why: "keying it on the session would make the lock trivially satisfiable by opening a second session." AC-2 says "per session". They agree in practice — B-01 permits one non-terminal session per company — and the company key is the stricter of the two. I used the existing builder rather than adding a second lock.

## Not delivered

Frame schemas, monotonic `seq`, the capped Redis frame buffer and `resume`/resync — all PR 2. Rate limiting (4429) is defined as a constant but nothing emits it yet; no story has specified the limit.