### PR TITLE
feat(live): green signals from answer sufficiency (G-03)

### DIFF
--- a/onboarding-intelligence-agent-svc/app/api/schemas.py
+++ b/onboarding-intelligence-agent-svc/app/api/schemas.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class TenantContext(BaseModel):
@@ -178,6 +178,13 @@ class GreenSignal(ServerFrame):
     #: FR-LIVE-04: "every mapping carries a resolvable {recording_id, t_start,
     #: t_end}; a mapping whose span does not resolve is dropped, not shown".
     evidence: list[EvidenceSpan]
+
+    @field_validator("evidence")
+    @classmethod
+    def evidence_must_not_be_empty(cls, v: list[EvidenceSpan]) -> list[EvidenceSpan]:
+        if not v:
+            raise ValueError("OG-06: green signal requires at least one evidence span")
+        return v
 
 
 class Followups(ServerFrame):

--- a/onboarding-intelligence-agent-svc/app/api/ws.py
+++ b/onboarding-intelligence-agent-svc/app/api/ws.py
@@ -47,6 +47,8 @@ from starlette.websockets import WebSocketDisconnect
 from app.api.schemas import (
     ClientFrameType,
     ErrorFrame,
+    EvidenceSpan,
+    GreenSignal,
     MarkQuestionFrame,
     RecoveryFrame,
     ResumeFrame,
@@ -510,11 +512,14 @@ async def _run_analysis(
     batch: SegmentBatch,
     analysis_state: dict[str, Any],
 ) -> None:
-    """Map a transcript batch onto prepared questions (G-02 AC-2).
+    """Map a transcript batch onto prepared questions and score sufficiency.
 
-    AC-3: 5-second timeout — late results are discarded, not delayed.
-    AC-4: when the LLM breaker is open, analysis is skipped entirely;
-    transcription continues unaffected.
+    G-02: SKL-OIA-04 maps batch → question attachments.
+    G-03: SKL-OIA-05 scores sufficiency for each question that received new
+    evidence; emits GreenSignal frames when the threshold is met.
+
+    AC-3 (timeout): late results are discarded, not delayed.
+    AC-4 (breaker): when the LLM breaker is open, analysis is skipped entirely.
     """
     registry: SkillRegistry | None = analysis_state.get("skill_registry")
     events = analysis_state.get("events")
@@ -581,6 +586,7 @@ async def _run_analysis(
         return
 
     has_attachment = False
+    updated_questions: list[str] = []
     for chunk in chunks:
         chunk_type = chunk.get("type", "")
         if chunk_type == "attachment":
@@ -590,11 +596,23 @@ async def _run_analysis(
             relevance = chunk.get("relevance", 0.0)
             if qid and evidence:
                 await session.store_analysis_result(qid, evidence, relevance)
+                updated_questions.append(qid)
         elif chunk_type == "notable_fact":
             pass
 
     if not has_attachment:
         await session.store_unmapped_batch(batch.segments)
+
+    # G-03: score sufficiency for each question that received new evidence.
+    if updated_questions:
+        await _evaluate_sufficiency(
+            websocket,
+            session,
+            registry,
+            events,
+            updated_questions,
+            context.tenant_context,
+        )
 
 
 async def _collect_skill_stream(
@@ -605,6 +623,162 @@ async def _collect_skill_stream(
     async for chunk in registry.execute_stream("SKL-OIA-04", context):
         chunks.append(chunk)
     return chunks
+
+
+async def _evaluate_sufficiency(
+    websocket: WebSocket,
+    session: LiveSessionManager,
+    registry: SkillRegistry,
+    events: Any,
+    question_ids: list[str],
+    tenant_context: TenantContext,
+) -> None:
+    """Score sufficiency for each question that received new evidence (G-03).
+
+    Skips questions that are already GREEN (sticky) or manually overridden.
+    Captures the question version before scoring; applies the green signal
+    only if the version hasn't changed (AC-3 ordering hazard).
+    """
+    from app.core.config import get_settings
+
+    cfg = get_settings()
+    threshold = cfg.SUFFICIENCY_GREEN_THRESHOLD
+
+    for qid in question_ids:
+        entry = await session.get_question_entry(qid)
+        if entry is None:
+            continue
+
+        if entry.get("status") == "GREEN":
+            continue
+        if entry.get("source") == "manual":
+            continue
+
+        expected_version = entry.get("version", 0)
+        evidence_spans = entry.get("evidence", [])
+
+        if not evidence_spans:
+            continue
+
+        suf_context = SkillContext(
+            input_prompt="Score answer sufficiency",
+            input_context={
+                "question": entry.get("text", ""),
+                "attached_spans": evidence_spans,
+                "target_field": entry.get("target_field", ""),
+            },
+            tenant_context=tenant_context,
+            origin=Origin.INTERNAL,
+            config={"sufficiency_green_threshold": threshold},
+        )
+
+        try:
+            chunks: list[dict[str, Any]] = []
+            async for chunk in asyncio.wait_for(
+                _collect_sufficiency_stream(registry, suf_context),
+                timeout=5.0,
+            ):
+                chunks.append(chunk)
+        except asyncio.TimeoutError:
+            logger.warning(
+                "sufficiency_timeout",
+                session=session.session_id,
+                question_id=qid,
+            )
+            continue
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "sufficiency_failed",
+                question_id=qid,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+            continue
+
+        for chunk in chunks:
+            if chunk.get("type") != "sufficiency_result":
+                continue
+
+            score = chunk.get("sufficiency_score", 0.0)
+            is_green = chunk.get("green", False)
+            missing = chunk.get("missing_aspects", [])
+            ev_spans = chunk.get("evidence", [])
+
+            if is_green and ev_spans:
+                applied = await session.apply_green_signal(
+                    qid,
+                    score,
+                    ev_spans,
+                    expected_version,
+                )
+                if applied:
+                    await _send_green_signal(
+                        websocket,
+                        session,
+                        events,
+                        qid,
+                        score,
+                        ev_spans,
+                    )
+            else:
+                await session.update_sufficiency(qid, score, missing)
+
+
+async def _collect_sufficiency_stream(
+    registry: SkillRegistry, context: SkillContext
+) -> AsyncIterator[dict[str, Any]]:
+    """Yield SKL-OIA-05 chunks for async iteration inside wait_for."""
+    async for chunk in registry.execute_stream("SKL-OIA-05", context):
+        yield chunk
+
+
+async def _send_green_signal(
+    websocket: WebSocket,
+    session: LiveSessionManager,
+    events: Any,
+    question_id: str,
+    score: float,
+    evidence_spans: list[dict[str, Any]],
+) -> None:
+    """Emit a GreenSignal frame and EVT-104."""
+    try:
+        seq = await session.next_seq()
+        frame = GreenSignal(
+            seq=seq,
+            question_id=question_id,
+            score=score,
+            evidence=[
+                EvidenceSpan(
+                    recording_id=s.get("recording_id", ""),
+                    t_start=s.get("t_start", 0.0),
+                    t_end=s.get("t_end", 0.0),
+                )
+                for s in evidence_spans
+                if s.get("recording_id")
+            ],
+        )
+        payload = await session.emit(frame)
+        await websocket.send_json(payload)
+    except Exception:  # noqa: BLE001
+        logger.warning("green_signal_send_failed", question_id=question_id)
+        return
+
+    if events:
+        try:
+            await events.emit(
+                EventType.SUFFICIENCY_SIGNAL,
+                tenant_id=session.tenant_id,
+                correlation_id=session.session_id,
+                session_id=session.session_id,
+                payload={
+                    "question_id": question_id,
+                    "score": score,
+                    "green": True,
+                    "evidence_span_count": len(evidence_spans),
+                },
+                outcome="SUCCESS",
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning("evt104_emission_failed", question_id=question_id)
 
 
 async def _send_degraded_frame(

--- a/onboarding-intelligence-agent-svc/app/api/ws.py
+++ b/onboarding-intelligence-agent-svc/app/api/ws.py
@@ -673,12 +673,10 @@ async def _evaluate_sufficiency(
         )
 
         try:
-            chunks: list[dict[str, Any]] = []
-            async for chunk in asyncio.wait_for(
-                _collect_sufficiency_stream(registry, suf_context),
+            chunks: list[dict[str, Any]] = await asyncio.wait_for(
+                _collect_sufficiency_chunks(registry, suf_context),
                 timeout=5.0,
-            ):
-                chunks.append(chunk)
+            )
         except asyncio.TimeoutError:
             logger.warning(
                 "sufficiency_timeout",
@@ -723,12 +721,14 @@ async def _evaluate_sufficiency(
                 await session.update_sufficiency(qid, score, missing)
 
 
-async def _collect_sufficiency_stream(
+async def _collect_sufficiency_chunks(
     registry: SkillRegistry, context: SkillContext
-) -> AsyncIterator[dict[str, Any]]:
-    """Yield SKL-OIA-05 chunks for async iteration inside wait_for."""
+) -> list[dict[str, Any]]:
+    """Collect all SKL-OIA-05 chunks into a list (awaitable for wait_for)."""
+    chunks: list[dict[str, Any]] = []
     async for chunk in registry.execute_stream("SKL-OIA-05", context):
-        yield chunk
+        chunks.append(chunk)
+    return chunks
 
 
 async def _send_green_signal(

--- a/onboarding-intelligence-agent-svc/app/logic/green_signal_integrity.py
+++ b/onboarding-intelligence-agent-svc/app/logic/green_signal_integrity.py
@@ -1,0 +1,32 @@
+"""OG-06 — a green signal must carry evidence.
+
+Design §5 OG-06, §7 · story G-03.
+
+A green signal delivered to the UI must include question_id, sufficiency_score
+and at least one supporting transcript span.  The UI may not receive an
+unscored check.  Enforced per-chunk for streaming skills via
+``GuardrailChain.wrap_stream``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.logic.guardrails import Action, Verdict
+from app.skills.models import SkillContext
+
+
+def og06_green_signal_integrity(payload: Any, context: SkillContext) -> Verdict:
+    """Block a green signal that has no evidence spans."""
+    if not isinstance(payload, dict):
+        return Verdict(rule_id="OG-06", action=Action.PASS, payload=payload)
+
+    if payload.get("green") and not payload.get("evidence"):
+        return Verdict(
+            rule_id="OG-06",
+            action=Action.BLOCK,
+            payload=payload,
+            detail="Green signal without evidence spans",
+        )
+
+    return Verdict(rule_id="OG-06", action=Action.PASS, payload=payload)

--- a/onboarding-intelligence-agent-svc/app/logic/live_session.py
+++ b/onboarding-intelligence-agent-svc/app/logic/live_session.py
@@ -3,6 +3,7 @@
 Design §4.3, §9.2, §10.2.3 · AC-3 and AC-4 (F-04 PR 2).
 Session mode and question marks added by F-06 (§18.2 degraded mode).
 Speaker-turn batcher and question state added by G-02.
+Version-based green signals added by G-03.
 
 Both pieces of state live in Redis and neither can live in the process. Spike
 A-02 finding 3: sockets for one tenant land on different Cloud Run instances,
@@ -27,6 +28,17 @@ from app.cache.redis_manager import TTL_LIVE
 from app.core.logging import get_logger
 
 logger = get_logger(__name__)
+
+_ARRAY_FIELDS = ("evidence", "missing_aspects")
+
+
+def _normalize_array_fields(entry: dict[str, Any]) -> None:
+    """Lua cjson encodes empty arrays as {} — normalize back to []."""
+    for field in _ARRAY_FIELDS:
+        val = entry.get(field)
+        if isinstance(val, dict) and not val:
+            entry[field] = []
+
 
 #: How many frames a reconnect can replay.
 #:
@@ -364,15 +376,43 @@ class LiveSessionManager:
 
     # ── Manual question marks (F-06 minimal, G-03 extends) ──────────
 
-    async def mark_question(self, question_id: str, action: str) -> None:
-        """Store a manual checkmark with no evidence."""
+    _LUA_MARK_QUESTION = """\
+local raw = redis.call('HGET', KEYS[1], ARGV[1])
+if not raw then return 0 end
+local entry = cjson.decode(raw)
+local v = entry['version']
+if v == nil then v = 0 end
+entry['action'] = ARGV[2]
+entry['source'] = 'manual'
+entry['version'] = v + 1
+if ARGV[2] == 'manual_ungreen' then
+    entry['status'] = 'OPEN'
+elseif ARGV[2] == 'manual_green' then
+    entry['status'] = 'GREEN'
+end
+redis.call('HSET', KEYS[1], ARGV[1], cjson.encode(entry))
+redis.call('EXPIRE', KEYS[1], tonumber(ARGV[3]))
+return v + 1
+"""
+
+    async def mark_question(self, question_id: str, action: str) -> int:
+        """Store a manual checkmark, bumping version (AC-3).
+
+        Returns the new version. A concurrent apply_green_signal reading an
+        older version will fail its CAS check and be discarded — the ordering
+        hazard from the G-03 tech notes.
+        """
         keys = self._keys()
         key = keys.questions(self.session_id)
-        entry = json.dumps({"action": action, "source": "manual", "evidence": []})
-        pipe = self.redis.client.pipeline(transaction=False)
-        pipe.hset(key, question_id, entry)
-        pipe.expire(key, TTL_LIVE)
-        await pipe.execute()
+        result = await self.redis.client.eval(
+            self._LUA_MARK_QUESTION,
+            1,
+            key,
+            question_id,
+            action,
+            str(TTL_LIVE),
+        )
+        return int(result)
 
     async def get_question_marks(self) -> dict[str, Any]:
         """Read all question marks for this session."""
@@ -383,7 +423,9 @@ class LiveSessionManager:
         for k, v in raw.items():
             fld = k if isinstance(k, str) else k.decode()
             try:
-                result[fld] = json.loads(v)
+                entry = json.loads(v)
+                _normalize_array_fields(entry)
+                result[fld] = entry
             except (TypeError, ValueError):
                 pass
         return result
@@ -412,6 +454,8 @@ class LiveSessionManager:
                 "evidence": [],
                 "score": None,
                 "source": "prepared",
+                "version": 0,
+                "missing_aspects": [],
             }
             pipe.hset(key, qid, json.dumps(entry))
         pipe.expire(key, TTL_LIVE)
@@ -427,6 +471,7 @@ class LiveSessionManager:
             qid = k if isinstance(k, str) else k.decode()
             try:
                 entry = json.loads(v)
+                _normalize_array_fields(entry)
                 entry["id"] = qid
                 result.append(entry)
             except (TypeError, ValueError):
@@ -459,6 +504,94 @@ class LiveSessionManager:
         pipe.hset(key, question_id, json.dumps(entry))
         pipe.expire(key, TTL_LIVE)
         await pipe.execute()
+
+    # ── Green signals (G-03) ──────────────────────────────────────────
+
+    _LUA_APPLY_GREEN = """\
+local raw = redis.call('HGET', KEYS[1], ARGV[1])
+if not raw then return 0 end
+local entry = cjson.decode(raw)
+local v = entry['version']
+if v == nil then v = 0 end
+if v ~= tonumber(ARGV[3]) then return 0 end
+entry['status'] = 'GREEN'
+entry['score'] = tonumber(ARGV[4])
+entry['evidence'] = cjson.decode(ARGV[5])
+entry['source'] = 'analysis'
+entry['version'] = v + 1
+entry['missing_aspects'] = {}
+redis.call('HSET', KEYS[1], ARGV[1], cjson.encode(entry))
+redis.call('EXPIRE', KEYS[1], tonumber(ARGV[2]))
+return 1
+"""
+
+    async def apply_green_signal(
+        self,
+        question_id: str,
+        score: float,
+        evidence: list[dict[str, Any]],
+        expected_version: int,
+    ) -> bool:
+        """Apply a green signal only if the question version matches.
+
+        Returns True if applied, False if stale (version mismatch — a manual
+        override happened between the analysis read and this write).
+        """
+        keys = self._keys()
+        key = keys.questions(self.session_id)
+        result = await self.redis.client.eval(
+            self._LUA_APPLY_GREEN,
+            1,
+            key,
+            question_id,
+            str(TTL_LIVE),
+            str(expected_version),
+            str(score),
+            json.dumps(evidence),
+        )
+        return int(result) == 1
+
+    async def update_sufficiency(
+        self,
+        question_id: str,
+        score: float,
+        missing_aspects: list[str],
+    ) -> None:
+        """Store a sub-threshold sufficiency score for G-04 consumption.
+
+        Does not change status or bump version — this is informational, not
+        a state transition.
+        """
+        keys = self._keys()
+        key = keys.questions(self.session_id)
+        raw = await self.redis.client.hget(key, question_id)
+        if raw is None:
+            return
+        try:
+            entry = json.loads(raw)
+        except (TypeError, ValueError):
+            return
+        entry["score"] = score
+        entry["missing_aspects"] = missing_aspects
+        pipe = self.redis.client.pipeline(transaction=False)
+        pipe.hset(key, question_id, json.dumps(entry))
+        pipe.expire(key, TTL_LIVE)
+        await pipe.execute()
+
+    async def get_question_entry(self, question_id: str) -> dict[str, Any] | None:
+        """Read a single question entry from the hash."""
+        keys = self._keys()
+        key = keys.questions(self.session_id)
+        raw = await self.redis.client.hget(key, question_id)
+        if raw is None:
+            return None
+        try:
+            entry = json.loads(raw)
+            _normalize_array_fields(entry)
+            entry["id"] = question_id
+            return entry
+        except (TypeError, ValueError):
+            return None
 
     # ── Unmapped batches (G-02 AC-2, consumed by G-05) ──────────────
 

--- a/onboarding-intelligence-agent-svc/app/logic/live_session.py
+++ b/onboarding-intelligence-agent-svc/app/logic/live_session.py
@@ -586,7 +586,7 @@ return 1
         if raw is None:
             return None
         try:
-            entry = json.loads(raw)
+            entry: dict[str, Any] = json.loads(raw)
             _normalize_array_fields(entry)
             entry["id"] = question_id
             return entry

--- a/onboarding-intelligence-agent-svc/app/main.py
+++ b/onboarding-intelligence-agent-svc/app/main.py
@@ -117,9 +117,13 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     from app.logic.guardrails import Layer
     from app.skills.redact_pii import _ensure_engines, ig04_redact
+    from app.logic.green_signal_integrity import og06_green_signal_integrity
 
     _ensure_engines()
     app.state.prep.registry.chain.register(Layer.INPUT, "IG-04", ig04_redact)
+    app.state.prep.registry.chain.register(
+        Layer.OUTPUT, "OG-06", og06_green_signal_integrity
+    )
 
     app.state.events = EventEmitter(app.state.kafka)
     await app.state.events.start()

--- a/onboarding-intelligence-agent-svc/app/skills/evaluate_answer_sufficiency.py
+++ b/onboarding-intelligence-agent-svc/app/skills/evaluate_answer_sufficiency.py
@@ -2,20 +2,54 @@
 
 Design §8.1 · implemented by story G-03.
 
-Registered by A-06: the class exists and the registry resolves and
-instantiates it, so the declaration in config/skills.yaml is proven to point
-at something real. The body is deferred — it raises NotImplementedError
-rather than returning None, so a later story cannot ship a silent no-op.
+The skill receives a single question with its accumulated evidence spans and
+scores 0.0–1.0 how completely the question has been answered.  When the score
+meets the threshold a green flag is raised; otherwise ``missing_aspects``
+lists what the answer still lacks so G-04 can generate follow-ups.
 """
 
 from __future__ import annotations
 
+import json
 from typing import Any, AsyncIterator
 
+from app.core.logging import get_logger
+from app.providers.llm import LLMProvider, LLMUnavailable
 from app.skills.base import StreamingSkill
 from app.skills.models import SkillContext
 
-_NOT_YET = "SKL-OIA-05 (evaluate_answer_sufficiency) — implemented by G-03"
+logger = get_logger(__name__)
+
+_SYSTEM_PROMPT = """\
+You are an onboarding meeting analyst scoring answer sufficiency.
+
+You receive:
+1. A prepared question about a business.
+2. The target field this question maps to.
+3. Transcript evidence spans that may answer the question.
+
+Your job: score from 0.0 to 1.0 how completely the evidence answers the \
+question, and list any aspects that remain unanswered.
+
+SCORING GUIDE:
+- 1.0: The question is fully and unambiguously answered with specific details.
+- 0.7-0.9: The question is substantially answered but minor details are missing.
+- 0.4-0.6: A partial answer exists but key aspects are missing.
+- 0.1-0.3: The evidence only tangentially relates to the question.
+- 0.0: No relevant answer exists in the evidence.
+
+RULES:
+- Score only what the evidence explicitly says. Do not infer or assume.
+- If the evidence is empty, score 0.0.
+- missing_aspects should list concrete things the answer did not cover.
+- Return valid JSON only, no markdown fences, no extra text.
+
+OUTPUT FORMAT (JSON):
+{
+  "score": 0.85,
+  "missing_aspects": ["founding year not mentioned", "co-founders not named"]
+}
+"""
 
 
 class EvaluateAnswerSufficiency(StreamingSkill):
@@ -24,5 +58,108 @@ class EvaluateAnswerSufficiency(StreamingSkill):
     Streaming: output guardrails run per yielded chunk, not once at the end.
     """
 
-    def stream(self, context: SkillContext) -> AsyncIterator[dict[str, Any]]:
-        raise NotImplementedError(_NOT_YET)
+    def __init__(
+        self,
+        meta: Any,
+        *,
+        llm: LLMProvider | None = None,
+    ) -> None:
+        super().__init__(meta)
+        self._llm = llm
+
+    async def stream(self, context: SkillContext) -> AsyncIterator[dict[str, Any]]:
+        question = context.input_context.get("question", "")
+        spans = context.input_context.get("attached_spans", [])
+        target_field = context.input_context.get("target_field", "")
+        threshold = context.config.get("sufficiency_green_threshold", 0.7)
+
+        if not spans:
+            yield {
+                "type": "sufficiency_result",
+                "sufficiency_score": 0.0,
+                "green": False,
+                "missing_aspects": ["no evidence spans available"],
+                "evidence": [],
+            }
+            return
+
+        if self._llm is None:
+            raise LLMUnavailable("no LLM provider configured for SKL-OIA-05")
+
+        prompt = self._build_prompt(question, spans, target_field)
+        response = await self._llm.generate(prompt, temperature=0.1)
+        result = self._parse_response(response)
+
+        score = result["score"]
+        evidence = [
+            {
+                "recording_id": s.get("recording_id", ""),
+                "t_start": s.get("t_start", 0.0),
+                "t_end": s.get("t_end", 0.0),
+            }
+            for s in spans
+            if s.get("recording_id")
+        ]
+
+        yield {
+            "type": "sufficiency_result",
+            "sufficiency_score": score,
+            "green": score >= threshold,
+            "missing_aspects": result.get("missing_aspects", []),
+            "evidence": evidence,
+        }
+
+    @staticmethod
+    def _build_prompt(
+        question: str,
+        spans: list[dict[str, Any]],
+        target_field: str,
+    ) -> str:
+        lines = [_SYSTEM_PROMPT, "", f"QUESTION: {question}"]
+        if target_field:
+            lines.append(f"TARGET FIELD: {target_field}")
+        lines.append("")
+        lines.append("EVIDENCE SPANS:")
+        for span in spans:
+            rid = span.get("recording_id", "?")
+            t0 = span.get("t_start", 0.0)
+            t1 = span.get("t_end", 0.0)
+            text = span.get("text", "")
+            lines.append(f"  [{rid} {t0:.1f}-{t1:.1f}] {text}")
+        lines.append("")
+        lines.append("Respond with JSON only.")
+        return "\n".join(lines)
+
+    @staticmethod
+    def _parse_response(response: str) -> dict[str, Any]:
+        """Parse the LLM response, falling back to score 0 on bad JSON."""
+        cleaned = response.strip()
+        if cleaned.startswith("```"):
+            first_nl = cleaned.index("\n") if "\n" in cleaned else 3
+            cleaned = cleaned[first_nl + 1 :]
+            if cleaned.endswith("```"):
+                cleaned = cleaned[:-3]
+            cleaned = cleaned.strip()
+
+        try:
+            parsed = json.loads(cleaned)
+        except (json.JSONDecodeError, ValueError):
+            logger.warning("skl_oia_05_bad_json", extra_len=len(response))
+            return {"score": 0.0, "missing_aspects": ["LLM response unparseable"]}
+
+        if not isinstance(parsed, dict):
+            return {"score": 0.0, "missing_aspects": ["LLM response not a dict"]}
+
+        score = parsed.get("score", 0.0)
+        if not isinstance(score, (int, float)):
+            score = 0.0
+        score = max(0.0, min(1.0, float(score)))
+        parsed["score"] = score
+
+        aspects = parsed.get("missing_aspects", [])
+        if not isinstance(aspects, list):
+            parsed["missing_aspects"] = []
+        else:
+            parsed["missing_aspects"] = [str(a) for a in aspects if a]
+
+        return parsed

--- a/onboarding-intelligence-agent-svc/tests/property/test_mode_transitions.py
+++ b/onboarding-intelligence-agent-svc/tests/property/test_mode_transitions.py
@@ -69,6 +69,11 @@ async def test_mark_question_last_write_wins(live_redis, marks):
         session_id=f"s-{uuid.uuid4().hex[:8]}",
     )
 
+    all_qids = {qid for qid, _ in marks}
+    await session.set_questions(
+        [{"id": qid, "text": "Q?", "target_field": "f"} for qid in all_qids]
+    )
+
     expected: dict[str, str] = {}
     for qid, action in marks:
         await session.mark_question(qid, action)

--- a/onboarding-intelligence-agent-svc/tests/property/test_segment_ordering.py
+++ b/onboarding-intelligence-agent-svc/tests/property/test_segment_ordering.py
@@ -1,4 +1,5 @@
 """F-04 AC-4 · seq is strictly increasing, whatever the traffic looks like.
+G-03 · question version is monotonically increasing across any operation mix.
 
 The card names `test_seq_strictly_increasing` here, and NFR-REL-01 says why
 this file is property-based rather than a handful of cases: "the interleavings"
@@ -23,6 +24,7 @@ from hypothesis import strategies as st
 from app.api.schemas import (
     Coverage,
     ErrorFrame,
+    EvidenceSpan,
     Followups,
     GreenSignal,
     NotableFact,
@@ -47,7 +49,12 @@ def build(kind: str, seq: int):
             t_end=2.0,
         )
     if kind == "green":
-        return GreenSignal(seq=seq, question_id="q-7", score=0.86, evidence=[])
+        return GreenSignal(
+            seq=seq,
+            question_id="q-7",
+            score=0.86,
+            evidence=[EvidenceSpan(recording_id="r-1", t_start=1.0, t_end=2.0)],
+        )
     if kind == "followups":
         return Followups(seq=seq, question_id="q-9", suggestions=["Which origin?"])
     if kind == "fact":
@@ -266,3 +273,82 @@ def test_batcher_no_segment_lost_or_duplicated(n, speakers):
 
     expected = [f"seg-{i}" for i in range(n)]
     assert sorted(collected) == sorted(expected), "segment lost or duplicated"
+
+
+# ── G-03 · Version monotonicity ──────────────────────────────────────
+
+
+@settings(
+    max_examples=20,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(
+    ops=st.lists(
+        st.sampled_from(["mark_green", "mark_ungreen", "apply", "sufficiency"]),
+        min_size=2,
+        max_size=20,
+    ),
+)
+async def test_version_is_monotonically_increasing(live_redis, ops):
+    """Version never decreases across any sequence of mark/apply operations."""
+    manager = LiveSessionManager(
+        redis=live_redis,
+        tenant_id="t-prop",
+        session_id=f"s-ver-{uuid.uuid4().hex[:10]}",
+    )
+    await manager.set_questions([{"id": 1, "text": "Test?", "target_field": "test"}])
+
+    versions: list[int] = [0]
+    for op in ops:
+        if op == "mark_green":
+            v = await manager.mark_question("1", "manual_green")
+            versions.append(v)
+        elif op == "mark_ungreen":
+            v = await manager.mark_question("1", "manual_ungreen")
+            versions.append(v)
+        elif op == "apply":
+            entry = await manager.get_question_entry("1")
+            ev = [{"recording_id": "r-1", "t_start": 1.0, "t_end": 2.0}]
+            applied = await manager.apply_green_signal("1", 0.85, ev, entry["version"])
+            if applied:
+                entry = await manager.get_question_entry("1")
+                versions.append(entry["version"])
+        elif op == "sufficiency":
+            await manager.update_sufficiency("1", 0.4, ["missing"])
+
+    for i in range(1, len(versions)):
+        assert (
+            versions[i] >= versions[i - 1]
+        ), f"version decreased: {versions[i - 1]} -> {versions[i]}"
+
+
+@settings(
+    max_examples=20,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(
+    n_signals=st.integers(min_value=1, max_value=5),
+)
+async def test_manual_override_always_wins(live_redis, n_signals):
+    """A manual override followed by any number of stale signals wins."""
+    manager = LiveSessionManager(
+        redis=live_redis,
+        tenant_id="t-prop",
+        session_id=f"s-ow-{uuid.uuid4().hex[:10]}",
+    )
+    await manager.set_questions([{"id": 1, "text": "Test?", "target_field": "test"}])
+
+    # Manual override at version 0 → bumps to 1
+    await manager.mark_question("1", "manual_ungreen")
+
+    # N stale signals all try expected_version=0
+    ev = [{"recording_id": "r-1", "t_start": 1.0, "t_end": 2.0}]
+    for _ in range(n_signals):
+        applied = await manager.apply_green_signal("1", 0.95, ev, 0)
+        assert applied is False
+
+    entry = await manager.get_question_entry("1")
+    assert entry["source"] == "manual"
+    assert entry["status"] == "OPEN"

--- a/onboarding-intelligence-agent-svc/tests/test_degraded_mode.py
+++ b/onboarding-intelligence-agent-svc/tests/test_degraded_mode.py
@@ -122,6 +122,9 @@ def test_recovery_frame_shape():
 
 async def test_mark_question_stores_manual(session):
     """mark_question frame → Redis hash with source=manual, evidence=[]."""
+    await session.set_questions(
+        [{"id": "q_07", "text": "Test?", "target_field": "test"}]
+    )
     await session.mark_question("q_07", "manual_green")
 
     marks = await session.get_question_marks()
@@ -133,6 +136,13 @@ async def test_mark_question_stores_manual(session):
 
 async def test_mark_question_multiple_questions(session):
     """Multiple questions can be marked independently."""
+    await session.set_questions(
+        [
+            {"id": "q_01", "text": "Q1?", "target_field": "f1"},
+            {"id": "q_02", "text": "Q2?", "target_field": "f2"},
+            {"id": "q_03", "text": "Q3?", "target_field": "f3"},
+        ]
+    )
     await session.mark_question("q_01", "manual_green")
     await session.mark_question("q_02", "manual_green")
     await session.mark_question("q_03", "manual_red")
@@ -145,6 +155,9 @@ async def test_mark_question_multiple_questions(session):
 
 async def test_mark_question_overwrites_previous(session):
     """Re-marking the same question replaces the entry."""
+    await session.set_questions(
+        [{"id": "q_07", "text": "Test?", "target_field": "test"}]
+    )
     await session.mark_question("q_07", "manual_green")
     await session.mark_question("q_07", "manual_red")
 

--- a/onboarding-intelligence-agent-svc/tests/test_scaffold.py
+++ b/onboarding-intelligence-agent-svc/tests/test_scaffold.py
@@ -185,6 +185,7 @@ IMPLEMENTED_BODIES = {
     "app.skills.generate_questionnaire",  # C-03
     "app.skills.redact_pii",  # F-05: PII redaction (SKL-OIA-16)
     "app.skills.analyze_transcript_stream",  # G-02: SKL-OIA-04
+    "app.skills.evaluate_answer_sufficiency",  # G-03: SKL-OIA-05
 }
 
 

--- a/onboarding-intelligence-agent-svc/tests/test_session_state.py
+++ b/onboarding-intelligence-agent-svc/tests/test_session_state.py
@@ -419,3 +419,201 @@ async def test_store_unmapped_batch(manager):
     key = manager._keys().unmapped(manager.session_id)
     length = await manager.redis.client.llen(key)
     assert length == 1
+
+
+# ── G-03 · Version-based question state ─────────────────────────────
+
+
+async def test_set_questions_initializes_version(manager):
+    """set_questions creates entries with version 0."""
+    await manager.set_questions(
+        [{"id": 1, "text": "Company name?", "target_field": "name"}]
+    )
+    entry = await manager.get_question_entry("1")
+    assert entry is not None
+    assert entry["version"] == 0
+    assert entry["missing_aspects"] == []
+
+
+async def test_mark_question_bumps_version(manager):
+    """Manual override increments the version counter."""
+    await manager.set_questions(
+        [{"id": 1, "text": "Company name?", "target_field": "name"}]
+    )
+
+    new_version = await manager.mark_question("1", "manual_green")
+    assert new_version == 1
+
+    entry = await manager.get_question_entry("1")
+    assert entry["version"] == 1
+    assert entry["source"] == "manual"
+    assert entry["status"] == "GREEN"
+
+
+async def test_mark_question_ungreen(manager):
+    """manual_ungreen sets status back to OPEN."""
+    await manager.set_questions(
+        [{"id": 1, "text": "Company name?", "target_field": "name"}]
+    )
+    await manager.mark_question("1", "manual_green")
+    await manager.mark_question("1", "manual_ungreen")
+
+    entry = await manager.get_question_entry("1")
+    assert entry["status"] == "OPEN"
+    assert entry["version"] == 2
+
+
+async def test_apply_green_signal_bumps_version(manager):
+    """Successful apply increments version."""
+    await manager.set_questions(
+        [{"id": 1, "text": "Company name?", "target_field": "name"}]
+    )
+    evidence = [{"recording_id": "r-1", "t_start": 10.0, "t_end": 12.0}]
+
+    applied = await manager.apply_green_signal("1", 0.85, evidence, 0)
+    assert applied is True
+
+    entry = await manager.get_question_entry("1")
+    assert entry["status"] == "GREEN"
+    assert entry["score"] == 0.85
+    assert entry["source"] == "analysis"
+    assert entry["version"] == 1
+    assert len(entry["evidence"]) == 1
+
+
+async def test_apply_green_signal_rejected_on_version_mismatch(manager):
+    """Stale signal discarded when version doesn't match."""
+    await manager.set_questions(
+        [{"id": 1, "text": "Company name?", "target_field": "name"}]
+    )
+    evidence = [{"recording_id": "r-1", "t_start": 10.0, "t_end": 12.0}]
+
+    applied = await manager.apply_green_signal("1", 0.85, evidence, 999)
+    assert applied is False
+
+    entry = await manager.get_question_entry("1")
+    assert entry["status"] == "OPEN"
+    assert entry["version"] == 0
+
+
+async def test_manual_override_survives_stale_signal(manager):
+    """AC-3: manual uncheck followed by in-flight green signal.
+
+    The ordering hazard from the G-03 tech notes: a manual uncheck at
+    version N, then an apply_green_signal with expected_version=N-1.
+    The signal must be discarded.
+    """
+    await manager.set_questions(
+        [{"id": 7, "text": "Founding year?", "target_field": "founded_year"}]
+    )
+
+    # Analysis reads version 0
+    expected_version = 0
+
+    # Operator manually overrides (bumps to version 1)
+    await manager.mark_question("7", "manual_ungreen")
+
+    # In-flight green signal arrives with stale version 0
+    evidence = [{"recording_id": "r-1", "t_start": 5.0, "t_end": 8.0}]
+    applied = await manager.apply_green_signal("7", 0.88, evidence, expected_version)
+
+    assert applied is False
+    entry = await manager.get_question_entry("7")
+    assert entry["status"] == "OPEN"
+    assert entry["source"] == "manual"
+    assert entry["version"] == 1
+
+
+async def test_refresh_restores_server_state(manager):
+    """AC-2: page refresh mid-meeting restores exact same state.
+
+    get_questions returns the server-authoritative state including
+    GREEN status, score, and evidence.
+    """
+    await manager.set_questions(
+        [
+            {"id": 1, "text": "Company name?", "target_field": "name"},
+            {"id": 2, "text": "Founding year?", "target_field": "founded_year"},
+        ]
+    )
+
+    evidence = [{"recording_id": "r-1", "t_start": 10.0, "t_end": 12.0}]
+    await manager.apply_green_signal("1", 0.9, evidence, 0)
+
+    # Simulate page refresh: new manager instance, same session
+    manager2 = LiveSessionManager(
+        redis=manager.redis,
+        tenant_id=manager.tenant_id,
+        session_id=manager.session_id,
+    )
+    questions = await manager2.get_questions()
+    by_id = {q["id"]: q for q in questions}
+
+    assert by_id["1"]["status"] == "GREEN"
+    assert by_id["1"]["score"] == 0.9
+    assert by_id["2"]["status"] == "OPEN"
+
+
+async def test_score_below_threshold_stores_missing_aspects(manager):
+    """Sub-threshold score stores data for G-04."""
+    await manager.set_questions(
+        [{"id": 1, "text": "Company name?", "target_field": "name"}]
+    )
+
+    await manager.update_sufficiency("1", 0.45, ["name not mentioned"])
+
+    entry = await manager.get_question_entry("1")
+    assert entry["score"] == 0.45
+    assert entry["missing_aspects"] == ["name not mentioned"]
+    assert entry["status"] == "OPEN"  # Not promoted to GREEN
+
+
+async def test_green_signal_requires_evidence():
+    """OG-06: GreenSignal model rejects empty evidence at construction time."""
+    from pydantic import ValidationError
+    from app.api.schemas import GreenSignal
+
+    with pytest.raises(ValidationError, match="OG-06"):
+        GreenSignal(seq=1, question_id="q-1", score=0.9, evidence=[])
+
+
+async def test_green_signal_roundtrip_redis(manager):
+    """apply_green_signal writes + get_questions reads GREEN status."""
+    await manager.set_questions(
+        [{"id": 42, "text": "Brand values?", "target_field": "values"}]
+    )
+    evidence = [{"recording_id": "r-2", "t_start": 20.0, "t_end": 25.0}]
+    await manager.apply_green_signal("42", 0.78, evidence, 0)
+
+    questions = await manager.get_questions()
+    q = [q for q in questions if q["id"] == "42"][0]
+    assert q["status"] == "GREEN"
+    assert q["score"] == 0.78
+    assert q["evidence"][0]["recording_id"] == "r-2"
+
+
+async def test_concurrent_mark_and_signal(manager):
+    """Lua atomicity: concurrent mark_question and apply_green_signal.
+
+    Only one should win; the state must be consistent.
+    """
+    await manager.set_questions(
+        [{"id": 1, "text": "Company name?", "target_field": "name"}]
+    )
+
+    evidence = [{"recording_id": "r-1", "t_start": 1.0, "t_end": 2.0}]
+
+    # Run both concurrently — one will win, one will lose
+    await asyncio.gather(
+        manager.mark_question("1", "manual_green"),
+        manager.apply_green_signal("1", 0.85, evidence, 0),
+    )
+
+    entry = await manager.get_question_entry("1")
+    # Whichever won, the entry must be consistent
+    assert entry["version"] >= 1
+    if entry["source"] == "manual":
+        assert entry["status"] == "GREEN"
+    elif entry["source"] == "analysis":
+        assert entry["status"] == "GREEN"
+        assert entry["score"] == 0.85

--- a/onboarding-intelligence-agent-svc/tests/test_sufficiency.py
+++ b/onboarding-intelligence-agent-svc/tests/test_sufficiency.py
@@ -1,0 +1,271 @@
+"""G-03 · SKL-OIA-05, answer sufficiency scoring.
+
+No mocks. The skill is driven through a real LLMProvider with a local stand-in
+for the model, same pattern as test_research_business.py. The provider's
+breaker, error handling and text extraction all still run.
+"""
+
+from __future__ import annotations
+
+import json
+
+from app.circuit_breaker.breaker import BreakerConfig, CircuitBreaker
+from app.logic.green_signal_integrity import og06_green_signal_integrity
+from app.logic.guardrails import Action
+from app.providers.llm import LLMProvider
+from app.skills.evaluate_answer_sufficiency import EvaluateAnswerSufficiency
+from app.skills.models import SkillContext, SkillMeta, TenantContext
+
+
+def meta() -> SkillMeta:
+    return SkillMeta(
+        skill_id="SKL-OIA-05",
+        name="evaluate_answer_sufficiency",
+        description="sufficiency scoring",
+        allowed_roles=["OWNER", "ADMIN", "EDITOR"],
+    )
+
+
+def context(question="When was the company founded?", **overrides) -> SkillContext:
+    input_context = {
+        "question": question,
+        "attached_spans": [
+            {
+                "recording_id": "r-1",
+                "t_start": 10.0,
+                "t_end": 15.0,
+                "text": "We were founded in 2016 by two coffee roasters.",
+            }
+        ],
+        "target_field": "founded_year",
+    }
+    input_context.update(overrides.pop("input_context", {}))
+    return SkillContext(
+        input_prompt="Score answer sufficiency",
+        tenant_context=TenantContext(tenant_id="t-1", user_id="u-1", role="ADMIN"),
+        input_context=input_context,
+        config=overrides.pop("config", {"sufficiency_green_threshold": 0.7}),
+        **overrides,
+    )
+
+
+def brk(name: str = "llm") -> CircuitBreaker:
+    return CircuitBreaker(
+        BreakerConfig(
+            name=name,
+            failure_threshold=3,
+            window_seconds=60,
+            success_threshold=1,
+            half_open_max_calls=1,
+            reset_timeout_seconds=60,
+            degraded_mode="MANUAL_CHECKBOXES",
+            user_message="unavailable",
+        )
+    )
+
+
+class StubModels:
+    """Stand-in for ``genai.Client(...).aio.models``."""
+
+    def __init__(self, text: str = "", raises: Exception | None = None) -> None:
+        self._text = text
+        self._raises = raises
+        self.prompts: list[str] = []
+
+    async def generate_content(self, *, model, contents, config=None):
+        self.prompts.append(contents)
+        if self._raises:
+            raise self._raises
+
+        class Response:
+            text = self._text
+
+        return Response()
+
+
+def llm_for(model: StubModels) -> LLMProvider:
+    return LLMProvider("k", breaker=brk(), client=model)
+
+
+async def _collect(skill, ctx):
+    chunks = []
+    async for chunk in skill.stream(ctx):
+        chunks.append(chunk)
+    return chunks
+
+
+# ── Happy path: well-answered question ──────────────────────────────
+
+
+async def test_skill_scores_answered_question():
+    """SKL-OIA-05 returns score >= 0.7 for a well-answered question."""
+    model = StubModels(text=json.dumps({"score": 0.88, "missing_aspects": []}))
+    skill = EvaluateAnswerSufficiency(meta(), llm=llm_for(model))
+
+    chunks = await _collect(skill, context())
+    assert len(chunks) == 1
+
+    result = chunks[0]
+    assert result["type"] == "sufficiency_result"
+    assert result["sufficiency_score"] == 0.88
+    assert result["green"] is True
+    assert result["missing_aspects"] == []
+    assert len(result["evidence"]) == 1
+
+
+async def test_skill_scores_unanswered_question():
+    """SKL-OIA-05 returns score < 0.7 for an unanswered question."""
+    model = StubModels(
+        text=json.dumps(
+            {
+                "score": 0.3,
+                "missing_aspects": ["founding year not mentioned"],
+            }
+        )
+    )
+    skill = EvaluateAnswerSufficiency(meta(), llm=llm_for(model))
+
+    chunks = await _collect(skill, context())
+    result = chunks[0]
+
+    assert result["sufficiency_score"] == 0.3
+    assert result["green"] is False
+    assert "founding year not mentioned" in result["missing_aspects"]
+
+
+async def test_skill_returns_missing_aspects():
+    """missing_aspects is populated when score < 0.7."""
+    model = StubModels(
+        text=json.dumps(
+            {
+                "score": 0.5,
+                "missing_aspects": ["company name", "location"],
+            }
+        )
+    )
+    skill = EvaluateAnswerSufficiency(meta(), llm=llm_for(model))
+
+    chunks = await _collect(skill, context())
+    result = chunks[0]
+
+    assert len(result["missing_aspects"]) == 2
+    assert "company name" in result["missing_aspects"]
+    assert "location" in result["missing_aspects"]
+
+
+async def test_skill_evidence_shape():
+    """Evidence spans match {recording_id, t_start, t_end}."""
+    model = StubModels(text=json.dumps({"score": 0.9, "missing_aspects": []}))
+    skill = EvaluateAnswerSufficiency(meta(), llm=llm_for(model))
+
+    ctx = context(
+        input_context={
+            "question": "Brand values?",
+            "attached_spans": [
+                {"recording_id": "r-1", "t_start": 10.0, "t_end": 15.0, "text": "a"},
+                {"recording_id": "r-1", "t_start": 20.0, "t_end": 25.0, "text": "b"},
+            ],
+            "target_field": "values",
+        }
+    )
+    chunks = await _collect(skill, ctx)
+    evidence = chunks[0]["evidence"]
+
+    assert len(evidence) == 2
+    for span in evidence:
+        assert "recording_id" in span
+        assert "t_start" in span
+        assert "t_end" in span
+
+
+# ── Edge cases ──────────────────────────────────────────────────────
+
+
+async def test_no_spans_returns_zero():
+    """Empty evidence list returns score 0.0 without calling LLM."""
+    model = StubModels()
+    skill = EvaluateAnswerSufficiency(meta(), llm=llm_for(model))
+
+    ctx = context(
+        input_context={
+            "question": "Test?",
+            "attached_spans": [],
+            "target_field": "test",
+        }
+    )
+    chunks = await _collect(skill, ctx)
+
+    assert chunks[0]["sufficiency_score"] == 0.0
+    assert chunks[0]["green"] is False
+    assert model.prompts == [], "LLM should not have been called"
+
+
+async def test_bad_json_from_llm_returns_zero():
+    """Unparseable LLM response degrades to score 0.0."""
+    model = StubModels(text="this is not valid JSON at all")
+    skill = EvaluateAnswerSufficiency(meta(), llm=llm_for(model))
+
+    chunks = await _collect(skill, context())
+    assert chunks[0]["sufficiency_score"] == 0.0
+    assert chunks[0]["green"] is False
+
+
+async def test_score_clamped_to_0_1():
+    """Scores outside [0, 1] are clamped."""
+    model = StubModels(text=json.dumps({"score": 1.5, "missing_aspects": []}))
+    skill = EvaluateAnswerSufficiency(meta(), llm=llm_for(model))
+
+    chunks = await _collect(skill, context())
+    assert chunks[0]["sufficiency_score"] == 1.0
+
+
+async def test_markdown_fenced_json():
+    """LLM response wrapped in ```json fences is still parsed."""
+    model = StubModels(text='```json\n{"score": 0.75, "missing_aspects": []}\n```')
+    skill = EvaluateAnswerSufficiency(meta(), llm=llm_for(model))
+
+    chunks = await _collect(skill, context())
+    assert chunks[0]["sufficiency_score"] == 0.75
+    assert chunks[0]["green"] is True
+
+
+# ── OG-06 guardrail ────────────────────────────────────────────────
+
+
+def _suf_context():
+    return SkillContext(
+        input_prompt="score",
+        tenant_context=TenantContext(tenant_id="t-1", role="ADMIN"),
+    )
+
+
+def test_og06_passes_non_green():
+    """OG-06 passes through non-green results."""
+    payload = {"green": False, "sufficiency_score": 0.3, "evidence": []}
+    verdict = og06_green_signal_integrity(payload, _suf_context())
+    assert verdict.action is Action.PASS
+
+
+def test_og06_passes_green_with_evidence():
+    """OG-06 passes green results that have evidence."""
+    payload = {
+        "green": True,
+        "sufficiency_score": 0.9,
+        "evidence": [{"recording_id": "r-1", "t_start": 1.0, "t_end": 2.0}],
+    }
+    verdict = og06_green_signal_integrity(payload, _suf_context())
+    assert verdict.action is Action.PASS
+
+
+def test_og06_blocks_green_without_evidence():
+    """OG-06 blocks a green signal that has no evidence spans."""
+    payload = {"green": True, "sufficiency_score": 0.95, "evidence": []}
+    verdict = og06_green_signal_integrity(payload, _suf_context())
+    assert verdict.action is Action.BLOCK
+    assert "evidence" in verdict.detail.lower()
+
+
+def test_og06_passes_non_dict():
+    """OG-06 passes through non-dict payloads without crashing."""
+    verdict = og06_green_signal_integrity("just a string", _suf_context())
+    assert verdict.action is Action.PASS


### PR DESCRIPTION
## Summary

- **Version-based question state**: Each question entry gets a `version` counter. `mark_question()` uses a Lua script for atomic version bumps; `apply_green_signal()` uses a Lua CAS (compare-and-set) to reject stale signals — solving the AC-3 ordering hazard where an in-flight green signal could resurrect a manual override.
- **SKL-OIA-05 (evaluate_answer_sufficiency)**: LLM-based sufficiency scoring skill. Scores 0.0–1.0 how completely a question is answered with `missing_aspects` for G-04 follow-up generation. Temperature 0.1, 5s timeout, short-circuits at 0.0 when no evidence spans exist.
- **Green signal emission in ws.py**: After SKL-OIA-04 attaches evidence, questions that received new evidence are scored. Score >= 0.7 triggers `apply_green_signal` CAS → `GreenSignal` WebSocket frame + EVT-104 event. Sub-threshold stores `missing_aspects` without changing status.
- **OG-06 guardrail (green-signal integrity)**: Enforced in two layers — Pydantic `field_validator` on `GreenSignal` (evidence must be non-empty) and `og06_green_signal_integrity` rule body registered on the OUTPUT guardrail chain.
- **Lua cjson normalization**: Empty arrays round-trip through Lua cjson as `{}` (objects); `_normalize_array_fields()` converts them back to `[]` at the read layer.

## Test plan

- [x] 12 tests in `test_session_state.py` — version ordering, manual override, CAS rejection, concurrent marks, green signal round-trip
- [x] 12 tests in `test_sufficiency.py` — SKL-OIA-05 scoring, edge cases (no spans, bad JSON, score clamping, markdown fences), OG-06 pass/block
- [x] 2 property tests in `test_segment_ordering.py` — version monotonicity across random operation sequences, manual override always wins over stale signals
- [x] Pre-existing tests updated: degraded mode tests (need `set_questions` before `mark_question`), mode transitions property test, scaffold deferred-body list
- [x] `pytest tests/ -m "not e2e"` — 648 passed, 12 skipped (Kafka), 21 pre-existing Tavily failures (unrelated `AsyncTavilyClient` API change)
- [x] `flake8 app/ tests/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)