### PR TITLE
feat(onboarding): player and recording summary with key moments (I-02)

### DIFF
--- a/ai-brand-automator-frontend/src/components/onboarding/RecordingPlayer.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/RecordingPlayer.tsx
@@ -1,0 +1,240 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ArrowLeft, Clock, FileText, Loader2, Pause, Play, X } from 'lucide-react';
+
+import {
+  getRecordingDetail,
+  type RecordingDetail,
+  type KeyMoment,
+} from '@/lib/onboarding-sessions';
+
+function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+export interface RecordingPlayerProps {
+  recordingId: string;
+  onClose: () => void;
+}
+
+export default function RecordingPlayer({
+  recordingId,
+  onClose,
+}: RecordingPlayerProps) {
+  const [detail, setDetail] = useState<RecordingDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    getRecordingDetail(recordingId)
+      .then((data) => {
+        if (!cancelled) setDetail(data);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [recordingId]);
+
+  const togglePlay = useCallback(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    if (audio.paused) {
+      void audio.play();
+    } else {
+      audio.pause();
+    }
+  }, []);
+
+  const seekTo = useCallback((t: number) => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    audio.currentTime = t;
+    void audio.play();
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      const audio = audioRef.current;
+      if (!audio) return;
+      if (e.key === ' ') {
+        e.preventDefault();
+        togglePlay();
+      } else if (e.key === 'ArrowLeft') {
+        e.preventDefault();
+        audio.currentTime = Math.max(0, audio.currentTime - 5);
+      } else if (e.key === 'ArrowRight') {
+        e.preventDefault();
+        audio.currentTime = Math.min(audio.duration || 0, audio.currentTime + 5);
+      }
+    },
+    [togglePlay],
+  );
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="h-5 w-5 animate-spin text-brand-silver" />
+      </div>
+    );
+  }
+
+  if (error || !detail) {
+    return (
+      <div className="space-y-2">
+        <button
+          type="button"
+          onClick={onClose}
+          className="flex items-center gap-1 text-sm text-brand-silver hover:text-white"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          Back
+        </button>
+        <p className="text-sm text-red-400">{error || 'Recording not found'}</p>
+      </div>
+    );
+  }
+
+  const summary = detail.summary;
+
+  return (
+    <div
+      className="space-y-4"
+      onKeyDown={handleKeyDown}
+      tabIndex={0}
+      role="region"
+      aria-label="Recording player"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <button
+          type="button"
+          onClick={onClose}
+          className="flex items-center gap-1 text-sm text-brand-silver hover:text-white"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          Recording
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close player"
+          className="rounded p-1 text-brand-silver hover:text-white"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      {/* Audio player */}
+      {detail.playback_url && (
+        <div className="rounded-lg border border-white/10 p-3">
+          <audio
+            ref={audioRef}
+            src={detail.playback_url}
+            preload="metadata"
+            onTimeUpdate={() =>
+              setCurrentTime(audioRef.current?.currentTime ?? 0)
+            }
+            onLoadedMetadata={() =>
+              setDuration(audioRef.current?.duration ?? 0)
+            }
+            onPlay={() => setIsPlaying(true)}
+            onPause={() => setIsPlaying(false)}
+            onEnded={() => setIsPlaying(false)}
+          />
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={togglePlay}
+              aria-label={isPlaying ? 'Pause' : 'Play'}
+              className="rounded-full bg-brand-electric p-2 text-white hover:bg-brand-electric/80"
+            >
+              {isPlaying ? (
+                <Pause className="h-4 w-4" />
+              ) : (
+                <Play className="h-4 w-4" />
+              )}
+            </button>
+            <input
+              type="range"
+              min={0}
+              max={duration || 0}
+              step={0.1}
+              value={currentTime}
+              onChange={(e) => {
+                const t = parseFloat(e.target.value);
+                if (audioRef.current) audioRef.current.currentTime = t;
+                setCurrentTime(t);
+              }}
+              className="h-1.5 flex-1 cursor-pointer appearance-none rounded-full bg-white/20 accent-brand-electric"
+              aria-label="Seek"
+            />
+            <span className="shrink-0 text-xs tabular-nums text-brand-silver">
+              {formatTime(currentTime)} / {formatTime(duration)}
+            </span>
+          </div>
+        </div>
+      )}
+
+      {/* Summary */}
+      {summary && (
+        <div className="space-y-3">
+          <h3 className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wider text-brand-silver">
+            <FileText className="h-3.5 w-3.5" />
+            Summary
+          </h3>
+          <div className="text-sm leading-relaxed text-white/90">
+            {summary.text.split('\n\n').map((paragraph, i) => (
+              <p key={i} className={i > 0 ? 'mt-2' : ''}>
+                {paragraph}
+              </p>
+            ))}
+          </div>
+
+          {/* Key moments */}
+          {summary.key_moments.length > 0 && (
+            <div>
+              <h4 className="mb-2 flex items-center gap-1.5 text-xs font-medium uppercase tracking-wider text-brand-silver">
+                <Clock className="h-3.5 w-3.5" />
+                Key Moments
+              </h4>
+              <div className="flex flex-wrap gap-1.5">
+                {summary.key_moments.map((km: KeyMoment, i: number) => (
+                  <button
+                    key={i}
+                    type="button"
+                    onClick={() => seekTo(km.t)}
+                    className="inline-flex items-center gap-1.5 rounded-full border border-brand-electric/30 bg-brand-electric/10 px-2.5 py-1 text-xs text-brand-electric transition-colors hover:bg-brand-electric/20"
+                  >
+                    <span className="tabular-nums text-brand-electric/70">
+                      {formatTime(km.t)}
+                    </span>
+                    {km.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {!summary && !detail.playback_url && (
+        <p className="text-sm text-brand-silver">
+          No summary or playback available yet.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/ai-brand-automator-frontend/src/components/onboarding/RecordingsLibrary.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/RecordingsLibrary.tsx
@@ -20,6 +20,7 @@ import {
   type CapturedMedia,
   type RecordingItem,
 } from '@/lib/onboarding-sessions';
+import RecordingPlayer from '@/components/onboarding/RecordingPlayer';
 
 // ── Status rendering ──
 
@@ -96,6 +97,7 @@ export default function RecordingsLibrary({
   canDelete,
   onDeleted,
 }: RecordingsLibraryProps) {
+  const [selectedRecordingId, setSelectedRecordingId] = useState<string | null>(null);
   const [playingId, setPlayingId] = useState<string | null>(null);
   const [playbackUrl, setPlaybackUrl] = useState<string | null>(null);
   const [loadingPlay, setLoadingPlay] = useState(false);
@@ -137,6 +139,15 @@ export default function RecordingsLibrary({
 
   const hasItems = recordings.length > 0 || captures.length > 0;
 
+  if (selectedRecordingId) {
+    return (
+      <RecordingPlayer
+        recordingId={selectedRecordingId}
+        onClose={() => setSelectedRecordingId(null)}
+      />
+    );
+  }
+
   if (!hasItems) {
     return (
       <p className="text-sm text-brand-silver">
@@ -161,7 +172,8 @@ export default function RecordingsLibrary({
               return (
                 <li
                   key={r.id}
-                  className="rounded border border-white/10 px-3 py-2"
+                  className={`rounded border border-white/10 px-3 py-2${r.has_summary ? ' cursor-pointer hover:border-brand-electric/30' : ''}`}
+                  onClick={r.has_summary ? () => setSelectedRecordingId(r.id) : undefined}
                 >
                   <div className="flex items-center gap-2 text-sm">
                     <Mic

--- a/ai-brand-automator-frontend/src/components/onboarding/__tests__/RecordingPlayer.test.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/__tests__/RecordingPlayer.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * I-02 · RecordingPlayer with key-moment seeking.
+ *
+ * Tests summary rendering, key moment chips, and audio controls.
+ */
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+import RecordingPlayer from '@/components/onboarding/RecordingPlayer';
+import type { RecordingDetail } from '@/lib/onboarding-sessions';
+
+function detail(overrides: Partial<RecordingDetail> = {}): RecordingDetail {
+  return {
+    id: 'rec-1',
+    session: 'sess-1',
+    modality: 'AUDIO',
+    status: 'SUMMARIZED',
+    duration_s: 120,
+    audio_asset: 'asset-1',
+    has_transcript: false,
+    has_summary: true,
+    started_at: '2026-08-15T10:00:00Z',
+    stopped_at: '2026-08-15T10:02:00Z',
+    summary: {
+      text: 'The meeting covered brand positioning.\n\nKey decisions were made about target audience.',
+      key_moments: [
+        { t: 5.0, label: 'introduction' },
+        { t: 45.0, label: 'brand vision' },
+        { t: 90.0, label: 'budget discussion' },
+      ],
+    },
+    playback_url: 'https://storage.example.com/audio.webm',
+    ...overrides,
+  };
+}
+
+jest.mock('@/lib/onboarding-sessions', () => ({
+  getRecordingDetail: jest.fn(),
+}));
+
+const mockGetDetail = jest.requireMock('@/lib/onboarding-sessions')
+  .getRecordingDetail as jest.Mock;
+
+beforeEach(() => {
+  mockGetDetail.mockReset();
+});
+
+it('shows loading state initially', () => {
+  mockGetDetail.mockReturnValue(new Promise(() => {}));
+  render(<RecordingPlayer recordingId="rec-1" onClose={jest.fn()} />);
+  expect(document.querySelector('.animate-spin')).toBeTruthy();
+});
+
+it('renders summary text after loading', async () => {
+  mockGetDetail.mockResolvedValue(detail());
+  render(<RecordingPlayer recordingId="rec-1" onClose={jest.fn()} />);
+  await waitFor(() => {
+    expect(screen.getByText(/brand positioning/)).toBeInTheDocument();
+    expect(screen.getByText(/target audience/)).toBeInTheDocument();
+  });
+});
+
+it('renders key moment chips', async () => {
+  mockGetDetail.mockResolvedValue(detail());
+  render(<RecordingPlayer recordingId="rec-1" onClose={jest.fn()} />);
+  await waitFor(() => {
+    expect(screen.getByText('introduction')).toBeInTheDocument();
+    expect(screen.getByText('brand vision')).toBeInTheDocument();
+    expect(screen.getByText('budget discussion')).toBeInTheDocument();
+  });
+});
+
+it('renders formatted timestamps on key moment chips', async () => {
+  mockGetDetail.mockResolvedValue(detail());
+  render(<RecordingPlayer recordingId="rec-1" onClose={jest.fn()} />);
+  await waitFor(() => {
+    expect(screen.getByText('0:05')).toBeInTheDocument();
+    expect(screen.getByText('0:45')).toBeInTheDocument();
+    expect(screen.getByText('1:30')).toBeInTheDocument();
+  });
+});
+
+it('calls onClose when back button is clicked', async () => {
+  mockGetDetail.mockResolvedValue(detail());
+  const onClose = jest.fn();
+  render(<RecordingPlayer recordingId="rec-1" onClose={onClose} />);
+  await waitFor(() => screen.getByText('Recording'));
+  fireEvent.click(screen.getByText('Recording'));
+  expect(onClose).toHaveBeenCalled();
+});
+
+it('calls onClose when X button is clicked', async () => {
+  mockGetDetail.mockResolvedValue(detail());
+  const onClose = jest.fn();
+  render(<RecordingPlayer recordingId="rec-1" onClose={onClose} />);
+  await waitFor(() => screen.getByLabelText('Close player'));
+  fireEvent.click(screen.getByLabelText('Close player'));
+  expect(onClose).toHaveBeenCalled();
+});
+
+it('shows error state when fetch fails', async () => {
+  mockGetDetail.mockRejectedValue(new Error('Network error'));
+  render(<RecordingPlayer recordingId="rec-1" onClose={jest.fn()} />);
+  await waitFor(() => {
+    expect(screen.getByText('Network error')).toBeInTheDocument();
+  });
+});
+
+it('renders play button when playback url exists', async () => {
+  mockGetDetail.mockResolvedValue(detail());
+  render(<RecordingPlayer recordingId="rec-1" onClose={jest.fn()} />);
+  await waitFor(() => {
+    expect(screen.getByLabelText('Play')).toBeInTheDocument();
+  });
+});
+
+it('handles recording without summary', async () => {
+  mockGetDetail.mockResolvedValue(detail({ summary: null, playback_url: undefined }));
+  render(<RecordingPlayer recordingId="rec-1" onClose={jest.fn()} />);
+  await waitFor(() => {
+    expect(screen.getByText(/No summary or playback/)).toBeInTheDocument();
+  });
+});

--- a/ai-brand-automator-frontend/src/lib/onboarding-sessions.ts
+++ b/ai-brand-automator-frontend/src/lib/onboarding-sessions.ts
@@ -138,6 +138,24 @@ export interface RecordingItem {
   stopped_at: string | null;
 }
 
+/** A clickable timestamp in a recording summary (I-02). */
+export interface KeyMoment {
+  t: number;
+  label: string;
+}
+
+/** The LLM-generated summary for a recording (I-02). */
+export interface RecordingSummary {
+  text: string;
+  key_moments: KeyMoment[];
+}
+
+/** Detail view of a single recording, including summary blob (I-02). */
+export interface RecordingDetail extends RecordingItem {
+  summary: RecordingSummary | null;
+  playback_url?: string;
+}
+
 /**
  * Paths are relative to `/api/v1`, which `env.getApiUrl()` already prepends.
  *
@@ -492,6 +510,27 @@ export async function getRecordingPlaybackUrl(
   }
   const data = await response.json();
   return data.playback_url ?? null;
+}
+
+/** Fetch a single recording with its summary and signed playback URL (I-02). */
+export async function getRecordingDetail(
+  recordingId: string,
+): Promise<RecordingDetail> {
+  const response = await apiClient.get(
+    `${BASE}/recordings/${recordingId}/?include=signed_urls`,
+  );
+  if (!response.ok) {
+    throw new Error(`API ${response.status}: ${await response.text()}`);
+  }
+  const data = (await response.json()) as RecordingDetail;
+  if (
+    data.summary &&
+    typeof data.summary === 'object' &&
+    Object.keys(data.summary).length === 0
+  ) {
+    data.summary = null;
+  }
+  return data;
 }
 
 /** Delete a recording (Admin+ only, §15). */

--- a/ai-brand-automator/apps/onboarding/serializers.py
+++ b/ai-brand-automator/apps/onboarding/serializers.py
@@ -318,6 +318,20 @@ class MeetingRecordingSerializer(serializers.ModelSerializer):
         return bool(obj.transcript_gcs_path)
 
 
+class MeetingRecordingDetailSerializer(MeetingRecordingSerializer):
+    """Single-recording detail (I-02).
+
+    Adds the summary blob that the list serializer deliberately omits.
+    Used by retrieve when the caller needs the full payload.
+    """
+
+    summary = serializers.JSONField(read_only=True)
+
+    class Meta(MeetingRecordingSerializer.Meta):
+        fields = MeetingRecordingSerializer.Meta.fields + ["summary"]
+        read_only_fields = fields
+
+
 class RecordingStopSerializer(serializers.Serializer):
     """The body of ``POST /recordings/{id}/stop/``.
 

--- a/ai-brand-automator/apps/onboarding/tasks.py
+++ b/ai-brand-automator/apps/onboarding/tasks.py
@@ -1,0 +1,63 @@
+"""Celery tasks for onboarding session recordings (I-02)."""
+
+import logging
+
+import requests
+from celery import shared_task
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+
+@shared_task(bind=True, max_retries=3, default_retry_delay=30)
+def trigger_recording_summary(
+    self, *, tenant_id, recording_id, session_id, started_at, stopped_at
+):
+    """Ask the OIA service to summarise a recording.
+
+    Fire-and-forget from the stop action. Retries on 5xx / connection errors;
+    4xx is non-retryable (bad payload, not a transient failure).
+    """
+    url = f"{settings.OIA_SERVICE_URL.rstrip('/')}/v1/execute/skill"
+    payload = {
+        "skill_id": "SKL-OIA-08",
+        "tenant_context": {
+            "tenant_id": str(tenant_id),
+            "user_id": "system",
+            "role": "ADMIN",
+            "trace_id": f"celery:{self.request.id or 'unknown'}",
+        },
+        "input_context": {
+            "recording_id": str(recording_id),
+            "session_id": str(session_id),
+            "started_at": started_at,
+            "stopped_at": stopped_at,
+        },
+    }
+    headers = {"X-Service-Token": settings.OIA_SERVICE_TOKEN}
+
+    try:
+        resp = requests.post(url, json=payload, headers=headers, timeout=(5, 120))
+    except requests.ConnectionError as exc:
+        logger.warning("OIA unreachable for recording %s: %s", recording_id, exc)
+        raise self.retry(exc=exc)
+    except requests.Timeout as exc:
+        logger.warning("OIA timed out for recording %s: %s", recording_id, exc)
+        raise self.retry(exc=exc)
+
+    if resp.status_code >= 500:
+        logger.warning(
+            "OIA returned %s for recording %s", resp.status_code, recording_id
+        )
+        raise self.retry(exc=Exception(f"OIA {resp.status_code}"))
+
+    if resp.status_code >= 400:
+        logger.error(
+            "OIA rejected recording %s with %s: %s",
+            recording_id,
+            resp.status_code,
+            resp.text[:500],
+        )
+        return
+
+    logger.info("Summary triggered for recording %s", recording_id)

--- a/ai-brand-automator/apps/onboarding/tasks.py
+++ b/ai-brand-automator/apps/onboarding/tasks.py
@@ -60,4 +60,19 @@ def trigger_recording_summary(
         )
         return
 
+    try:
+        body = resp.json()
+    except ValueError:
+        body = {}
+
+    if body.get("status") == "FAILED":
+        output = body.get("output", {})
+        detail = output.get("error", "unknown") if isinstance(output, dict) else ""
+        logger.error(
+            "OIA skill failed for recording %s: %s",
+            recording_id,
+            str(detail)[:500],
+        )
+        raise self.retry(exc=Exception("OIA skill returned FAILED"))
+
     logger.info("Summary triggered for recording %s", recording_id)

--- a/ai-brand-automator/apps/onboarding/urls.py
+++ b/ai-brand-automator/apps/onboarding/urls.py
@@ -20,6 +20,7 @@ from apps.onboarding.views import (
     create_questionnaire,
     field_vocabulary,
     live_precheck,
+    update_recording_summary,
     upsert_research_brief,
 )
 
@@ -61,6 +62,12 @@ urlpatterns = [
         "sessions/<pk>/live-precheck/",
         live_precheck,
         name="onboarding-live-precheck",
+    ),
+    # I-02: OIA writes summary results back via X-Service-Token auth.
+    path(
+        "internal/recordings/<pk>/summary/",
+        update_recording_summary,
+        name="onboarding-recording-summary-update",
     ),
     path("", include(router.urls)),
 ]

--- a/ai-brand-automator/apps/onboarding/views.py
+++ b/ai-brand-automator/apps/onboarding/views.py
@@ -83,6 +83,7 @@ from apps.onboarding.serializers import (
     ConsentRecordSerializer,
     FieldProvenanceSerializer,
     MediaCaptureSerializer,
+    MeetingRecordingDetailSerializer,
     MeetingRecordingSerializer,
     OnboardingSessionSerializer,
     ProvenanceEditSerializer,
@@ -661,6 +662,11 @@ class MeetingRecordingViewSet(
         "destroy": [IsAuthenticated, IsTenantAdmin],
     }
 
+    def get_serializer_class(self):
+        if self.action == "retrieve":
+            return MeetingRecordingDetailSerializer
+        return MeetingRecordingSerializer
+
     def get_queryset(self):
         tenant = getattr(self.request, "tenant", None)
         return MeetingRecording.objects.select_related("session").filter(
@@ -795,6 +801,18 @@ class MeetingRecordingViewSet(
             fields.append("audio_asset")
 
         recording.save(update_fields=fields)
+
+        # I-02: trigger async summary generation via the OIA service.
+        from apps.onboarding.tasks import trigger_recording_summary
+
+        trigger_recording_summary.delay(
+            tenant_id=str(recording.tenant_id),
+            recording_id=str(recording.pk),
+            session_id=str(recording.session_id),
+            started_at=recording.started_at.timestamp(),
+            stopped_at=recording.stopped_at.timestamp(),
+        )
+
         return Response(MeetingRecordingSerializer(recording).data)
 
     def _register_asset(self, recording, request):
@@ -2069,3 +2087,61 @@ class ScheduledMeetingViewSet(
             meeting.save(update_fields=["status", "updated_at"])
 
         return Response(ScheduledMeetingSerializer(meeting).data)
+
+
+# ── Internal service-to-service endpoint (I-02) ─────────────────────
+
+
+@api_view(["PATCH"])
+@permission_classes([AllowAny])
+def update_recording_summary(request, pk):
+    """``PATCH /api/v1/onboarding/internal/recordings/<pk>/summary/``
+
+    OIA writes the generated summary back to MeetingRecording and transitions
+    status to SUMMARIZED. X-Service-Token auth (same pattern as
+    upsert_research_brief).
+    """
+    token = request.META.get("HTTP_X_SERVICE_TOKEN", "")
+    expected = getattr(settings, "OIA_SERVICE_TOKEN", "") or decouple_config(
+        "OIA_SERVICE_TOKEN", default=""
+    )
+    if not expected or not hmac.compare_digest(token, expected):
+        return Response(
+            {"error": "Invalid or missing X-Service-Token"},
+            status=http.HTTP_403_FORBIDDEN,
+        )
+
+    tenant, error = _service_tenant(request)
+    if error is not None:
+        return error
+
+    summary = request.data.get("summary")
+    if not isinstance(summary, dict):
+        return Response(
+            {"error": "summary object is required"},
+            status=http.HTTP_400_BAD_REQUEST,
+        )
+
+    with db_transaction.atomic():
+        recording = (
+            MeetingRecording.objects.filter(pk=pk, tenant=tenant)
+            .select_for_update(of=("self",))
+            .first()
+        )
+        if recording is None:
+            return Response(
+                {"error": "Recording not found"},
+                status=http.HTTP_404_NOT_FOUND,
+            )
+
+        recording.summary = summary
+        recording.status = RecordingStatus.SUMMARIZED
+        recording.save(update_fields=["summary", "status", "updated_at"])
+
+    return Response(
+        {
+            "recording_id": recording.pk,
+            "status": recording.status,
+        },
+        status=http.HTTP_200_OK,
+    )

--- a/ai-brand-automator/apps/onboarding/views.py
+++ b/ai-brand-automator/apps/onboarding/views.py
@@ -805,12 +805,13 @@ class MeetingRecordingViewSet(
         # I-02: trigger async summary generation via the OIA service.
         from apps.onboarding.tasks import trigger_recording_summary
 
+        duration = (recording.stopped_at - recording.started_at).total_seconds()
         trigger_recording_summary.delay(
             tenant_id=str(recording.tenant_id),
             recording_id=str(recording.pk),
             session_id=str(recording.session_id),
-            started_at=recording.started_at.timestamp(),
-            stopped_at=recording.stopped_at.timestamp(),
+            started_at=0.0,
+            stopped_at=duration,
         )
 
         return Response(MeetingRecordingSerializer(recording).data)
@@ -2132,6 +2133,12 @@ def update_recording_summary(request, pk):
             return Response(
                 {"error": "Recording not found"},
                 status=http.HTTP_404_NOT_FOUND,
+            )
+
+        if recording.status == RecordingStatus.FAILED:
+            return Response(
+                {"error": "Cannot summarise a failed recording"},
+                status=http.HTTP_409_CONFLICT,
             )
 
         recording.summary = summary

--- a/onboarding-intelligence-agent-svc/app/api/routes.py
+++ b/onboarding-intelligence-agent-svc/app/api/routes.py
@@ -18,11 +18,12 @@ from app.api.schemas import (
     ExecuteRequest,
     ExecuteResponse,
     GuardrailReport,
+    SkillExecuteRequest,
     UsageReport,
 )
 from app.cache.conversation import ConversationStore
 from app.logic.prep_executor import QUESTIONNAIRE_SKILL, RESEARCH_SKILL
-from app.skills.models import TenantContext
+from app.skills.models import Origin, SkillContext, TenantContext
 from app.skills.questionnaire_models import GeneratedQuestionnaire
 from app.skills.research_brief import BusinessResearchBrief
 
@@ -292,4 +293,64 @@ async def execute(request: Request, payload: ExecuteRequest) -> ExecuteResponse:
             output="PASS",
         ),
         usage=UsageReport(duration_ms=int((time.monotonic() - started) * 1000)),
+    )
+
+
+@router.post(
+    "/v1/execute/skill",
+    response_model=ExecuteResponse,
+    dependencies=[Depends(verify_service_token)],
+)
+async def execute_skill(
+    request: Request, payload: SkillExecuteRequest
+) -> ExecuteResponse:
+    """Direct skill invocation for backend-triggered skills (I-02).
+
+    Unlike ``/v1/execute`` this does not carry conversation state or run the
+    PREP orchestrator. It dispatches a single skill through the registry's
+    full guardrail chain (IG → RBAC → PG → skill → OG) and returns the
+    result. Used by Django's Celery task to trigger SKL-OIA-08 after a
+    recording stops.
+    """
+    started = time.monotonic()
+
+    tenant = TenantContext(
+        tenant_id=payload.tenant_context.tenant_id,
+        user_id=payload.tenant_context.user_id,
+        role=payload.tenant_context.role,
+    )
+    context = SkillContext(
+        input_prompt="",
+        tenant_context=tenant,
+        input_context=payload.input_context,
+        config=payload.config,
+        correlation_id=payload.tenant_context.correlation_id or "",
+        origin=Origin.INTERNAL,
+    )
+
+    registry = request.app.state.skill_registry
+    try:
+        result = await registry.execute(payload.skill_id, context)
+    except NotImplementedError:
+        return ExecuteResponse(
+            status="FAILED",
+            skill_id=payload.skill_id,
+            output={"error": f"Skill {payload.skill_id} is not yet implemented"},
+            usage=UsageReport(duration_ms=int((time.monotonic() - started) * 1000)),
+        )
+    except Exception as exc:
+        return ExecuteResponse(
+            status="FAILED",
+            skill_id=payload.skill_id,
+            output={"error": str(exc)},
+            usage=UsageReport(duration_ms=int((time.monotonic() - started) * 1000)),
+        )
+
+    return ExecuteResponse(
+        status="SUCCEEDED",
+        skill_id=result.skill_id,
+        output=result.output,
+        usage=UsageReport(
+            duration_ms=result.duration_ms or int((time.monotonic() - started) * 1000)
+        ),
     )

--- a/onboarding-intelligence-agent-svc/app/api/routes.py
+++ b/onboarding-intelligence-agent-svc/app/api/routes.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import time
 from typing import Any
 
+from app.core.logging import get_logger
+
 from fastapi import APIRouter, Depends, Request, Response, status
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 
@@ -26,6 +28,8 @@ from app.logic.prep_executor import QUESTIONNAIRE_SKILL, RESEARCH_SKILL
 from app.skills.models import Origin, SkillContext, TenantContext
 from app.skills.questionnaire_models import GeneratedQuestionnaire
 from app.skills.research_brief import BusinessResearchBrief
+
+logger = get_logger(__name__)
 
 router = APIRouter()
 
@@ -339,10 +343,11 @@ async def execute_skill(
             usage=UsageReport(duration_ms=int((time.monotonic() - started) * 1000)),
         )
     except Exception as exc:
+        logger.error("skill_execute_failed", skill_id=payload.skill_id, error=str(exc))
         return ExecuteResponse(
             status="FAILED",
             skill_id=payload.skill_id,
-            output={"error": str(exc)},
+            output={"error": f"{type(exc).__name__}: skill execution failed"},
             usage=UsageReport(duration_ms=int((time.monotonic() - started) * 1000)),
         )
 

--- a/onboarding-intelligence-agent-svc/app/api/schemas.py
+++ b/onboarding-intelligence-agent-svc/app/api/schemas.py
@@ -95,6 +95,17 @@ class ExecuteResponse(BaseModel):
     usage: UsageReport = Field(default_factory=UsageReport)
 
 
+class SkillExecuteRequest(BaseModel):
+    """``POST /v1/execute/skill`` — direct skill invocation (I-02)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    skill_id: str
+    tenant_context: TenantContext
+    input_context: dict[str, Any] = Field(default_factory=dict)
+    config: dict[str, Any] = Field(default_factory=dict)
+
+
 # ── Live frames (F-04 PR 2, Design §10.2.3) ──────────────────────────
 #
 # Pydantic models rather than hand-built dicts, which AC-4 asks for by name:

--- a/onboarding-intelligence-agent-svc/app/main.py
+++ b/onboarding-intelligence-agent-svc/app/main.py
@@ -138,6 +138,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             "ocr": ocr_provider,
             "vision": vision_provider,
             "backend": app.state.backend,
+            "llm": LLMProvider(settings.GEMINI_KEY),
+            "redis": app.state.redis,
         }
     )
     app.state.skill_registry.load()

--- a/onboarding-intelligence-agent-svc/app/services/backend_client.py
+++ b/onboarding-intelligence-agent-svc/app/services/backend_client.py
@@ -33,6 +33,9 @@ logger = get_logger(__name__)
 
 DEPENDENCY = "backend"
 OCR_UPDATE_PATH = "/api/v1/internal/assets/{asset_id}/ocr/"
+RECORDING_SUMMARY_PATH = (
+    "/api/v1/onboarding/internal/recordings/{recording_id}/summary/"
+)
 UPSERT_PATH = "/api/v1/onboarding/research-briefs/upsert/"
 QUESTIONNAIRE_PATH = "/api/v1/onboarding/questionnaires/generate/"
 VOCABULARY_PATH = "/api/v1/onboarding/field-vocabulary/"
@@ -316,6 +319,22 @@ class BackendClient:
                 "sensitivity_class": sensitivity_class,
                 "rag_excluded": rag_excluded,
             },
+            tenant_id=tenant_id,
+        )
+        return body is not None
+
+    async def update_recording_summary(
+        self,
+        *,
+        tenant_id: str,
+        recording_id: str,
+        summary: dict[str, Any],
+    ) -> bool:
+        """Write summary results back to a MeetingRecording (I-02)."""
+        path = RECORDING_SUMMARY_PATH.format(recording_id=recording_id)
+        body = await self._patch(
+            path,
+            {"summary": summary},
             tenant_id=tenant_id,
         )
         return body is not None

--- a/onboarding-intelligence-agent-svc/app/skills/summarize_recording.py
+++ b/onboarding-intelligence-agent-svc/app/skills/summarize_recording.py
@@ -101,7 +101,7 @@ class SummarizeRecording(BaseSkill):
                 summary=summary,
             )
 
-        await self._store_idempotency(tenant_id, recording_id, summary)
+            await self._store_idempotency(tenant_id, recording_id, summary)
 
         return SkillResult(skill_id=self.meta.skill_id, output=summary)
 

--- a/onboarding-intelligence-agent-svc/app/skills/summarize_recording.py
+++ b/onboarding-intelligence-agent-svc/app/skills/summarize_recording.py
@@ -1,23 +1,231 @@
 """SKL-OIA-08 — Summarise a recording into key moments with timestamps.
 
 Design §8.1 · implemented by story I-02.
-
-Registered by A-06: the class exists and the registry resolves and
-instantiates it, so the declaration in config/skills.yaml is proven to point
-at something real. The body is deferred — it raises NotImplementedError
-rather than returning None, so a later story cannot ship a silent no-op.
 """
 
 from __future__ import annotations
 
+import json
+import logging
+from typing import Any
+
+from app.cache.redis_manager import RedisManager, TTL_IDEMPOTENCY
+from app.providers.llm import LLMProvider
+from app.services.backend_client import BackendClient
 from app.skills.base import BaseSkill
 from app.skills.models import SkillContext, SkillResult
 
-_NOT_YET = "SKL-OIA-08 (summarize_recording) — implemented by I-02"
+logger = logging.getLogger(__name__)
+
+PROMPT_TEMPLATE = """\
+You are summarising an onboarding meeting recording for a brand-building \
+platform. The transcript below has been processed for privacy: segments \
+containing personal information have had those values replaced with markers \
+like [PHONE_NUMBER], [EMAIL_ADDRESS], [PERSON_NAME], etc.
+
+Produce a JSON object with exactly two keys:
+
+1. "text": A concise summary (2-4 paragraphs) of the conversation. Where a \
+redaction marker appears and the redacted content was material to the \
+conversation, note what kind of information was shared — for example, \
+"The brand owner shared contact information (redacted for privacy)" — \
+rather than silently omitting it.
+
+2. "key_moments": An array of objects, each with:
+   - "t": The timestamp in seconds (float) from the transcript where the \
+moment begins.
+   - "label": A short, descriptive label in the operator's language — \
+"founding story", "budget discussion", "target audience", "brand vision". \
+NOT a timestamp repeated as text. NOT a direct quote. The label is the \
+retrieval affordance: it must tell the reader what they will hear if they \
+click it.
+
+Return ONLY valid JSON. No markdown fences, no commentary.
+
+TRANSCRIPT:
+{transcript}
+"""
 
 
 class SummarizeRecording(BaseSkill):
     """Summarise a recording into key moments with timestamps."""
 
+    def __init__(
+        self,
+        meta: Any,
+        *,
+        llm: LLMProvider | None = None,
+        backend: BackendClient | None = None,
+        redis: RedisManager | None = None,
+    ) -> None:
+        super().__init__(meta)
+        self._llm = llm
+        self._backend = backend
+        self._redis = redis
+
     async def run(self, context: SkillContext) -> SkillResult:
-        raise NotImplementedError(_NOT_YET)
+        recording_id = context.input_context["recording_id"]
+        session_id = context.input_context["session_id"]
+        tenant_id = context.tenant_context.tenant_id
+        started_at = float(context.input_context["started_at"])
+        stopped_at = float(context.input_context["stopped_at"])
+
+        if self._redis is None or self._llm is None:
+            raise RuntimeError("SummarizeRecording requires llm and redis providers")
+
+        cached = await self._check_idempotency(tenant_id, recording_id)
+        if cached is not None:
+            logger.info("summary_idempotent_hit", recording_id=recording_id)
+            return SkillResult(skill_id=self.meta.skill_id, output=cached)
+
+        segments = await self._read_transcript(
+            tenant_id, session_id, started_at, stopped_at
+        )
+        if not segments:
+            logger.warning("summary_no_transcript", recording_id=recording_id)
+            summary: dict[str, Any] = {
+                "text": "No transcript available for this recording.",
+                "key_moments": [],
+            }
+        else:
+            transcript_text = self._format_transcript(segments)
+            prompt = PROMPT_TEMPLATE.format(transcript=transcript_text)
+            raw = await self._llm.generate(prompt, temperature=0.2)
+            summary = self._parse_response(raw, segments)
+
+        if self._backend is not None:
+            await self._backend.update_recording_summary(
+                tenant_id=tenant_id,
+                recording_id=recording_id,
+                summary=summary,
+            )
+
+        await self._store_idempotency(tenant_id, recording_id, summary)
+
+        return SkillResult(skill_id=self.meta.skill_id, output=summary)
+
+    # -- transcript assembly --------------------------------------------------
+
+    async def _read_transcript(
+        self,
+        tenant_id: str,
+        session_id: str,
+        started_at: float,
+        stopped_at: float,
+    ) -> list[dict[str, Any]]:
+        assert self._redis is not None
+        keys = self._redis.keys_for(tenant_id)
+        key = keys.live_frames(session_id)
+        raw_frames = await self._redis.client.lrange(key, 0, -1)
+        return extract_transcript_segments(raw_frames, started_at, stopped_at)
+
+    @staticmethod
+    def _format_transcript(segments: list[dict[str, Any]]) -> str:
+        lines: list[str] = []
+        for seg in segments:
+            t = seg["t_start"]
+            m, s = divmod(int(t), 60)
+            tag = "[REDACTED] " if seg.get("redaction_applied") else ""
+            lines.append(f"[{m:02d}:{s:02d}] {tag}{seg['text']}")
+        return "\n".join(lines)
+
+    # -- LLM response parsing -------------------------------------------------
+
+    @staticmethod
+    def _parse_response(raw: str, segments: list[dict[str, Any]]) -> dict[str, Any]:
+        try:
+            cleaned = raw.strip()
+            if cleaned.startswith("```"):
+                cleaned = cleaned.split("\n", 1)[1] if "\n" in cleaned else cleaned
+                if cleaned.endswith("```"):
+                    cleaned = cleaned[: -len("```")]
+                cleaned = cleaned.strip()
+
+            parsed = json.loads(cleaned)
+        except (json.JSONDecodeError, ValueError):
+            logger.warning("summary_parse_failed", raw_len=len(raw))
+            text = "\n".join(seg["text"] for seg in segments)
+            return {"text": text, "key_moments": []}
+
+        text = parsed.get("text", "")
+        raw_moments = parsed.get("key_moments", [])
+
+        moments: list[dict[str, Any]] = []
+        seg_times = [s["t_start"] for s in segments]
+        for km in raw_moments:
+            if not isinstance(km, dict):
+                continue
+            t = km.get("t")
+            label = km.get("label", "")
+            if t is None or not label:
+                continue
+            snapped = _snap_to_boundary(float(t), seg_times)
+            moments.append({"t": snapped, "label": str(label)})
+
+        return {"text": str(text), "key_moments": moments}
+
+    # -- idempotency -----------------------------------------------------------
+
+    async def _check_idempotency(
+        self, tenant_id: str, recording_id: str
+    ) -> dict[str, Any] | None:
+        assert self._redis is not None
+        keys = self._redis.keys_for(tenant_id)
+        key = keys.idempotency(f"skl08:{recording_id}")
+        raw = await self._redis.client.get(key)
+        if raw is None:
+            return None
+        try:
+            return json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            return None
+
+    async def _store_idempotency(
+        self, tenant_id: str, recording_id: str, summary: dict[str, Any]
+    ) -> None:
+        assert self._redis is not None
+        keys = self._redis.keys_for(tenant_id)
+        key = keys.idempotency(f"skl08:{recording_id}")
+        await self._redis.client.set(key, json.dumps(summary), ex=TTL_IDEMPOTENCY)
+
+
+# -- pure helpers (module-level for testability) ------------------------------
+
+
+def extract_transcript_segments(
+    raw_frames: list[bytes | str],
+    started_at: float,
+    stopped_at: float,
+) -> list[dict[str, Any]]:
+    segments: list[dict[str, Any]] = []
+    for raw in raw_frames:
+        try:
+            frame = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if frame.get("type") != "transcript.final":
+            continue
+        t_start = frame.get("t_start")
+        t_end = frame.get("t_end")
+        if t_start is None or t_end is None:
+            continue
+        if t_start < started_at or t_end > stopped_at:
+            continue
+        segments.append(
+            {
+                "text": frame.get("text", ""),
+                "speaker": frame.get("speaker", 0),
+                "t_start": float(t_start),
+                "t_end": float(t_end),
+                "redaction_applied": frame.get("redaction_applied", False),
+            }
+        )
+    segments.sort(key=lambda s: s["t_start"])
+    return segments
+
+
+def _snap_to_boundary(t: float, seg_times: list[float]) -> float:
+    if not seg_times:
+        return t
+    closest = min(seg_times, key=lambda s: abs(s - t))
+    return closest

--- a/onboarding-intelligence-agent-svc/app/skills/summarize_recording.py
+++ b/onboarding-intelligence-agent-svc/app/skills/summarize_recording.py
@@ -177,7 +177,8 @@ class SummarizeRecording(BaseSkill):
         if raw is None:
             return None
         try:
-            return json.loads(raw)
+            parsed: dict[str, Any] = json.loads(raw)
+            return parsed
         except (json.JSONDecodeError, TypeError):
             return None
 

--- a/onboarding-intelligence-agent-svc/app/skills/summarize_recording.py
+++ b/onboarding-intelligence-agent-svc/app/skills/summarize_recording.py
@@ -6,8 +6,9 @@ Design §8.1 · implemented by story I-02.
 from __future__ import annotations
 
 import json
-import logging
 from typing import Any
+
+from app.core.logging import get_logger
 
 from app.cache.redis_manager import RedisManager, TTL_IDEMPOTENCY
 from app.providers.llm import LLMProvider
@@ -15,7 +16,7 @@ from app.services.backend_client import BackendClient
 from app.skills.base import BaseSkill
 from app.skills.models import SkillContext, SkillResult
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 PROMPT_TEMPLATE = """\
 You are summarising an onboarding meeting recording for a brand-building \

--- a/onboarding-intelligence-agent-svc/tests/test_scaffold.py
+++ b/onboarding-intelligence-agent-svc/tests/test_scaffold.py
@@ -191,6 +191,7 @@ IMPLEMENTED_BODIES = {
     "app.skills.generate_followups",  # G-04: SKL-OIA-06
     "app.skills.check_workflow_coverage",  # G-06: SKL-OIA-09
     "app.skills.analyze_captured_media",  # H-03: SKL-OIA-07
+    "app.skills.summarize_recording",  # I-02: SKL-OIA-08
 }
 
 

--- a/onboarding-intelligence-agent-svc/tests/test_summarize_recording.py
+++ b/onboarding-intelligence-agent-svc/tests/test_summarize_recording.py
@@ -1,0 +1,177 @@
+"""Tests for SKL-OIA-08 — SummarizeRecording skill (I-02).
+
+Covers transcript extraction, LLM response parsing, timestamp snapping,
+idempotency, redaction awareness, and edge cases.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.skills.summarize_recording import (
+    SummarizeRecording,
+    _snap_to_boundary,
+    extract_transcript_segments,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ── extract_transcript_segments ──────────────────────────────────────
+
+
+class TestExtractTranscriptSegments:
+    """Filter and sort TranscriptFinal frames from a mixed buffer."""
+
+    def _frame(self, type_: str, t_start: float, t_end: float, **kw):
+        return json.dumps(
+            {"type": type_, "text": kw.get("text", "hello"), "speaker": 0,
+             "t_start": t_start, "t_end": t_end, "seq": 1,
+             "redaction_applied": kw.get("redaction_applied", False)}
+        ).encode()
+
+    def test_filters_by_type(self):
+        frames = [
+            self._frame("transcript.final", 1.0, 2.0, text="good"),
+            self._frame("transcript.partial", 2.0, 3.0, text="skip"),
+            self._frame("green_signal", 3.0, 4.0, text="skip"),
+            self._frame("transcript.final", 5.0, 6.0, text="also good"),
+        ]
+        result = extract_transcript_segments(frames, 0.0, 10.0)
+        assert len(result) == 2
+        assert result[0]["text"] == "good"
+        assert result[1]["text"] == "also good"
+
+    def test_filters_by_time_window(self):
+        frames = [
+            self._frame("transcript.final", 1.0, 2.0, text="before"),
+            self._frame("transcript.final", 5.0, 6.0, text="inside"),
+            self._frame("transcript.final", 9.0, 10.0, text="inside2"),
+            self._frame("transcript.final", 10.0, 11.0, text="after"),
+        ]
+        result = extract_transcript_segments(frames, 4.0, 10.0)
+        assert len(result) == 2
+        assert result[0]["text"] == "inside"
+        assert result[1]["text"] == "inside2"
+
+    def test_sorts_by_t_start(self):
+        frames = [
+            self._frame("transcript.final", 5.0, 6.0, text="second"),
+            self._frame("transcript.final", 1.0, 2.0, text="first"),
+            self._frame("transcript.final", 3.0, 4.0, text="middle"),
+        ]
+        result = extract_transcript_segments(frames, 0.0, 10.0)
+        assert [s["text"] for s in result] == ["first", "middle", "second"]
+
+    def test_preserves_redaction_flag(self):
+        frames = [
+            self._frame("transcript.final", 1.0, 2.0,
+                        text="[PHONE_NUMBER]", redaction_applied=True),
+        ]
+        result = extract_transcript_segments(frames, 0.0, 10.0)
+        assert result[0]["redaction_applied"] is True
+
+    def test_empty_buffer_returns_empty(self):
+        assert extract_transcript_segments([], 0.0, 10.0) == []
+
+    def test_malformed_json_skipped(self):
+        frames = [b"not json", self._frame("transcript.final", 1.0, 2.0)]
+        result = extract_transcript_segments(frames, 0.0, 10.0)
+        assert len(result) == 1
+
+    def test_missing_timestamps_skipped(self):
+        frames = [json.dumps({"type": "transcript.final", "text": "no ts"}).encode()]
+        result = extract_transcript_segments(frames, 0.0, 10.0)
+        assert len(result) == 0
+
+
+# ── _snap_to_boundary ────────────────────────────────────────────────
+
+
+class TestSnapToBoundary:
+    def test_snaps_to_nearest(self):
+        assert _snap_to_boundary(4.7, [1.0, 3.0, 5.0, 8.0]) == 5.0
+
+    def test_exact_match(self):
+        assert _snap_to_boundary(3.0, [1.0, 3.0, 5.0]) == 3.0
+
+    def test_empty_times_returns_original(self):
+        assert _snap_to_boundary(4.7, []) == 4.7
+
+    def test_single_boundary(self):
+        assert _snap_to_boundary(100.0, [5.0]) == 5.0
+
+
+# ── _parse_response ──────────────────────────────────────────────────
+
+
+class TestParseResponse:
+    segments = [
+        {"text": "hello", "t_start": 1.0, "t_end": 2.0},
+        {"text": "world", "t_start": 3.0, "t_end": 4.0},
+    ]
+
+    def test_valid_json(self):
+        raw = json.dumps({
+            "text": "Summary text.",
+            "key_moments": [{"t": 1.0, "label": "intro"}],
+        })
+        result = SummarizeRecording._parse_response(raw, self.segments)
+        assert result["text"] == "Summary text."
+        assert len(result["key_moments"]) == 1
+        assert result["key_moments"][0]["label"] == "intro"
+
+    def test_markdown_fenced_json(self):
+        raw = "```json\n" + json.dumps({
+            "text": "Fenced.", "key_moments": [],
+        }) + "\n```"
+        result = SummarizeRecording._parse_response(raw, self.segments)
+        assert result["text"] == "Fenced."
+
+    def test_malformed_degrades(self):
+        result = SummarizeRecording._parse_response(
+            "not valid json at all", self.segments
+        )
+        assert "hello" in result["text"]
+        assert result["key_moments"] == []
+
+    def test_key_moment_without_label_skipped(self):
+        raw = json.dumps({
+            "text": "Ok",
+            "key_moments": [{"t": 1.0}, {"t": 3.0, "label": "good"}],
+        })
+        result = SummarizeRecording._parse_response(raw, self.segments)
+        assert len(result["key_moments"]) == 1
+        assert result["key_moments"][0]["label"] == "good"
+
+    def test_key_moment_snapped_to_segment_boundary(self):
+        raw = json.dumps({
+            "text": "Ok",
+            "key_moments": [{"t": 2.5, "label": "between"}],
+        })
+        result = SummarizeRecording._parse_response(raw, self.segments)
+        assert result["key_moments"][0]["t"] == 3.0
+
+
+# ── _format_transcript ───────────────────────────────────────────────
+
+
+class TestFormatTranscript:
+    def test_formats_with_timestamps(self):
+        segments = [
+            {"text": "hello", "t_start": 65.0, "t_end": 66.0},
+            {"text": "world", "t_start": 125.0, "t_end": 126.0},
+        ]
+        result = SummarizeRecording._format_transcript(segments)
+        assert "[01:05]" in result
+        assert "[02:05]" in result
+
+    def test_redaction_marker(self):
+        segments = [
+            {"text": "[PHONE]", "t_start": 1.0, "t_end": 2.0,
+             "redaction_applied": True},
+        ]
+        result = SummarizeRecording._format_transcript(segments)
+        assert "[REDACTED]" in result

--- a/onboarding-intelligence-agent-svc/tests/test_summarize_recording.py
+++ b/onboarding-intelligence-agent-svc/tests/test_summarize_recording.py
@@ -27,9 +27,15 @@ class TestExtractTranscriptSegments:
 
     def _frame(self, type_: str, t_start: float, t_end: float, **kw):
         return json.dumps(
-            {"type": type_, "text": kw.get("text", "hello"), "speaker": 0,
-             "t_start": t_start, "t_end": t_end, "seq": 1,
-             "redaction_applied": kw.get("redaction_applied", False)}
+            {
+                "type": type_,
+                "text": kw.get("text", "hello"),
+                "speaker": 0,
+                "t_start": t_start,
+                "t_end": t_end,
+                "seq": 1,
+                "redaction_applied": kw.get("redaction_applied", False),
+            }
         ).encode()
 
     def test_filters_by_type(self):
@@ -67,8 +73,13 @@ class TestExtractTranscriptSegments:
 
     def test_preserves_redaction_flag(self):
         frames = [
-            self._frame("transcript.final", 1.0, 2.0,
-                        text="[PHONE_NUMBER]", redaction_applied=True),
+            self._frame(
+                "transcript.final",
+                1.0,
+                2.0,
+                text="[PHONE_NUMBER]",
+                redaction_applied=True,
+            ),
         ]
         result = extract_transcript_segments(frames, 0.0, 10.0)
         assert result[0]["redaction_applied"] is True
@@ -114,19 +125,28 @@ class TestParseResponse:
     ]
 
     def test_valid_json(self):
-        raw = json.dumps({
-            "text": "Summary text.",
-            "key_moments": [{"t": 1.0, "label": "intro"}],
-        })
+        raw = json.dumps(
+            {
+                "text": "Summary text.",
+                "key_moments": [{"t": 1.0, "label": "intro"}],
+            }
+        )
         result = SummarizeRecording._parse_response(raw, self.segments)
         assert result["text"] == "Summary text."
         assert len(result["key_moments"]) == 1
         assert result["key_moments"][0]["label"] == "intro"
 
     def test_markdown_fenced_json(self):
-        raw = "```json\n" + json.dumps({
-            "text": "Fenced.", "key_moments": [],
-        }) + "\n```"
+        raw = (
+            "```json\n"
+            + json.dumps(
+                {
+                    "text": "Fenced.",
+                    "key_moments": [],
+                }
+            )
+            + "\n```"
+        )
         result = SummarizeRecording._parse_response(raw, self.segments)
         assert result["text"] == "Fenced."
 
@@ -138,19 +158,23 @@ class TestParseResponse:
         assert result["key_moments"] == []
 
     def test_key_moment_without_label_skipped(self):
-        raw = json.dumps({
-            "text": "Ok",
-            "key_moments": [{"t": 1.0}, {"t": 3.0, "label": "good"}],
-        })
+        raw = json.dumps(
+            {
+                "text": "Ok",
+                "key_moments": [{"t": 1.0}, {"t": 3.0, "label": "good"}],
+            }
+        )
         result = SummarizeRecording._parse_response(raw, self.segments)
         assert len(result["key_moments"]) == 1
         assert result["key_moments"][0]["label"] == "good"
 
     def test_key_moment_snapped_to_segment_boundary(self):
-        raw = json.dumps({
-            "text": "Ok",
-            "key_moments": [{"t": 2.5, "label": "between"}],
-        })
+        raw = json.dumps(
+            {
+                "text": "Ok",
+                "key_moments": [{"t": 2.5, "label": "between"}],
+            }
+        )
         result = SummarizeRecording._parse_response(raw, self.segments)
         assert result["key_moments"][0]["t"] == 3.0
 
@@ -170,8 +194,12 @@ class TestFormatTranscript:
 
     def test_redaction_marker(self):
         segments = [
-            {"text": "[PHONE]", "t_start": 1.0, "t_end": 2.0,
-             "redaction_applied": True},
+            {
+                "text": "[PHONE]",
+                "t_start": 1.0,
+                "t_end": 2.0,
+                "redaction_applied": True,
+            },
         ]
         result = SummarizeRecording._format_transcript(segments)
         assert "[REDACTED]" in result


### PR DESCRIPTION
## Summary

- **OIA service**: Implements SKL-OIA-08 `SummarizeRecording` skill that reads `TranscriptFinal` frames from Redis replay buffer, calls Gemini to produce `{text, key_moments: [{t, label}]}`, snaps timestamps to real segment boundaries, and writes back to Django. Adds `POST /v1/execute/skill` route for direct skill invocation and wires `llm`/`redis` providers into the skill registry.
- **Django backend**: Celery task `trigger_recording_summary` fires when a recording stops, calling OIA's new endpoint. Internal callback `PATCH /internal/recordings/<pk>/summary/` writes the summary and transitions status to `SUMMARIZED`. Detail serializer includes the summary blob on retrieve.
- **Frontend**: `RecordingPlayer` slide-over panel with custom audio player (play/pause, seek bar, Space/Arrow keyboard nav), summary text, and clickable key-moment timestamp chips that seek the audio to that position. Recordings with summaries show an indicator and open the player on click.

## Test plan

- [x] OIA: 18 unit tests (transcript extraction, LLM parsing, timestamp snapping, redaction markers, edge cases)
- [x] OIA: 632 existing tests still pass
- [x] Django: locking test passes (no `.objects.select_for_update` in views)
- [x] Frontend: 9 RecordingPlayer tests (summary rendering, key moments, controls, loading/error)
- [x] Frontend: 11 existing RecordingsLibrary tests still pass
- [x] TypeScript: `npx tsc --noEmit` clean
- [x] ESLint: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)