### PR TITLE
feat(live): WF1/WF2/WF3 coverage checklist (G-06)

### DIFF
--- a/onboarding-intelligence-agent-svc/app/api/ws.py
+++ b/onboarding-intelligence-agent-svc/app/api/ws.py
@@ -47,6 +47,7 @@ from starlette.websockets import WebSocketDisconnect
 from app.api.schemas import (
     AdhocDetected,
     ClientFrameType,
+    Coverage,
     ErrorFrame,
     EvidenceSpan,
     Followups,
@@ -83,6 +84,7 @@ from app.logic.live_handshake import (
     expired,
 )
 from app.logic.live_lock import REFRESH_S, LiveLock, acquire
+from app.logic.coverage import compute_coverage
 from app.logic.field_map import WorkflowTarget, resolve_field, resolve_workflow_target
 from app.logic.live_session import LiveSessionManager, SegmentBatcher, SegmentBatch
 from app.providers.stt import STTAdapter, STTResult, STTUnavailable
@@ -668,6 +670,31 @@ async def _run_analysis(
             context.tenant_context,
         )
 
+    # G-06: recompute coverage after any evidence change.
+    if updated_questions:
+        await _update_coverage(
+            websocket, session, events, analysis_state, updated_questions
+        )
+
+
+async def _update_coverage(
+    websocket: WebSocket,
+    session: LiveSessionManager,
+    events: Any,
+    analysis_state: dict[str, Any],
+    updated_question_ids: list[str],
+) -> None:
+    """Recompute and emit WF1/WF2/WF3 coverage fractions."""
+    try:
+        settings = analysis_state.get("settings")
+        threshold = settings.COVERAGE_GREEN_THRESHOLD if settings else 0.7
+        questions = await session.get_questions()
+        result = compute_coverage(questions, threshold)
+        await session.store_coverage(result)
+        await _send_coverage(websocket, session, events, result, updated_question_ids)
+    except Exception:  # noqa: BLE001
+        logger.warning("coverage_update_failed", session_id=session.session_id)
+
 
 async def _collect_stream(
     registry: SkillRegistry, skill_id: str, context: SkillContext
@@ -1004,6 +1031,41 @@ async def _send_notable_fact(
         await websocket.send_json(payload)
     except Exception:  # noqa: BLE001
         logger.warning("notable_fact_send_failed")
+
+
+async def _send_coverage(
+    websocket: WebSocket,
+    session: LiveSessionManager,
+    events: Any,
+    result: Any,
+    updated_question_ids: list[str],
+) -> None:
+    """Emit a Coverage frame and EVT-107."""
+    try:
+        seq = await session.next_seq()
+        frame = Coverage(seq=seq, map=result.as_map())
+        payload = await session.emit(frame)
+        await websocket.send_json(payload)
+    except Exception:  # noqa: BLE001
+        logger.warning("coverage_send_failed", session_id=session.session_id)
+        return
+
+    if events:
+        try:
+            await events.emit(
+                EventType.COVERAGE_UPDATED,
+                tenant_id=session.tenant_id,
+                correlation_id=session.session_id,
+                session_id=session.session_id,
+                payload={
+                    "map": result.as_map(),
+                    "satisfied": result.satisfied,
+                    "delta_question_ids": updated_question_ids,
+                },
+                outcome="SUCCESS",
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning("evt107_emission_failed")
 
 
 async def _send_degraded_frame(

--- a/onboarding-intelligence-agent-svc/app/api/ws.py
+++ b/onboarding-intelligence-agent-svc/app/api/ws.py
@@ -681,13 +681,17 @@ async def _update_coverage(
     websocket: WebSocket,
     session: LiveSessionManager,
     events: Any,
-    analysis_state: dict[str, Any],
+    analysis_state: dict[str, Any] | None,
     updated_question_ids: list[str],
 ) -> None:
     """Recompute and emit WF1/WF2/WF3 coverage fractions."""
     try:
-        settings = analysis_state.get("settings")
-        threshold = settings.COVERAGE_GREEN_THRESHOLD if settings else 0.7
+        settings = analysis_state.get("settings") if analysis_state else None
+        if settings is None:
+            from app.core.config import get_settings
+
+            settings = get_settings()
+        threshold = settings.COVERAGE_GREEN_THRESHOLD
         questions = await session.get_questions()
         result = compute_coverage(questions, threshold)
         await session.store_coverage(result)
@@ -1214,6 +1218,8 @@ async def _handle_control(
             question_id=mark.question_id,
             action=mark.action,
         )
+        events = getattr(websocket.app.state, "events", None)
+        await _update_coverage(websocket, session, events, None, [mark.question_id])
         return
 
     if frame_type == ClientFrameType.MARK_FOLLOWUP_ASKED.value:

--- a/onboarding-intelligence-agent-svc/app/core/config.py
+++ b/onboarding-intelligence-agent-svc/app/core/config.py
@@ -74,6 +74,7 @@ class Settings(BaseSettings):
 
     # ── Behavioural settings (Design §19) ────────────────────
     SUFFICIENCY_GREEN_THRESHOLD: float = 0.7
+    COVERAGE_GREEN_THRESHOLD: float = 0.7
     LIVE_ANALYSIS_SILENCE_MS: int = 4000
     TRANSCRIPT_BUFFER_MAX: int = 4000
     CONTEXT_SUMMARIZE_AT: float = 0.75
@@ -110,7 +111,11 @@ class Settings(BaseSettings):
     # ── Observability ────────────────────────────────────────
     OTEL_EXPORTER_ENDPOINT: str = ""
 
-    @field_validator("SUFFICIENCY_GREEN_THRESHOLD", "CONTEXT_SUMMARIZE_AT")
+    @field_validator(
+        "SUFFICIENCY_GREEN_THRESHOLD",
+        "COVERAGE_GREEN_THRESHOLD",
+        "CONTEXT_SUMMARIZE_AT",
+    )
     @classmethod
     def _must_be_a_fraction(cls, v: float) -> float:
         if not 0.0 <= v <= 1.0:

--- a/onboarding-intelligence-agent-svc/app/logic/coverage.py
+++ b/onboarding-intelligence-agent-svc/app/logic/coverage.py
@@ -1,0 +1,103 @@
+"""G-06 — WF1/WF2/WF3 coverage computation.
+
+Pure arithmetic on question state: group by workflow_target, count GREEN vs
+total, compute fractions. No LLM, no Redis, no I/O — a function that takes
+a list of question dicts and returns a result.
+
+Shared by the LIVE path (ws.py calls it directly after sufficiency) and the
+PROCESS path (SKL-OIA-09 calls it through the skill registry in J-01).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+WORKFLOWS = ("WF1", "WF2", "WF3")
+
+
+@dataclass
+class WorkflowCoverage:
+    """Per-workflow breakdown: which questions are covered, which are not."""
+
+    covered: list[str] = field(default_factory=list)
+    missing: list[str] = field(default_factory=list)
+    missing_fields: list[str] = field(default_factory=list)
+    pct: float = 0.0
+
+
+@dataclass
+class CoverageResult:
+    """Coverage across all three workflows."""
+
+    wf1: WorkflowCoverage = field(default_factory=WorkflowCoverage)
+    wf2: WorkflowCoverage = field(default_factory=WorkflowCoverage)
+    wf3: WorkflowCoverage = field(default_factory=WorkflowCoverage)
+    satisfied: bool = False
+    blocking_gaps: list[dict[str, str]] = field(default_factory=list)
+
+    def as_map(self) -> dict[str, float]:
+        return {"WF1": self.wf1.pct, "WF2": self.wf2.pct, "WF3": self.wf3.pct}
+
+    def by_workflow(self, wf: str) -> WorkflowCoverage:
+        return {"WF1": self.wf1, "WF2": self.wf2, "WF3": self.wf3}[wf]
+
+
+def compute_coverage(
+    questions: list[dict[str, Any]],
+    threshold: float = 0.7,
+) -> CoverageResult:
+    """Group questions by workflow_target, compute per-WF coverage fractions.
+
+    Each question dict must have at least ``workflow_target``, ``status``,
+    ``text``, and ``target_field``. These are the fields that
+    ``LiveSessionManager.get_questions()`` and ``set_questions()`` guarantee.
+    """
+    buckets: dict[str, list[dict[str, Any]]] = {wf: [] for wf in WORKFLOWS}
+
+    for q in questions:
+        wf = q.get("workflow_target", "WF1")
+        if wf in buckets:
+            buckets[wf].append(q)
+
+    wf_coverages: dict[str, WorkflowCoverage] = {}
+    for wf in WORKFLOWS:
+        qs = buckets[wf]
+        covered = [q.get("text", "") for q in qs if q.get("status") == "GREEN"]
+        missing = [q.get("text", "") for q in qs if q.get("status") != "GREEN"]
+        missing_fields = [
+            q.get("target_field", "") for q in qs if q.get("status") != "GREEN"
+        ]
+        total = len(covered) + len(missing)
+        pct = len(covered) / total if total > 0 else 0.0
+        wf_coverages[wf] = WorkflowCoverage(
+            covered=covered,
+            missing=missing,
+            missing_fields=missing_fields,
+            pct=pct,
+        )
+
+    satisfied = all(wf_coverages[wf].pct >= threshold for wf in WORKFLOWS)
+
+    blocking_gaps: list[dict[str, str]] = []
+    if not satisfied:
+        for wf in WORKFLOWS:
+            wc = wf_coverages[wf]
+            if wc.pct < threshold:
+                for q in buckets[wf]:
+                    if q.get("status") != "GREEN":
+                        blocking_gaps.append(
+                            {
+                                "workflow": wf,
+                                "question_text": q.get("text", ""),
+                                "target_field": q.get("target_field", ""),
+                            }
+                        )
+
+    return CoverageResult(
+        wf1=wf_coverages["WF1"],
+        wf2=wf_coverages["WF2"],
+        wf3=wf_coverages["WF3"],
+        satisfied=satisfied,
+        blocking_gaps=blocking_gaps,
+    )

--- a/onboarding-intelligence-agent-svc/app/logic/coverage.py
+++ b/onboarding-intelligence-agent-svc/app/logic/coverage.py
@@ -84,15 +84,24 @@ def compute_coverage(
         for wf in WORKFLOWS:
             wc = wf_coverages[wf]
             if wc.pct < threshold:
-                for q in buckets[wf]:
-                    if q.get("status") != "GREEN":
-                        blocking_gaps.append(
-                            {
-                                "workflow": wf,
-                                "question_text": q.get("text", ""),
-                                "target_field": q.get("target_field", ""),
-                            }
-                        )
+                if not buckets[wf]:
+                    blocking_gaps.append(
+                        {
+                            "workflow": wf,
+                            "question_text": "",
+                            "target_field": "",
+                        }
+                    )
+                else:
+                    for q in buckets[wf]:
+                        if q.get("status") != "GREEN":
+                            blocking_gaps.append(
+                                {
+                                    "workflow": wf,
+                                    "question_text": q.get("text", ""),
+                                    "target_field": q.get("target_field", ""),
+                                }
+                            )
 
     return CoverageResult(
         wf1=wf_coverages["WF1"],

--- a/onboarding-intelligence-agent-svc/app/logic/live_session.py
+++ b/onboarding-intelligence-agent-svc/app/logic/live_session.py
@@ -727,3 +727,50 @@ return 1
             return int(val)
         except (ValueError, TypeError):
             return None
+
+    # ── Coverage state (G-06) ────────────────────────────────────────
+
+    async def store_coverage(self, coverage: Any) -> None:
+        """Store coverage fractions and metadata in the Redis coverage hash.
+
+        ``coverage`` is a ``CoverageResult`` from ``app.logic.coverage``.
+        The type is ``Any`` to avoid a circular import; the dataclass fields
+        are accessed by name.
+        """
+        keys = self._keys()
+        key = keys.coverage(self.session_id)
+        pipe = self.redis.client.pipeline(transaction=False)
+        pipe.hset(
+            key,
+            mapping={
+                "WF1": str(coverage.wf1.pct),
+                "WF2": str(coverage.wf2.pct),
+                "WF3": str(coverage.wf3.pct),
+                "satisfied": "1" if coverage.satisfied else "0",
+                "blocking_gaps": json.dumps(coverage.blocking_gaps),
+                "updated_at": str(time.time()),
+            },
+        )
+        pipe.expire(key, TTL_LIVE)
+        await pipe.execute()
+
+    async def get_coverage(self) -> dict[str, Any] | None:
+        """Read stored coverage. Returns None if not yet computed."""
+        keys = self._keys()
+        key = keys.coverage(self.session_id)
+        raw = await self.redis.client.hgetall(key)
+        if not raw:
+            return None
+        result: dict[str, Any] = {}
+        for k, v in raw.items():
+            field = k if isinstance(k, str) else k.decode()
+            val = v if isinstance(v, str) else v.decode()
+            if field in ("WF1", "WF2", "WF3"):
+                result[field] = float(val)
+            elif field == "satisfied":
+                result[field] = val == "1"
+            elif field == "blocking_gaps":
+                result[field] = json.loads(val)
+            elif field == "updated_at":
+                result[field] = float(val)
+        return result

--- a/onboarding-intelligence-agent-svc/app/skills/check_workflow_coverage.py
+++ b/onboarding-intelligence-agent-svc/app/skills/check_workflow_coverage.py
@@ -2,22 +2,54 @@
 
 Design §8.1 · implemented by story G-06.
 
-Registered by A-06: the class exists and the registry resolves and
-instantiates it, so the declaration in config/skills.yaml is proven to point
-at something real. The body is deferred — it raises NotImplementedError
-rather than returning None, so a later story cannot ship a silent no-op.
+Coverage is pure arithmetic: group questions by workflow_target, count GREEN
+vs total. The shared ``compute_coverage`` function does the work; the skill
+wraps it in the standard SkillResult envelope so the registry, guardrails,
+and RBAC all apply when invoked through the PROCESS path (J-01).
+
+The LIVE path bypasses the skill and calls ``compute_coverage`` directly —
+coverage does not depend on the LLM, so the ``circuit_breaker_dependency:
+llm`` declared in skills.yaml should not prevent coverage from updating when
+the LLM breaker opens.
 """
 
 from __future__ import annotations
 
+from app.logic.coverage import compute_coverage
 from app.skills.base import BaseSkill
 from app.skills.models import SkillContext, SkillResult
 
-_NOT_YET = "SKL-OIA-09 (check_workflow_coverage) — implemented by G-06"
+SKILL_ID = "SKL-OIA-09"
 
 
 class CheckWorkflowCoverage(BaseSkill):
     """Report WF1, WF2 and WF3 coverage as fractions."""
 
     async def run(self, context: SkillContext) -> SkillResult:
-        raise NotImplementedError(_NOT_YET)
+        question_states = context.input_context.get("question_states", [])
+        threshold = context.config.get("coverage_threshold", 0.7)
+        result = compute_coverage(question_states, threshold)
+        return SkillResult(
+            skill_id=SKILL_ID,
+            output={
+                "coverage": {
+                    "WF1": {
+                        "covered": result.wf1.covered,
+                        "missing": result.wf1.missing,
+                        "pct": result.wf1.pct,
+                    },
+                    "WF2": {
+                        "covered": result.wf2.covered,
+                        "missing": result.wf2.missing,
+                        "pct": result.wf2.pct,
+                    },
+                    "WF3": {
+                        "covered": result.wf3.covered,
+                        "missing": result.wf3.missing,
+                        "pct": result.wf3.pct,
+                    },
+                },
+                "satisfied": result.satisfied,
+                "blocking_gaps": result.blocking_gaps,
+            },
+        )

--- a/onboarding-intelligence-agent-svc/tests/test_coverage.py
+++ b/onboarding-intelligence-agent-svc/tests/test_coverage.py
@@ -91,6 +91,10 @@ def test_empty_questions_zero_coverage():
     assert result.wf1.pct == 0.0
     assert result.wf2.pct == 0.0
     assert result.wf3.pct == 0.0
+    assert not result.satisfied
+    assert len(result.blocking_gaps) == 3
+    gap_wfs = {g["workflow"] for g in result.blocking_gaps}
+    assert gap_wfs == {"WF1", "WF2", "WF3"}
 
 
 def test_adhoc_questions_count():

--- a/onboarding-intelligence-agent-svc/tests/test_coverage.py
+++ b/onboarding-intelligence-agent-svc/tests/test_coverage.py
@@ -1,0 +1,310 @@
+"""G-06 — WF1/WF2/WF3 coverage computation.
+
+Unit tests for the pure coverage function, property tests for invariants,
+and a skill-level test for SKL-OIA-09's output shape.
+"""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from app.logic.coverage import compute_coverage
+
+pytestmark = pytest.mark.unit
+
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+
+def _q(
+    text: str,
+    wf: str = "WF1",
+    status: str = "OPEN",
+    target_field: str = "unknown",
+    origin: str = "PREPARED",
+) -> dict:
+    return {
+        "id": text.lower().replace(" ", "_"),
+        "text": text,
+        "workflow_target": wf,
+        "status": status,
+        "target_field": target_field,
+        "origin": origin,
+    }
+
+
+# ── Basic coverage computation ────────────────────────────────────────
+
+
+def test_all_green_full_coverage():
+    questions = [
+        _q("Company name?", wf="WF1", status="GREEN"),
+        _q("Brand voice?", wf="WF2", status="GREEN"),
+        _q("Ad budget?", wf="WF3", status="GREEN"),
+    ]
+    result = compute_coverage(questions)
+    assert result.wf1.pct == 1.0
+    assert result.wf2.pct == 1.0
+    assert result.wf3.pct == 1.0
+
+
+def test_none_green_zero_coverage():
+    questions = [
+        _q("Company name?", wf="WF1"),
+        _q("Brand voice?", wf="WF2"),
+        _q("Ad budget?", wf="WF3"),
+    ]
+    result = compute_coverage(questions)
+    assert result.wf1.pct == 0.0
+    assert result.wf2.pct == 0.0
+    assert result.wf3.pct == 0.0
+
+
+def test_mixed_coverage():
+    questions = [
+        _q("Company name?", wf="WF1", status="GREEN"),
+        _q("Founded year?", wf="WF1"),
+        _q("Industry?", wf="WF1", status="GREEN"),
+    ]
+    result = compute_coverage(questions)
+    assert abs(result.wf1.pct - 2.0 / 3.0) < 1e-9
+
+
+def test_per_workflow_independence():
+    """WF1 at 100%, WF3 at 0% — computed independently."""
+    questions = [
+        _q("Company name?", wf="WF1", status="GREEN"),
+        _q("Brand voice?", wf="WF2", status="GREEN"),
+        _q("Ad budget?", wf="WF3"),
+        _q("Sales channels?", wf="WF3"),
+    ]
+    result = compute_coverage(questions)
+    assert result.wf1.pct == 1.0
+    assert result.wf2.pct == 1.0
+    assert result.wf3.pct == 0.0
+
+
+def test_empty_questions_zero_coverage():
+    result = compute_coverage([])
+    assert result.wf1.pct == 0.0
+    assert result.wf2.pct == 0.0
+    assert result.wf3.pct == 0.0
+
+
+def test_adhoc_questions_count():
+    """ADHOC origin questions count the same as PREPARED."""
+    questions = [
+        _q("Company name?", wf="WF1", status="GREEN", origin="PREPARED"),
+        _q("Retail locations?", wf="WF3", status="GREEN", origin="ADHOC"),
+    ]
+    result = compute_coverage(questions)
+    assert result.wf1.pct == 1.0
+    assert result.wf3.pct == 1.0
+
+
+# ── Covered and missing lists ────────────────────────────────────────
+
+
+def test_covered_lists_green_questions():
+    questions = [
+        _q("Company name?", wf="WF1", status="GREEN"),
+        _q("Founded year?", wf="WF1"),
+    ]
+    result = compute_coverage(questions)
+    assert "Company name?" in result.wf1.covered
+    assert "Founded year?" in result.wf1.missing
+
+
+def test_missing_fields_tracked():
+    questions = [
+        _q("Ad budget?", wf="WF3", target_field="marketing_budget_range"),
+    ]
+    result = compute_coverage(questions)
+    assert "marketing_budget_range" in result.wf3.missing_fields
+
+
+# ── Satisfied and blocking_gaps ───────────────────────────────────────
+
+
+def test_satisfied_when_all_above_threshold():
+    questions = [
+        _q("Q1", wf="WF1", status="GREEN"),
+        _q("Q2", wf="WF2", status="GREEN"),
+        _q("Q3", wf="WF3", status="GREEN"),
+    ]
+    result = compute_coverage(questions, threshold=0.7)
+    assert result.satisfied is True
+
+
+def test_not_satisfied_when_one_below():
+    questions = [
+        _q("Q1", wf="WF1", status="GREEN"),
+        _q("Q2", wf="WF2", status="GREEN"),
+        _q("Q3", wf="WF3"),
+    ]
+    result = compute_coverage(questions, threshold=0.7)
+    assert result.satisfied is False
+
+
+def test_not_satisfied_when_empty():
+    """No questions at all means no coverage — not satisfied."""
+    result = compute_coverage([])
+    assert result.satisfied is False
+
+
+def test_blocking_gaps_lists_missing():
+    questions = [
+        _q("Q1", wf="WF1", status="GREEN"),
+        _q("Q2", wf="WF2", status="GREEN"),
+        _q("Ad budget?", wf="WF3", target_field="marketing_budget_range"),
+        _q("Sales channels?", wf="WF3", target_field="sales_channels"),
+    ]
+    result = compute_coverage(questions, threshold=0.7)
+    assert len(result.blocking_gaps) == 2
+    texts = [g["question_text"] for g in result.blocking_gaps]
+    assert "Ad budget?" in texts
+    assert "Sales channels?" in texts
+    assert all(g["workflow"] == "WF3" for g in result.blocking_gaps)
+
+
+def test_blocking_gaps_empty_when_satisfied():
+    questions = [
+        _q("Q1", wf="WF1", status="GREEN"),
+        _q("Q2", wf="WF2", status="GREEN"),
+        _q("Q3", wf="WF3", status="GREEN"),
+    ]
+    result = compute_coverage(questions, threshold=0.5)
+    assert result.blocking_gaps == []
+
+
+def test_coverage_threshold_configurable():
+    questions = [
+        _q("Q1", wf="WF1", status="GREEN"),
+        _q("Q2", wf="WF1"),
+        _q("Q3", wf="WF2", status="GREEN"),
+        _q("Q4", wf="WF3", status="GREEN"),
+    ]
+    assert compute_coverage(questions, threshold=0.5).satisfied is True
+    assert compute_coverage(questions, threshold=0.6).satisfied is False
+
+
+# ── AC-2 named test: WF3 low without assets ──────────────────────────
+
+
+def test_wf3_low_without_assets():
+    """AC-2: WF1 high, WF3 low → specific missing items are nameable."""
+    questions = [
+        _q("Company name?", wf="WF1", status="GREEN"),
+        _q("Founded year?", wf="WF1", status="GREEN"),
+        _q("Mission?", wf="WF1", status="GREEN"),
+        _q("Brand voice?", wf="WF2", status="GREEN"),
+        _q("Competitors?", wf="WF2", status="GREEN"),
+        _q("Business photos?", wf="WF3", target_field="business_photos"),
+        _q("Previous ads?", wf="WF3", target_field="previous_ads"),
+    ]
+    result = compute_coverage(questions, threshold=0.5)
+    assert result.wf1.pct == 1.0
+    assert result.wf3.pct == 0.0
+    assert not result.satisfied
+    gap_texts = [g["question_text"] for g in result.blocking_gaps]
+    assert "Business photos?" in gap_texts
+    assert "Previous ads?" in gap_texts
+
+
+# ── as_map helper ─────────────────────────────────────────────────────
+
+
+def test_as_map_returns_three_fractions():
+    result = compute_coverage([_q("Q1", wf="WF1", status="GREEN")])
+    m = result.as_map()
+    assert set(m.keys()) == {"WF1", "WF2", "WF3"}
+    assert m["WF1"] == 1.0
+    assert m["WF2"] == 0.0
+    assert m["WF3"] == 0.0
+
+
+def test_by_workflow_accessor():
+    result = compute_coverage([_q("Q1", wf="WF2", status="GREEN")])
+    wf2 = result.by_workflow("WF2")
+    assert wf2.pct == 1.0
+
+
+# ── SKL-OIA-09 skill body ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_skill_returns_correct_output():
+    """SKL-OIA-09 run() produces the expected SkillResult shape."""
+    from app.skills.check_workflow_coverage import CheckWorkflowCoverage
+    from app.skills.models import SkillContext, SkillMeta, TenantContext
+
+    skill = CheckWorkflowCoverage(
+        meta=SkillMeta(skill_id="SKL-OIA-09", name="check_workflow_coverage")
+    )
+    ctx = SkillContext(
+        input_prompt="assess coverage",
+        tenant_context=TenantContext(tenant_id="t-1"),
+        input_context={
+            "question_states": [
+                _q("Company name?", wf="WF1", status="GREEN"),
+                _q("Ad budget?", wf="WF3"),
+            ]
+        },
+        config={"coverage_threshold": 0.7},
+    )
+    result = await skill.run(ctx)
+    assert result.skill_id == "SKL-OIA-09"
+    assert "coverage" in result.output
+    assert "satisfied" in result.output
+    assert "blocking_gaps" in result.output
+    coverage = result.output["coverage"]
+    assert set(coverage.keys()) == {"WF1", "WF2", "WF3"}
+    assert coverage["WF1"]["pct"] == 1.0
+    assert coverage["WF3"]["pct"] == 0.0
+    assert len(coverage["WF3"]["missing"]) == 1
+
+
+# ── Property tests ────────────────────────────────────────────────────
+
+
+WORKFLOW_ST = st.sampled_from(["WF1", "WF2", "WF3"])
+STATUS_ST = st.sampled_from(["OPEN", "GREEN"])
+
+QUESTION_ST = st.fixed_dictionaries(
+    {
+        "text": st.text(min_size=1, max_size=30),
+        "workflow_target": WORKFLOW_ST,
+        "status": STATUS_ST,
+        "target_field": st.text(min_size=1, max_size=20),
+        "origin": st.sampled_from(["PREPARED", "ADHOC"]),
+    }
+)
+
+
+@settings(max_examples=50, deadline=None)
+@given(questions=st.lists(QUESTION_ST, max_size=30))
+def test_fractions_always_between_zero_and_one(questions):
+    result = compute_coverage(questions)
+    for wf in ["WF1", "WF2", "WF3"]:
+        pct = result.by_workflow(wf).pct
+        assert 0.0 <= pct <= 1.0, f"{wf} pct out of range: {pct}"
+
+
+@settings(max_examples=50, deadline=None)
+@given(questions=st.lists(QUESTION_ST, max_size=30))
+def test_three_fractions_never_blended(questions):
+    """FR-LIVE-09: always three separate values in as_map()."""
+    m = compute_coverage(questions).as_map()
+    assert set(m.keys()) == {"WF1", "WF2", "WF3"}
+
+
+@settings(max_examples=50, deadline=None)
+@given(questions=st.lists(QUESTION_ST, max_size=30))
+def test_covered_plus_missing_equals_total(questions):
+    result = compute_coverage(questions)
+    for wf in ["WF1", "WF2", "WF3"]:
+        wc = result.by_workflow(wf)
+        total_input = len([q for q in questions if q.get("workflow_target") == wf])
+        assert len(wc.covered) + len(wc.missing) == total_input

--- a/onboarding-intelligence-agent-svc/tests/test_scaffold.py
+++ b/onboarding-intelligence-agent-svc/tests/test_scaffold.py
@@ -187,6 +187,7 @@ IMPLEMENTED_BODIES = {
     "app.skills.analyze_transcript_stream",  # G-02: SKL-OIA-04
     "app.skills.evaluate_answer_sufficiency",  # G-03: SKL-OIA-05
     "app.skills.generate_followups",  # G-04: SKL-OIA-06
+    "app.skills.check_workflow_coverage",  # G-06: SKL-OIA-09
 }
 
 

--- a/onboarding-intelligence-agent-svc/tests/test_session_state.py
+++ b/onboarding-intelligence-agent-svc/tests/test_session_state.py
@@ -935,3 +935,156 @@ async def test_adhoc_detected_frame_in_buffer(manager):
     assert frames[0]["question_id"] == "adhoc_abc12345"
     assert frames[0]["workflow_target"] == "WF3"
     assert frames[0]["target_field"] == "retail_locations"
+
+
+# ── G-06 · Coverage state ────────────────────────────────────────────
+
+
+async def test_store_and_get_coverage_round_trip(manager):
+    """Coverage fractions survive a Redis round-trip."""
+    from app.logic.coverage import compute_coverage
+
+    questions = [
+        {
+            "text": "Company name?",
+            "workflow_target": "WF1",
+            "status": "GREEN",
+            "target_field": "name",
+        },
+        {
+            "text": "Founded year?",
+            "workflow_target": "WF1",
+            "status": "OPEN",
+            "target_field": "founded_year",
+        },
+        {
+            "text": "Brand voice?",
+            "workflow_target": "WF2",
+            "status": "GREEN",
+            "target_field": "brand_voice",
+        },
+        {
+            "text": "Ad budget?",
+            "workflow_target": "WF3",
+            "status": "OPEN",
+            "target_field": "marketing_budget_range",
+        },
+    ]
+    result = compute_coverage(questions, threshold=0.7)
+    await manager.store_coverage(result)
+    stored = await manager.get_coverage()
+
+    assert stored is not None
+    assert stored["WF1"] == 0.5
+    assert stored["WF2"] == 1.0
+    assert stored["WF3"] == 0.0
+    assert stored["satisfied"] is False
+    assert len(stored["blocking_gaps"]) > 0
+    assert "updated_at" in stored
+
+
+async def test_coverage_not_yet_computed(manager):
+    """get_coverage returns None before any coverage has been stored."""
+    assert await manager.get_coverage() is None
+
+
+async def test_coverage_survives_reconnect(manager):
+    """Coverage hash persists across a simulated reconnect."""
+    from app.logic.coverage import compute_coverage
+
+    questions = [
+        {
+            "text": "Q1",
+            "workflow_target": "WF1",
+            "status": "GREEN",
+            "target_field": "name",
+        },
+        {
+            "text": "Q2",
+            "workflow_target": "WF2",
+            "status": "GREEN",
+            "target_field": "brand_voice",
+        },
+        {
+            "text": "Q3",
+            "workflow_target": "WF3",
+            "status": "GREEN",
+            "target_field": "sales_channels",
+        },
+    ]
+    await manager.store_coverage(compute_coverage(questions))
+
+    reconnected = LiveSessionManager(
+        redis=manager.redis,
+        tenant_id=manager.tenant_id,
+        session_id=manager.session_id,
+    )
+    stored = await reconnected.get_coverage()
+    assert stored is not None
+    assert stored["WF1"] == 1.0
+    assert stored["satisfied"] is True
+
+
+async def test_coverage_frame_in_replay_buffer(manager):
+    """Coverage frame round-trips through the replay buffer."""
+    frame = Coverage(
+        seq=await manager.next_seq(),
+        map={"WF1": 0.8, "WF2": 0.5, "WF3": 0.3},
+    )
+    await manager.emit(frame)
+
+    frames, _ = await manager.replay_after(0)
+    assert len(frames) == 1
+    assert frames[0]["type"] == "coverage"
+    assert frames[0]["map"]["WF1"] == 0.8
+    assert frames[0]["map"]["WF3"] == 0.3
+
+
+async def test_coverage_incremental_matches_full(manager):
+    """Named in story test table: recomputing from all questions matches
+    an incremental approach (both are the same function, so they must agree)."""
+    from app.logic.coverage import compute_coverage
+
+    questions = [
+        {
+            "text": "Q1",
+            "workflow_target": "WF1",
+            "status": "GREEN",
+            "target_field": "name",
+        },
+        {
+            "text": "Q2",
+            "workflow_target": "WF1",
+            "status": "OPEN",
+            "target_field": "mission",
+        },
+        {
+            "text": "Q3",
+            "workflow_target": "WF2",
+            "status": "GREEN",
+            "target_field": "competitors",
+        },
+        {
+            "text": "Q4",
+            "workflow_target": "WF3",
+            "status": "OPEN",
+            "target_field": "sales_channels",
+        },
+    ]
+
+    # "Incremental": compute from first 2, then recompute from all 4
+    partial = compute_coverage(questions[:2])
+    assert partial.wf1.pct == 0.5  # confirms partial view is different
+    full = compute_coverage(questions)
+
+    # The full recompute is the ground truth
+    assert full.wf1.pct == 0.5
+    assert full.wf2.pct == 1.0
+    assert full.wf3.pct == 0.0
+
+    # Store and retrieve via Redis
+    await manager.store_coverage(full)
+    stored = await manager.get_coverage()
+    assert stored["WF1"] == full.wf1.pct
+    assert stored["WF2"] == full.wf2.pct
+    assert stored["WF3"] == full.wf3.pct


### PR DESCRIPTION
## Summary
- Implement `compute_coverage()` pure function that groups questions by `workflow_target`, counts GREEN vs total, and computes per-workflow fractions with `satisfied` and `blocking_gaps`
- Implement SKL-OIA-09 (`CheckWorkflowCoverage`) skill body delegating to the shared computation — reusable by J-01 for PROCESS mode
- Add `store_coverage()`/`get_coverage()` to `LiveSessionManager` for Redis persistence (coverage hash with 4h TTL)
- Wire coverage emission in `ws.py`: after sufficiency evaluation, recompute fractions, emit `Coverage` frame + EVT-107
- Add `COVERAGE_GREEN_THRESHOLD` config setting (default 0.7)

## Acceptance Criteria
- **AC-1**: Coverage recomputes incrementally when evidence lands (no full re-analysis)
- **AC-2**: Three separate WF1/WF2/WF3 fractions, never blended (FR-LIVE-09)
- **AC-3**: Backend delivers gap details via Redis coverage hash; frontend computes actionable items from question list (frontend portion deferred)
- **AC-4**: Coverage state carries shortfall for J-01's process button; operator never blocked

## Test plan
- [ ] 21 unit tests in `test_coverage.py` (computation, thresholds, gaps, property tests, skill output)
- [ ] 5 integration tests in `test_session_state.py` (Redis round-trip, reconnect, replay buffer, incremental vs full)
- [ ] Scaffold test confirms SKL-OIA-09 no longer raises NotImplementedError
- [ ] Property tests verify fractions always in [0,1], never blended, no questions lost
- [ ] `black`, `flake8`, `mypy` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)