### PR TITLE
feat(onboarding): photo capture with usage tagging (H-01)

### DIFF
--- a/ai-brand-automator-frontend/src/components/onboarding/CaptureControl.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/CaptureControl.tsx
@@ -1,0 +1,277 @@
+'use client';
+
+/**
+ * CaptureControl — photo capture with usage tagging (H-01, §11).
+ *
+ * State machine: idle → preview → confirm → tagging → idle.
+ *
+ * §11's focus rule does not apply here: CaptureControl is operator-initiated,
+ * so the modal overlay is intentional, not agent-driven interruption.
+ *
+ * Consent is checked identically to RecorderControl (F-01, IG-08): the camera
+ * cannot open without an active ConsentRecord.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Camera, X, RotateCcw, Upload } from 'lucide-react';
+
+import type { UsageTag } from '@/lib/onboarding-sessions';
+
+type Phase = 'idle' | 'preview' | 'confirm' | 'tagging';
+
+const USAGE_TAGS: { value: UsageTag; label: string }[] = [
+  { value: 'business_photo', label: 'Business photo' },
+  { value: 'previous_ad', label: 'Previous ad' },
+  { value: 'brand_asset', label: 'Brand asset' },
+  { value: 'identity_document', label: 'Identity document' },
+  { value: 'other', label: 'Other' },
+];
+
+export interface CaptureControlProps {
+  consentGranted: boolean;
+  onRecordConsent?: () => void;
+  onCapture?: (blob: Blob, tag: UsageTag) => void;
+}
+
+export default function CaptureControl({
+  consentGranted,
+  onRecordConsent,
+  onCapture,
+}: CaptureControlProps) {
+  const [phase, setPhase] = useState<Phase>('idle');
+  const [selectedTag, setSelectedTag] = useState<UsageTag | null>(null);
+  const [snapshot, setSnapshot] = useState<Blob | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+
+  const stopCamera = useCallback(() => {
+    streamRef.current?.getTracks().forEach((t) => t.stop());
+    streamRef.current = null;
+  }, []);
+
+  const dismiss = useCallback(() => {
+    stopCamera();
+    setPhase('idle');
+    setSnapshot(null);
+    setSelectedTag(null);
+    if (previewUrl) URL.revokeObjectURL(previewUrl);
+    setPreviewUrl(null);
+  }, [stopCamera, previewUrl]);
+
+  useEffect(() => {
+    return () => {
+      stopCamera();
+      if (previewUrl) URL.revokeObjectURL(previewUrl);
+    };
+  }, [stopCamera, previewUrl]);
+
+  const openCamera = useCallback(async () => {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        video: { facingMode: 'environment' },
+      });
+      streamRef.current = stream;
+      setPhase('preview');
+      requestAnimationFrame(() => {
+        if (videoRef.current) {
+          videoRef.current.srcObject = stream;
+        }
+      });
+    } catch {
+      // Camera not available or denied — stay idle.
+    }
+  }, []);
+
+  const takePhoto = useCallback(() => {
+    const video = videoRef.current;
+    if (!video) return;
+
+    const canvas = document.createElement('canvas');
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.drawImage(video, 0, 0);
+
+    canvas.toBlob(
+      (blob) => {
+        if (!blob) return;
+        stopCamera();
+        setSnapshot(blob);
+        setPreviewUrl(URL.createObjectURL(blob));
+        setPhase('confirm');
+      },
+      'image/jpeg',
+      0.95,
+    );
+  }, [stopCamera]);
+
+  const retake = useCallback(() => {
+    setSnapshot(null);
+    if (previewUrl) URL.revokeObjectURL(previewUrl);
+    setPreviewUrl(null);
+    setSelectedTag(null);
+    void openCamera();
+  }, [openCamera, previewUrl]);
+
+  const confirmPhoto = useCallback(() => {
+    setPhase('tagging');
+  }, []);
+
+  const submitCapture = useCallback(() => {
+    if (!snapshot || !selectedTag || !onCapture) return;
+    onCapture(snapshot, selectedTag);
+    dismiss();
+  }, [snapshot, selectedTag, onCapture, dismiss]);
+
+  if (!consentGranted) {
+    return (
+      <button
+        type="button"
+        aria-disabled="true"
+        onClick={onRecordConsent}
+        className="flex w-full items-center gap-2 rounded border border-white/10 px-3 py-2 text-sm text-brand-silver"
+      >
+        <Camera aria-hidden="true" className="h-4 w-4 shrink-0" />
+        Capture photo
+      </button>
+    );
+  }
+
+  if (phase === 'idle') {
+    return (
+      <button
+        type="button"
+        onClick={openCamera}
+        className="flex w-full items-center gap-2 rounded border border-white/15 px-3 py-2 text-sm text-white hover:bg-white/5"
+      >
+        <Camera aria-hidden="true" className="h-4 w-4 shrink-0" />
+        Capture photo
+      </button>
+    );
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Photo capture"
+      data-testid="capture-overlay"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/80"
+    >
+      <div className="glass-card relative w-full max-w-md p-6">
+        <button
+          type="button"
+          onClick={dismiss}
+          aria-label="Close"
+          className="absolute right-3 top-3 text-brand-silver hover:text-white"
+        >
+          <X className="h-5 w-5" />
+        </button>
+
+        {phase === 'preview' && (
+          <div className="space-y-4">
+            <h3 className="text-sm font-semibold text-white">Camera preview</h3>
+            <video
+              ref={videoRef}
+              autoPlay
+              playsInline
+              muted
+              data-testid="camera-preview"
+              className="w-full rounded bg-black"
+            />
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={dismiss}
+                className="flex-1 rounded border border-white/15 px-3 py-2 text-sm text-brand-silver"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={takePhoto}
+                className="btn-primary flex-1 rounded px-3 py-2 text-sm"
+              >
+                Take photo
+              </button>
+            </div>
+          </div>
+        )}
+
+        {phase === 'confirm' && previewUrl && (
+          <div className="space-y-4">
+            <h3 className="text-sm font-semibold text-white">Review photo</h3>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={previewUrl}
+              alt="Captured photo"
+              data-testid="capture-preview"
+              className="w-full rounded"
+            />
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={retake}
+                className="flex flex-1 items-center justify-center gap-1 rounded border border-white/15 px-3 py-2 text-sm text-brand-silver"
+              >
+                <RotateCcw className="h-3 w-3" aria-hidden />
+                Retake
+              </button>
+              <button
+                type="button"
+                onClick={confirmPhoto}
+                className="btn-primary flex-1 rounded px-3 py-2 text-sm"
+              >
+                Use this photo
+              </button>
+            </div>
+          </div>
+        )}
+
+        {phase === 'tagging' && (
+          <div className="space-y-4">
+            <h3 className="text-sm font-semibold text-white">
+              What is this photo?
+            </h3>
+            <fieldset>
+              <legend className="sr-only">Usage tag</legend>
+              <div className="space-y-2" data-testid="tag-picker">
+                {USAGE_TAGS.map(({ value, label }) => (
+                  <label
+                    key={value}
+                    className={`flex cursor-pointer items-center gap-2 rounded border px-3 py-2 text-sm transition-colors ${
+                      selectedTag === value
+                        ? 'border-brand-electric bg-brand-electric/10 text-white'
+                        : 'border-white/10 text-brand-silver hover:border-white/20'
+                    }`}
+                  >
+                    <input
+                      type="radio"
+                      name="usage_tag"
+                      value={value}
+                      checked={selectedTag === value}
+                      onChange={() => setSelectedTag(value)}
+                      className="sr-only"
+                    />
+                    {label}
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+            <button
+              type="button"
+              disabled={selectedTag === null}
+              onClick={submitCapture}
+              data-testid="upload-btn"
+              className="btn-primary flex w-full items-center justify-center gap-2 rounded px-3 py-2 text-sm disabled:opacity-50"
+            >
+              <Upload className="h-4 w-4" aria-hidden />
+              Upload
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ai-brand-automator-frontend/src/components/onboarding/CaptureControl.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/CaptureControl.tsx
@@ -19,7 +19,7 @@ import type { UsageTag } from '@/lib/onboarding-sessions';
 
 type Phase = 'idle' | 'preview' | 'confirm' | 'tagging';
 
-const USAGE_TAGS: { value: UsageTag; label: string }[] = [
+export const USAGE_TAGS: { value: UsageTag; label: string }[] = [
   { value: 'business_photo', label: 'Business photo' },
   { value: 'previous_ad', label: 'Previous ad' },
   { value: 'brand_asset', label: 'Brand asset' },

--- a/ai-brand-automator-frontend/src/components/onboarding/MeetingView.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/MeetingView.tsx
@@ -30,6 +30,7 @@ import { useCallback, useState } from 'react';
 import Link from 'next/link';
 import { AlertTriangle, ArrowLeft } from 'lucide-react';
 
+import { useCaptureQueue } from '@/hooks/useCaptureQueue';
 import { useLiveSocket } from '@/hooks/useLiveSocket';
 
 import AgentFeedbackStream, {
@@ -120,6 +121,8 @@ export default function MeetingView({
     sessionId: sessionId ?? null,
     enabled: granted,
   });
+
+  const captureQueue = useCaptureQueue(sessionId ?? null);
 
   return (
     /*
@@ -224,6 +227,8 @@ export default function MeetingView({
             consentGranted={granted}
             sessionId={sessionId}
             onRecordConsent={() => setConsentOpen(true)}
+            onCapture={captureQueue.enqueue}
+            captures={captureQueue.captures}
           />
         </div>
       </div>

--- a/ai-brand-automator-frontend/src/components/onboarding/RightRail.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/RightRail.tsx
@@ -3,21 +3,16 @@
 /**
  * The meeting view's right rail (E-02, Design §11).
  *
- * Shells only. §11 gives the rail to RecorderControl, CaptureControl and
- * RecordingsLibrary, and each of those is its own story — F-02, H-01 and
- * I-01 respectively. What E-02 owes them is a place to attach that is already
- * the right shape and already scrolls independently.
- *
- * The controls are rendered disabled rather than omitted, following the
- * precedent E-01 set and for the same reason: a greyed control tells the
- * operator the capability exists and is not ready, where an absent one reads
- * as a missing feature. They carry an explicit reason so the state is legible
- * rather than mysterious.
+ * RecorderControl, CaptureControl (H-01) and RecordingsLibrary (I-01) live
+ * here. The rail scrolls independently so a long media list cannot push the
+ * capture controls off screen (FR-LIVE-02).
  */
 
-import { Camera, Video } from 'lucide-react';
+import { Video } from 'lucide-react';
 
 import RecorderControl from '@/components/onboarding/RecorderControl';
+import CaptureControl from '@/components/onboarding/CaptureControl';
+import type { CapturedMedia, UsageTag } from '@/lib/onboarding-sessions';
 
 export interface RightRailProps {
   /** Placeholder count until I-01 lists real recordings. */
@@ -28,19 +23,22 @@ export interface RightRailProps {
   sessionId?: string | null;
   /** Opens the consent modal. AC-1: the disabled control still does this. */
   onRecordConsent?: () => void;
+  /** H-01: called when a photo is captured and tagged. */
+  onCapture?: (blob: Blob, tag: UsageTag) => void;
+  /** H-01: completed captures to display in the scroller. */
+  captures?: CapturedMedia[];
 }
-
-const CAPTURE_CONTROLS = [
-  { icon: Camera, label: 'Capture photo', owner: 'H-01' },
-  { icon: Video, label: 'Capture video', owner: 'H-02' },
-] as const;
 
 export default function RightRail({
   recordingCount = 0,
   consentGranted = false,
   sessionId,
   onRecordConsent,
+  onCapture,
+  captures = [],
 }: RightRailProps) {
+  const itemCount = recordingCount + captures.length;
+
   return (
     <aside
       aria-labelledby="rail-heading"
@@ -51,49 +49,59 @@ export default function RightRail({
       </h2>
 
       <div className="mt-3 space-y-2">
-        {/*
-          F-02 owns the record control now. It was inline here through E-02
-          (a disabled shell) and F-01 (inert, with the consent reason), and it
-          has outgrown that: permission, codec refusal, the elapsed timer and
-          the recording indicator are a component's worth of behaviour, not a
-          button's.
-        */}
         <RecorderControl
           consentGranted={consentGranted}
           sessionId={sessionId}
           onRecordConsent={onRecordConsent}
         />
 
-        {CAPTURE_CONTROLS.map(({ icon: Icon, label }) => (
-          <button
-            key={label}
-            type="button"
-            disabled
-            // The reason travels with the control. "Not available yet" on its
-            // own invites a support ticket asking when.
-            title="Available once live capture ships"
-            className="flex w-full items-center gap-2 rounded border border-white/10 px-3 py-2 text-sm text-brand-silver opacity-60"
-          >
-            <Icon aria-hidden="true" className="h-4 w-4 shrink-0" />
-            {label}
-          </button>
-        ))}
+        <CaptureControl
+          consentGranted={consentGranted}
+          onRecordConsent={onRecordConsent}
+          onCapture={onCapture}
+        />
+
+        {/* H-02: video capture — disabled until that story ships. */}
+        <button
+          type="button"
+          disabled
+          title="Available once live video capture ships"
+          className="flex w-full items-center gap-2 rounded border border-white/10 px-3 py-2 text-sm text-brand-silver opacity-60"
+        >
+          <Video aria-hidden="true" className="h-4 w-4 shrink-0" />
+          Capture video
+        </button>
       </div>
 
       <div
         data-testid="rail-scroller"
-        // AC-1: the rail scrolls on its own. A long recordings list must not
-        // push the capture controls off the top — they are the reason the rail
-        // is "always reachable" in FR-LIVE-02.
         className="mt-4 min-h-0 flex-1 overflow-y-auto"
       >
-        {recordingCount === 0 ? (
+        {captures.length > 0 && (
+          <ul className="space-y-2" data-testid="captured-media-list">
+            {captures.map((c) => (
+              <li
+                key={c.id}
+                className="flex items-center gap-2 rounded border border-white/10 px-3 py-2 text-sm"
+              >
+                <span className="truncate text-white">{c.file_name}</span>
+                <span className="shrink-0 rounded bg-brand-electric/20 px-1.5 py-0.5 text-xs text-brand-electric">
+                  {c.usage_tag.replace(/_/g, ' ')}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {itemCount === 0 && (
           <p className="text-sm text-brand-silver">
             Recordings and captured media appear here during the meeting.
           </p>
-        ) : (
+        )}
+
+        {recordingCount > 0 && (
           <p className="text-sm text-brand-silver">
-            {recordingCount} item{recordingCount === 1 ? '' : 's'}
+            {recordingCount} recording{recordingCount === 1 ? '' : 's'}
           </p>
         )}
       </div>

--- a/ai-brand-automator-frontend/src/components/onboarding/__tests__/CaptureControl.test.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/__tests__/CaptureControl.test.tsx
@@ -34,9 +34,10 @@ beforeEach(() => {
   jest.spyOn(document, 'createElement').mockImplementation((tag: string) => {
     const el = origCreateElement(tag);
     if (tag === 'canvas') {
+      const canvas = el as HTMLCanvasElement;
       const fakeCtx = { drawImage: jest.fn() };
-      el.getContext = () => fakeCtx;
-      el.toBlob = (cb: BlobCallback) => {
+      canvas.getContext = (() => fakeCtx) as unknown as typeof canvas.getContext;
+      canvas.toBlob = (cb: BlobCallback) => {
         cb(new Blob(['fake-jpeg'], { type: 'image/jpeg' }));
       };
     }

--- a/ai-brand-automator-frontend/src/components/onboarding/__tests__/CaptureControl.test.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/__tests__/CaptureControl.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * H-01 · photo capture with usage tagging.
+ *
+ * jsdom has no getUserMedia, so the camera preview phase is tested by mocking
+ * navigator.mediaDevices. The canvas snapshot is simulated by directly
+ * invoking onCapture.
+ */
+
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import CaptureControl from '@/components/onboarding/CaptureControl';
+
+const TAGS = [
+  'business_photo',
+  'previous_ad',
+  'brand_asset',
+  'identity_document',
+  'other',
+] as const;
+
+// ── AC-1 · consent gate ─────────────────────────────────────────────
+
+it('consent gates capture — shows aria-disabled without consent', () => {
+  render(<CaptureControl consentGranted={false} />);
+  const btn = screen.getByRole('button', { name: /capture photo/i });
+  expect(btn).toHaveAttribute('aria-disabled', 'true');
+});
+
+it('consent-gated button calls onRecordConsent on click', async () => {
+  const onConsent = jest.fn();
+  render(
+    <CaptureControl consentGranted={false} onRecordConsent={onConsent} />,
+  );
+  await userEvent.click(screen.getByRole('button', { name: /capture photo/i }));
+  expect(onConsent).toHaveBeenCalledTimes(1);
+});
+
+it('shows a live capture button when consent is granted', () => {
+  render(<CaptureControl consentGranted={true} />);
+  const btn = screen.getByRole('button', { name: /capture photo/i });
+  expect(btn).not.toHaveAttribute('aria-disabled');
+  expect(btn).not.toBeDisabled();
+});
+
+// ── AC-1 · overlay opens (camera preview) ───────────────────────────
+
+it('opens camera preview overlay on click', async () => {
+  const fakeStream = { getTracks: () => [{ stop: jest.fn() }] };
+  Object.defineProperty(navigator, 'mediaDevices', {
+    value: { getUserMedia: jest.fn().mockResolvedValue(fakeStream) },
+    writable: true,
+    configurable: true,
+  });
+
+  render(<CaptureControl consentGranted={true} />);
+  await userEvent.click(screen.getByRole('button', { name: /capture photo/i }));
+
+  expect(await screen.findByTestId('capture-overlay')).toBeInTheDocument();
+  expect(screen.getByRole('dialog')).toBeInTheDocument();
+});
+
+it('dismiss returns to idle (no overlay)', async () => {
+  const fakeStream = { getTracks: () => [{ stop: jest.fn() }] };
+  Object.defineProperty(navigator, 'mediaDevices', {
+    value: { getUserMedia: jest.fn().mockResolvedValue(fakeStream) },
+    writable: true,
+    configurable: true,
+  });
+
+  render(<CaptureControl consentGranted={true} />);
+  await userEvent.click(screen.getByRole('button', { name: /capture photo/i }));
+  await screen.findByTestId('capture-overlay');
+  await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+  expect(screen.queryByTestId('capture-overlay')).not.toBeInTheDocument();
+});
+
+// ── AC-2 · tag picker ───────────────────────────────────────────────
+
+it('all five tags are available', () => {
+  const { container } = render(
+    <CaptureControl consentGranted={true} />,
+  );
+
+  // Force into tagging phase by rendering the component with a specific state
+  // Since we can't easily get to tagging phase without camera, we'll verify
+  // the tag list is defined in the component by checking the idle render
+  // and the tag constant via a direct import
+  expect(TAGS).toHaveLength(5);
+  expect(TAGS).toContain('business_photo');
+  expect(TAGS).toContain('previous_ad');
+  expect(TAGS).toContain('brand_asset');
+  expect(TAGS).toContain('identity_document');
+  expect(TAGS).toContain('other');
+});
+
+it('identity_document is not first or last in the tag list', () => {
+  const idx = TAGS.indexOf('identity_document');
+  expect(idx).toBeGreaterThan(0);
+  expect(idx).toBeLessThan(TAGS.length - 1);
+});
+
+// ── AC-3 · onCapture callback ───────────────────────────────────────
+
+it('onCapture is called with blob and tag', () => {
+  const onCapture = jest.fn();
+  // Directly verify the callback contract: CaptureControl calls
+  // onCapture(blob, tag) when the user completes the flow.
+  const blob = new Blob(['test'], { type: 'image/jpeg' });
+  onCapture(blob, 'business_photo');
+
+  expect(onCapture).toHaveBeenCalledWith(blob, 'business_photo');
+  expect(onCapture).toHaveBeenCalledTimes(1);
+});

--- a/ai-brand-automator-frontend/src/components/onboarding/__tests__/CaptureControl.test.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/__tests__/CaptureControl.test.tsx
@@ -1,23 +1,78 @@
 /**
  * H-01 · photo capture with usage tagging.
  *
- * jsdom has no getUserMedia, so the camera preview phase is tested by mocking
- * navigator.mediaDevices. The canvas snapshot is simulated by directly
- * invoking onCapture.
+ * jsdom has no getUserMedia or canvas rendering, so reaching the tagging phase
+ * requires mocking the camera stream, canvas getContext, and toBlob. The
+ * camera preview and snapshot are faked; the tag picker and submit run real.
  */
 
-import { render, screen, within } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import CaptureControl from '@/components/onboarding/CaptureControl';
+import CaptureControl, {
+  USAGE_TAGS,
+} from '@/components/onboarding/CaptureControl';
 
-const TAGS = [
-  'business_photo',
-  'previous_ad',
-  'brand_asset',
-  'identity_document',
-  'other',
-] as const;
+const fakeStop = jest.fn();
+const fakeStream = { getTracks: () => [{ stop: fakeStop }] };
+
+beforeEach(() => {
+  fakeStop.mockClear();
+  Object.defineProperty(navigator, 'mediaDevices', {
+    value: { getUserMedia: jest.fn().mockResolvedValue(fakeStream) },
+    writable: true,
+    configurable: true,
+  });
+
+  // jsdom lacks URL.createObjectURL / revokeObjectURL
+  global.URL.createObjectURL = jest.fn(() => 'blob:fake-url');
+  global.URL.revokeObjectURL = jest.fn();
+
+  // jsdom has no canvas 2d context — mock createElement to return one
+  // that drawImage is callable on and toBlob produces a blob.
+  const origCreateElement = document.createElement.bind(document);
+  jest.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+    const el = origCreateElement(tag);
+    if (tag === 'canvas') {
+      const fakeCtx = { drawImage: jest.fn() };
+      el.getContext = () => fakeCtx;
+      el.toBlob = (cb: BlobCallback) => {
+        cb(new Blob(['fake-jpeg'], { type: 'image/jpeg' }));
+      };
+    }
+    return el;
+  });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+/**
+ * Navigate through camera → take photo → confirm → tagging.
+ */
+async function reachTaggingPhase(onCapture?: jest.Mock) {
+  render(
+    <CaptureControl consentGranted={true} onCapture={onCapture} />,
+  );
+
+  // Open camera → preview phase
+  await userEvent.click(screen.getByRole('button', { name: /capture photo/i }));
+  await screen.findByTestId('capture-overlay');
+
+  // Video element needs dimensions for takePhoto
+  const video = screen.getByTestId('camera-preview') as HTMLVideoElement;
+  Object.defineProperty(video, 'videoWidth', { value: 640 });
+  Object.defineProperty(video, 'videoHeight', { value: 480 });
+
+  // Take photo → confirm phase
+  await userEvent.click(screen.getByRole('button', { name: /take photo/i }));
+  await screen.findByTestId('capture-preview');
+
+  // Confirm → tagging phase
+  await userEvent.click(screen.getByRole('button', { name: /use this photo/i }));
+  await screen.findByTestId('tag-picker');
+}
 
 // ── AC-1 · consent gate ─────────────────────────────────────────────
 
@@ -43,16 +98,9 @@ it('shows a live capture button when consent is granted', () => {
   expect(btn).not.toBeDisabled();
 });
 
-// ── AC-1 · overlay opens (camera preview) ───────────────────────────
+// ── AC-1 · overlay opens and dismisses ──────────────────────────────
 
 it('opens camera preview overlay on click', async () => {
-  const fakeStream = { getTracks: () => [{ stop: jest.fn() }] };
-  Object.defineProperty(navigator, 'mediaDevices', {
-    value: { getUserMedia: jest.fn().mockResolvedValue(fakeStream) },
-    writable: true,
-    configurable: true,
-  });
-
   render(<CaptureControl consentGranted={true} />);
   await userEvent.click(screen.getByRole('button', { name: /capture photo/i }));
 
@@ -61,13 +109,6 @@ it('opens camera preview overlay on click', async () => {
 });
 
 it('dismiss returns to idle (no overlay)', async () => {
-  const fakeStream = { getTracks: () => [{ stop: jest.fn() }] };
-  Object.defineProperty(navigator, 'mediaDevices', {
-    value: { getUserMedia: jest.fn().mockResolvedValue(fakeStream) },
-    writable: true,
-    configurable: true,
-  });
-
   render(<CaptureControl consentGranted={true} />);
   await userEvent.click(screen.getByRole('button', { name: /capture photo/i }));
   await screen.findByTestId('capture-overlay');
@@ -76,40 +117,64 @@ it('dismiss returns to idle (no overlay)', async () => {
   expect(screen.queryByTestId('capture-overlay')).not.toBeInTheDocument();
 });
 
-// ── AC-2 · tag picker ───────────────────────────────────────────────
+// ── AC-2 · tag picker (rendered) ────────────────────────────────────
 
-it('all five tags are available', () => {
-  const { container } = render(
-    <CaptureControl consentGranted={true} />,
+it('all five tags are rendered in the tag picker', async () => {
+  await reachTaggingPhase();
+
+  const picker = screen.getByTestId('tag-picker');
+  const radios = picker.querySelectorAll('input[type="radio"]');
+  expect(radios).toHaveLength(5);
+
+  for (const { label } of USAGE_TAGS) {
+    expect(screen.getByText(label)).toBeInTheDocument();
+  }
+});
+
+it('identity_document is not first or last in the rendered tag list', () => {
+  const idx = USAGE_TAGS.findIndex((t) => t.value === 'identity_document');
+  expect(idx).toBeGreaterThan(0);
+  expect(idx).toBeLessThan(USAGE_TAGS.length - 1);
+});
+
+it('no default tag is selected', async () => {
+  await reachTaggingPhase();
+
+  const radios = screen.getByTestId('tag-picker').querySelectorAll('input[type="radio"]');
+  for (const radio of radios) {
+    expect(radio).not.toBeChecked();
+  }
+});
+
+it('upload button is disabled without a tag selected', async () => {
+  await reachTaggingPhase();
+
+  const uploadBtn = screen.getByTestId('upload-btn');
+  expect(uploadBtn).toBeDisabled();
+});
+
+// ── AC-3 · onCapture fires through the full rendered flow ───────────
+
+it('onCapture is called with blob and selected tag after submit', async () => {
+  const onCapture = jest.fn();
+  await reachTaggingPhase(onCapture);
+
+  // Select a tag
+  await userEvent.click(screen.getByText('Previous ad'));
+
+  // Upload button should now be enabled
+  const uploadBtn = screen.getByTestId('upload-btn');
+  expect(uploadBtn).not.toBeDisabled();
+
+  // Submit
+  await userEvent.click(uploadBtn);
+
+  expect(onCapture).toHaveBeenCalledTimes(1);
+  expect(onCapture).toHaveBeenCalledWith(
+    expect.any(Blob),
+    'previous_ad',
   );
 
-  // Force into tagging phase by rendering the component with a specific state
-  // Since we can't easily get to tagging phase without camera, we'll verify
-  // the tag list is defined in the component by checking the idle render
-  // and the tag constant via a direct import
-  expect(TAGS).toHaveLength(5);
-  expect(TAGS).toContain('business_photo');
-  expect(TAGS).toContain('previous_ad');
-  expect(TAGS).toContain('brand_asset');
-  expect(TAGS).toContain('identity_document');
-  expect(TAGS).toContain('other');
-});
-
-it('identity_document is not first or last in the tag list', () => {
-  const idx = TAGS.indexOf('identity_document');
-  expect(idx).toBeGreaterThan(0);
-  expect(idx).toBeLessThan(TAGS.length - 1);
-});
-
-// ── AC-3 · onCapture callback ───────────────────────────────────────
-
-it('onCapture is called with blob and tag', () => {
-  const onCapture = jest.fn();
-  // Directly verify the callback contract: CaptureControl calls
-  // onCapture(blob, tag) when the user completes the flow.
-  const blob = new Blob(['test'], { type: 'image/jpeg' });
-  onCapture(blob, 'business_photo');
-
-  expect(onCapture).toHaveBeenCalledWith(blob, 'business_photo');
-  expect(onCapture).toHaveBeenCalledTimes(1);
+  // Should return to idle
+  expect(screen.queryByTestId('capture-overlay')).not.toBeInTheDocument();
 });

--- a/ai-brand-automator-frontend/src/hooks/__tests__/useCaptureQueue.test.ts
+++ b/ai-brand-automator-frontend/src/hooks/__tests__/useCaptureQueue.test.ts
@@ -1,0 +1,165 @@
+/**
+ * H-01 · useCaptureQueue — offline-aware upload queue.
+ */
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import { useCaptureQueue } from '@/hooks/useCaptureQueue';
+import * as sessions from '@/lib/onboarding-sessions';
+
+jest.mock('@/lib/onboarding-sessions', () => ({
+  ...jest.requireActual('@/lib/onboarding-sessions'),
+  uploadCapture: jest.fn(),
+}));
+
+const mockUpload = sessions.uploadCapture as jest.MockedFunction<
+  typeof sessions.uploadCapture
+>;
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+it('enqueue calls uploadCapture', async () => {
+  mockUpload.mockResolvedValue({
+    id: '42',
+    file_name: 'test.jpg',
+    usage_tag: 'business_photo',
+    file_size: 1024,
+    uploaded_at: '2026-08-01T00:00:00Z',
+  });
+
+  const { result } = renderHook(() => useCaptureQueue('session-1'));
+
+  act(() => {
+    result.current.enqueue(
+      new Blob(['img'], { type: 'image/jpeg' }),
+      'business_photo',
+      'test.jpg',
+    );
+  });
+
+  await waitFor(() => {
+    expect(mockUpload).toHaveBeenCalledTimes(1);
+    expect(result.current.captures).toHaveLength(1);
+    expect(result.current.captures[0].usage_tag).toBe('business_photo');
+  });
+});
+
+it('failed upload retries', async () => {
+  mockUpload
+    .mockRejectedValueOnce(new Error('offline'))
+    .mockResolvedValueOnce({
+      id: '43',
+      file_name: 'retry.jpg',
+      usage_tag: 'other',
+      file_size: 512,
+      uploaded_at: '2026-08-01T00:00:00Z',
+    });
+
+  jest.useFakeTimers();
+
+  const { result } = renderHook(() => useCaptureQueue('session-1'));
+
+  act(() => {
+    result.current.enqueue(
+      new Blob(['img'], { type: 'image/jpeg' }),
+      'other',
+      'retry.jpg',
+    );
+  });
+
+  // First attempt fails, triggers retry with backoff
+  await waitFor(() => {
+    expect(mockUpload).toHaveBeenCalledTimes(1);
+    expect(result.current.status).toBe('error');
+  });
+
+  // Advance past backoff timer
+  act(() => {
+    jest.advanceTimersByTime(5000);
+  });
+
+  await waitFor(() => {
+    expect(mockUpload).toHaveBeenCalledTimes(2);
+    expect(result.current.captures).toHaveLength(1);
+  });
+
+  jest.useRealTimers();
+});
+
+it('online event triggers drain', async () => {
+  mockUpload.mockRejectedValueOnce(new Error('offline'));
+
+  jest.useFakeTimers();
+
+  const { result } = renderHook(() => useCaptureQueue('session-1'));
+
+  act(() => {
+    result.current.enqueue(
+      new Blob(['img'], { type: 'image/jpeg' }),
+      'brand_asset',
+      'online.jpg',
+    );
+  });
+
+  await waitFor(() => {
+    expect(result.current.status).toBe('error');
+  });
+
+  // Simulate coming back online
+  mockUpload.mockResolvedValueOnce({
+    id: '44',
+    file_name: 'online.jpg',
+    usage_tag: 'brand_asset',
+    file_size: 256,
+    uploaded_at: '2026-08-01T00:00:00Z',
+  });
+
+  act(() => {
+    window.dispatchEvent(new Event('online'));
+  });
+
+  await waitFor(() => {
+    expect(result.current.captures).toHaveLength(1);
+  });
+
+  jest.useRealTimers();
+});
+
+it('tag is preserved through retry', async () => {
+  mockUpload
+    .mockRejectedValueOnce(new Error('offline'))
+    .mockResolvedValueOnce({
+      id: '45',
+      file_name: 'tagged.jpg',
+      usage_tag: 'identity_document',
+      file_size: 4096,
+      uploaded_at: '2026-08-01T00:00:00Z',
+    });
+
+  jest.useFakeTimers();
+
+  const { result } = renderHook(() => useCaptureQueue('session-1'));
+
+  act(() => {
+    result.current.enqueue(
+      new Blob(['img'], { type: 'image/jpeg' }),
+      'identity_document',
+      'tagged.jpg',
+    );
+  });
+
+  await waitFor(() => expect(mockUpload).toHaveBeenCalledTimes(1));
+
+  act(() => {
+    jest.advanceTimersByTime(5000);
+  });
+
+  await waitFor(() => {
+    expect(mockUpload).toHaveBeenCalledTimes(2);
+    expect(result.current.captures[0].usage_tag).toBe('identity_document');
+  });
+
+  jest.useRealTimers();
+});

--- a/ai-brand-automator-frontend/src/hooks/useCaptureQueue.ts
+++ b/ai-brand-automator-frontend/src/hooks/useCaptureQueue.ts
@@ -1,0 +1,106 @@
+'use client';
+
+/**
+ * Offline-aware upload queue for photo captures (H-01, AC-4).
+ *
+ * Simpler than useChunkUploader (discrete photos vs streaming byte ranges).
+ * Each enqueued capture is uploaded via uploadCapture(); failures retry with
+ * exponential backoff, and an 'online' event flushes the queue when
+ * connectivity returns.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { backoffMs } from '@/lib/resumable-upload';
+import {
+  uploadCapture,
+  type CapturedMedia,
+  type UsageTag,
+} from '@/lib/onboarding-sessions';
+
+interface QueueEntry {
+  id: string;
+  blob: Blob;
+  fileName: string;
+  tag: UsageTag;
+  sessionId: string;
+  attempt: number;
+}
+
+export type CaptureQueueStatus = 'idle' | 'uploading' | 'error';
+
+export interface CaptureQueueReturn {
+  enqueue: (blob: Blob, tag: UsageTag, fileName?: string) => void;
+  captures: CapturedMedia[];
+  pending: number;
+  status: CaptureQueueStatus;
+}
+
+let nextId = 0;
+
+export function useCaptureQueue(sessionId: string | null): CaptureQueueReturn {
+  const queue = useRef<QueueEntry[]>([]);
+  const draining = useRef(false);
+  const [captures, setCaptures] = useState<CapturedMedia[]>([]);
+  const [pending, setPending] = useState(0);
+  const [status, setStatus] = useState<CaptureQueueStatus>('idle');
+
+  const drain = useCallback(async () => {
+    if (draining.current || queue.current.length === 0) return;
+    draining.current = true;
+    setStatus('uploading');
+
+    while (queue.current.length > 0) {
+      const entry = queue.current[0];
+      try {
+        const file = new File([entry.blob], entry.fileName, {
+          type: entry.blob.type || 'image/jpeg',
+        });
+        const result = await uploadCapture(entry.sessionId, file, entry.tag);
+        queue.current.shift();
+        setPending(queue.current.length);
+        setCaptures((prev) => [...prev, result]);
+      } catch {
+        entry.attempt += 1;
+        setStatus('error');
+        const delay = backoffMs(entry.attempt);
+        draining.current = false;
+        setTimeout(() => {
+          void drain();
+        }, delay);
+        return;
+      }
+    }
+
+    draining.current = false;
+    setStatus('idle');
+  }, []);
+
+  const enqueue = useCallback(
+    (blob: Blob, tag: UsageTag, fileName?: string) => {
+      if (!sessionId) return;
+      const entry: QueueEntry = {
+        id: String(nextId++),
+        blob,
+        fileName: fileName ?? `capture-${Date.now()}.jpg`,
+        tag,
+        sessionId,
+        attempt: 0,
+      };
+      queue.current.push(entry);
+      setPending(queue.current.length);
+      void drain();
+    },
+    [sessionId, drain],
+  );
+
+  useEffect(() => {
+    const handler = () => {
+      void drain();
+    };
+    window.addEventListener('online', handler);
+    return () => window.removeEventListener('online', handler);
+  }, [drain]);
+
+  return { enqueue, captures, pending, status };
+}

--- a/ai-brand-automator-frontend/src/lib/onboarding-sessions.ts
+++ b/ai-brand-automator-frontend/src/lib/onboarding-sessions.ts
@@ -405,3 +405,39 @@ export async function finaliseRecording(
     throw new Error(`API ${response.status}: ${await response.text()}`);
   }
 }
+
+// ── Media capture (H-01) ─────────────────────────────────────────────
+
+export type UsageTag =
+  | 'business_photo'
+  | 'previous_ad'
+  | 'brand_asset'
+  | 'identity_document'
+  | 'other';
+
+export interface CapturedMedia {
+  id: string;
+  file_name: string;
+  usage_tag: UsageTag;
+  file_size: number;
+  uploaded_at: string;
+}
+
+export async function uploadCapture(
+  sessionId: string,
+  file: File | Blob,
+  usageTag: UsageTag,
+): Promise<CapturedMedia> {
+  const form = new FormData();
+  form.append('file', file, file instanceof File ? file.name : 'capture.jpg');
+  form.append('usage_tag', usageTag);
+
+  const response = await apiClient.upload(
+    `${BASE}/sessions/${sessionId}/media/`,
+    form,
+  );
+  if (!response.ok) {
+    throw new Error(`API ${response.status}: ${await response.text()}`);
+  }
+  return (await response.json()) as CapturedMedia;
+}

--- a/ai-brand-automator/apps/onboarding/serializers.py
+++ b/ai-brand-automator/apps/onboarding/serializers.py
@@ -563,3 +563,28 @@ class ScheduledMeetingSerializer(serializers.ModelSerializer):
                     }
                 )
         return attrs
+
+
+class MediaCaptureSerializer(serializers.Serializer):
+    """Validates photo captures submitted via ``POST /sessions/{id}/media/``.
+
+    ``usage_tag`` has no default — the data-protection concern from §11 is
+    that an untagged ``identity_document`` would bypass PG-08 downstream.
+    """
+
+    USAGE_TAGS = [
+        "business_photo",
+        "previous_ad",
+        "brand_asset",
+        "identity_document",
+        "other",
+    ]
+
+    file = serializers.FileField()
+    usage_tag = serializers.ChoiceField(choices=USAGE_TAGS)
+
+    def validate_file(self, value):
+        max_size = 50 * 1024 * 1024
+        if value.size > max_size:
+            raise serializers.ValidationError("File size cannot exceed 50MB")
+        return value

--- a/ai-brand-automator/apps/onboarding/tests/test_media_capture.py
+++ b/ai-brand-automator/apps/onboarding/tests/test_media_capture.py
@@ -284,3 +284,80 @@ def test_cross_tenant_returns_404(public_tenant, editor, consented_session):
         format="multipart",
     )
     assert resp.status_code == 404
+
+
+# ── Content-type validation ──────────────────────────────────────────
+
+
+def test_non_image_content_type_rejected(public_tenant, editor, consented_session):
+    client = client_for(editor, public_tenant)
+    bad_file = SimpleUploadedFile(
+        "malware.exe", b"\x00" * 100, content_type="application/x-msdownload"
+    )
+    resp = client.post(
+        media_url(consented_session.pk),
+        {"file": bad_file, "usage_tag": "other"},
+        format="multipart",
+    )
+    assert resp.status_code == 400
+    assert "file" in resp.data
+
+
+# ── Race condition (IntegrityError) ──────────────────────────────────
+
+
+@patch("apps.onboarding.views.gcs_service")
+@patch("apps.onboarding.views.get_pipeline_service")
+def test_concurrent_duplicate_returns_200_not_500(
+    mock_pipeline, mock_gcs, public_tenant, editor, consented_session
+):
+    """Two concurrent uploads of the same filename should not 500."""
+    from django.db.utils import IntegrityError
+
+    mock_gcs.get_bucket.return_value = MagicMock()
+    mock_gcs.bucket_name = "test-bucket"
+    client = client_for(editor, public_tenant)
+
+    # Pre-create the asset so the recovery filter inside the except block
+    # can find it after IntegrityError.
+    BrandAsset.objects.create(
+        tenant=public_tenant,
+        company=consented_session.company,
+        file_name="race.jpg",
+        file_type="image",
+        file_size=100,
+        gcs_path="_landing/x/race.jpg",
+    )
+
+    # Simulate the TOCTOU window: the first filter (dedup check) misses,
+    # create() hits the unique constraint, the second filter (recovery)
+    # finds the existing row.
+    original_filter = BrandAsset.objects.filter
+    call_count = {"n": 0}
+
+    def race_filter(*args, **kwargs):
+        qs = original_filter(*args, **kwargs)
+        if kwargs.get("file_name") == "race.jpg":
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return qs.none()
+        return qs
+
+    original_create = BrandAsset.objects.create
+
+    def race_create(**kwargs):
+        if kwargs.get("file_name") == "race.jpg":
+            raise IntegrityError("duplicate key")
+        return original_create(**kwargs)
+
+    with (
+        patch.object(BrandAsset.objects, "filter", side_effect=race_filter),
+        patch.object(BrandAsset.objects, "create", side_effect=race_create),
+    ):
+        resp = client.post(
+            media_url(consented_session.pk),
+            {"file": make_photo(name="race.jpg"), "usage_tag": "business_photo"},
+            format="multipart",
+        )
+
+    assert resp.status_code in (200, 409)

--- a/ai-brand-automator/apps/onboarding/tests/test_media_capture.py
+++ b/ai-brand-automator/apps/onboarding/tests/test_media_capture.py
@@ -360,4 +360,4 @@ def test_concurrent_duplicate_returns_200_not_500(
             format="multipart",
         )
 
-    assert resp.status_code in (200, 409)
+    assert resp.status_code == 200

--- a/ai-brand-automator/apps/onboarding/tests/test_media_capture.py
+++ b/ai-brand-automator/apps/onboarding/tests/test_media_capture.py
@@ -1,0 +1,286 @@
+"""H-01 — photo capture with usage tagging (AC-1 … AC-4).
+
+The consent gate, the tag requirement and the GCS landing path are the parts
+that matter. This follows the same pattern as test_recording_api.py:
+force-authenticate, real Postgres, GCS mocked.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth.models import User
+from django.core.files.uploadedfile import SimpleUploadedFile
+from rest_framework.test import APIClient
+from unittest.mock import patch, MagicMock
+
+from apps.onboarding.tests.factories import (
+    make_company,
+    make_consent,
+    make_session,
+)
+from onboarding.models import BrandAsset
+from tenants.models import Membership, Tenant
+
+pytestmark = pytest.mark.django_db
+
+SESSIONS = "/api/v1/onboarding/sessions/"
+
+
+def client_for(user, tenant) -> APIClient:
+    client = APIClient()
+    client.defaults["SERVER_NAME"] = "localhost"
+    client.force_authenticate(user=user)
+    client.defaults["HTTP_X_TENANT_ID"] = str(tenant.id)
+    return client
+
+
+def member(tenant, role, username) -> User:
+    user = User.objects.create_user(
+        username=username, email=f"{username}@test.com", password="TestPass123!"
+    )
+    Membership.objects.create(user=user, tenant=tenant, role=role)
+    return user
+
+
+def make_photo(name="storefront.jpg", size=2048):
+    return SimpleUploadedFile(
+        name, b"\xff\xd8" + b"\x00" * size, content_type="image/jpeg"
+    )
+
+
+@pytest.fixture
+def editor(public_tenant):
+    return member(public_tenant, Membership.Role.EDITOR, "h01_editor")
+
+
+@pytest.fixture
+def viewer(public_tenant):
+    return member(public_tenant, Membership.Role.VIEWER, "h01_viewer")
+
+
+@pytest.fixture
+def consented_session(public_tenant):
+    company = make_company(tenant=public_tenant)
+    session = make_session(company=company, tenant=public_tenant)
+    make_consent(session=session, tenant=public_tenant)
+    return session
+
+
+def media_url(session_id):
+    return f"{SESSIONS}{session_id}/media/"
+
+
+# ── AC-3 · happy path ───────────────────────────────────────────────
+
+
+@patch("apps.onboarding.views.gcs_service")
+@patch("apps.onboarding.views.get_pipeline_service")
+def test_capture_returns_201(
+    mock_pipeline, mock_gcs, public_tenant, editor, consented_session
+):
+    mock_gcs.get_bucket.return_value = MagicMock()
+    mock_gcs.bucket_name = "test-bucket"
+    client = client_for(editor, public_tenant)
+
+    resp = client.post(
+        media_url(consented_session.pk),
+        {"file": make_photo(), "usage_tag": "business_photo"},
+        format="multipart",
+    )
+    assert resp.status_code == 201, resp.data
+    assert resp.data["usage_tag"] == "business_photo"
+    assert resp.data["file_name"] == "storefront.jpg"
+
+
+# ── AC-1 · consent gate ─────────────────────────────────────────────
+
+
+def test_capture_without_consent_403(public_tenant, editor):
+    company = make_company(tenant=public_tenant, name="No Consent Co")
+    session = make_session(company=company, tenant=public_tenant)
+    client = client_for(editor, public_tenant)
+
+    resp = client.post(
+        media_url(session.pk),
+        {"file": make_photo(), "usage_tag": "business_photo"},
+        format="multipart",
+    )
+    assert resp.status_code == 403
+    assert resp.data["code"] == "ERR-03"
+
+
+# ── AC-3 · role gate ────────────────────────────────────────────────
+
+
+def test_capture_as_viewer_403(public_tenant, viewer, consented_session):
+    client = client_for(viewer, public_tenant)
+
+    resp = client.post(
+        media_url(consented_session.pk),
+        {"file": make_photo(), "usage_tag": "business_photo"},
+        format="multipart",
+    )
+    assert resp.status_code == 403
+
+
+# ── AC-2 · tag validation ───────────────────────────────────────────
+
+
+def test_capture_without_tag_400(public_tenant, editor, consented_session):
+    client = client_for(editor, public_tenant)
+
+    resp = client.post(
+        media_url(consented_session.pk),
+        {"file": make_photo()},
+        format="multipart",
+    )
+    assert resp.status_code == 400
+    assert "usage_tag" in resp.data
+
+
+def test_capture_with_invalid_tag_400(public_tenant, editor, consented_session):
+    client = client_for(editor, public_tenant)
+
+    resp = client.post(
+        media_url(consented_session.pk),
+        {"file": make_photo(), "usage_tag": "selfie"},
+        format="multipart",
+    )
+    assert resp.status_code == 400
+    assert "usage_tag" in resp.data
+
+
+VALID_TAGS = [
+    "business_photo",
+    "previous_ad",
+    "brand_asset",
+    "identity_document",
+    "other",
+]
+
+
+@pytest.mark.parametrize("tag", VALID_TAGS)
+@patch("apps.onboarding.views.gcs_service")
+@patch("apps.onboarding.views.get_pipeline_service")
+def test_each_valid_tag_accepted(mock_pipeline, mock_gcs, tag, public_tenant, editor):
+    mock_gcs.get_bucket.return_value = MagicMock()
+    mock_gcs.bucket_name = "test-bucket"
+    company = make_company(tenant=public_tenant, name=f"Co-{tag}")
+    session = make_session(company=company, tenant=public_tenant)
+    make_consent(session=session, tenant=public_tenant)
+    client = client_for(editor, public_tenant)
+
+    resp = client.post(
+        media_url(session.pk),
+        {"file": make_photo(name=f"{tag}.jpg"), "usage_tag": tag},
+        format="multipart",
+    )
+    assert resp.status_code == 201, resp.data
+    assert resp.data["usage_tag"] == tag
+
+
+# ── AC-3 · asset registration ───────────────────────────────────────
+
+
+@patch("apps.onboarding.views.gcs_service")
+@patch("apps.onboarding.views.get_pipeline_service")
+def test_asset_registered_with_session_and_tag(
+    mock_pipeline, mock_gcs, public_tenant, editor, consented_session
+):
+    mock_gcs.get_bucket.return_value = MagicMock()
+    mock_gcs.bucket_name = "test-bucket"
+    client = client_for(editor, public_tenant)
+
+    resp = client.post(
+        media_url(consented_session.pk),
+        {"file": make_photo(name="logo.png"), "usage_tag": "brand_asset"},
+        format="multipart",
+    )
+    assert resp.status_code == 201
+    asset = BrandAsset.objects.get(pk=resp.data["id"])
+    assert asset.usage_tag == "brand_asset"
+    assert asset.onboarding_session_id == consented_session.pk
+
+
+@patch("apps.onboarding.views.gcs_service")
+@patch("apps.onboarding.views.get_pipeline_service")
+def test_gcs_path_matches_landing_convention(
+    mock_pipeline, mock_gcs, public_tenant, editor, consented_session
+):
+    mock_gcs.get_bucket.return_value = MagicMock()
+    mock_gcs.bucket_name = "test-bucket"
+    client = client_for(editor, public_tenant)
+
+    resp = client.post(
+        media_url(consented_session.pk),
+        {"file": make_photo(name="receipt.jpg"), "usage_tag": "other"},
+        format="multipart",
+    )
+    assert resp.status_code == 201
+    asset = BrandAsset.objects.get(pk=resp.data["id"])
+    assert asset.gcs_path.startswith(f"_landing/{public_tenant.id}/")
+    assert asset.gcs_path.endswith("_receipt.jpg")
+
+
+@patch("apps.onboarding.views.gcs_service")
+@patch("apps.onboarding.views.get_pipeline_service")
+def test_pipeline_event_published(
+    mock_pipeline, mock_gcs, public_tenant, editor, consented_session
+):
+    mock_gcs.get_bucket.return_value = MagicMock()
+    mock_gcs.bucket_name = "test-bucket"
+    pipeline_svc = MagicMock()
+    mock_pipeline.return_value = pipeline_svc
+    client = client_for(editor, public_tenant)
+
+    resp = client.post(
+        media_url(consented_session.pk),
+        {"file": make_photo(name="ad.jpg"), "usage_tag": "previous_ad"},
+        format="multipart",
+    )
+    assert resp.status_code == 201
+    pipeline_svc.publish_asset_event.assert_called_once()
+
+
+# ── AC-3 · idempotency ──────────────────────────────────────────────
+
+
+@patch("apps.onboarding.views.gcs_service")
+@patch("apps.onboarding.views.get_pipeline_service")
+def test_duplicate_upload_idempotent(
+    mock_pipeline, mock_gcs, public_tenant, editor, consented_session
+):
+    mock_gcs.get_bucket.return_value = MagicMock()
+    mock_gcs.bucket_name = "test-bucket"
+    client = client_for(editor, public_tenant)
+
+    first = client.post(
+        media_url(consented_session.pk),
+        {"file": make_photo(name="dup.jpg"), "usage_tag": "business_photo"},
+        format="multipart",
+    )
+    assert first.status_code == 201
+
+    second = client.post(
+        media_url(consented_session.pk),
+        {"file": make_photo(name="dup.jpg"), "usage_tag": "business_photo"},
+        format="multipart",
+    )
+    assert second.status_code == 200
+    assert BrandAsset.objects.filter(file_name="dup.jpg").count() == 1
+
+
+# ── AC-3 · cross-tenant ─────────────────────────────────────────────
+
+
+def test_cross_tenant_returns_404(public_tenant, editor, consented_session):
+    other_tenant = Tenant.objects.create(name="Other Org", schema_name="other_org")
+    other_user = member(other_tenant, Membership.Role.EDITOR, "h01_other_ed")
+    client = client_for(other_user, other_tenant)
+
+    resp = client.post(
+        media_url(consented_session.pk),
+        {"file": make_photo(), "usage_tag": "business_photo"},
+        format="multipart",
+    )
+    assert resp.status_code == 404

--- a/ai-brand-automator/apps/onboarding/views.py
+++ b/ai-brand-automator/apps/onboarding/views.py
@@ -7,8 +7,11 @@ validated here rather than in the client.
 
 from __future__ import annotations
 
+import logging
 import json
 import uuid
+
+logger = logging.getLogger(__name__)
 
 from django.db import IntegrityError
 from django.db.models import Prefetch
@@ -487,7 +490,6 @@ class OnboardingSessionViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):
         )
 
     @action(detail=True, methods=["post"])
-    @db_transaction.atomic
     def media(self, request, pk=None):
         """``POST /sessions/{id}/media/`` — photo capture with usage tag (H-01).
 
@@ -517,6 +519,22 @@ class OnboardingSessionViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):
         file = serializer.validated_data["file"]
         usage_tag = serializer.validated_data["usage_tag"]
 
+        from brand_automator.validators import ALLOWED_IMAGE_TYPES
+
+        content_type = file.content_type
+        if content_type in ("application/octet-stream", "", None):
+            import mimetypes
+
+            guessed, _ = mimetypes.guess_type(file.name)
+            if guessed:
+                content_type = guessed
+
+        if content_type not in ALLOWED_IMAGE_TYPES:
+            return Response(
+                {"file": [f"Invalid image type: {content_type}"]},
+                status=http.HTTP_400_BAD_REQUEST,
+            )
+
         safe_filename = sanitize_filename(file.name)
         tenant = session.tenant
         company = session.company
@@ -529,8 +547,9 @@ class OnboardingSessionViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):
                 BrandAssetSerializer(existing).data, status=http.HTTP_200_OK
             )
 
+        tenant_id = tenant.id if tenant else "unknown"
         unique_id = uuid.uuid4().hex[:8]
-        landing_path = f"_landing/{tenant.id}/{unique_id}_{safe_filename}"
+        landing_path = f"_landing/{tenant_id}/{unique_id}_{safe_filename}"
         raw_bucket = tenant.get_raw_bucket() if tenant else gcs_service.bucket_name
 
         gcs_uploaded = False
@@ -538,28 +557,46 @@ class OnboardingSessionViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):
             target_bucket = gcs_service.get_bucket(raw_bucket)
             if target_bucket:
                 gcs_service.upload_file(
-                    file, landing_path, file.content_type, bucket_name=raw_bucket
+                    file, landing_path, content_type, bucket_name=raw_bucket
                 )
                 gcs_uploaded = True
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.exception(
+                "GCS upload failed for %s (bucket=%s): %s",
+                safe_filename,
+                raw_bucket,
+                exc,
+            )
 
-        asset = BrandAsset.objects.create(
-            tenant=tenant,
-            company=company,
-            file_name=safe_filename,
-            file_type="image",
-            file_size=file.size,
-            gcs_path=landing_path,
-            gcs_bucket=raw_bucket,
-            processed=False,
-            pipeline_status="pending" if gcs_uploaded else "failed",
-            pipeline_error=(
-                "" if gcs_uploaded else "GCS not configured - file not stored"
-            ),
-            usage_tag=usage_tag,
-            onboarding_session=session,
-        )
+        try:
+            asset = BrandAsset.objects.create(
+                tenant=tenant,
+                company=company,
+                file_name=safe_filename,
+                file_type="image",
+                file_size=file.size,
+                gcs_path=landing_path,
+                gcs_bucket=raw_bucket,
+                processed=False,
+                pipeline_status="pending" if gcs_uploaded else "failed",
+                pipeline_error=(
+                    "" if gcs_uploaded else "GCS not configured - file not stored"
+                ),
+                usage_tag=usage_tag,
+                onboarding_session=session,
+            )
+        except IntegrityError:
+            existing = BrandAsset.objects.filter(
+                tenant=tenant, company=company, file_name=safe_filename
+            ).first()
+            if existing is not None:
+                return Response(
+                    BrandAssetSerializer(existing).data, status=http.HTTP_200_OK
+                )
+            return Response(
+                {"error": "duplicate_file", "message": "Concurrent upload."},
+                status=http.HTTP_409_CONFLICT,
+            )
 
         if gcs_uploaded:
             pipeline_service = get_pipeline_service()

--- a/ai-brand-automator/apps/onboarding/views.py
+++ b/ai-brand-automator/apps/onboarding/views.py
@@ -8,6 +8,7 @@ validated here rather than in the client.
 from __future__ import annotations
 
 import json
+import uuid
 
 from django.db import IntegrityError
 from django.db.models import Prefetch
@@ -32,7 +33,11 @@ from django.http import Http404
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny
 
+from brand_automator.validators import sanitize_filename
+from files.services import gcs_service
 from onboarding.models import BrandAsset, Company
+from onboarding.serializers import BrandAssetSerializer
+from onboarding.services import get_pipeline_service
 from tenants.models import Tenant
 
 from apps.onboarding import errors
@@ -75,6 +80,7 @@ from apps.onboarding.models import (
 from apps.onboarding.serializers import (
     ConsentRecordSerializer,
     FieldProvenanceSerializer,
+    MediaCaptureSerializer,
     MeetingRecordingSerializer,
     OnboardingSessionSerializer,
     ProvenanceEditSerializer,
@@ -134,6 +140,7 @@ class OnboardingSessionViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):
         # decides the role rather than the action name. Editor+ is enforced
         # inside for the write; the entry keeps Viewer out of neither.
         "recordings": [IsAuthenticated, IsTenantViewer],
+        "media": [IsAuthenticated, IsTenantEditor],
     }
 
     def get_queryset(self):
@@ -478,6 +485,87 @@ class OnboardingSessionViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):
         return Response(
             MeetingRecordingSerializer(recording).data, status=http.HTTP_201_CREATED
         )
+
+    @action(detail=True, methods=["post"])
+    @db_transaction.atomic
+    def media(self, request, pk=None):
+        """``POST /sessions/{id}/media/`` — photo capture with usage tag (H-01).
+
+        Follows the recordings action pattern: consent-gated, session from
+        URL (server-authoritative), and the asset FK set server-side rather
+        than accepted from the body (see BrandAssetSerializer.onboarding_session).
+        """
+        session = self.get_object()
+
+        has_consent = session.consent_records.filter(revoked_at__isnull=True).exists()
+        if not has_consent:
+            return Response(
+                {
+                    "code": errors.CONSENT_MISSING,
+                    "detail": (
+                        "This session has no active consent. Record consent "
+                        "before capturing media."
+                    ),
+                },
+                status=http.HTTP_403_FORBIDDEN,
+            )
+
+        serializer = MediaCaptureSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=http.HTTP_400_BAD_REQUEST)
+
+        file = serializer.validated_data["file"]
+        usage_tag = serializer.validated_data["usage_tag"]
+
+        safe_filename = sanitize_filename(file.name)
+        tenant = session.tenant
+        company = session.company
+
+        existing = BrandAsset.objects.filter(
+            tenant=tenant, company=company, file_name=safe_filename
+        ).first()
+        if existing is not None:
+            return Response(
+                BrandAssetSerializer(existing).data, status=http.HTTP_200_OK
+            )
+
+        unique_id = uuid.uuid4().hex[:8]
+        landing_path = f"_landing/{tenant.id}/{unique_id}_{safe_filename}"
+        raw_bucket = tenant.get_raw_bucket() if tenant else gcs_service.bucket_name
+
+        gcs_uploaded = False
+        try:
+            target_bucket = gcs_service.get_bucket(raw_bucket)
+            if target_bucket:
+                gcs_service.upload_file(
+                    file, landing_path, file.content_type, bucket_name=raw_bucket
+                )
+                gcs_uploaded = True
+        except Exception:
+            pass
+
+        asset = BrandAsset.objects.create(
+            tenant=tenant,
+            company=company,
+            file_name=safe_filename,
+            file_type="image",
+            file_size=file.size,
+            gcs_path=landing_path,
+            gcs_bucket=raw_bucket,
+            processed=False,
+            pipeline_status="pending" if gcs_uploaded else "failed",
+            pipeline_error=(
+                "" if gcs_uploaded else "GCS not configured - file not stored"
+            ),
+            usage_tag=usage_tag,
+            onboarding_session=session,
+        )
+
+        if gcs_uploaded:
+            pipeline_service = get_pipeline_service()
+            pipeline_service.publish_asset_event(asset)
+
+        return Response(BrandAssetSerializer(asset).data, status=http.HTTP_201_CREATED)
 
 
 class MeetingRecordingViewSet(

--- a/ai-brand-automator/apps/onboarding/views.py
+++ b/ai-brand-automator/apps/onboarding/views.py
@@ -11,8 +11,6 @@ import logging
 import json
 import uuid
 
-logger = logging.getLogger(__name__)
-
 from django.db import IntegrityError
 from django.db.models import Prefetch
 from django.db import transaction as db_transaction
@@ -100,6 +98,8 @@ from tenants.permissions import (
     IsTenantViewer,
     RoleBasedPermissionMixin,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class OnboardingSessionViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):


### PR DESCRIPTION
## Summary

- **Backend**: `POST /sessions/{id}/media/` action on `OnboardingSessionViewSet` — consent-gated, role-gated (Editor+), creates a `BrandAsset` with `usage_tag` and `onboarding_session` FK. Follows the `recordings` action pattern. Idempotent on duplicate filename. Triggers the ingestion pipeline via `publish_asset_event()`.
- **Frontend**: `CaptureControl` component (camera overlay → preview → confirm → tag picker), `useCaptureQueue` hook (offline-aware with backoff + online event drain), `uploadCapture()` API helper. Wired into `RightRail` and `MeetingView`, replacing the disabled Camera placeholder.
- **No model changes** — `BrandAsset.usage_tag` and `onboarding_session` already exist from B-02.

## Test plan

- [x] 15 backend tests (`test_media_capture.py`): consent gate, role gate, tag validation (all 5 tags), session+tag FK, GCS path, pipeline event, idempotency, cross-tenant 404
- [x] 8 `CaptureControl` frontend tests: consent gating, overlay open/dismiss, tag list integrity, `identity_document` position check
- [x] 4 `useCaptureQueue` frontend tests: upload call, retry with backoff, online event drain, tag preservation through retry
- [x] TypeScript strict — `npx tsc --noEmit` clean
- [x] ESLint clean
- [x] Black + Flake8 clean
- [ ] Manual: open meeting view, tap capture, take photo, select tag, verify thumbnail + tag badge in rail

🤖 Generated with [Claude Code](https://claude.com/claude-code)