### PR TITLE
feat(onboarding): review page with key findings and provenance (K-01)

### DIFF
--- a/ai-brand-automator-frontend/src/app/onboarding/sessions/[sessionId]/page.tsx
+++ b/ai-brand-automator-frontend/src/app/onboarding/sessions/[sessionId]/page.tsx
@@ -12,7 +12,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
-import { ArrowLeft, Radio } from 'lucide-react';
+import { ArrowLeft, ClipboardCheck, Radio } from 'lucide-react';
 
 import { useAuth } from '@/hooks/useAuth';
 import { useLibraryPolling } from '@/hooks/useLibraryPolling';
@@ -98,15 +98,30 @@ export default function SessionPage() {
 
       <div className="flex flex-wrap items-center justify-between gap-3">
         <h1 className="text-2xl font-semibold text-white">Session</h1>
-        {sessionId && (
-          <Link
-            href={`/onboarding/sessions/${sessionId}/meeting`}
-            className="btn-primary inline-flex items-center gap-2 text-sm"
-          >
-            <Radio className="h-4 w-4" aria-hidden />
-            Open meeting view
-          </Link>
-        )}
+        <div className="flex flex-wrap gap-2">
+          {sessionId && session && (
+            session.status === 'REVIEW_PENDING' ||
+            session.status === 'CONFIRMED' ||
+            session.status === 'COMPLETED'
+          ) && (
+            <Link
+              href={`/onboarding/sessions/${sessionId}/review`}
+              className="btn-primary inline-flex items-center gap-2 text-sm"
+            >
+              <ClipboardCheck className="h-4 w-4" aria-hidden />
+              Review findings
+            </Link>
+          )}
+          {sessionId && (
+            <Link
+              href={`/onboarding/sessions/${sessionId}/meeting`}
+              className="inline-flex items-center gap-2 rounded border border-white/10 px-3 py-1.5 text-sm text-brand-silver hover:bg-white/5 hover:text-white"
+            >
+              <Radio className="h-4 w-4" aria-hidden />
+              Open meeting view
+            </Link>
+          )}
+        </div>
       </div>
 
       {sessionId && session && (

--- a/ai-brand-automator-frontend/src/app/onboarding/sessions/[sessionId]/review/page.tsx
+++ b/ai-brand-automator-frontend/src/app/onboarding/sessions/[sessionId]/review/page.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+
+import { useAuth } from '@/hooks/useAuth';
+import KeyFindingsReview from '@/components/onboarding/KeyFindingsReview';
+
+export default function ReviewPage() {
+  useAuth();
+  const params = useParams<{ sessionId: string }>();
+  const sessionId = params?.sessionId;
+
+  if (!sessionId) {
+    return (
+      <p className="text-sm text-brand-silver">No session selected.</p>
+    );
+  }
+
+  return <KeyFindingsReview sessionId={sessionId} />;
+}

--- a/ai-brand-automator-frontend/src/components/onboarding/KeyFindingsReview.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/KeyFindingsReview.tsx
@@ -1,0 +1,345 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import {
+  AlertTriangle,
+  ArrowLeft,
+  Calendar,
+  CheckCircle,
+  ChevronDown,
+  FileWarning,
+  Sparkles,
+} from 'lucide-react';
+
+import ProvenanceCard from '@/components/onboarding/ProvenanceCard';
+import ProvenanceDrawer from '@/components/onboarding/ProvenanceDrawer';
+import {
+  getSessionDetail,
+  getSessionProvenance,
+  getRecordingDetail,
+  listSessionRecordings,
+  type FieldProvenanceRow,
+  type ProcessSummary,
+  type ProvenanceGroup,
+  type RecordingDetail,
+  type SessionDetail,
+} from '@/lib/onboarding-sessions';
+
+const WORKFLOW_LABELS: Record<string, string> = {
+  WF1: 'Discovery & Research',
+  WF2: 'Brand Strategy',
+  WF3: 'Campaign & Content',
+};
+
+const COVERAGE_CONSEQUENCES: Record<string, string> = {
+  WF1: 'Market research and competitor analysis will have less input data to work from.',
+  WF2: 'Brand positioning and identity outputs may be less precisely tailored.',
+  WF3: 'Campaign architecture and creative generation will rely on broader assumptions.',
+};
+
+interface KeyFindingsReviewProps {
+  sessionId: string;
+}
+
+export default function KeyFindingsReview({
+  sessionId,
+}: KeyFindingsReviewProps) {
+  const [session, setSession] = useState<SessionDetail | null>(null);
+  const [groups, setGroups] = useState<ProvenanceGroup[]>([]);
+  const [recordings, setRecordings] = useState<RecordingDetail[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [drawerRow, setDrawerRow] = useState<FieldProvenanceRow | null>(null);
+  const [secondaryOpen, setSecondaryOpen] = useState<Record<number, boolean>>({});
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [sess, prov, recs] = await Promise.all([
+        getSessionDetail(sessionId),
+        getSessionProvenance(sessionId),
+        listSessionRecordings(sessionId),
+      ]);
+      setSession(sess);
+      setGroups(prov.groups);
+
+      const details = await Promise.all(
+        recs
+          .filter((r) => r.has_summary)
+          .map((r) => getRecordingDetail(r.id)),
+      );
+      setRecordings(details);
+    } catch (err) {
+      setError(String(err));
+      setSession(null);
+      setGroups([]);
+      setRecordings([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [sessionId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const summary: ProcessSummary | null =
+    session?.process_summary
+      ? (session.process_summary as unknown as ProcessSummary)
+      : null;
+
+  const conflictRows = groups
+    .flatMap((g) => g.fields)
+    .filter((f) => f.status === 'CONFLICT');
+
+  const coverageShortfalls = summary
+    ? Object.entries(summary.coverage).filter(([, v]) => v < 1.0)
+    : [];
+
+  const toggleSecondary = useCallback((page: number) => {
+    setSecondaryOpen((prev) => ({ ...prev, [page]: !prev[page] }));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <p className="text-sm text-brand-silver">Loading review...</p>
+      </div>
+    );
+  }
+
+  if (error || !session) {
+    return (
+      <div className="space-y-6">
+        <p className="text-sm text-red-400">
+          Failed to load review data.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <Link
+          href={`/onboarding/sessions/${sessionId}`}
+          className="mb-3 inline-flex items-center gap-2 text-sm text-brand-silver hover:text-white"
+        >
+          <ArrowLeft className="h-4 w-4" aria-hidden />
+          Back to session
+        </Link>
+        <div className="flex flex-wrap items-center gap-3">
+          <h1 className="text-2xl font-semibold text-white">Key Findings</h1>
+          <span className="rounded bg-blue-500/20 px-2 py-0.5 text-xs font-medium text-blue-400">
+            {session.status.replace(/_/g, ' ')}
+          </span>
+        </div>
+      </div>
+
+      {/* Summary bar */}
+      {summary && (
+        <div className="glass-card grid grid-cols-2 gap-4 p-5 sm:grid-cols-4" data-testid="summary-bar">
+          <div>
+            <p className="text-xs text-brand-silver">Fields written</p>
+            <p className="text-lg font-semibold text-white">
+              {summary.fields_written}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-brand-silver">Conflicts</p>
+            <p className="text-lg font-semibold text-white">
+              {summary.conflicts}
+            </p>
+          </div>
+          <div title="Values considered but rejected because they lacked evidence">
+            <p className="text-xs text-brand-silver">Dropped (ungrounded)</p>
+            <p className="text-lg font-semibold text-white" data-testid="dropped-count">
+              {summary.dropped_ungrounded}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-brand-silver">Generated</p>
+            <p className="text-sm font-medium text-white" data-testid="generated-list">
+              {summary.generated.length > 0
+                ? summary.generated
+                    .map((g) => g.replace(/_/g, ' '))
+                    .join(', ')
+                : 'None'}
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Conflicts — above field lists (AC-4) */}
+      {conflictRows.length > 0 && (
+        <section data-testid="conflicts-section" className="glass-card border border-amber-500/30 p-5">
+          <h2 className="mb-3 flex items-center gap-2 text-sm font-semibold text-amber-400">
+            <AlertTriangle className="h-4 w-4" aria-hidden />
+            Unresolved conflicts ({conflictRows.length})
+          </h2>
+          <p className="mb-4 text-xs text-brand-silver">
+            These fields have conflicting values from different sources and
+            require manual resolution before final submission.
+          </p>
+          <div className="space-y-3">
+            {conflictRows.map((row) => (
+              <ProvenanceCard
+                key={row.id}
+                row={row}
+                onViewSource={setDrawerRow}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Coverage shortfalls (AC-3) */}
+      {coverageShortfalls.length > 0 && (
+        <section data-testid="coverage-section" className="glass-card border border-yellow-500/30 p-5">
+          <h2 className="mb-3 flex items-center gap-2 text-sm font-semibold text-yellow-400">
+            <FileWarning className="h-4 w-4" aria-hidden />
+            Coverage shortfalls
+          </h2>
+          <ul className="mb-4 space-y-2">
+            {coverageShortfalls.map(([wf, pct]) => (
+              <li key={wf} className="text-sm text-brand-silver">
+                <span className="font-medium text-white">
+                  {WORKFLOW_LABELS[wf] ?? wf}
+                </span>
+                : {Math.round(pct * 100)}% covered.{' '}
+                {COVERAGE_CONSEQUENCES[wf] ?? ''}
+              </li>
+            ))}
+          </ul>
+          <Link
+            href="/onboarding"
+            className="inline-flex items-center gap-2 rounded bg-yellow-500/10 px-3 py-1.5 text-sm text-yellow-400 hover:bg-yellow-500/20"
+          >
+            <Calendar className="h-4 w-4" aria-hidden />
+            Schedule follow-up
+          </Link>
+        </section>
+      )}
+
+      {/* Recording summaries */}
+      {recordings.length > 0 && (
+        <section className="glass-card p-5">
+          <h2 className="mb-3 text-sm font-semibold text-white">
+            Recording summaries
+          </h2>
+          <div className="space-y-4">
+            {recordings.map((rec) => (
+              <div key={rec.id} className="rounded-lg bg-white/5 p-4">
+                {rec.summary ? (
+                  <>
+                    <p className="mb-2 text-sm text-brand-silver">
+                      {rec.summary.text}
+                    </p>
+                    {rec.summary.key_moments.length > 0 && (
+                      <div className="flex flex-wrap gap-2">
+                        {rec.summary.key_moments.map((km, i) => (
+                          <span
+                            key={i}
+                            className="rounded bg-brand-electric/10 px-2 py-0.5 text-xs text-brand-electric"
+                          >
+                            {km.label}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </>
+                ) : (
+                  <p className="text-sm text-brand-silver">
+                    No summary available.
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Provenance groups — KEY prominent, SECONDARY collapsed */}
+      {groups.map((group) => {
+        const keyFields = group.fields.filter(
+          (f) => f.classification === 'KEY' && f.status !== 'CONFLICT',
+        );
+        const secondaryFields = group.fields.filter(
+          (f) => f.classification === 'SECONDARY' && f.status !== 'CONFLICT',
+        );
+        const pageKey = group.page ?? -1;
+        const isOpen = secondaryOpen[pageKey] ?? false;
+
+        if (keyFields.length === 0 && secondaryFields.length === 0) {
+          return null;
+        }
+
+        return (
+          <section key={pageKey} className="glass-card p-5">
+            <h2 className="mb-4 text-sm font-semibold text-white">
+              {group.label}
+            </h2>
+
+            {keyFields.length > 0 && (
+              <div className="mb-4 space-y-3" data-testid="key-fields">
+                {keyFields.map((row) => (
+                  <ProvenanceCard
+                    key={row.id}
+                    row={row}
+                    onViewSource={setDrawerRow}
+                  />
+                ))}
+              </div>
+            )}
+
+            {secondaryFields.length > 0 && (
+              <div data-testid="secondary-fields">
+                <button
+                  type="button"
+                  onClick={() => toggleSecondary(pageKey)}
+                  className="mb-2 flex items-center gap-2 text-sm text-brand-silver hover:text-white"
+                >
+                  <ChevronDown
+                    className={`h-4 w-4 transition-transform ${isOpen ? 'rotate-180' : ''}`}
+                    aria-hidden
+                  />
+                  <span>
+                    Auto-filled fields ({secondaryFields.length})
+                  </span>
+                  <span className="rounded bg-zinc-700/50 px-1.5 py-0.5 text-xs">
+                    review
+                  </span>
+                </button>
+                {isOpen && (
+                  <div className="space-y-3">
+                    {secondaryFields.map((row) => (
+                      <ProvenanceCard
+                        key={row.id}
+                        row={row}
+                        onViewSource={setDrawerRow}
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+          </section>
+        );
+      })}
+
+      {groups.length === 0 && !loading && (
+        <div className="glass-card p-5 text-center">
+          <p className="text-sm text-brand-silver">
+            No provenance data available yet.
+          </p>
+        </div>
+      )}
+
+      {/* Provenance evidence drawer */}
+      <ProvenanceDrawer row={drawerRow} onClose={() => setDrawerRow(null)} />
+    </div>
+  );
+}

--- a/ai-brand-automator-frontend/src/components/onboarding/KeyFindingsReview.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/KeyFindingsReview.tsx
@@ -93,7 +93,7 @@ export default function KeyFindingsReview({
     .filter((f) => f.status === 'CONFLICT');
 
   const coverageShortfalls = summary
-    ? Object.entries(summary.coverage).filter(([, v]) => v < 1.0)
+    ? Object.entries(summary.coverage ?? {}).filter(([, v]) => v < 1.0)
     : [];
 
   const toggleSecondary = useCallback((page: number) => {
@@ -149,7 +149,7 @@ export default function KeyFindingsReview({
           <div>
             <p className="text-xs text-brand-silver">Conflicts</p>
             <p className="text-lg font-semibold text-white">
-              {summary.conflicts}
+              {summary.conflicts.length}
             </p>
           </div>
           <div title="Values considered but rejected because they lacked evidence">
@@ -161,8 +161,8 @@ export default function KeyFindingsReview({
           <div>
             <p className="text-xs text-brand-silver">Generated</p>
             <p className="text-sm font-medium text-white" data-testid="generated-list">
-              {summary.generated.length > 0
-                ? summary.generated
+              {(summary.generated ?? []).length > 0
+                ? (summary.generated ?? [])
                     .map((g) => g.replace(/_/g, ' '))
                     .join(', ')
                 : 'None'}

--- a/ai-brand-automator-frontend/src/components/onboarding/KeyFindingsReview.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/KeyFindingsReview.tsx
@@ -6,10 +6,8 @@ import {
   AlertTriangle,
   ArrowLeft,
   Calendar,
-  CheckCircle,
   ChevronDown,
   FileWarning,
-  Sparkles,
 } from 'lucide-react';
 
 import ProvenanceCard from '@/components/onboarding/ProvenanceCard';

--- a/ai-brand-automator-frontend/src/components/onboarding/ProvenanceCard.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/ProvenanceCard.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { FileText, Image } from 'lucide-react';
+import type {
+  FieldProvenanceRow,
+  FieldClassification,
+  ProvenanceStatus,
+} from '@/lib/onboarding-sessions';
+
+const CLASSIFICATION_STYLE: Record<FieldClassification, string> = {
+  KEY: 'bg-blue-500/20 text-blue-400',
+  SECONDARY: 'bg-zinc-700/50 text-brand-silver',
+};
+
+const STATUS_STYLE: Record<ProvenanceStatus, string> = {
+  PENDING: 'bg-yellow-500/20 text-yellow-400',
+  CONFIRMED: 'bg-emerald-500/20 text-emerald-400',
+  EDITED: 'bg-purple-500/20 text-purple-400',
+  CONFLICT: 'bg-red-500/20 text-red-400',
+};
+
+function humanFieldName(raw: string): string {
+  return raw.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function displayValue(value: unknown): string {
+  if (value === null || value === undefined) return '—';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  return JSON.stringify(value, null, 2);
+}
+
+interface ProvenanceCardProps {
+  row: FieldProvenanceRow;
+  onViewSource?: (row: FieldProvenanceRow) => void;
+  onConfirm?: (row: FieldProvenanceRow) => void;
+  onEdit?: (row: FieldProvenanceRow) => void;
+}
+
+export default function ProvenanceCard({
+  row,
+  onViewSource,
+  onConfirm,
+  onEdit,
+}: ProvenanceCardProps) {
+  const hasSource = row.source_span !== null || row.source_media !== null;
+  const confidencePct = Math.round(row.confidence * 100);
+
+  return (
+    <div className="rounded-lg border border-white/10 bg-white/5 p-4">
+      <div className="mb-2 flex flex-wrap items-center gap-2">
+        <h4 className="text-sm font-medium text-white">
+          {humanFieldName(row.field_name)}
+        </h4>
+        <span
+          className={`rounded px-1.5 py-0.5 text-xs font-medium ${CLASSIFICATION_STYLE[row.classification]}`}
+        >
+          {row.classification}
+        </span>
+        <span
+          className={`rounded px-1.5 py-0.5 text-xs font-medium ${STATUS_STYLE[row.status]}`}
+        >
+          {row.status}
+        </span>
+      </div>
+
+      <p className="mb-3 whitespace-pre-wrap text-sm text-brand-silver">
+        {displayValue(row.extracted_value)}
+      </p>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="flex items-center gap-1.5 text-xs text-brand-silver">
+          <div className="h-1.5 w-16 overflow-hidden rounded-full bg-white/10">
+            <div
+              className="h-full rounded-full bg-brand-electric"
+              style={{ width: `${confidencePct}%` }}
+            />
+          </div>
+          <span>{confidencePct}%</span>
+        </div>
+
+        {hasSource && onViewSource && (
+          <button
+            type="button"
+            onClick={() => onViewSource(row)}
+            className="inline-flex items-center gap-1 rounded px-2 py-1 text-xs text-brand-electric hover:bg-white/10"
+            aria-label={`View source for ${humanFieldName(row.field_name)}`}
+          >
+            {row.source_span ? (
+              <FileText className="h-3.5 w-3.5" aria-hidden />
+            ) : (
+              <Image className="h-3.5 w-3.5" aria-hidden />
+            )}
+            View source
+          </button>
+        )}
+
+        {onConfirm && row.status === 'PENDING' && (
+          <button
+            type="button"
+            onClick={() => onConfirm(row)}
+            className="rounded px-2 py-1 text-xs text-emerald-400 hover:bg-emerald-500/10"
+          >
+            Confirm
+          </button>
+        )}
+
+        {onEdit && (row.status === 'PENDING' || row.status === 'CONFIRMED') && (
+          <button
+            type="button"
+            onClick={() => onEdit(row)}
+            className="rounded px-2 py-1 text-xs text-purple-400 hover:bg-purple-500/10"
+          >
+            Edit
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ai-brand-automator-frontend/src/components/onboarding/ProvenanceCard.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/ProvenanceCard.tsx
@@ -46,7 +46,8 @@ export default function ProvenanceCard({
   onEdit,
 }: ProvenanceCardProps) {
   const hasSource = row.source_span !== null || row.source_media !== null;
-  const confidencePct = Math.round(row.confidence * 100);
+  const confidencePct =
+    row.confidence != null ? Math.round(Number(row.confidence) * 100) : null;
 
   return (
     <div className="rounded-lg border border-white/10 bg-white/5 p-4">
@@ -71,15 +72,17 @@ export default function ProvenanceCard({
       </p>
 
       <div className="flex flex-wrap items-center gap-3">
-        <div className="flex items-center gap-1.5 text-xs text-brand-silver">
-          <div className="h-1.5 w-16 overflow-hidden rounded-full bg-white/10">
-            <div
-              className="h-full rounded-full bg-brand-electric"
-              style={{ width: `${confidencePct}%` }}
-            />
+        {confidencePct != null && (
+          <div className="flex items-center gap-1.5 text-xs text-brand-silver">
+            <div className="h-1.5 w-16 overflow-hidden rounded-full bg-white/10">
+              <div
+                className="h-full rounded-full bg-brand-electric"
+                style={{ width: `${confidencePct}%` }}
+              />
+            </div>
+            <span>{confidencePct}%</span>
           </div>
-          <span>{confidencePct}%</span>
-        </div>
+        )}
 
         {hasSource && onViewSource && (
           <button

--- a/ai-brand-automator-frontend/src/components/onboarding/ProvenanceDrawer.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/ProvenanceDrawer.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { X } from 'lucide-react';
+
+import TranscriptView from '@/components/onboarding/TranscriptView';
+import {
+  getRecordingTranscript,
+  type FieldProvenanceRow,
+  type TranscriptSegment,
+} from '@/lib/onboarding-sessions';
+
+interface ProvenanceDrawerProps {
+  row: FieldProvenanceRow | null;
+  onClose: () => void;
+}
+
+export default function ProvenanceDrawer({
+  row,
+  onClose,
+}: ProvenanceDrawerProps) {
+  const [segments, setSegments] = useState<TranscriptSegment[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const recordingId = row?.source_span?.recording_id ?? null;
+  const initialTime = row?.source_span?.t_start ?? 0;
+
+  useEffect(() => {
+    if (!recordingId) return;
+    let cancelled = false;
+    const fetchTranscript = async () => {
+      try {
+        const segs = await getRecordingTranscript(recordingId);
+        if (!cancelled) {
+          setSegments(segs);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(String(err));
+          setSegments([]);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    setLoading(true);
+    void fetchTranscript();
+    return () => {
+      cancelled = true;
+    };
+  }, [recordingId]);
+
+  const handleSeek = useCallback(() => {
+    // no-op: audio playback is out of scope for K-01
+  }, []);
+
+  useEffect(() => {
+    if (!row) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [row, onClose]);
+
+  if (!row) return null;
+
+  const isTranscriptSource = row.source_span !== null;
+  const isMediaSource =
+    !isTranscriptSource && row.source_media !== null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end" role="dialog" aria-label="Source evidence">
+      <div
+        className="absolute inset-0 bg-black/50"
+        onClick={onClose}
+        aria-hidden
+      />
+      <div className="relative flex h-full w-full max-w-lg flex-col bg-brand-midnight shadow-xl">
+        <div className="flex items-center justify-between border-b border-white/10 p-4">
+          <h3 className="text-sm font-semibold text-white">
+            Source evidence
+          </h3>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded p-1 text-brand-silver hover:bg-white/10 hover:text-white"
+            aria-label="Close drawer"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-4">
+          {isTranscriptSource && (
+            <>
+              {loading && (
+                <p className="text-sm text-brand-silver">
+                  Loading transcript...
+                </p>
+              )}
+              {error && (
+                <p className="text-sm text-red-400">
+                  Failed to load transcript.
+                </p>
+              )}
+              {!loading && !error && segments.length > 0 && (
+                <TranscriptView
+                  segments={segments}
+                  currentTime={initialTime}
+                  onSeek={handleSeek}
+                  initialTime={initialTime}
+                />
+              )}
+              {!loading && !error && segments.length === 0 && (
+                <p className="text-sm text-brand-silver">
+                  No transcript segments found.
+                </p>
+              )}
+            </>
+          )}
+          {isMediaSource && (
+            <p className="text-sm text-brand-silver">
+              Media source #{row.source_media}
+            </p>
+          )}
+          {!isTranscriptSource && !isMediaSource && (
+            <p className="text-sm text-brand-silver">
+              No source evidence available.
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ai-brand-automator-frontend/src/components/onboarding/__tests__/KeyFindingsReview.test.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/__tests__/KeyFindingsReview.test.tsx
@@ -68,7 +68,7 @@ function makeRow(overrides: Partial<FieldProvenanceRow> = {}): FieldProvenanceRo
 
 const baseSummary: ProcessSummary = {
   fields_written: 34,
-  conflicts: 0,
+  conflicts: [],
   dropped_ungrounded: 6,
   coverage: { WF1: 0.94, WF2: 0.88, WF3: 1.0 },
   generated: ['brand_strategy', 'brand_identity'],
@@ -154,7 +154,10 @@ it('shows conflicts section above provenance groups (AC-4)', async () => {
     classification: 'KEY',
   });
   const normalRow = makeRow({ id: 100, field_name: 'company_name' });
-  setupMocks({ conflicts: 1 }, [conflictRow, normalRow]);
+  setupMocks(
+    { conflicts: [{ field_name: 'industry', existing_status: 'CONFIRMED' }] },
+    [conflictRow, normalRow],
+  );
 
   const { container } = render(<KeyFindingsReview sessionId="sess-1" />);
   await waitFor(() => {

--- a/ai-brand-automator-frontend/src/components/onboarding/__tests__/KeyFindingsReview.test.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/__tests__/KeyFindingsReview.test.tsx
@@ -1,0 +1,264 @@
+/**
+ * K-01 — KeyFindingsReview component tests.
+ */
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+import KeyFindingsReview from '@/components/onboarding/KeyFindingsReview';
+import type {
+  FieldProvenanceRow,
+  ProcessSummary,
+  ProvenanceGroup,
+  SessionDetail,
+  RecordingItem,
+  RecordingDetail,
+} from '@/lib/onboarding-sessions';
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = jest.fn();
+});
+
+jest.mock('next/navigation', () => ({
+  useParams: () => ({ sessionId: 'sess-1' }),
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({}),
+}));
+
+jest.mock('@/lib/onboarding-sessions', () => ({
+  getSessionDetail: jest.fn(),
+  getSessionProvenance: jest.fn(),
+  listSessionRecordings: jest.fn(),
+  getRecordingDetail: jest.fn(),
+  getRecordingTranscript: jest.fn(),
+  formatTime: (seconds: number) => {
+    const m = Math.floor(seconds / 60);
+    const s = Math.floor(seconds % 60);
+    return `${m}:${s.toString().padStart(2, '0')}`;
+  },
+}));
+
+const mockApi = jest.requireMock('@/lib/onboarding-sessions');
+
+function makeRow(overrides: Partial<FieldProvenanceRow> = {}): FieldProvenanceRow {
+  return {
+    id: 1,
+    session: 1,
+    model_name: 'Company',
+    field_name: 'company_name',
+    extracted_value: 'Acme Corp',
+    final_value: null,
+    classification: 'KEY',
+    confidence: 0.92,
+    source_recording: 10,
+    source_span: { recording_id: '10', t_start: 12.5, t_end: 18.0 },
+    source_media: null,
+    status: 'PENDING',
+    reviewed_by: null,
+    reviewed_at: null,
+    wizard_page: 1,
+    wizard_page_label: 'Company Info',
+    created_at: '2026-08-01T00:00:00Z',
+    updated_at: '2026-08-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+const baseSummary: ProcessSummary = {
+  fields_written: 34,
+  conflicts: 0,
+  dropped_ungrounded: 6,
+  coverage: { WF1: 0.94, WF2: 0.88, WF3: 1.0 },
+  generated: ['brand_strategy', 'brand_identity'],
+};
+
+function makeSession(overrides: Partial<ProcessSummary> = {}): SessionDetail {
+  return {
+    id: 'sess-1',
+    company: 'comp-1',
+    status: 'REVIEW_PENDING',
+    questionnaire: null,
+    created_at: '2026-08-01T00:00:00Z',
+    updated_at: '2026-08-01T00:00:00Z',
+    legal_next_states: ['CONFIRMED'],
+    evidence_manifest_hash: '',
+    process_job_id: 'job-1',
+    process_summary: { ...baseSummary, ...overrides } as Record<string, unknown>,
+    consent: { granted: true, granted_at: null, method: null, scope: null },
+  };
+}
+
+function makeGroups(rows: FieldProvenanceRow[]): { session: number; groups: ProvenanceGroup[] } {
+  const buckets: Record<number, FieldProvenanceRow[]> = {};
+  for (const r of rows) {
+    const p = r.wizard_page ?? -1;
+    (buckets[p] ??= []).push(r);
+  }
+  return {
+    session: 1,
+    groups: Object.entries(buckets).map(([p, fields]) => ({
+      page: Number(p),
+      label: fields[0]?.wizard_page_label ?? 'Unmapped',
+      fields,
+    })),
+  };
+}
+
+function setupMocks(
+  summary: Partial<ProcessSummary> = {},
+  rows: FieldProvenanceRow[] = [makeRow()],
+  recordings: RecordingItem[] = [],
+) {
+  mockApi.getSessionDetail.mockResolvedValue(makeSession(summary));
+  mockApi.getSessionProvenance.mockResolvedValue(makeGroups(rows));
+  mockApi.listSessionRecordings.mockResolvedValue(recordings);
+  mockApi.getRecordingDetail.mockResolvedValue({
+    id: '1',
+    session: 'sess-1',
+    modality: 'AUDIO',
+    status: 'SUMMARIZED',
+    duration_s: 120,
+    audio_asset: null,
+    has_transcript: true,
+    has_summary: true,
+    started_at: '2026-08-01T00:00:00Z',
+    stopped_at: '2026-08-01T00:02:00Z',
+    summary: { text: 'Test summary', key_moments: [] },
+  } as RecordingDetail);
+  mockApi.getRecordingTranscript.mockResolvedValue([
+    { text: 'Hello', speaker: 0, t_start: 0, t_end: 2, redaction_applied: false },
+  ]);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+it('renders summary bar with fields_written and dropped_ungrounded', async () => {
+  setupMocks();
+  render(<KeyFindingsReview sessionId="sess-1" />);
+  await waitFor(() => {
+    expect(screen.getByTestId('summary-bar')).toBeInTheDocument();
+  });
+  expect(screen.getByTestId('dropped-count')).toHaveTextContent('6');
+  expect(screen.getByText('34')).toBeInTheDocument();
+});
+
+it('shows conflicts section above provenance groups (AC-4)', async () => {
+  const conflictRow = makeRow({
+    id: 99,
+    field_name: 'industry',
+    status: 'CONFLICT',
+    classification: 'KEY',
+  });
+  const normalRow = makeRow({ id: 100, field_name: 'company_name' });
+  setupMocks({ conflicts: 1 }, [conflictRow, normalRow]);
+
+  const { container } = render(<KeyFindingsReview sessionId="sess-1" />);
+  await waitFor(() => {
+    expect(screen.getByTestId('conflicts-section')).toBeInTheDocument();
+  });
+
+  const conflictsSection = container.querySelector('[data-testid="conflicts-section"]');
+  const keyFields = container.querySelector('[data-testid="key-fields"]');
+  expect(conflictsSection).toBeTruthy();
+  expect(keyFields).toBeTruthy();
+
+  const all = Array.from(container.querySelectorAll('[data-testid]'));
+  const conflictsIdx = all.indexOf(conflictsSection!);
+  const keyIdx = all.indexOf(keyFields!);
+  expect(conflictsIdx).toBeLessThan(keyIdx);
+});
+
+it('renders dropped_ungrounded count visibly (AC-1)', async () => {
+  setupMocks({ dropped_ungrounded: 12 });
+  render(<KeyFindingsReview sessionId="sess-1" />);
+  await waitFor(() => {
+    expect(screen.getByTestId('dropped-count')).toHaveTextContent('12');
+  });
+});
+
+it('opens provenance drawer when source indicator is clicked (AC-2)', async () => {
+  setupMocks();
+  render(<KeyFindingsReview sessionId="sess-1" />);
+  await waitFor(() => {
+    expect(screen.getByText('Company Name')).toBeInTheDocument();
+  });
+
+  const viewSourceBtn = screen.getByLabelText(/View source for Company Name/);
+  fireEvent.click(viewSourceBtn);
+
+  await waitFor(() => {
+    expect(screen.getByRole('dialog', { name: /Source evidence/ })).toBeInTheDocument();
+  });
+});
+
+it('renders KEY fields prominently (not collapsed)', async () => {
+  setupMocks({}, [makeRow({ classification: 'KEY', field_name: 'brand_voice' })]);
+  render(<KeyFindingsReview sessionId="sess-1" />);
+  await waitFor(() => {
+    expect(screen.getByText('Brand Voice')).toBeInTheDocument();
+  });
+  expect(screen.getByText('Acme Corp')).toBeInTheDocument();
+});
+
+it('renders SECONDARY fields collapsed by default', async () => {
+  const sec = makeRow({
+    id: 2,
+    classification: 'SECONDARY',
+    field_name: 'phone_number',
+    extracted_value: '555-1234',
+  });
+  setupMocks({}, [makeRow(), sec]);
+  render(<KeyFindingsReview sessionId="sess-1" />);
+  await waitFor(() => {
+    expect(screen.getByText(/Auto-filled fields/)).toBeInTheDocument();
+  });
+  expect(screen.queryByText('555-1234')).not.toBeInTheDocument();
+
+  fireEvent.click(screen.getByText(/Auto-filled fields/));
+  expect(screen.getByText('555-1234')).toBeInTheDocument();
+});
+
+it('shows coverage shortfall with consequences (AC-3)', async () => {
+  setupMocks({ coverage: { WF1: 0.5, WF2: 1.0, WF3: 0.3 } });
+  render(<KeyFindingsReview sessionId="sess-1" />);
+  await waitFor(() => {
+    expect(screen.getByTestId('coverage-section')).toBeInTheDocument();
+  });
+  expect(screen.getByText(/Discovery & Research/)).toBeInTheDocument();
+  expect(screen.getByText(/50% covered/)).toBeInTheDocument();
+  expect(screen.getByText(/Schedule follow-up/)).toBeInTheDocument();
+});
+
+it('shows generated items list', async () => {
+  setupMocks({ generated: ['brand_strategy', 'brand_identity'] });
+  render(<KeyFindingsReview sessionId="sess-1" />);
+  await waitFor(() => {
+    expect(screen.getByTestId('generated-list')).toHaveTextContent(
+      'brand strategy, brand identity',
+    );
+  });
+});
+
+it('shows recording summaries when available', async () => {
+  const rec: RecordingItem = {
+    id: 'rec-1',
+    session: 'sess-1',
+    modality: 'AUDIO',
+    status: 'SUMMARIZED' as RecordingItem['status'],
+    duration_s: 120,
+    audio_asset: null,
+    has_transcript: true,
+    has_summary: true,
+    started_at: '2026-08-01T00:00:00Z',
+    stopped_at: '2026-08-01T00:02:00Z',
+  };
+  setupMocks({}, [makeRow()], [rec]);
+  render(<KeyFindingsReview sessionId="sess-1" />);
+  await waitFor(() => {
+    expect(screen.getByText('Test summary')).toBeInTheDocument();
+  });
+});

--- a/ai-brand-automator-frontend/src/lib/onboarding-sessions.ts
+++ b/ai-brand-automator-frontend/src/lib/onboarding-sessions.ts
@@ -596,6 +596,74 @@ export async function getRecordingTranscript(
   return data.segments;
 }
 
+// ── Provenance (K-01) ───────────────────────────────────────────────
+
+export interface ProvenanceSourceSpan {
+  recording_id: string;
+  t_start: number;
+  t_end: number;
+}
+
+export type FieldClassification = 'KEY' | 'SECONDARY';
+
+export type ProvenanceStatus = 'PENDING' | 'CONFIRMED' | 'EDITED' | 'CONFLICT';
+
+export interface FieldProvenanceRow {
+  id: number;
+  session: number;
+  model_name: string;
+  field_name: string;
+  extracted_value: unknown;
+  final_value: unknown;
+  classification: FieldClassification;
+  confidence: number;
+  source_recording: number | null;
+  source_span: ProvenanceSourceSpan | null;
+  source_media: number | null;
+  status: ProvenanceStatus;
+  reviewed_by: number | null;
+  reviewed_at: string | null;
+  wizard_page: number | null;
+  wizard_page_label: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ProvenanceGroup {
+  page: number | null;
+  label: string;
+  fields: FieldProvenanceRow[];
+}
+
+export interface ProvenanceResponse {
+  session: number;
+  groups: ProvenanceGroup[];
+}
+
+export interface ProcessSummary {
+  fields_written: number;
+  key_count?: number;
+  secondary_count?: number;
+  conflicts: number;
+  dropped_ungrounded: number;
+  coverage: Record<string, number>;
+  coverage_satisfied?: boolean;
+  blocking_gaps?: string[];
+  generated: string[];
+}
+
+export async function getSessionProvenance(
+  sessionId: string,
+): Promise<ProvenanceResponse> {
+  const response = await apiClient.get(
+    `${BASE}/sessions/${sessionId}/provenance/`,
+  );
+  if (!response.ok) {
+    throw new Error(`API ${response.status}: ${await response.text()}`);
+  }
+  return (await response.json()) as ProvenanceResponse;
+}
+
 // ── Process dispatch (J-01) ──────────────────────────────────────────
 
 /** Fetch full session detail including process state. */

--- a/ai-brand-automator-frontend/src/lib/onboarding-sessions.ts
+++ b/ai-brand-automator-frontend/src/lib/onboarding-sessions.ts
@@ -616,7 +616,7 @@ export interface FieldProvenanceRow {
   extracted_value: unknown;
   final_value: unknown;
   classification: FieldClassification;
-  confidence: number;
+  confidence: number | null;
   source_recording: number | null;
   source_span: ProvenanceSourceSpan | null;
   source_media: number | null;
@@ -640,11 +640,18 @@ export interface ProvenanceResponse {
   groups: ProvenanceGroup[];
 }
 
+export interface ConflictSummaryItem {
+  field_name: string;
+  existing_status: string;
+  new_confidence?: number;
+  new_classification?: string;
+}
+
 export interface ProcessSummary {
   fields_written: number;
   key_count?: number;
   secondary_count?: number;
-  conflicts: number;
+  conflicts: ConflictSummaryItem[];
   dropped_ungrounded: number;
   coverage: Record<string, number>;
   coverage_satisfied?: boolean;


### PR DESCRIPTION
## Summary
- **New route**: `/onboarding/sessions/[sessionId]/review` — KeyFindingsReview page showing all PROCESS output in one scrollable screen
- **Provenance display**: KEY fields rendered prominently, SECONDARY fields collapsed with "auto-filled — review" badge, each with confidence bar and source indicator
- **AC-1**: Summary bar shows fields_written, dropped_ungrounded (with explanation tooltip), conflicts count, generated items
- **AC-2**: One-click provenance — clicking source indicator opens ProvenanceDrawer with I-03's TranscriptView at the exact timestamp from `source_span.t_start`
- **AC-3**: Coverage shortfalls shown with consequence descriptions per workflow target + "Schedule follow-up" link to calendar
- **AC-4**: Conflicts section rendered **above** provenance groups, styled as amber warnings
- **Session page**: "Review findings" button appears when status is REVIEW_PENDING/CONFIRMED/COMPLETED
- **No backend changes**: all endpoints already exist (B-06 provenance, J-01 session, I-01–I-03 recordings/transcripts)
- **Types**: Added `FieldProvenanceRow`, `ProvenanceGroup`, `ProcessSummary` types and `getSessionProvenance()` API function

## New files
- `src/app/onboarding/sessions/[sessionId]/review/page.tsx` — Route wrapper
- `src/components/onboarding/KeyFindingsReview.tsx` — Main review component
- `src/components/onboarding/ProvenanceCard.tsx` — Single field provenance display
- `src/components/onboarding/ProvenanceDrawer.tsx` — Slide-out transcript/media evidence viewer
- `src/components/onboarding/__tests__/KeyFindingsReview.test.tsx` — 9 tests

## Test plan
- [x] TypeScript check passes (`npx tsc --noEmit`)
- [x] ESLint passes (0 new errors)
- [x] 9 K-01 tests pass (conflicts above fields, dropped count visible, drawer opens, KEY prominent, SECONDARY collapsed, coverage shortfalls, generated list, recording summaries)
- [x] All 214 onboarding tests pass (no regressions across 18 test suites)
- [ ] Manual: navigate to REVIEW_PENDING session → "Review findings" → verify layout
- [ ] Manual: click provenance source → verify drawer opens with transcript at correct timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)