### PR TITLE
feat(oia): video snippet OCR — keyframe extraction, dedup, multi-frame Gemini (H-04)

### DIFF
--- a/onboarding-intelligence-agent-svc/Dockerfile
+++ b/onboarding-intelligence-agent-svc/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.12-slim
 WORKDIR /app
 
 # Install curl for health checks
-RUN apt-get update && apt-get install -y --no-install-recommends curl && \
+RUN apt-get update && apt-get install -y --no-install-recommends curl ffmpeg && \
     rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .

--- a/onboarding-intelligence-agent-svc/app/api/schemas.py
+++ b/onboarding-intelligence-agent-svc/app/api/schemas.py
@@ -300,6 +300,7 @@ class CaptureMediaFrame(BaseModel):
     media_id: str
     gcs_uri: str
     usage_tag: str = "other"
+    mime_type: str = "image/jpeg"
 
 
 class MediaAnalyzed(ServerFrame):

--- a/onboarding-intelligence-agent-svc/app/api/ws.py
+++ b/onboarding-intelligence-agent-svc/app/api/ws.py
@@ -1324,6 +1324,7 @@ async def _process_captured_media(
             "media_id": capture.media_id,
             "gcs_uri": capture.gcs_uri,
             "usage_tag": capture.usage_tag,
+            "mime_type": capture.mime_type,
             "asset_id": asset_id,
             "redis": redis_pool,
             "events": events,

--- a/onboarding-intelligence-agent-svc/app/core/config.py
+++ b/onboarding-intelligence-agent-svc/app/core/config.py
@@ -97,6 +97,12 @@ class Settings(BaseSettings):
         "IBAN_CODE,US_SSN,US_ITIN,LOCATION"
     )
 
+    # ── Video OCR (H-04, Design §8.4) ─────────────────────────
+    VIDEO_MAX_FRAMES: int = 30
+    VIDEO_FPS: float = 1.0
+    VIDEO_DEDUP_THRESHOLD: int = 8
+    VIDEO_MAX_DURATION_S: int = 120
+
     # ── Secret references (never inline; Design §19) ─────────
     STT_CREDENTIALS: str = ""
     GEMINI_KEY: str = ""

--- a/onboarding-intelligence-agent-svc/app/logic/video_pipeline.py
+++ b/onboarding-intelligence-agent-svc/app/logic/video_pipeline.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import asyncio
 import io
-import logging
 import os
 import shutil
 import tempfile
@@ -20,7 +19,9 @@ from pathlib import Path
 import imagehash
 from PIL import Image
 
-logger = logging.getLogger(__name__)
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
 
 SCENE_CHANGE_THRESHOLD = 0.3
 
@@ -70,9 +71,9 @@ async def extract_keyframes(
         duration = await _probe_duration(video_path)
         if duration is not None and duration > max_duration_s:
             logger.warning(
-                "video_too_long duration_s=%s max_s=%s",
-                duration,
-                max_duration_s,
+                "video_too_long",
+                duration_s=duration,
+                max_s=max_duration_s,
             )
             duration = float(max_duration_s)
 
@@ -155,10 +156,10 @@ async def extract_keyframes(
             frames = sorted(combined[:max_frames], key=lambda f: f.timestamp_s)
 
         logger.info(
-            "keyframes_extracted total=%d fps_count=%d scene_count=%d",
-            len(frames),
-            sum(1 for f in frames if f.source == "fps"),
-            sum(1 for f in frames if f.source == "scene"),
+            "keyframes_extracted",
+            total=len(frames),
+            fps_count=sum(1 for f in frames if f.source == "fps"),
+            scene_count=sum(1 for f in frames if f.source == "scene"),
         )
 
         return frames
@@ -225,7 +226,7 @@ def dedup_frames(
             img = Image.open(io.BytesIO(frame.frame_bytes))
             h = imagehash.average_hash(img)
         except Exception:
-            logger.warning("frame_hash_failed timestamp_s=%s", frame.timestamp_s)
+            logger.warning("frame_hash_failed", timestamp_s=frame.timestamp_s)
             kept.append((frame, imagehash.hex_to_hash("0" * 16)))
             continue
 
@@ -243,10 +244,10 @@ def dedup_frames(
     ratio = 1.0 - (len(unique) / total) if total > 0 else 0.0
 
     logger.info(
-        "frames_deduped total=%d unique=%d reduction_ratio=%.3f",
-        total,
-        len(unique),
-        ratio,
+        "frames_deduped",
+        total=total,
+        unique=len(unique),
+        reduction_ratio=round(ratio, 3),
     )
 
     return unique, ratio

--- a/onboarding-intelligence-agent-svc/app/logic/video_pipeline.py
+++ b/onboarding-intelligence-agent-svc/app/logic/video_pipeline.py
@@ -76,19 +76,23 @@ async def extract_keyframes(
             )
             duration = float(max_duration_s)
 
-        t_limit = (
-            ["-t", str(max_duration_s)] if max_duration_s else []
-        )
+        t_limit = ["-t", str(max_duration_s)] if max_duration_s else []
 
         fps_proc = await asyncio.create_subprocess_exec(
             "ffmpeg",
-            "-i", video_path,
+            "-i",
+            video_path,
             *t_limit,
-            "-vf", f"fps={fps}",
-            "-vsync", "vfr",
-            "-frame_pts", "1",
+            "-vf",
+            f"fps={fps}",
+            "-vsync",
+            "vfr",
+            "-frame_pts",
+            "1",
             os.path.join(fps_dir, "frame_%06d.png"),
-            "-y", "-loglevel", "error",
+            "-y",
+            "-loglevel",
+            "error",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -96,12 +100,17 @@ async def extract_keyframes(
 
         scene_proc = await asyncio.create_subprocess_exec(
             "ffmpeg",
-            "-i", video_path,
+            "-i",
+            video_path,
             *t_limit,
-            "-vf", f"select='gt(scene,{SCENE_CHANGE_THRESHOLD})',showinfo",
-            "-vsync", "vfr",
+            "-vf",
+            f"select='gt(scene,{SCENE_CHANGE_THRESHOLD})',showinfo",
+            "-vsync",
+            "vfr",
             os.path.join(scene_dir, "frame_%06d.png"),
-            "-y", "-loglevel", "error",
+            "-y",
+            "-loglevel",
+            "error",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -116,22 +125,26 @@ async def extract_keyframes(
         fps_files = sorted(Path(fps_dir).glob("frame_*.png"))
         for i, fp in enumerate(fps_files):
             ts = i / fps if fps > 0 else 0.0
-            frames.append(KeyFrame(
-                frame_bytes=fp.read_bytes(),
-                timestamp_s=ts,
-                source="fps",
-            ))
+            frames.append(
+                KeyFrame(
+                    frame_bytes=fp.read_bytes(),
+                    timestamp_s=ts,
+                    source="fps",
+                )
+            )
 
         scene_files = sorted(Path(scene_dir).glob("frame_*.png"))
         for i, fp in enumerate(scene_files):
             ts = scene_timestamps[i] if i < len(scene_timestamps) else 0.0
             existing_ts = {f.timestamp_s for f in frames}
             if not any(abs(ts - et) < 0.5 for et in existing_ts):
-                frames.append(KeyFrame(
-                    frame_bytes=fp.read_bytes(),
-                    timestamp_s=ts,
-                    source="scene",
-                ))
+                frames.append(
+                    KeyFrame(
+                        frame_bytes=fp.read_bytes(),
+                        timestamp_s=ts,
+                        source="scene",
+                    )
+                )
 
         frames.sort(key=lambda f: f.timestamp_s)
 
@@ -157,9 +170,12 @@ async def _probe_duration(video_path: str) -> float | None:
     """Get video duration in seconds via ffprobe."""
     proc = await asyncio.create_subprocess_exec(
         "ffprobe",
-        "-v", "error",
-        "-show_entries", "format=duration",
-        "-of", "default=noprint_wrappers=1:nokey=1",
+        "-v",
+        "error",
+        "-show_entries",
+        "format=duration",
+        "-of",
+        "default=noprint_wrappers=1:nokey=1",
         video_path,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
@@ -209,9 +225,7 @@ def dedup_frames(
             img = Image.open(io.BytesIO(frame.frame_bytes))
             h = imagehash.average_hash(img)
         except Exception:
-            logger.warning(
-                "frame_hash_failed timestamp_s=%s", frame.timestamp_s
-            )
+            logger.warning("frame_hash_failed timestamp_s=%s", frame.timestamp_s)
             kept.append((frame, imagehash.hex_to_hash("0" * 16)))
             continue
 
@@ -284,8 +298,6 @@ def merge_ocr_texts(
     merged = "\n".join(lines)
 
     confidences = [r.confidence for r in frame_results if r.text.strip()]
-    avg_confidence = (
-        sum(confidences) / len(confidences) if confidences else 0.0
-    )
+    avg_confidence = sum(confidences) / len(confidences) if confidences else 0.0
 
     return merged, avg_confidence

--- a/onboarding-intelligence-agent-svc/app/logic/video_pipeline.py
+++ b/onboarding-intelligence-agent-svc/app/logic/video_pipeline.py
@@ -57,6 +57,9 @@ async def extract_keyframes(
     configured rate and on scene changes, then reads the output PNGs.
     Capped at max_frames; scene-change frames are prioritised.
     """
+    if not video_bytes:
+        return []
+
     tmp_dir = tempfile.mkdtemp(prefix="oia_video_")
     try:
         video_path = os.path.join(tmp_dir, "input.mp4")

--- a/onboarding-intelligence-agent-svc/app/logic/video_pipeline.py
+++ b/onboarding-intelligence-agent-svc/app/logic/video_pipeline.py
@@ -1,0 +1,291 @@
+"""Video snippet keyframe extraction, dedup and OCR merge.
+
+Design §8.4 · implemented by story H-04.
+
+Pipeline: ffmpeg keyframe extraction (1 fps + scene-change) → perceptual
+hash dedup → per-frame OCR → text merge with frame timestamps.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import logging
+import os
+import shutil
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import imagehash
+from PIL import Image
+
+logger = logging.getLogger(__name__)
+
+SCENE_CHANGE_THRESHOLD = 0.3
+
+
+@dataclass
+class KeyFrame:
+    """A single extracted frame with its timestamp."""
+
+    frame_bytes: bytes
+    timestamp_s: float
+    source: str  # "fps" or "scene"
+
+
+@dataclass
+class FrameOCRResult:
+    """OCR result for a single frame."""
+
+    timestamp_s: float
+    text: str
+    confidence: float
+    frame_bytes: bytes = field(repr=False)
+
+
+async def extract_keyframes(
+    video_bytes: bytes,
+    fps: float = 1.0,
+    max_frames: int = 30,
+    max_duration_s: int = 120,
+) -> list[KeyFrame]:
+    """Extract keyframes from video at fixed fps plus scene changes.
+
+    Writes video to a temp file, runs ffmpeg to extract frames at the
+    configured rate and on scene changes, then reads the output PNGs.
+    Capped at max_frames; scene-change frames are prioritised.
+    """
+    tmp_dir = tempfile.mkdtemp(prefix="oia_video_")
+    try:
+        video_path = os.path.join(tmp_dir, "input.mp4")
+        fps_dir = os.path.join(tmp_dir, "fps")
+        scene_dir = os.path.join(tmp_dir, "scene")
+        os.makedirs(fps_dir)
+        os.makedirs(scene_dir)
+
+        with open(video_path, "wb") as f:
+            f.write(video_bytes)
+
+        duration = await _probe_duration(video_path)
+        if duration is not None and duration > max_duration_s:
+            logger.warning(
+                "video_too_long duration_s=%s max_s=%s",
+                duration,
+                max_duration_s,
+            )
+            duration = float(max_duration_s)
+
+        t_limit = (
+            ["-t", str(max_duration_s)] if max_duration_s else []
+        )
+
+        fps_proc = await asyncio.create_subprocess_exec(
+            "ffmpeg",
+            "-i", video_path,
+            *t_limit,
+            "-vf", f"fps={fps}",
+            "-vsync", "vfr",
+            "-frame_pts", "1",
+            os.path.join(fps_dir, "frame_%06d.png"),
+            "-y", "-loglevel", "error",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        await fps_proc.communicate()
+
+        scene_proc = await asyncio.create_subprocess_exec(
+            "ffmpeg",
+            "-i", video_path,
+            *t_limit,
+            "-vf", f"select='gt(scene,{SCENE_CHANGE_THRESHOLD})',showinfo",
+            "-vsync", "vfr",
+            os.path.join(scene_dir, "frame_%06d.png"),
+            "-y", "-loglevel", "error",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, scene_stderr = await scene_proc.communicate()
+
+        scene_timestamps = _parse_showinfo_timestamps(
+            scene_stderr.decode(errors="replace")
+        )
+
+        frames: list[KeyFrame] = []
+
+        fps_files = sorted(Path(fps_dir).glob("frame_*.png"))
+        for i, fp in enumerate(fps_files):
+            ts = i / fps if fps > 0 else 0.0
+            frames.append(KeyFrame(
+                frame_bytes=fp.read_bytes(),
+                timestamp_s=ts,
+                source="fps",
+            ))
+
+        scene_files = sorted(Path(scene_dir).glob("frame_*.png"))
+        for i, fp in enumerate(scene_files):
+            ts = scene_timestamps[i] if i < len(scene_timestamps) else 0.0
+            existing_ts = {f.timestamp_s for f in frames}
+            if not any(abs(ts - et) < 0.5 for et in existing_ts):
+                frames.append(KeyFrame(
+                    frame_bytes=fp.read_bytes(),
+                    timestamp_s=ts,
+                    source="scene",
+                ))
+
+        frames.sort(key=lambda f: f.timestamp_s)
+
+        if len(frames) > max_frames:
+            scene_frames = [f for f in frames if f.source == "scene"]
+            fps_frames = [f for f in frames if f.source == "fps"]
+            combined = scene_frames + fps_frames
+            frames = sorted(combined[:max_frames], key=lambda f: f.timestamp_s)
+
+        logger.info(
+            "keyframes_extracted total=%d fps_count=%d scene_count=%d",
+            len(frames),
+            sum(1 for f in frames if f.source == "fps"),
+            sum(1 for f in frames if f.source == "scene"),
+        )
+
+        return frames
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+async def _probe_duration(video_path: str) -> float | None:
+    """Get video duration in seconds via ffprobe."""
+    proc = await asyncio.create_subprocess_exec(
+        "ffprobe",
+        "-v", "error",
+        "-show_entries", "format=duration",
+        "-of", "default=noprint_wrappers=1:nokey=1",
+        video_path,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, _ = await proc.communicate()
+    try:
+        return float(stdout.decode().strip())
+    except (ValueError, AttributeError):
+        return None
+
+
+def _parse_showinfo_timestamps(stderr: str) -> list[float]:
+    """Extract pts_time values from ffmpeg showinfo filter output."""
+    timestamps: list[float] = []
+    for line in stderr.split("\n"):
+        if "pts_time:" not in line:
+            continue
+        for part in line.split():
+            if part.startswith("pts_time:"):
+                try:
+                    timestamps.append(float(part.split(":")[1]))
+                except (ValueError, IndexError):
+                    pass
+    return timestamps
+
+
+def dedup_frames(
+    frames: list[KeyFrame],
+    threshold: int = 8,
+) -> tuple[list[KeyFrame], float]:
+    """Collapse near-duplicate frames by perceptual hashing.
+
+    Returns (unique_frames, reduction_ratio) where
+    reduction_ratio = 1 - (unique / total). A ratio of 0.6 means 60%
+    of frames were duplicates.
+    """
+    if not frames:
+        return [], 0.0
+
+    if len(frames) == 1:
+        return list(frames), 0.0
+
+    kept: list[tuple[KeyFrame, imagehash.ImageHash]] = []
+
+    for frame in frames:
+        try:
+            img = Image.open(io.BytesIO(frame.frame_bytes))
+            h = imagehash.average_hash(img)
+        except Exception:
+            logger.warning(
+                "frame_hash_failed timestamp_s=%s", frame.timestamp_s
+            )
+            kept.append((frame, imagehash.hex_to_hash("0" * 16)))
+            continue
+
+        is_dup = False
+        for _, existing_hash in kept:
+            if abs(h - existing_hash) < threshold:
+                is_dup = True
+                break
+
+        if not is_dup:
+            kept.append((frame, h))
+
+    unique = [f for f, _ in kept]
+    total = len(frames)
+    ratio = 1.0 - (len(unique) / total) if total > 0 else 0.0
+
+    logger.info(
+        "frames_deduped total=%d unique=%d reduction_ratio=%.3f",
+        total,
+        len(unique),
+        ratio,
+    )
+
+    return unique, ratio
+
+
+def merge_ocr_texts(
+    frame_results: list[FrameOCRResult],
+) -> tuple[str, float]:
+    """Merge per-frame OCR texts with timestamps, deduplicating lines.
+
+    Each unique text block is prefixed with [MM:SS] of its first
+    occurrence. Duplicate lines across frames are collapsed.
+    Returns (merged_text, average_confidence).
+    """
+    if not frame_results:
+        return "", 0.0
+
+    seen_lines: dict[str, float] = {}
+    blocks: list[tuple[float, str]] = []
+
+    for result in sorted(frame_results, key=lambda r: r.timestamp_s):
+        if not result.text.strip():
+            continue
+
+        for line in result.text.strip().split("\n"):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if stripped not in seen_lines:
+                seen_lines[stripped] = result.timestamp_s
+                blocks.append((result.timestamp_s, stripped))
+
+    if not blocks:
+        confidences = [r.confidence for r in frame_results]
+        avg = sum(confidences) / len(confidences) if confidences else 0.0
+        return "", avg
+
+    current_ts: float | None = None
+    lines: list[str] = []
+    for ts, text in blocks:
+        if current_ts is None or abs(ts - current_ts) > 0.01:
+            minutes = int(ts) // 60
+            seconds = int(ts) % 60
+            lines.append(f"[{minutes:02d}:{seconds:02d}] {text}")
+            current_ts = ts
+        else:
+            lines.append(f"[{minutes:02d}:{seconds:02d}] {text}")
+
+    merged = "\n".join(lines)
+
+    confidences = [r.confidence for r in frame_results if r.text.strip()]
+    avg_confidence = (
+        sum(confidences) / len(confidences) if confidences else 0.0
+    )
+
+    return merged, avg_confidence

--- a/onboarding-intelligence-agent-svc/app/providers/vision.py
+++ b/onboarding-intelligence-agent-svc/app/providers/vision.py
@@ -197,9 +197,7 @@ class VisionProvider:
         self._breaker.record_success()
         return result
 
-    async def analyze_multi(
-        self, frames: list[bytes], ocr_text: str
-    ) -> VisionResult:
+    async def analyze_multi(self, frames: list[bytes], ocr_text: str) -> VisionResult:
         """Send multiple video frames + merged OCR text to Gemini.
 
         Used by the video snippet path (H-04 AC-4): one doc_type and one
@@ -225,9 +223,7 @@ class VisionProvider:
             contents: list[Any] = []
             for frame_bytes in frames[:MAX_MULTI_FRAMES]:
                 contents.append(
-                    types.Part.from_bytes(
-                        data=frame_bytes, mime_type="image/png"
-                    )
+                    types.Part.from_bytes(data=frame_bytes, mime_type="image/png")
                 )
             contents.append(prompt)
 

--- a/onboarding-intelligence-agent-svc/app/providers/vision.py
+++ b/onboarding-intelligence-agent-svc/app/providers/vision.py
@@ -10,7 +10,6 @@ same treatment of a missing key as degradation rather than a crash.
 from __future__ import annotations
 
 import json
-import logging
 from dataclasses import dataclass
 from typing import Any
 
@@ -19,8 +18,9 @@ from app.circuit_breaker.breaker import (
     CircuitBreaker,
     CircuitBreakerOpen,
 )
+from app.core.logging import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 DEPENDENCY = "vision"
 DEFAULT_MODEL = "gemini-3.5-flash"
@@ -191,7 +191,9 @@ class VisionProvider:
             raise
         except Exception as exc:
             self._breaker.record_failure()
-            logger.warning("vision analysis failed: %s: %s", type(exc).__name__, exc)
+            logger.warning(
+                "vision_analysis_failed", error_type=type(exc).__name__, error=str(exc)
+            )
             raise VisionUnavailable(f"analysis failed: {type(exc).__name__}") from exc
 
         self._breaker.record_success()
@@ -244,9 +246,9 @@ class VisionProvider:
         except Exception as exc:
             self._breaker.record_failure()
             logger.warning(
-                "vision multi-frame analysis failed: %s: %s",
-                type(exc).__name__,
-                exc,
+                "vision_multi_frame_analysis_failed",
+                error_type=type(exc).__name__,
+                error=str(exc),
             )
             raise VisionUnavailable(
                 f"multi-frame analysis failed: {type(exc).__name__}"

--- a/onboarding-intelligence-agent-svc/app/providers/vision.py
+++ b/onboarding-intelligence-agent-svc/app/providers/vision.py
@@ -1,6 +1,6 @@
 """Gemini multimodal semantic pass over captured media.
 
-Design §8.4 · implemented by story H-03.
+Design §8.4 · implemented by stories H-03 (image) and H-04 (video).
 
 Mirrors :class:`app.providers.llm.LLMProvider` — same breaker discipline,
 same ``_ensure_client`` pattern (genai.Client lifetime bug from C-02),
@@ -44,6 +44,34 @@ VALID_DOC_TYPES = frozenset(
 )
 
 VALID_SENSITIVITY = frozenset({"GENERAL", "IDENTITY", "FINANCIAL"})
+
+MULTI_FRAME_PROMPT = """\
+You are analyzing frames extracted from a short video snippet captured \
+during a business onboarding meeting. The video shows a document, product, \
+or premises that a single photo could not capture.
+
+Given the frames and the merged OCR text extracted from them, provide a \
+JSON response with:
+
+1. "caption": A brief one-sentence description of what the video shows.
+2. "doc_type": One of: invoice, receipt, contract, id_card, passport, \
+business_card, presentation, report, letter, form, photo, screenshot, other.
+3. "sensitivity_class": One of:
+   - "GENERAL" — no sensitive personal or financial data
+   - "IDENTITY" — contains personal identification (names+IDs, photos, \
+signatures, addresses linked to persons)
+   - "FINANCIAL" — contains financial data (account numbers, tax IDs, \
+salary, bank details)
+
+Merged OCR text from all frames:
+{ocr_text}
+
+Respond ONLY with valid JSON, no markdown fences, no explanation.
+Example: {{"caption": "A multi-page contract", "doc_type": "contract", \
+"sensitivity_class": "GENERAL"}}
+"""
+
+MAX_MULTI_FRAMES = 4
 
 ANALYSIS_PROMPT = """\
 You are analyzing a document image captured during a business onboarding meeting.
@@ -165,6 +193,68 @@ class VisionProvider:
             self._breaker.record_failure()
             logger.warning("vision analysis failed: %s: %s", type(exc).__name__, exc)
             raise VisionUnavailable(f"analysis failed: {type(exc).__name__}") from exc
+
+        self._breaker.record_success()
+        return result
+
+    async def analyze_multi(
+        self, frames: list[bytes], ocr_text: str
+    ) -> VisionResult:
+        """Send multiple video frames + merged OCR text to Gemini.
+
+        Used by the video snippet path (H-04 AC-4): one doc_type and one
+        caption for the entire video, not per-frame.
+        """
+        if not self.configured:
+            raise VisionUnavailable("no Gemini API key is configured")
+
+        try:
+            self._breaker.before_call()
+        except CircuitBreakerOpen as exc:
+            raise VisionUnavailable(
+                exc.user_message or f"{exc.dependency} is unavailable"
+            ) from exc
+
+        try:
+            from google.genai import types
+
+            prompt = MULTI_FRAME_PROMPT.format(
+                ocr_text=ocr_text[:4000] if ocr_text else "(no text detected)"
+            )
+
+            contents: list[Any] = []
+            for frame_bytes in frames[:MAX_MULTI_FRAMES]:
+                contents.append(
+                    types.Part.from_bytes(
+                        data=frame_bytes, mime_type="image/png"
+                    )
+                )
+            contents.append(prompt)
+
+            response = await self._ensure_client().generate_content(
+                model=self._model_name,
+                contents=contents,
+                config={"temperature": 0.1},
+            )
+
+            text = getattr(response, "text", None)
+            if not text or not str(text).strip():
+                raise ValueError("the model returned no text")
+
+            result = self._parse_response(str(text))
+
+        except VisionUnavailable:
+            raise
+        except Exception as exc:
+            self._breaker.record_failure()
+            logger.warning(
+                "vision multi-frame analysis failed: %s: %s",
+                type(exc).__name__,
+                exc,
+            )
+            raise VisionUnavailable(
+                f"multi-frame analysis failed: {type(exc).__name__}"
+            ) from exc
 
         self._breaker.record_success()
         return result

--- a/onboarding-intelligence-agent-svc/app/skills/analyze_captured_media.py
+++ b/onboarding-intelligence-agent-svc/app/skills/analyze_captured_media.py
@@ -1,9 +1,13 @@
 """SKL-OIA-07 — Describe and classify media captured during the meeting.
 
-Design §8.1, §8.4 · implemented by story H-03.
+Design §8.1, §8.4 · implemented by stories H-03 (image) and H-04 (video).
 
-Pipeline: download → preprocess → Cloud Vision OCR → Gemini semantic
+Image path: download → preprocess → Cloud Vision OCR → Gemini semantic
 → PII redaction → PG-08 check → write back to Django → emit EVT-106.
+
+Video path: download → ffmpeg keyframe extraction → perceptual hash dedup
+→ per-frame Cloud Vision OCR → merge text with timestamps → Gemini
+multi-frame semantic → PII redaction → PG-08 check → write back → EVT-106.
 """
 
 from __future__ import annotations
@@ -13,10 +17,17 @@ import time
 from typing import Any
 
 from app.cache.redis_manager import TenantKeys
+from app.core.config import get_settings
 from app.core.logging import get_logger
 from app.cache.retry_queue import OCRRetryItem, enqueue_retry
 from app.events.catalog import EventType
 from app.logic.preprocessing import preprocess_image
+from app.logic.video_pipeline import (
+    FrameOCRResult,
+    dedup_frames,
+    extract_keyframes,
+    merge_ocr_texts,
+)
 from app.providers.ocr import OCRProvider, OCRResult, OCRUnavailable
 from app.providers.vision import VisionProvider, VisionResult, VisionUnavailable
 from app.services.backend_client import BackendClient
@@ -48,6 +59,14 @@ class AnalyzeCapturedMedia(BaseSkill):
         self._backend = backend
 
     async def run(self, context: SkillContext) -> SkillResult:
+        mime_type = context.input_context.get("mime_type", "image/jpeg")
+
+        if mime_type.startswith("video/"):
+            return await self._run_video_pipeline(context)
+        return await self._run_image_pipeline(context)
+
+    async def _run_image_pipeline(self, context: SkillContext) -> SkillResult:
+        """Original image OCR path from H-03."""
         start_ms = int(time.time() * 1000)
 
         media_id = context.input_context.get("media_id", "")
@@ -73,7 +92,7 @@ class AnalyzeCapturedMedia(BaseSkill):
                     output={"status": "already_processed", "media_id": media_id},
                 )
 
-        image_bytes = await self._download_image(gcs_uri)
+        image_bytes = await self._download_media(gcs_uri)
 
         preprocessed = preprocess_image(image_bytes)
 
@@ -190,7 +209,211 @@ class AnalyzeCapturedMedia(BaseSkill):
             duration_ms=duration_ms,
         )
 
-    async def _download_image(self, gcs_uri: str) -> bytes:
+    async def _run_video_pipeline(self, context: SkillContext) -> SkillResult:
+        """Video snippet OCR path from H-04."""
+        start_ms = int(time.time() * 1000)
+        settings = get_settings()
+
+        media_id = context.input_context.get("media_id", "")
+        gcs_uri = context.input_context.get("gcs_uri", "")
+        usage_tag = context.input_context.get("usage_tag", "other")
+        tenant_id = context.tenant_context.tenant_id
+        asset_id = context.input_context.get("asset_id")
+        redis = context.input_context.get("redis")
+        events = context.input_context.get("events")
+        session_id = context.tenant_context.session_id
+
+        keys = TenantKeys(tenant_id)
+
+        idem_key = keys.idempotency(
+            hashlib.sha256(f"video_ocr:{media_id}".encode()).hexdigest()[:16]
+        )
+        if redis:
+            existing = await redis.get(idem_key)
+            if existing:
+                logger.info("video_ocr_idempotent_skip", media_id=media_id)
+                return SkillResult(
+                    skill_id=self.meta.skill_id,
+                    output={"status": "already_processed", "media_id": media_id},
+                )
+
+        video_bytes = await self._download_media(gcs_uri)
+
+        frames = await extract_keyframes(
+            video_bytes,
+            fps=settings.VIDEO_FPS,
+            max_frames=settings.VIDEO_MAX_FRAMES,
+            max_duration_s=settings.VIDEO_MAX_DURATION_S,
+        )
+
+        if not frames:
+            logger.warning("video_no_frames", media_id=media_id)
+            duration_ms = int(time.time() * 1000) - start_ms
+            return SkillResult(
+                skill_id=self.meta.skill_id,
+                output={
+                    "media_id": media_id,
+                    "ocr_text": "",
+                    "ocr_confidence": 0.0,
+                    "caption": "Video snippet (no readable frames)",
+                    "doc_type": "other",
+                    "usage_tag": usage_tag,
+                    "sensitivity_class": "GENERAL",
+                    "rag_excluded": False,
+                    "retake_suggested": True,
+                    "redaction_applied": False,
+                    "degraded": False,
+                },
+                confidence=0.0,
+                duration_ms=duration_ms,
+            )
+
+        unique_frames, reduction_ratio = dedup_frames(
+            frames, threshold=settings.VIDEO_DEDUP_THRESHOLD
+        )
+        logger.info(
+            "video_dedup_complete",
+            media_id=media_id,
+            total_frames=len(frames),
+            unique_frames=len(unique_frames),
+            reduction_ratio=reduction_ratio,
+        )
+
+        assert self._ocr is not None
+        assert self._vision is not None
+
+        frame_results: list[FrameOCRResult] = []
+        degraded = False
+
+        for frame in unique_frames:
+            preprocessed = preprocess_image(frame.frame_bytes)
+            try:
+                ocr_result = await self._ocr.detect_text(preprocessed)
+                frame_results.append(
+                    FrameOCRResult(
+                        timestamp_s=frame.timestamp_s,
+                        text=ocr_result.text,
+                        confidence=ocr_result.confidence,
+                        frame_bytes=preprocessed,
+                    )
+                )
+            except (OCRUnavailable, Exception) as exc:
+                logger.warning(
+                    "frame_ocr_failed",
+                    media_id=media_id,
+                    timestamp_s=frame.timestamp_s,
+                    error=str(exc),
+                )
+                frame_results.append(
+                    FrameOCRResult(
+                        timestamp_s=frame.timestamp_s,
+                        text="",
+                        confidence=0.0,
+                        frame_bytes=preprocessed,
+                    )
+                )
+                degraded = True
+
+        if not frame_results:
+            return await self._enqueue_and_degrade(
+                redis, keys, media_id, gcs_uri, usage_tag, tenant_id, start_ms
+            )
+
+        merged_text, avg_confidence = merge_ocr_texts(frame_results)
+
+        best_frames = sorted(
+            [fr for fr in frame_results if fr.text.strip()],
+            key=lambda fr: fr.confidence,
+            reverse=True,
+        )[:4]
+        if not best_frames:
+            best_frames = frame_results[:4]
+
+        try:
+            vision_result = await self._vision.analyze_multi(
+                [fr.frame_bytes for fr in best_frames],
+                merged_text,
+            )
+        except (VisionUnavailable, Exception) as exc:
+            logger.warning("video_vision_unavailable", error=str(exc))
+            vision_result = VisionResult(
+                caption="Video snippet",
+                doc_type="other",
+                sensitivity_class="GENERAL",
+            )
+
+        redaction = redact_text(merged_text) if merged_text else None
+        redacted_text = redaction.text if redaction else ""
+        redaction_applied = bool(redaction and redaction.applied)
+
+        sensitivity_class = vision_result.sensitivity_class
+        doc_type = vision_result.doc_type
+        caption = vision_result.caption
+
+        confidence = avg_confidence
+        if degraded:
+            confidence = min(confidence, DEGRADED_CONFIDENCE_CAP)
+
+        rag_excluded = False
+        if sensitivity_class in ("IDENTITY", "FINANCIAL"):
+            if not redaction_applied:
+                rag_excluded = True
+
+        if self._backend and asset_id:
+            await self._backend.update_asset_ocr(
+                tenant_id=tenant_id,
+                asset_id=int(asset_id),
+                ocr_text=redacted_text,
+                ocr_confidence=confidence,
+                sensitivity_class=sensitivity_class,
+                rag_excluded=rag_excluded,
+            )
+
+        if redis:
+            await redis.set(idem_key, "1", ex=IDEMPOTENCY_TTL)
+
+        if events and session_id:
+            try:
+                await events.emit(
+                    EventType.MEDIA_CAPTURED_ANALYZED,
+                    tenant_id=tenant_id,
+                    correlation_id=media_id,
+                    session_id=session_id,
+                    payload={
+                        "media_id": media_id,
+                        "usage_tag": usage_tag,
+                        "ocr_confidence": confidence,
+                        "sensitivity_class": sensitivity_class,
+                        "doc_type": doc_type,
+                        "rag_excluded": rag_excluded,
+                    },
+                    outcome="SUCCESS",
+                )
+            except Exception:
+                logger.warning("evt106_emission_failed", media_id=media_id)
+
+        duration_ms = int(time.time() * 1000) - start_ms
+
+        return SkillResult(
+            skill_id=self.meta.skill_id,
+            output={
+                "media_id": media_id,
+                "ocr_text": redacted_text,
+                "ocr_confidence": confidence,
+                "caption": caption,
+                "doc_type": doc_type,
+                "usage_tag": usage_tag,
+                "sensitivity_class": sensitivity_class,
+                "rag_excluded": rag_excluded,
+                "retake_suggested": confidence < RETAKE_THRESHOLD,
+                "redaction_applied": redaction_applied,
+                "degraded": degraded,
+            },
+            confidence=confidence,
+            duration_ms=duration_ms,
+        )
+
+    async def _download_media(self, gcs_uri: str) -> bytes:
         """Download from GCS using the client library directly."""
         from google.cloud.storage import Client
 

--- a/onboarding-intelligence-agent-svc/config/skills.yaml
+++ b/onboarding-intelligence-agent-svc/config/skills.yaml
@@ -180,7 +180,12 @@ skills:
   - skill_id: SKL-OIA-07
     name: analyze_captured_media
     description: >-
-      Describe and classify media captured during the meeting, including OCR. input_context carries {media_id, gcs_uri, usage_tag}.
+      Read a photo or short video snippet captured during the meeting.
+      Two-engine hybrid: Cloud Vision DOCUMENT_TEXT_DETECTION for OCR text
+      with per-word confidence, Gemini multimodal for caption, document-type
+      classification and usage_tag suggestion. Video path extracts keyframes
+      at 1 fps plus scene changes, OCRs each and de-duplicates by hashing.
+      input_context carries {media_id, gcs_uri, usage_tag, mime_type}.
     input_schema:
       - field: input_prompt
         type: string

--- a/onboarding-intelligence-agent-svc/requirements.txt
+++ b/onboarding-intelligence-agent-svc/requirements.txt
@@ -19,3 +19,5 @@ tavily-python>=0.5.0
 google-genai>=1.14.0
 google-cloud-vision>=3.7.0
 Pillow>=10.4.0
+ffmpeg-python>=0.2.0
+imagehash>=4.3.0

--- a/onboarding-intelligence-agent-svc/tests/property/test_video_invariants.py
+++ b/onboarding-intelligence-agent-svc/tests/property/test_video_invariants.py
@@ -1,0 +1,154 @@
+"""H-04 property tests — video OCR pipeline invariants.
+
+Hypothesis-driven checks that hold regardless of input:
+- merged text never contains duplicate lines
+- every line has [MM:SS] prefix
+- reduction_ratio always in [0.0, 1.0]
+- frame count after dedup <= frame count before
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from PIL import Image
+
+from app.logic.video_pipeline import (
+    FrameOCRResult,
+    KeyFrame,
+    dedup_frames,
+    merge_ocr_texts,
+)
+
+pytestmark = [pytest.mark.property, pytest.mark.hypothesis]
+
+
+def _frame_bytes(r: int = 128, g: int = 128, b: int = 128) -> bytes:
+    img = Image.new("RGB", (8, 8), (r, g, b))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+@given(
+    texts=st.lists(
+        st.text(
+            alphabet=st.characters(whitelist_categories=("L", "N", "P", "Z")),
+            min_size=1,
+            max_size=50,
+        ),
+        min_size=1,
+        max_size=10,
+    ),
+    timestamps=st.lists(
+        st.floats(min_value=0.0, max_value=3600.0, allow_nan=False),
+        min_size=1,
+        max_size=10,
+    ),
+)
+@settings(max_examples=50)
+def test_merged_text_no_duplicate_lines(texts, timestamps):
+    """No line appears more than once in merged output."""
+    n = min(len(texts), len(timestamps))
+    results = [
+        FrameOCRResult(
+            timestamp_s=timestamps[i],
+            text=texts[i],
+            confidence=0.8,
+            frame_bytes=b"",
+        )
+        for i in range(n)
+    ]
+
+    merged, _ = merge_ocr_texts(results)
+
+    if merged:
+        lines = merged.strip().split("\n")
+        text_parts = []
+        for line in lines:
+            if "] " in line:
+                text_parts.append(line.split("] ", 1)[1])
+            else:
+                text_parts.append(line)
+        assert len(text_parts) == len(set(text_parts))
+
+
+@given(
+    texts=st.lists(
+        st.text(
+            alphabet=st.characters(whitelist_categories=("L", "N")),
+            min_size=1,
+            max_size=20,
+        ),
+        min_size=1,
+        max_size=5,
+    ),
+)
+@settings(max_examples=50)
+def test_every_line_has_timestamp_prefix(texts):
+    """Every non-empty line starts with [MM:SS]."""
+    results = [
+        FrameOCRResult(
+            timestamp_s=float(i),
+            text=t,
+            confidence=0.8,
+            frame_bytes=b"",
+        )
+        for i, t in enumerate(texts)
+    ]
+
+    merged, _ = merge_ocr_texts(results)
+
+    if merged:
+        import re
+
+        for line in merged.strip().split("\n"):
+            if line.strip():
+                assert re.match(
+                    r"\[\d{2}:\d{2}\]", line
+                ), f"Line missing timestamp: {line!r}"
+
+
+@given(
+    n_frames=st.integers(min_value=0, max_value=20),
+    threshold=st.integers(min_value=1, max_value=64),
+)
+@settings(max_examples=50)
+def test_reduction_ratio_bounds(n_frames, threshold):
+    """reduction_ratio is always in [0.0, 1.0]."""
+    frames = [
+        KeyFrame(
+            frame_bytes=_frame_bytes(r=i * 13 % 256),
+            timestamp_s=float(i),
+            source="fps",
+        )
+        for i in range(n_frames)
+    ]
+
+    _, ratio = dedup_frames(frames, threshold=threshold)
+
+    assert 0.0 <= ratio <= 1.0
+
+
+@given(
+    n_frames=st.integers(min_value=0, max_value=20),
+    threshold=st.integers(min_value=1, max_value=64),
+)
+@settings(max_examples=50)
+def test_dedup_never_increases_count(n_frames, threshold):
+    """Frame count after dedup <= frame count before."""
+    frames = [
+        KeyFrame(
+            frame_bytes=_frame_bytes(r=i * 37 % 256, g=i * 71 % 256),
+            timestamp_s=float(i),
+            source="fps",
+        )
+        for i in range(n_frames)
+    ]
+
+    unique, _ = dedup_frames(frames, threshold=threshold)
+
+    assert len(unique) <= len(frames)

--- a/onboarding-intelligence-agent-svc/tests/test_analyze_captured_media.py
+++ b/onboarding-intelligence-agent-svc/tests/test_analyze_captured_media.py
@@ -1,6 +1,6 @@
-"""H-03 · SKL-OIA-07 analyze_captured_media skill tests.
+"""H-03 / H-04 · SKL-OIA-07 analyze_captured_media skill tests.
 
-Tests the skill pipeline: OCR → Vision → Redaction → PG-08.
+Tests the skill pipeline for both image (H-03) and video (H-04) paths.
 Providers are injected directly (no mocks on the skill itself — only
 the providers are test doubles, which the skill accepts by design).
 """
@@ -97,7 +97,7 @@ class TestPipelineStageOrder:
             vision=vision,
             backend=backend,
         )
-        skill._download_image = AsyncMock(return_value=b"fake-image")
+        skill._download_media = AsyncMock(return_value=b"fake-image")
 
         result = asyncio.run(skill.run(_context()))
 
@@ -120,7 +120,7 @@ class TestPipelineStageOrder:
             vision=vision,
             backend=backend,
         )
-        skill._download_image = AsyncMock(return_value=b"fake-image")
+        skill._download_media = AsyncMock(return_value=b"fake-image")
 
         result = asyncio.run(skill.run(_context()))
 
@@ -140,7 +140,7 @@ class TestRetakeSuggested:
             vision=vision,
             backend=_backend(),
         )
-        skill._download_image = AsyncMock(return_value=b"fake")
+        skill._download_media = AsyncMock(return_value=b"fake")
 
         result = asyncio.run(skill.run(_context()))
 
@@ -157,7 +157,7 @@ class TestRetakeSuggested:
             vision=vision,
             backend=_backend(),
         )
-        skill._download_image = AsyncMock(return_value=b"fake")
+        skill._download_media = AsyncMock(return_value=b"fake")
 
         result = asyncio.run(skill.run(_context()))
 
@@ -176,7 +176,7 @@ class TestPG08:
             vision=vision,
             backend=_backend(),
         )
-        skill._download_image = AsyncMock(return_value=b"fake")
+        skill._download_media = AsyncMock(return_value=b"fake")
 
         result = asyncio.run(skill.run(_context()))
 
@@ -192,7 +192,7 @@ class TestPG08:
             vision=vision,
             backend=_backend(),
         )
-        skill._download_image = AsyncMock(return_value=b"fake")
+        skill._download_media = AsyncMock(return_value=b"fake")
 
         result = asyncio.run(skill.run(_context()))
 
@@ -208,7 +208,7 @@ class TestPG08:
             vision=vision,
             backend=_backend(),
         )
-        skill._download_image = AsyncMock(return_value=b"fake")
+        skill._download_media = AsyncMock(return_value=b"fake")
 
         result = asyncio.run(skill.run(_context()))
 
@@ -225,7 +225,7 @@ class TestPG08:
             vision=vision,
             backend=_backend(),
         )
-        skill._download_image = AsyncMock(return_value=b"fake")
+        skill._download_media = AsyncMock(return_value=b"fake")
 
         result = asyncio.run(skill.run(_context()))
 
@@ -250,7 +250,7 @@ class TestDegradation:
             vision=vision,
             backend=_backend(),
         )
-        skill._download_image = AsyncMock(return_value=b"fake")
+        skill._download_media = AsyncMock(return_value=b"fake")
 
         result = asyncio.run(skill.run(_context()))
 
@@ -270,7 +270,7 @@ class TestBackendWrite:
             vision=vision,
             backend=backend,
         )
-        skill._download_image = AsyncMock(return_value=b"fake")
+        skill._download_media = AsyncMock(return_value=b"fake")
 
         asyncio.run(skill.run(_context()))
 
@@ -279,3 +279,221 @@ class TestBackendWrite:
         assert call_kwargs["tenant_id"] == "t-1"
         assert call_kwargs["asset_id"] == 42
         assert call_kwargs["sensitivity_class"] == "GENERAL"
+
+
+def _video_context(**overrides) -> SkillContext:
+    """Context with video mime_type to trigger the video pipeline."""
+    base = dict(
+        input_prompt="",
+        tenant_context=TenantContext(
+            tenant_id="t-1",
+            session_id="s-1",
+            role="OWNER",
+        ),
+        input_context={
+            "media_id": "v-001",
+            "gcs_uri": "gs://bucket/test.mp4",
+            "usage_tag": "business_photo",
+            "mime_type": "video/mp4",
+            "asset_id": "42",
+            "redis": None,
+            "events": None,
+        },
+        origin=Origin.INTERNAL,
+    )
+    base.update(overrides)
+    return SkillContext(**base)
+
+
+def _vision_multi_provider(
+    caption="A multi-page document",
+    doc_type="report",
+    sensitivity_class="GENERAL",
+):
+    """Vision provider with analyze_multi configured."""
+    provider = AsyncMock()
+    provider.analyze.return_value = VisionResult(
+        caption=caption,
+        doc_type=doc_type,
+        sensitivity_class=sensitivity_class,
+    )
+    provider.analyze_multi.return_value = VisionResult(
+        caption=caption,
+        doc_type=doc_type,
+        sensitivity_class=sensitivity_class,
+    )
+    return provider
+
+
+class TestVideoPath:
+    """H-04: video snippet OCR pipeline tests."""
+
+    def test_video_mime_triggers_video_pipeline(self):
+        """AC-1: video/* mime_type triggers the video path."""
+        from unittest.mock import patch, AsyncMock as AM
+
+        ocr = _ocr_provider(text="Invoice line 1")
+        vision = _vision_multi_provider()
+        backend = _backend()
+
+        skill = AnalyzeCapturedMedia(
+            _meta(), ocr=ocr, vision=vision, backend=backend
+        )
+        skill._download_media = AM(return_value=b"fake-video")
+
+        with patch(
+            "app.skills.analyze_captured_media.extract_keyframes"
+        ) as mock_extract:
+            from app.logic.video_pipeline import KeyFrame
+            import io
+            from PIL import Image
+
+            img = Image.new("RGB", (10, 10), (255, 0, 0))
+            buf = io.BytesIO()
+            img.save(buf, format="PNG")
+            frame_bytes = buf.getvalue()
+
+            mock_extract.return_value = [
+                KeyFrame(frame_bytes=frame_bytes, timestamp_s=0.0, source="fps"),
+                KeyFrame(frame_bytes=frame_bytes, timestamp_s=1.0, source="fps"),
+            ]
+
+            with patch(
+                "app.skills.analyze_captured_media.dedup_frames"
+            ) as mock_dedup:
+                mock_dedup.return_value = (
+                    [KeyFrame(frame_bytes=frame_bytes, timestamp_s=0.0, source="fps")],
+                    0.5,
+                )
+
+                result = asyncio.run(skill.run(_video_context()))
+
+                mock_extract.assert_called_once()
+                mock_dedup.assert_called_once()
+                assert result.output["media_id"] == "v-001"
+                assert "ocr_text" in result.output
+
+    def test_image_mime_uses_image_path(self):
+        """Image mime_type must NOT trigger the video pipeline."""
+        ocr = _ocr_provider()
+        vision = _vision_provider(sensitivity_class="GENERAL")
+
+        skill = AnalyzeCapturedMedia(
+            _meta(), ocr=ocr, vision=vision, backend=_backend()
+        )
+        skill._download_media = AsyncMock(return_value=b"fake")
+
+        result = asyncio.run(skill.run(_context()))
+
+        assert result.output["media_id"] == "m-001"
+        vision.analyze.assert_called_once()
+
+    def test_video_merged_text_stored(self):
+        """AC-3: merged text with timestamps is stored."""
+        from unittest.mock import patch, AsyncMock as AM
+
+        ocr = _ocr_provider(text="Page one content")
+        vision = _vision_multi_provider()
+        backend = _backend()
+
+        skill = AnalyzeCapturedMedia(
+            _meta(), ocr=ocr, vision=vision, backend=backend
+        )
+        skill._download_media = AM(return_value=b"fake-video")
+
+        with patch(
+            "app.skills.analyze_captured_media.extract_keyframes"
+        ) as mock_extract:
+            import io
+            from PIL import Image
+            from app.logic.video_pipeline import KeyFrame
+
+            img = Image.new("RGB", (10, 10), (255, 0, 0))
+            buf = io.BytesIO()
+            img.save(buf, format="PNG")
+            frame_bytes = buf.getvalue()
+
+            mock_extract.return_value = [
+                KeyFrame(frame_bytes=frame_bytes, timestamp_s=0.0, source="fps"),
+            ]
+
+            with patch(
+                "app.skills.analyze_captured_media.dedup_frames"
+            ) as mock_dedup:
+                mock_dedup.return_value = (
+                    [KeyFrame(frame_bytes=frame_bytes, timestamp_s=0.0, source="fps")],
+                    0.0,
+                )
+
+                result = asyncio.run(skill.run(_video_context()))
+
+                assert result.output["ocr_text"]
+
+    def test_video_gemini_receives_multiple_frames(self):
+        """AC-4: analyze_multi is called, not analyze."""
+        from unittest.mock import patch, AsyncMock as AM
+
+        ocr = _ocr_provider(text="Frame text")
+        vision = _vision_multi_provider()
+        backend = _backend()
+
+        skill = AnalyzeCapturedMedia(
+            _meta(), ocr=ocr, vision=vision, backend=backend
+        )
+        skill._download_media = AM(return_value=b"fake-video")
+
+        with patch(
+            "app.skills.analyze_captured_media.extract_keyframes"
+        ) as mock_extract:
+            import io
+            from PIL import Image
+            from app.logic.video_pipeline import KeyFrame
+
+            img = Image.new("RGB", (10, 10), (255, 0, 0))
+            buf = io.BytesIO()
+            img.save(buf, format="PNG")
+            frame_bytes = buf.getvalue()
+
+            mock_extract.return_value = [
+                KeyFrame(frame_bytes=frame_bytes, timestamp_s=0.0, source="fps"),
+                KeyFrame(frame_bytes=frame_bytes, timestamp_s=1.0, source="fps"),
+            ]
+
+            with patch(
+                "app.skills.analyze_captured_media.dedup_frames"
+            ) as mock_dedup:
+                mock_dedup.return_value = (
+                    [
+                        KeyFrame(frame_bytes=frame_bytes, timestamp_s=0.0, source="fps"),
+                        KeyFrame(frame_bytes=frame_bytes, timestamp_s=1.0, source="fps"),
+                    ],
+                    0.0,
+                )
+
+                result = asyncio.run(skill.run(_video_context()))
+
+                vision.analyze_multi.assert_called_once()
+                vision.analyze.assert_not_called()
+                assert result.output["doc_type"] == "report"
+
+    def test_video_no_frames_suggests_retake(self):
+        """Empty extraction → retake_suggested."""
+        from unittest.mock import patch, AsyncMock as AM
+
+        ocr = _ocr_provider()
+        vision = _vision_multi_provider()
+
+        skill = AnalyzeCapturedMedia(
+            _meta(), ocr=ocr, vision=vision, backend=_backend()
+        )
+        skill._download_media = AM(return_value=b"fake-video")
+
+        with patch(
+            "app.skills.analyze_captured_media.extract_keyframes"
+        ) as mock_extract:
+            mock_extract.return_value = []
+
+            result = asyncio.run(skill.run(_video_context()))
+
+            assert result.output["retake_suggested"] is True
+            assert result.output["ocr_confidence"] == 0.0

--- a/onboarding-intelligence-agent-svc/tests/test_analyze_captured_media.py
+++ b/onboarding-intelligence-agent-svc/tests/test_analyze_captured_media.py
@@ -336,9 +336,7 @@ class TestVideoPath:
         vision = _vision_multi_provider()
         backend = _backend()
 
-        skill = AnalyzeCapturedMedia(
-            _meta(), ocr=ocr, vision=vision, backend=backend
-        )
+        skill = AnalyzeCapturedMedia(_meta(), ocr=ocr, vision=vision, backend=backend)
         skill._download_media = AM(return_value=b"fake-video")
 
         with patch(
@@ -358,9 +356,7 @@ class TestVideoPath:
                 KeyFrame(frame_bytes=frame_bytes, timestamp_s=1.0, source="fps"),
             ]
 
-            with patch(
-                "app.skills.analyze_captured_media.dedup_frames"
-            ) as mock_dedup:
+            with patch("app.skills.analyze_captured_media.dedup_frames") as mock_dedup:
                 mock_dedup.return_value = (
                     [KeyFrame(frame_bytes=frame_bytes, timestamp_s=0.0, source="fps")],
                     0.5,
@@ -396,9 +392,7 @@ class TestVideoPath:
         vision = _vision_multi_provider()
         backend = _backend()
 
-        skill = AnalyzeCapturedMedia(
-            _meta(), ocr=ocr, vision=vision, backend=backend
-        )
+        skill = AnalyzeCapturedMedia(_meta(), ocr=ocr, vision=vision, backend=backend)
         skill._download_media = AM(return_value=b"fake-video")
 
         with patch(
@@ -417,9 +411,7 @@ class TestVideoPath:
                 KeyFrame(frame_bytes=frame_bytes, timestamp_s=0.0, source="fps"),
             ]
 
-            with patch(
-                "app.skills.analyze_captured_media.dedup_frames"
-            ) as mock_dedup:
+            with patch("app.skills.analyze_captured_media.dedup_frames") as mock_dedup:
                 mock_dedup.return_value = (
                     [KeyFrame(frame_bytes=frame_bytes, timestamp_s=0.0, source="fps")],
                     0.0,
@@ -437,9 +429,7 @@ class TestVideoPath:
         vision = _vision_multi_provider()
         backend = _backend()
 
-        skill = AnalyzeCapturedMedia(
-            _meta(), ocr=ocr, vision=vision, backend=backend
-        )
+        skill = AnalyzeCapturedMedia(_meta(), ocr=ocr, vision=vision, backend=backend)
         skill._download_media = AM(return_value=b"fake-video")
 
         with patch(
@@ -459,13 +449,15 @@ class TestVideoPath:
                 KeyFrame(frame_bytes=frame_bytes, timestamp_s=1.0, source="fps"),
             ]
 
-            with patch(
-                "app.skills.analyze_captured_media.dedup_frames"
-            ) as mock_dedup:
+            with patch("app.skills.analyze_captured_media.dedup_frames") as mock_dedup:
                 mock_dedup.return_value = (
                     [
-                        KeyFrame(frame_bytes=frame_bytes, timestamp_s=0.0, source="fps"),
-                        KeyFrame(frame_bytes=frame_bytes, timestamp_s=1.0, source="fps"),
+                        KeyFrame(
+                            frame_bytes=frame_bytes, timestamp_s=0.0, source="fps"
+                        ),
+                        KeyFrame(
+                            frame_bytes=frame_bytes, timestamp_s=1.0, source="fps"
+                        ),
                     ],
                     0.0,
                 )

--- a/onboarding-intelligence-agent-svc/tests/test_video_pipeline.py
+++ b/onboarding-intelligence-agent-svc/tests/test_video_pipeline.py
@@ -231,7 +231,8 @@ class TestMergeOcrTexts:
         ]
         merged, _ = merge_ocr_texts(results)
         lines_text = [
-            l.split("] ", 1)[1] if "] " in l else l for l in merged.split("\n")
+            line.split("] ", 1)[1] if "] " in line else line
+            for line in merged.split("\n")
         ]
         assert len(lines_text) == len(set(lines_text))
 

--- a/onboarding-intelligence-agent-svc/tests/test_video_pipeline.py
+++ b/onboarding-intelligence-agent-svc/tests/test_video_pipeline.py
@@ -1,0 +1,288 @@
+"""Tests for the video keyframe extraction, dedup and merge pipeline.
+
+H-04 AC-1: keyframes from fixed rate (1 fps) AND scene changes
+H-04 AC-2: near-duplicate frames collapsed; reduction ratio logged
+H-04 AC-3: merged text retains frame timestamps; no duplicate lines
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import shutil
+import subprocess
+
+import pytest
+from PIL import Image
+
+from app.logic.video_pipeline import (
+    FrameOCRResult,
+    KeyFrame,
+    dedup_frames,
+    extract_keyframes,
+    merge_ocr_texts,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _make_frame(
+    width: int = 100,
+    height: int = 100,
+    color: tuple[int, int, int] = (255, 0, 0),
+    pattern: str = "solid",
+) -> bytes:
+    """Create a PNG frame with a visually distinct pattern.
+
+    Patterns: solid, checkerboard, stripes, diagonal — each produces
+    a structurally different image that perceptual hashing can tell apart.
+    """
+    img = Image.new("RGB", (width, height), color)
+    pixels = img.load()
+    assert pixels is not None
+
+    if pattern == "checkerboard":
+        for y in range(height):
+            for x in range(width):
+                if (x // 10 + y // 10) % 2 == 0:
+                    pixels[x, y] = (0, 0, 0)
+    elif pattern == "stripes":
+        for y in range(height):
+            if (y // 10) % 2 == 0:
+                for x in range(width):
+                    pixels[x, y] = (0, 0, 0)
+    elif pattern == "diagonal":
+        for y in range(height):
+            for x in range(width):
+                if (x + y) % 20 < 10:
+                    pixels[x, y] = (0, 0, 0)
+
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _make_keyframe(
+    timestamp_s: float = 0.0,
+    source: str = "fps",
+    color: tuple[int, int, int] = (255, 0, 0),
+    pattern: str = "solid",
+) -> KeyFrame:
+    return KeyFrame(
+        frame_bytes=_make_frame(color=color, pattern=pattern),
+        timestamp_s=timestamp_s,
+        source=source,
+    )
+
+
+def _make_video(duration_s: float = 3.0, fps: int = 10) -> bytes:
+    """Create a minimal test video using ffmpeg."""
+    import tempfile
+    import os
+
+    if not shutil.which("ffmpeg"):
+        pytest.skip("ffmpeg not installed")
+
+    with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as tmp:
+        tmp_path = tmp.name
+
+    try:
+        result = subprocess.run(
+            [
+                "ffmpeg",
+                "-f", "lavfi",
+                "-i", f"color=c=red:s=64x64:d={duration_s}:r={fps}",
+                "-c:v", "libx264",
+                "-pix_fmt", "yuv420p",
+                "-t", str(duration_s),
+                "-y",
+                tmp_path,
+            ],
+            capture_output=True,
+        )
+        if result.returncode != 0:
+            pytest.skip(
+                f"ffmpeg video generation failed: "
+                f"{result.stderr.decode()[:200]}"
+            )
+        with open(tmp_path, "rb") as f:
+            return f.read()
+    finally:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+
+
+# ── extract_keyframes (AC-1) ───────────────────────────────────────
+
+
+class TestExtractKeyframes:
+    def test_extracts_frames_from_video(self) -> None:
+        video = _make_video(duration_s=3.0)
+        frames = asyncio.run(
+            extract_keyframes(video, fps=1.0, max_frames=30)
+        )
+        assert len(frames) >= 1
+        for f in frames:
+            assert f.frame_bytes
+            assert f.timestamp_s >= 0.0
+            assert f.source in ("fps", "scene")
+
+    def test_frame_cap_enforced(self) -> None:
+        video = _make_video(duration_s=5.0)
+        frames = asyncio.run(
+            extract_keyframes(video, fps=1.0, max_frames=3)
+        )
+        assert len(frames) <= 3
+
+    def test_empty_video_returns_empty(self) -> None:
+        frames = asyncio.run(
+            extract_keyframes(b"", fps=1.0, max_frames=30)
+        )
+        assert frames == []
+
+    def test_max_duration_respected(self) -> None:
+        video = _make_video(duration_s=5.0)
+        frames = asyncio.run(
+            extract_keyframes(video, fps=1.0, max_frames=30, max_duration_s=2)
+        )
+        for f in frames:
+            assert f.timestamp_s <= 3.0
+
+    def test_timestamps_are_sorted(self) -> None:
+        video = _make_video(duration_s=4.0)
+        frames = asyncio.run(
+            extract_keyframes(video, fps=1.0, max_frames=30)
+        )
+        timestamps = [f.timestamp_s for f in frames]
+        assert timestamps == sorted(timestamps)
+
+
+# ── dedup_frames (AC-2) ───────────────────────────────────────────
+
+
+class TestDedupFrames:
+    def test_identical_frames_collapsed(self) -> None:
+        frames = [
+            _make_keyframe(0.0, color=(255, 0, 0)),
+            _make_keyframe(1.0, color=(255, 0, 0)),
+            _make_keyframe(2.0, color=(255, 0, 0)),
+        ]
+        unique, ratio = dedup_frames(frames, threshold=8)
+        assert len(unique) == 1
+        assert ratio > 0.0
+
+    def test_different_frames_kept(self) -> None:
+        frames = [
+            _make_keyframe(0.0, pattern="solid"),
+            _make_keyframe(1.0, pattern="checkerboard"),
+            _make_keyframe(2.0, pattern="stripes"),
+        ]
+        unique, ratio = dedup_frames(frames, threshold=8)
+        assert len(unique) == 3
+        assert ratio == 0.0
+
+    def test_reduction_ratio_correct(self) -> None:
+        frames = [
+            _make_keyframe(0.0, pattern="solid"),
+            _make_keyframe(1.0, pattern="solid"),
+            _make_keyframe(2.0, pattern="checkerboard"),
+            _make_keyframe(3.0, pattern="checkerboard"),
+        ]
+        unique, ratio = dedup_frames(frames, threshold=8)
+        assert len(unique) == 2
+        assert abs(ratio - 0.5) < 0.01
+
+    def test_single_frame_returns_zero_ratio(self) -> None:
+        frames = [_make_keyframe(0.0)]
+        unique, ratio = dedup_frames(frames, threshold=8)
+        assert len(unique) == 1
+        assert ratio == 0.0
+
+    def test_empty_returns_empty(self) -> None:
+        unique, ratio = dedup_frames([], threshold=8)
+        assert unique == []
+        assert ratio == 0.0
+
+    def test_threshold_boundary(self) -> None:
+        f1 = _make_keyframe(0.0, pattern="solid")
+        f2 = _make_keyframe(1.0, pattern="diagonal")
+        unique_tight, _ = dedup_frames([f1, f2], threshold=1)
+        unique_loose, _ = dedup_frames([f1, f2], threshold=64)
+        assert len(unique_tight) >= len(unique_loose)
+
+
+# ── merge_ocr_texts (AC-3) ────────────────────────────────────────
+
+
+class TestMergeOcrTexts:
+    def test_prefixes_timestamps(self) -> None:
+        results = [
+            FrameOCRResult(
+                timestamp_s=5.0,
+                text="Hello world",
+                confidence=0.9,
+                frame_bytes=b"",
+            ),
+        ]
+        merged, _ = merge_ocr_texts(results)
+        assert merged.startswith("[00:05]")
+        assert "Hello world" in merged
+
+    def test_no_duplicate_lines(self) -> None:
+        results = [
+            FrameOCRResult(0.0, "Line one\nLine two", 0.9, b""),
+            FrameOCRResult(1.0, "Line two\nLine three", 0.8, b""),
+        ]
+        merged, _ = merge_ocr_texts(results)
+        lines_text = [l.split("] ", 1)[1] if "] " in l else l for l in merged.split("\n")]
+        assert len(lines_text) == len(set(lines_text))
+
+    def test_preserves_all_unique_lines(self) -> None:
+        results = [
+            FrameOCRResult(0.0, "Alpha\nBeta", 0.9, b""),
+            FrameOCRResult(1.0, "Gamma\nDelta", 0.8, b""),
+        ]
+        merged, _ = merge_ocr_texts(results)
+        assert "Alpha" in merged
+        assert "Beta" in merged
+        assert "Gamma" in merged
+        assert "Delta" in merged
+
+    def test_timestamp_format_mm_ss(self) -> None:
+        results = [
+            FrameOCRResult(65.0, "At one minute five", 0.9, b""),
+        ]
+        merged, _ = merge_ocr_texts(results)
+        assert "[01:05]" in merged
+
+    def test_confidence_averaged(self) -> None:
+        results = [
+            FrameOCRResult(0.0, "A", 0.8, b""),
+            FrameOCRResult(1.0, "B", 0.6, b""),
+        ]
+        _, avg = merge_ocr_texts(results)
+        assert abs(avg - 0.7) < 0.01
+
+    def test_empty_text_frames_excluded(self) -> None:
+        results = [
+            FrameOCRResult(0.0, "", 0.5, b""),
+            FrameOCRResult(1.0, "Real text", 0.9, b""),
+        ]
+        merged, avg = merge_ocr_texts(results)
+        assert "Real text" in merged
+        assert avg == 0.9
+
+    def test_empty_results_returns_empty(self) -> None:
+        merged, avg = merge_ocr_texts([])
+        assert merged == ""
+        assert avg == 0.0
+
+    def test_sorted_by_timestamp(self) -> None:
+        results = [
+            FrameOCRResult(2.0, "Second", 0.9, b""),
+            FrameOCRResult(0.0, "First", 0.8, b""),
+        ]
+        merged, _ = merge_ocr_texts(results)
+        lines = merged.split("\n")
+        assert "First" in lines[0]
+        assert "Second" in lines[1]

--- a/onboarding-intelligence-agent-svc/tests/test_video_pipeline.py
+++ b/onboarding-intelligence-agent-svc/tests/test_video_pipeline.py
@@ -90,11 +90,16 @@ def _make_video(duration_s: float = 3.0, fps: int = 10) -> bytes:
         result = subprocess.run(
             [
                 "ffmpeg",
-                "-f", "lavfi",
-                "-i", f"color=c=red:s=64x64:d={duration_s}:r={fps}",
-                "-c:v", "libx264",
-                "-pix_fmt", "yuv420p",
-                "-t", str(duration_s),
+                "-f",
+                "lavfi",
+                "-i",
+                f"color=c=red:s=64x64:d={duration_s}:r={fps}",
+                "-c:v",
+                "libx264",
+                "-pix_fmt",
+                "yuv420p",
+                "-t",
+                str(duration_s),
                 "-y",
                 tmp_path,
             ],
@@ -102,8 +107,7 @@ def _make_video(duration_s: float = 3.0, fps: int = 10) -> bytes:
         )
         if result.returncode != 0:
             pytest.skip(
-                f"ffmpeg video generation failed: "
-                f"{result.stderr.decode()[:200]}"
+                f"ffmpeg video generation failed: " f"{result.stderr.decode()[:200]}"
             )
         with open(tmp_path, "rb") as f:
             return f.read()
@@ -118,9 +122,7 @@ def _make_video(duration_s: float = 3.0, fps: int = 10) -> bytes:
 class TestExtractKeyframes:
     def test_extracts_frames_from_video(self) -> None:
         video = _make_video(duration_s=3.0)
-        frames = asyncio.run(
-            extract_keyframes(video, fps=1.0, max_frames=30)
-        )
+        frames = asyncio.run(extract_keyframes(video, fps=1.0, max_frames=30))
         assert len(frames) >= 1
         for f in frames:
             assert f.frame_bytes
@@ -129,15 +131,11 @@ class TestExtractKeyframes:
 
     def test_frame_cap_enforced(self) -> None:
         video = _make_video(duration_s=5.0)
-        frames = asyncio.run(
-            extract_keyframes(video, fps=1.0, max_frames=3)
-        )
+        frames = asyncio.run(extract_keyframes(video, fps=1.0, max_frames=3))
         assert len(frames) <= 3
 
     def test_empty_video_returns_empty(self) -> None:
-        frames = asyncio.run(
-            extract_keyframes(b"", fps=1.0, max_frames=30)
-        )
+        frames = asyncio.run(extract_keyframes(b"", fps=1.0, max_frames=30))
         assert frames == []
 
     def test_max_duration_respected(self) -> None:
@@ -150,9 +148,7 @@ class TestExtractKeyframes:
 
     def test_timestamps_are_sorted(self) -> None:
         video = _make_video(duration_s=4.0)
-        frames = asyncio.run(
-            extract_keyframes(video, fps=1.0, max_frames=30)
-        )
+        frames = asyncio.run(extract_keyframes(video, fps=1.0, max_frames=30))
         timestamps = [f.timestamp_s for f in frames]
         assert timestamps == sorted(timestamps)
 
@@ -234,7 +230,9 @@ class TestMergeOcrTexts:
             FrameOCRResult(1.0, "Line two\nLine three", 0.8, b""),
         ]
         merged, _ = merge_ocr_texts(results)
-        lines_text = [l.split("] ", 1)[1] if "] " in l else l for l in merged.split("\n")]
+        lines_text = [
+            l.split("] ", 1)[1] if "] " in l else l for l in merged.split("\n")
+        ]
         assert len(lines_text) == len(set(lines_text))
 
     def test_preserves_all_unique_lines(self) -> None:

--- a/onboarding-intelligence-agent-svc/tests/test_vision_provider.py
+++ b/onboarding-intelligence-agent-svc/tests/test_vision_provider.py
@@ -176,20 +176,23 @@ class TestAnalyzeMulti:
         assert result.doc_type == "contract"
         assert result.caption == "Multi-page contract"
         call_args = client.generate_content.call_args
-        contents = call_args.kwargs.get("contents", call_args.args[0] if call_args.args else [])
+        contents = call_args.kwargs.get(
+            "contents", call_args.args[0] if call_args.args else []
+        )
         assert len(contents) == 4  # 3 frames + 1 prompt
 
     def test_multi_frame_caps_at_max(self):
         b = breaker()
         client = _fake_client(
-            '{"caption": "doc", "doc_type": "other", '
-            '"sensitivity_class": "GENERAL"}'
+            '{"caption": "doc", "doc_type": "other", ' '"sensitivity_class": "GENERAL"}'
         )
         provider = VisionProvider("key", breaker=b, client=client)
         frames = [b"f1", b"f2", b"f3", b"f4", b"f5", b"f6"]
         asyncio.run(provider.analyze_multi(frames, "text"))
         call_args = client.generate_content.call_args
-        contents = call_args.kwargs.get("contents", call_args.args[0] if call_args.args else [])
+        contents = call_args.kwargs.get(
+            "contents", call_args.args[0] if call_args.args else []
+        )
         assert len(contents) == 5  # MAX_MULTI_FRAMES (4) + 1 prompt
 
     def test_multi_frame_no_key_raises(self):

--- a/onboarding-intelligence-agent-svc/tests/test_vision_provider.py
+++ b/onboarding-intelligence-agent-svc/tests/test_vision_provider.py
@@ -1,8 +1,9 @@
-"""H-03 · Gemini multimodal vision provider.
+"""H-03 / H-04 · Gemini multimodal vision provider.
 
 Tests the provider's response parsing, breaker discipline, and input
 validation. The real Gemini call needs an API key, so we inject a test
-double through the ``client`` parameter.
+double through the ``client`` parameter. H-04 adds ``analyze_multi``
+for multi-frame video snippets.
 """
 
 from __future__ import annotations
@@ -158,3 +159,57 @@ class TestVisionResultShape:
                 f'"sensitivity_class": "{sc}"}}'
             )
             assert result.sensitivity_class == sc
+
+
+class TestAnalyzeMulti:
+    """H-04 AC-4: Gemini receives merged text + best frames."""
+
+    def test_multi_frame_sends_all_frames(self):
+        b = breaker()
+        client = _fake_client(
+            '{"caption": "Multi-page contract", "doc_type": "contract", '
+            '"sensitivity_class": "GENERAL"}'
+        )
+        provider = VisionProvider("key", breaker=b, client=client)
+        frames = [b"frame1", b"frame2", b"frame3"]
+        result = asyncio.run(provider.analyze_multi(frames, "merged text"))
+        assert result.doc_type == "contract"
+        assert result.caption == "Multi-page contract"
+        call_args = client.generate_content.call_args
+        contents = call_args.kwargs.get("contents", call_args.args[0] if call_args.args else [])
+        assert len(contents) == 4  # 3 frames + 1 prompt
+
+    def test_multi_frame_caps_at_max(self):
+        b = breaker()
+        client = _fake_client(
+            '{"caption": "doc", "doc_type": "other", '
+            '"sensitivity_class": "GENERAL"}'
+        )
+        provider = VisionProvider("key", breaker=b, client=client)
+        frames = [b"f1", b"f2", b"f3", b"f4", b"f5", b"f6"]
+        asyncio.run(provider.analyze_multi(frames, "text"))
+        call_args = client.generate_content.call_args
+        contents = call_args.kwargs.get("contents", call_args.args[0] if call_args.args else [])
+        assert len(contents) == 5  # MAX_MULTI_FRAMES (4) + 1 prompt
+
+    def test_multi_frame_no_key_raises(self):
+        b = breaker()
+        provider = VisionProvider("", breaker=b)
+        with pytest.raises(VisionUnavailable, match="no Gemini API key"):
+            asyncio.run(provider.analyze_multi([b"f1"], "text"))
+
+    def test_multi_frame_open_breaker_raises(self):
+        b = breaker(failure_threshold=1)
+        b.record_failure()
+        provider = VisionProvider("key", breaker=b)
+        with pytest.raises(VisionUnavailable):
+            asyncio.run(provider.analyze_multi([b"f1"], "text"))
+
+    def test_multi_frame_failure_records_on_breaker(self):
+        b = breaker(failure_threshold=2)
+        client = AsyncMock()
+        client.generate_content.side_effect = RuntimeError("boom")
+        provider = VisionProvider("key", breaker=b, client=client)
+        with pytest.raises(VisionUnavailable):
+            asyncio.run(provider.analyze_multi([b"f1"], "text"))
+        assert len(b._failures) == 1


### PR DESCRIPTION
## Summary

- **Keyframe extraction** (AC-1): ffmpeg at 1 fps + scene-change detection, merged and capped at `VIDEO_MAX_FRAMES` (30). Scene-change frames prioritised when cap is hit.
- **Perceptual hash dedup** (AC-2): `imagehash.average_hash` collapses near-duplicate frames before OCR spend. Reduction ratio logged. Threshold configurable via `OIA_VIDEO_DEDUP_THRESHOLD`.
- **Merged text with timestamps** (AC-3): Per-frame OCR results deduplicated by line content, prefixed with `[MM:SS]` of first occurrence. No duplicate lines in output.
- **Multi-frame Gemini semantic pass** (AC-4): `VisionProvider.analyze_multi()` sends up to 4 best frames + merged OCR text → single `{caption, doc_type, sensitivity_class}`.
- **Backward compatible**: `CaptureMediaFrame.mime_type` defaults to `"image/jpeg"`; existing image path unchanged. Video path activates on `video/*` mime types.

## Changes

| File | What |
|------|------|
| `Dockerfile` | Added `ffmpeg` to apt-get install |
| `requirements.txt` | Added `ffmpeg-python>=0.2.0`, `imagehash>=4.3.0` |
| `app/core/config.py` | `VIDEO_MAX_FRAMES`, `VIDEO_FPS`, `VIDEO_DEDUP_THRESHOLD`, `VIDEO_MAX_DURATION_S` |
| `app/logic/video_pipeline.py` | **NEW** — `extract_keyframes()`, `dedup_frames()`, `merge_ocr_texts()` |
| `app/providers/vision.py` | `analyze_multi()` method, `MULTI_FRAME_PROMPT`, `MAX_MULTI_FRAMES` |
| `app/skills/analyze_captured_media.py` | Video/image branching, `_run_video_pipeline()`, rename `_download_image` → `_download_media` |
| `app/api/schemas.py` | `mime_type` field on `CaptureMediaFrame` |
| `app/api/ws.py` | Pass `mime_type` through to `input_context` |
| `config/skills.yaml` | Updated SKL-OIA-07 description |

## Test plan

- [x] 19 unit tests for video pipeline (keyframe extraction, dedup, merge) — `tests/test_video_pipeline.py`
- [x] 5 unit tests for `analyze_multi` — `tests/test_vision_provider.py::TestAnalyzeMulti`
- [x] 5 unit tests for video skill path — `tests/test_analyze_captured_media.py::TestVideoPath`
- [x] 4 Hypothesis property tests — `tests/property/test_video_invariants.py`
- [x] All 57 H-04 tests pass
- [x] Pre-existing tests unaffected (7 `test_redact_pii.py` failures are pre-existing, require `en_core_web_sm`)
- [x] `black` and `mypy` clean (one pre-existing mypy note in `redact_pii.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)