### PR TITLE
feat(live): ad-hoc question detection (G-05)

### DIFF
--- a/onboarding-intelligence-agent-svc/app/api/schemas.py
+++ b/onboarding-intelligence-agent-svc/app/api/schemas.py
@@ -121,6 +121,7 @@ class ServerFrameType(str, Enum):
     GREEN_SIGNAL = "green_signal"
     FOLLOWUPS = "followups"
     NOTABLE_FACT = "notable_fact"
+    ADHOC_DETECTED = "adhoc_detected"
     COVERAGE = "coverage"
     ERROR = "error"
     #: F-06 §18.2: sent when a circuit breaker closes and STT resumes.
@@ -202,6 +203,14 @@ class NotableFact(ServerFrame):
     workflow_target: Literal["WF1", "WF2", "WF3"]
 
 
+class AdhocDetected(ServerFrame):
+    type: Literal[ServerFrameType.ADHOC_DETECTED] = ServerFrameType.ADHOC_DETECTED
+    question_id: str
+    text: str
+    workflow_target: Literal["WF1", "WF2", "WF3"]
+    target_field: str
+
+
 class Coverage(ServerFrame):
     type: Literal[ServerFrameType.COVERAGE] = ServerFrameType.COVERAGE
     #: FR-LIVE-09: three fractions, "never blended into one percentage
@@ -248,6 +257,7 @@ class StartFrame(BaseModel):
     recording_id: str
     codec: str
     sample_rate: int
+    operator_speaker: int | None = None
 
 
 class ResumeFrame(BaseModel):

--- a/onboarding-intelligence-agent-svc/app/api/ws.py
+++ b/onboarding-intelligence-agent-svc/app/api/ws.py
@@ -592,7 +592,8 @@ async def _run_analysis(
 
     has_result = False
     updated_questions: list[str] = []
-    batch_speaker = batch.segments[0].get("speaker") if batch.segments else None
+    raw_speaker = batch.segments[0].get("speaker") if batch.segments else None
+    batch_speaker = int(raw_speaker) if raw_speaker is not None else None
     op_speaker = await session.get_operator_speaker()
 
     for chunk in chunks:
@@ -646,10 +647,10 @@ async def _run_analysis(
             )
 
         elif chunk_type == "notable_fact":
-            has_result = True
             fact_text = chunk.get("text", "")
             suggested = chunk.get("suggested_field", "")
             if fact_text:
+                has_result = True
                 wf = resolve_workflow_target(suggested)
                 await _send_notable_fact(websocket, session, fact_text, wf)
 

--- a/onboarding-intelligence-agent-svc/app/api/ws.py
+++ b/onboarding-intelligence-agent-svc/app/api/ws.py
@@ -45,6 +45,7 @@ from pydantic import ValidationError
 from starlette.websockets import WebSocketDisconnect
 
 from app.api.schemas import (
+    AdhocDetected,
     ClientFrameType,
     ErrorFrame,
     EvidenceSpan,
@@ -52,6 +53,7 @@ from app.api.schemas import (
     GreenSignal,
     MarkFollowupAskedFrame,
     MarkQuestionFrame,
+    NotableFact,
     RecoveryFrame,
     ResumeFrame,
     StartFrame,
@@ -81,6 +83,7 @@ from app.logic.live_handshake import (
     expired,
 )
 from app.logic.live_lock import REFRESH_S, LiveLock, acquire
+from app.logic.field_map import WorkflowTarget, resolve_field, resolve_workflow_target
 from app.logic.live_session import LiveSessionManager, SegmentBatcher, SegmentBatch
 from app.providers.stt import STTAdapter, STTResult, STTUnavailable
 from app.skills.models import SkillContext, TenantContext, Origin
@@ -587,22 +590,70 @@ async def _run_analysis(
         logger.warning("analysis_failed", error=f"{type(exc).__name__}: {exc}")
         return
 
-    has_attachment = False
+    has_result = False
     updated_questions: list[str] = []
+    batch_speaker = batch.segments[0].get("speaker") if batch.segments else None
+    op_speaker = await session.get_operator_speaker()
+
     for chunk in chunks:
         chunk_type = chunk.get("type", "")
         if chunk_type == "attachment":
-            has_attachment = True
+            has_result = True
             qid = chunk.get("question_id", "")
             evidence = chunk.get("evidence", [])
             relevance = chunk.get("relevance", 0.0)
             if qid and evidence:
                 await session.store_analysis_result(qid, evidence, relevance)
                 updated_questions.append(qid)
-        elif chunk_type == "notable_fact":
-            pass
 
-    if not has_attachment:
+        elif chunk_type == "adhoc_question":
+            adhoc_text = chunk.get("text", "")
+            inferred = chunk.get("inferred_target_field", "")
+            t_start = chunk.get("t_start", batch.first_t)
+            if not adhoc_text:
+                continue
+
+            if op_speaker is not None and batch_speaker != op_speaker:
+                wf = resolve_workflow_target(inferred)
+                await _send_notable_fact(websocket, session, adhoc_text, wf)
+                has_result = True
+                continue
+
+            has_result = True
+            target_field, workflow_target = resolve_field(inferred)
+            evidence = [
+                {
+                    "recording_id": batch.recording_id,
+                    "t_start": t_start,
+                    "t_end": batch.last_t,
+                }
+            ]
+            qid = await session.add_adhoc_question(
+                text=adhoc_text,
+                target_field=target_field,
+                workflow_target=workflow_target,
+                evidence=evidence,
+            )
+            updated_questions.append(qid)
+            await _send_adhoc_detected(
+                websocket,
+                session,
+                events,
+                qid,
+                adhoc_text,
+                workflow_target,
+                target_field,
+            )
+
+        elif chunk_type == "notable_fact":
+            has_result = True
+            fact_text = chunk.get("text", "")
+            suggested = chunk.get("suggested_field", "")
+            if fact_text:
+                wf = resolve_workflow_target(suggested)
+                await _send_notable_fact(websocket, session, fact_text, wf)
+
+    if not has_result:
         await session.store_unmapped_batch(batch.segments)
 
     # G-03: score sufficiency for each question that received new evidence.
@@ -890,6 +941,70 @@ async def _send_green_signal(
             logger.warning("evt104_emission_failed", question_id=question_id)
 
 
+async def _send_adhoc_detected(
+    websocket: WebSocket,
+    session: LiveSessionManager,
+    events: Any,
+    question_id: str,
+    text: str,
+    workflow_target: WorkflowTarget,
+    target_field: str,
+) -> None:
+    """Emit an AdhocDetected frame and EVT-106."""
+    try:
+        seq = await session.next_seq()
+        frame = AdhocDetected(
+            seq=seq,
+            question_id=question_id,
+            text=text,
+            workflow_target=workflow_target,
+            target_field=target_field,
+        )
+        payload = await session.emit(frame)
+        await websocket.send_json(payload)
+    except Exception:  # noqa: BLE001
+        logger.warning("adhoc_detected_send_failed", question_id=question_id)
+        return
+
+    if events:
+        try:
+            await events.emit(
+                EventType.MEDIA_CAPTURED_ANALYZED,
+                tenant_id=session.tenant_id,
+                correlation_id=session.session_id,
+                session_id=session.session_id,
+                payload={
+                    "question_id": question_id,
+                    "origin": "ADHOC",
+                    "workflow_target": workflow_target,
+                    "target_field": target_field,
+                },
+                outcome="SUCCESS",
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning("evt106_adhoc_emission_failed", question_id=question_id)
+
+
+async def _send_notable_fact(
+    websocket: WebSocket,
+    session: LiveSessionManager,
+    text: str,
+    workflow_target: WorkflowTarget,
+) -> None:
+    """Emit a NotableFact frame and buffer it for replay."""
+    try:
+        seq = await session.next_seq()
+        frame = NotableFact(
+            seq=seq,
+            text=text,
+            workflow_target=workflow_target,
+        )
+        payload = await session.emit(frame)
+        await websocket.send_json(payload)
+    except Exception:  # noqa: BLE001
+        logger.warning("notable_fact_send_failed")
+
+
 async def _send_degraded_frame(
     websocket: WebSocket, session: LiveSessionManager, message: str
 ) -> None:
@@ -973,6 +1088,9 @@ async def _handle_control(
             return
 
         stt_state["recording_id"] = start.recording_id
+
+        if start.operator_speaker is not None:
+            await session.set_operator_speaker(start.operator_speaker)
 
         batcher_obj = stt_state.get("batcher")
         if batcher_obj is not None:

--- a/onboarding-intelligence-agent-svc/app/logic/field_map.py
+++ b/onboarding-intelligence-agent-svc/app/logic/field_map.py
@@ -90,7 +90,7 @@ def resolve_field(inferred_field: str) -> tuple[str, WorkflowTarget]:
     """
     normalised = _normalise(inferred_field)
     wf = FIELD_MAP.get(normalised, DEFAULT_WORKFLOW_TARGET)
-    return normalised or inferred_field, wf
+    return normalised or inferred_field.strip(), wf
 
 
 def resolve_workflow_target(suggested_field: str) -> WorkflowTarget:

--- a/onboarding-intelligence-agent-svc/app/logic/field_map.py
+++ b/onboarding-intelligence-agent-svc/app/logic/field_map.py
@@ -1,0 +1,99 @@
+"""Shared field → workflow_target mapping (Design §10.1).
+
+Both prepared questions (C-03) and ad-hoc questions (G-05) resolve
+target_field through this map so the workflow_target is consistent
+regardless of how the question was surfaced.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Final, Literal
+
+WorkflowTarget = Literal["WF1", "WF2", "WF3"]
+
+FIELD_MAP: Final[dict[str, WorkflowTarget]] = {
+    # WF1 — company identity
+    "name": "WF1",
+    "company_name": "WF1",
+    "legal_name": "WF1",
+    "founded_year": "WF1",
+    "founding_year": "WF1",
+    "founder_story": "WF1",
+    "founders": "WF1",
+    "products_services": "WF1",
+    "products": "WF1",
+    "services": "WF1",
+    "business_goals": "WF1",
+    "goals": "WF1",
+    "industry": "WF1",
+    "website": "WF1",
+    "mission": "WF1",
+    "vision": "WF1",
+    "values": "WF1",
+    "history": "WF1",
+    "location": "WF1",
+    "headquarters": "WF1",
+    "employees": "WF1",
+    "team_size": "WF1",
+    "revenue": "WF1",
+    # WF2 — brand strategy
+    "brand_asset_status": "WF2",
+    "brand_assets": "WF2",
+    "trademark_status": "WF2",
+    "trademarks": "WF2",
+    "competitors": "WF2",
+    "competition": "WF2",
+    "digital_presence": "WF2",
+    "social_media": "WF2",
+    "audience_languages": "WF2",
+    "languages": "WF2",
+    "decision_maker": "WF2",
+    "target_audience": "WF2",
+    "brand_voice": "WF2",
+    "brand_personality": "WF2",
+    "brand_positioning": "WF2",
+    "differentiation": "WF2",
+    # WF3 — go-to-market
+    "marketing_budget_range": "WF3",
+    "marketing_budget": "WF3",
+    "budget": "WF3",
+    "sales_channels": "WF3",
+    "distribution": "WF3",
+    "customer_proof": "WF3",
+    "testimonials": "WF3",
+    "case_studies": "WF3",
+    "pricing": "WF3",
+    "campaigns": "WF3",
+    "advertising": "WF3",
+    "retail_locations": "WF3",
+    "stores": "WF3",
+    "partnerships": "WF3",
+}
+
+_NORMALISE_RE = re.compile(r"[\s\-]+")
+
+DEFAULT_WORKFLOW_TARGET: Final[WorkflowTarget] = "WF1"
+
+
+def _normalise(field: str) -> str:
+    """Lowercase, strip, collapse whitespace/hyphens to underscores."""
+    return _NORMALISE_RE.sub("_", field.strip().lower())
+
+
+def resolve_field(inferred_field: str) -> tuple[str, WorkflowTarget]:
+    """Resolve an LLM-inferred field name to (target_field, workflow_target).
+
+    Known fields are normalised and looked up. Unknown fields pass through
+    as-is with the default workflow target — losing an unrecognised field is
+    worse than mis-routing it.
+    """
+    normalised = _normalise(inferred_field)
+    wf = FIELD_MAP.get(normalised, DEFAULT_WORKFLOW_TARGET)
+    return normalised or inferred_field, wf
+
+
+def resolve_workflow_target(suggested_field: str) -> WorkflowTarget:
+    """Map a suggested_field to its workflow_target (for notable facts)."""
+    normalised = _normalise(suggested_field)
+    return FIELD_MAP.get(normalised, DEFAULT_WORKFLOW_TARGET)

--- a/onboarding-intelligence-agent-svc/app/logic/live_session.py
+++ b/onboarding-intelligence-agent-svc/app/logic/live_session.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import json
 import time
+import uuid
 from dataclasses import dataclass
 from typing import Any
 
@@ -454,6 +455,7 @@ return v + 1
                 "evidence": [],
                 "score": None,
                 "source": "prepared",
+                "origin": "PREPARED",
                 "version": 0,
                 "missing_aspects": [],
             }
@@ -670,3 +672,56 @@ return 1
         pipe.ltrim(key, -500, -1)
         pipe.expire(key, TTL_LIVE)
         await pipe.execute()
+
+    # ── Ad-hoc questions (G-05) ───────────────────────────────────────
+
+    async def add_adhoc_question(
+        self,
+        text: str,
+        target_field: str,
+        workflow_target: str,
+        evidence: list[dict[str, Any]],
+    ) -> str:
+        """Create an ad-hoc question in the questions hash. Returns the ID."""
+        qid = f"adhoc_{uuid.uuid4().hex[:8]}"
+        entry = {
+            "text": text,
+            "target_field": target_field,
+            "workflow_target": workflow_target,
+            "status": "OPEN",
+            "evidence": evidence,
+            "score": None,
+            "source": "analysis",
+            "origin": "ADHOC",
+            "version": 0,
+            "missing_aspects": [],
+        }
+        keys = self._keys()
+        key = keys.questions(self.session_id)
+        pipe = self.redis.client.pipeline(transaction=False)
+        pipe.hset(key, qid, json.dumps(entry))
+        pipe.expire(key, TTL_LIVE)
+        await pipe.execute()
+        return qid
+
+    # ── Operator speaker (G-05 AC-2) ─────────────────────────────────
+
+    async def set_operator_speaker(self, speaker: int) -> None:
+        """Store the operator's speaker tag for AC-2 gating."""
+        keys = self._keys()
+        key = keys.session(self.session_id)
+        await self.redis.client.hset(key, "operator_speaker", str(speaker))
+        await self.redis.client.expire(key, TTL_LIVE)
+
+    async def get_operator_speaker(self) -> int | None:
+        """Read the operator speaker tag. None means 'trust the LLM'."""
+        keys = self._keys()
+        key = keys.session(self.session_id)
+        raw = await self.redis.client.hget(key, "operator_speaker")
+        if raw is None:
+            return None
+        val = raw if isinstance(raw, str) else raw.decode()
+        try:
+            return int(val)
+        except (ValueError, TypeError):
+            return None

--- a/onboarding-intelligence-agent-svc/app/logic/live_session.py
+++ b/onboarding-intelligence-agent-svc/app/logic/live_session.py
@@ -710,8 +710,10 @@ return 1
         """Store the operator's speaker tag for AC-2 gating."""
         keys = self._keys()
         key = keys.session(self.session_id)
-        await self.redis.client.hset(key, "operator_speaker", str(speaker))
-        await self.redis.client.expire(key, TTL_LIVE)
+        pipe = self.redis.client.pipeline(transaction=False)
+        pipe.hset(key, "operator_speaker", str(speaker))
+        pipe.expire(key, TTL_LIVE)
+        await pipe.execute()
 
     async def get_operator_speaker(self) -> int | None:
         """Read the operator speaker tag. None means 'trust the LLM'."""

--- a/onboarding-intelligence-agent-svc/tests/property/test_segment_ordering.py
+++ b/onboarding-intelligence-agent-svc/tests/property/test_segment_ordering.py
@@ -22,6 +22,7 @@ from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
 from app.api.schemas import (
+    AdhocDetected,
     Coverage,
     ErrorFrame,
     EvidenceSpan,
@@ -59,12 +60,20 @@ def build(kind: str, seq: int):
         return Followups(seq=seq, question_id="q-9", suggestions=["Which origin?"])
     if kind == "fact":
         return NotableFact(seq=seq, text="A second location.", workflow_target="WF3")
+    if kind == "adhoc":
+        return AdhocDetected(
+            seq=seq,
+            question_id="adhoc_a1b2c3d4",
+            text="How many stores?",
+            workflow_target="WF3",
+            target_field="retail_locations",
+        )
     if kind == "coverage":
         return Coverage(seq=seq, map={"WF1": 0.7, "WF2": 0.4, "WF3": 0.3})
     return ErrorFrame(seq=seq, code="ERR-07", message="degraded", recoverable=True)
 
 
-KINDS = ["partial", "final", "green", "followups", "fact", "coverage", "error"]
+KINDS = ["partial", "final", "green", "followups", "fact", "adhoc", "coverage", "error"]
 
 
 @settings(

--- a/onboarding-intelligence-agent-svc/tests/test_adhoc_detection.py
+++ b/onboarding-intelligence-agent-svc/tests/test_adhoc_detection.py
@@ -81,6 +81,13 @@ def test_resolve_field_empty_string():
     assert wf == "WF1"
 
 
+def test_resolve_field_whitespace_only():
+    """Whitespace-only input returns stripped empty string, not raw whitespace."""
+    field, wf = resolve_field("   ")
+    assert field == ""
+    assert wf == "WF1"
+
+
 def test_resolve_workflow_target_for_notable():
     """suggested_field maps to workflow_target for notable facts."""
     assert resolve_workflow_target("retail_locations") == "WF3"

--- a/onboarding-intelligence-agent-svc/tests/test_adhoc_detection.py
+++ b/onboarding-intelligence-agent-svc/tests/test_adhoc_detection.py
@@ -1,0 +1,109 @@
+"""G-05 — Ad-hoc question detection.
+
+Tests for the shared field map and speaker-tag gating logic. Integration
+tests for the full detection pipeline live in test_session_state.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.logic.field_map import (
+    DEFAULT_WORKFLOW_TARGET,
+    FIELD_MAP,
+    resolve_field,
+    resolve_workflow_target,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ── Field map resolution ───────────────────────────────────────────────
+
+
+def test_resolve_field_known():
+    """A known field returns the correct (target_field, workflow_target)."""
+    field, wf = resolve_field("competitors")
+    assert field == "competitors"
+    assert wf == "WF2"
+
+
+def test_resolve_field_wf1():
+    field, wf = resolve_field("founded_year")
+    assert field == "founded_year"
+    assert wf == "WF1"
+
+
+def test_resolve_field_wf3():
+    field, wf = resolve_field("sales_channels")
+    assert field == "sales_channels"
+    assert wf == "WF3"
+
+
+def test_resolve_field_unknown_defaults_to_wf1():
+    """Unknown fields pass through with the default workflow target."""
+    field, wf = resolve_field("favourite_colour")
+    assert field == "favourite_colour"
+    assert wf == DEFAULT_WORKFLOW_TARGET
+    assert wf == "WF1"
+
+
+def test_resolve_field_normalises_case():
+    """Case and whitespace are normalised before lookup."""
+    field, wf = resolve_field("Founded_Year")
+    assert field == "founded_year"
+    assert wf == "WF1"
+
+
+def test_resolve_field_normalises_hyphens():
+    """Hyphens are treated like underscores."""
+    field, wf = resolve_field("brand-asset-status")
+    assert field == "brand_asset_status"
+    assert wf == "WF2"
+
+
+def test_resolve_field_normalises_spaces():
+    """Spaces are collapsed to underscores."""
+    field, wf = resolve_field("marketing budget range")
+    assert field == "marketing_budget_range"
+    assert wf == "WF3"
+
+
+def test_resolve_field_strips_whitespace():
+    field, wf = resolve_field("  competitors  ")
+    assert field == "competitors"
+    assert wf == "WF2"
+
+
+def test_resolve_field_empty_string():
+    """An empty inferred_target_field doesn't crash."""
+    field, wf = resolve_field("")
+    assert wf == "WF1"
+
+
+def test_resolve_workflow_target_for_notable():
+    """suggested_field maps to workflow_target for notable facts."""
+    assert resolve_workflow_target("retail_locations") == "WF3"
+    assert resolve_workflow_target("competitors") == "WF2"
+    assert resolve_workflow_target("mission") == "WF1"
+
+
+def test_resolve_workflow_target_unknown():
+    assert resolve_workflow_target("obscure_field") == "WF1"
+
+
+def test_every_map_entry_is_valid():
+    """Every value in FIELD_MAP is a valid workflow target."""
+    valid = {"WF1", "WF2", "WF3"}
+    for field, wf in FIELD_MAP.items():
+        assert wf in valid, f"{field} maps to invalid {wf}"
+
+
+def test_adhoc_resolves_target_field_via_map():
+    """AC-3 named test: inferred_target_field resolves through field_map.
+
+    The retail location example from AC-4 maps to WF3.
+    """
+    field, wf = resolve_field("retail_locations")
+    assert field == "retail_locations"
+    assert wf == "WF3"

--- a/onboarding-intelligence-agent-svc/tests/test_session_state.py
+++ b/onboarding-intelligence-agent-svc/tests/test_session_state.py
@@ -16,6 +16,7 @@ import uuid
 import pytest
 
 from app.api.schemas import (
+    AdhocDetected,
     Coverage,
     NotableFact,
     ServerFrameType,
@@ -754,3 +755,183 @@ async def test_followups_survive_reconnect(manager):
     entry = await manager2.get_question_entry("4")
     assert len(entry["suggestions"]) == 1
     assert entry["suggestions"][0]["text"] == "Annual or monthly?"
+
+
+# ── G-05 · Ad-hoc questions ─────────────────────────────────────────
+
+
+async def test_add_adhoc_question_round_trip(manager):
+    """Ad-hoc question created, readable via get_questions, has origin ADHOC."""
+    qid = await manager.add_adhoc_question(
+        text="How many retail locations do you have?",
+        target_field="retail_locations",
+        workflow_target="WF3",
+        evidence=[{"recording_id": "r-1", "t_start": 45.0, "t_end": 48.0}],
+    )
+
+    questions = await manager.get_questions()
+    adhoc = [q for q in questions if q["id"] == qid]
+    assert len(adhoc) == 1
+
+    q = adhoc[0]
+    assert q["text"] == "How many retail locations do you have?"
+    assert q["origin"] == "ADHOC"
+    assert q["target_field"] == "retail_locations"
+    assert q["workflow_target"] == "WF3"
+    assert q["status"] == "OPEN"
+    assert q["source"] == "analysis"
+    assert q["version"] == 0
+
+
+async def test_adhoc_question_id_prefix(manager):
+    """ID starts with 'adhoc_'."""
+    qid = await manager.add_adhoc_question(
+        text="What is your pricing model?",
+        target_field="pricing",
+        workflow_target="WF3",
+        evidence=[],
+    )
+    assert qid.startswith("adhoc_")
+    assert len(qid) > len("adhoc_")
+
+
+async def test_adhoc_question_has_evidence(manager):
+    """Evidence spans attached at creation time."""
+    evidence = [
+        {"recording_id": "r-2", "t_start": 100.0, "t_end": 105.0},
+        {"recording_id": "r-2", "t_start": 106.0, "t_end": 110.0},
+    ]
+    qid = await manager.add_adhoc_question(
+        text="Who are your main competitors?",
+        target_field="competitors",
+        workflow_target="WF2",
+        evidence=evidence,
+    )
+
+    entry = await manager.get_question_entry(qid)
+    assert len(entry["evidence"]) == 2
+    assert entry["evidence"][0]["recording_id"] == "r-2"
+    assert entry["evidence"][1]["t_start"] == 106.0
+
+
+async def test_set_questions_has_origin_prepared(manager):
+    """Prepared questions have origin 'PREPARED'."""
+    await manager.set_questions(
+        [{"id": 1, "text": "Company name?", "target_field": "name"}]
+    )
+
+    entry = await manager.get_question_entry("1")
+    assert entry["origin"] == "PREPARED"
+
+
+async def test_adhoc_and_prepared_coexist(manager):
+    """Prepared and ad-hoc questions live in the same hash."""
+    await manager.set_questions(
+        [
+            {"id": 1, "text": "Company name?", "target_field": "name"},
+            {"id": 2, "text": "Founded year?", "target_field": "founded_year"},
+        ]
+    )
+
+    qid = await manager.add_adhoc_question(
+        text="What about trademarks?",
+        target_field="trademark_status",
+        workflow_target="WF2",
+        evidence=[],
+    )
+
+    questions = await manager.get_questions()
+    assert len(questions) == 3
+
+    origins = {q["origin"] for q in questions}
+    assert origins == {"PREPARED", "ADHOC"}
+
+    adhoc = [q for q in questions if q["id"] == qid]
+    assert adhoc[0]["origin"] == "ADHOC"
+
+
+async def test_adhoc_question_survives_reconnect(manager):
+    """Ad-hoc question readable after manager re-creation."""
+    qid = await manager.add_adhoc_question(
+        text="Distribution channels?",
+        target_field="distribution",
+        workflow_target="WF3",
+        evidence=[{"recording_id": "r-1", "t_start": 50.0, "t_end": 55.0}],
+    )
+
+    manager2 = LiveSessionManager(
+        redis=manager.redis,
+        tenant_id=manager.tenant_id,
+        session_id=manager.session_id,
+    )
+    entry = await manager2.get_question_entry(qid)
+    assert entry is not None
+    assert entry["origin"] == "ADHOC"
+    assert entry["text"] == "Distribution channels?"
+
+
+# ── G-05 · Operator speaker ─────────────────────────────────────────
+
+
+async def test_operator_speaker_round_trip(manager):
+    """set/get operator_speaker survives reconnect."""
+    await manager.set_operator_speaker(0)
+
+    manager2 = LiveSessionManager(
+        redis=manager.redis,
+        tenant_id=manager.tenant_id,
+        session_id=manager.session_id,
+    )
+    result = await manager2.get_operator_speaker()
+    assert result == 0
+
+
+async def test_operator_speaker_defaults_none(manager):
+    """Returns None when not set."""
+    result = await manager.get_operator_speaker()
+    assert result is None
+
+
+async def test_operator_speaker_nonzero(manager):
+    """Operator can be any speaker number, not just 0."""
+    await manager.set_operator_speaker(2)
+    result = await manager.get_operator_speaker()
+    assert result == 2
+
+
+# ── G-05 · Notable fact frame ───────────────────────────────────────
+
+
+async def test_notable_fact_frame_in_buffer(manager):
+    """NotableFact frame is in the replay buffer after emission."""
+    frame = NotableFact(
+        seq=await manager.next_seq(),
+        text="Owns a second retail location opening in October.",
+        workflow_target="WF3",
+    )
+    await manager.emit(frame)
+
+    frames, _ = await manager.replay_after(0)
+    assert len(frames) == 1
+    assert frames[0]["type"] == "notable_fact"
+    assert frames[0]["workflow_target"] == "WF3"
+    assert "October" in frames[0]["text"]
+
+
+async def test_adhoc_detected_frame_in_buffer(manager):
+    """AdhocDetected frame round-trips through the replay buffer."""
+    frame = AdhocDetected(
+        seq=await manager.next_seq(),
+        question_id="adhoc_abc12345",
+        text="How many retail locations do you have?",
+        workflow_target="WF3",
+        target_field="retail_locations",
+    )
+    await manager.emit(frame)
+
+    frames, _ = await manager.replay_after(0)
+    assert len(frames) == 1
+    assert frames[0]["type"] == "adhoc_detected"
+    assert frames[0]["question_id"] == "adhoc_abc12345"
+    assert frames[0]["workflow_target"] == "WF3"
+    assert frames[0]["target_field"] == "retail_locations"


### PR DESCRIPTION
## Summary

- **Field map** (`app/logic/field_map.py`): shared static mapping from Company model fields to workflow targets (WF1/WF2/WF3), used by both ad-hoc questions and notable facts to resolve `target_field` and `workflow_target`
- **Ad-hoc question detection**: handles `adhoc_question` chunks from SKL-OIA-04 (previously silently dropped), stores them in the questions hash with `origin: ADHOC`, and routes them through the existing sufficiency/follow-up pipeline (G-03/G-04)
- **Notable fact emission**: handles `notable_fact` chunks (previously explicit no-op), sends `NotableFact` frames over the WebSocket and buffers them for replay
- **Speaker-tag gating (AC-2)**: when `operator_speaker` is set on the start frame, non-operator questions are reclassified as notable facts instead of ad-hoc questions
- **Protocol additions**: `AdhocDetected` server frame type, `operator_speaker` field on `StartFrame`
- **No new LLM calls**: SKL-OIA-04 already produces these chunks — G-05 only handles what was being discarded

## Test plan

- [x] `pytest tests/test_adhoc_detection.py -v` — 13 unit tests for field map resolution, normalisation, and AC-named test cases
- [x] `pytest tests/test_session_state.py -v` — 11 new integration tests for ad-hoc state, operator speaker, notable fact and AdhocDetected frame replay
- [x] `pytest tests/property/test_segment_ordering.py -v` — AdhocDetected added to frame type sweep
- [x] `pytest tests/ -v -m "not e2e"` — 711 passed, 12 skipped, 17 deselected
- [x] `black --check app/ tests/` — clean
- [x] `flake8 app/ tests/` — clean
- [x] `mypy app/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)