### PR TITLE
feat(onboarding): wizard field extension with provenance markers (K-03)

### DIFF
--- a/ai-brand-automator-frontend/src/__tests__/integration.test.tsx
+++ b/ai-brand-automator-frontend/src/__tests__/integration.test.tsx
@@ -184,7 +184,7 @@ describe('Integration Tests: User Flows', () => {
 
       render(<CompanyForm />)
 
-      fireEvent.change(screen.getByLabelText(/name/i), {
+      fireEvent.change(screen.getByLabelText(/company name/i), {
         target: { value: 'Integration Test Co' },
       })
       fireEvent.change(screen.getByLabelText(/industry/i), {
@@ -339,7 +339,7 @@ describe('Integration Tests: User Flows', () => {
       render(<CompanyForm />)
 
       // First attempt
-      fireEvent.change(screen.getByLabelText(/name/i), {
+      fireEvent.change(screen.getByLabelText(/company name/i), {
         target: { value: 'Duplicate Name' },
       })
       fireEvent.change(screen.getByLabelText(/industry/i), {
@@ -363,7 +363,7 @@ describe('Integration Tests: User Flows', () => {
       expect(mockPush).not.toHaveBeenCalled()
 
       // Second attempt with different name
-      fireEvent.change(screen.getByLabelText(/name/i), {
+      fireEvent.change(screen.getByLabelText(/company name/i), {
         target: { value: 'Unique Company Name' },
       })
       fireEvent.click(screen.getByRole('button', { name: /next/i }))

--- a/ai-brand-automator-frontend/src/app/onboarding/step-1/page.tsx
+++ b/ai-brand-automator-frontend/src/app/onboarding/step-1/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Suspense } from 'react';
 import Link from 'next/link';
 import { StepWizard } from '@/components/onboarding/StepWizard';
 import { CompanyForm } from '@/components/onboarding/CompanyForm';
@@ -28,7 +29,7 @@ export default function OnboardingStep1() {
         <div className="mt-8 glass-card p-8">
           <h1 className="text-2xl font-heading font-bold text-white mb-4">Company Information</h1>
           <p className="text-brand-silver/70 font-body mb-8">Tell us about your company to get started with your brand automation.</p>
-          <CompanyForm />
+          <Suspense><CompanyForm /></Suspense>
         </div>
       </div>
     </div>

--- a/ai-brand-automator-frontend/src/app/onboarding/step-2/page.tsx
+++ b/ai-brand-automator-frontend/src/app/onboarding/step-2/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Suspense } from 'react';
 import Link from 'next/link';
 import { StepWizard } from '@/components/onboarding/StepWizard';
 import { BrandForm } from '@/components/onboarding/BrandForm';
@@ -28,7 +29,7 @@ export default function OnboardingStep2() {
         <div className="mt-8 glass-card p-8">
           <h1 className="text-2xl font-heading font-bold text-white mb-4">Brand Details</h1>
           <p className="text-brand-silver/70 font-body mb-8">Define your brand voice and positioning.</p>
-          <BrandForm />
+          <Suspense><BrandForm /></Suspense>
         </div>
       </div>
     </div>

--- a/ai-brand-automator-frontend/src/app/onboarding/step-3/page.tsx
+++ b/ai-brand-automator-frontend/src/app/onboarding/step-3/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Suspense } from 'react';
 import Link from 'next/link';
 import { StepWizard } from '@/components/onboarding/StepWizard';
 import { TargetAudienceForm } from '@/components/onboarding/TargetAudienceForm';
@@ -35,7 +36,7 @@ export default function OnboardingStep3() {
 
           <StepWizard currentStep={3} totalSteps={5} />
 
-          <TargetAudienceForm />
+          <Suspense><TargetAudienceForm /></Suspense>
         </div>
       </div>
     </div>

--- a/ai-brand-automator-frontend/src/app/onboarding/step-4/page.tsx
+++ b/ai-brand-automator-frontend/src/app/onboarding/step-4/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Suspense } from 'react';
 import Link from 'next/link';
 import { StepWizard } from '@/components/onboarding/StepWizard';
 import { AssetUploadForm } from '@/components/onboarding/AssetUploadForm';
@@ -35,7 +36,7 @@ export default function OnboardingStep4() {
 
           <StepWizard currentStep={4} totalSteps={5} />
 
-          <AssetUploadForm />
+          <Suspense><AssetUploadForm /></Suspense>
         </div>
       </div>
     </div>

--- a/ai-brand-automator-frontend/src/components/onboarding/AssetUploadForm.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/AssetUploadForm.tsx
@@ -184,16 +184,16 @@ function serializePresence(p: DigitalPresence): Record<string, string> | null {
 
 function serializeBudget(b: BudgetRange): Record<string, unknown> | null {
   const min = b.min.trim() ? Number(b.min) : null;
-  if (min == null) return null;
+  if (min == null || isNaN(min)) return null;
   const obj: Record<string, unknown> = { currency: b.currency, min, period: b.period };
   const max = b.max.trim() ? Number(b.max) : null;
-  if (max != null) obj.max = max;
+  if (max != null && !isNaN(max)) obj.max = max;
   return obj;
 }
 
 export function AssetUploadForm() {
   const router = useRouter();
-  const { provenanceMap, editField } = useWizardProvenance(4);
+  const { provenanceMap, editField, stepPath } = useWizardProvenance(4);
 
   const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>([]);
   const [totalCount, setTotalCount] = useState(0);
@@ -216,7 +216,7 @@ export function AssetUploadForm() {
   const [savingMarket, setSavingMarket] = useState(false);
   const [marketError, setMarketError] = useState('');
 
-  const initialMarket = useRef<string>('');
+  const initialMarket = useRef<Record<string, string>>({});
 
   useEffect(() => {
     const loadCompanyData = async () => {
@@ -234,14 +234,14 @@ export function AssetUploadForm() {
             setSalesChannels(parseSalesChannels(company.sales_channels));
             setDigitalPresence(parsePresence(company.digital_presence));
             setBudgetRange(parseBudget(company.marketing_budget_range));
-            initialMarket.current = JSON.stringify({
-              brandAssetStatus: company.brand_asset_status || '',
-              competitors: company.competitors,
-              products: company.products_services,
-              salesChannels: company.sales_channels,
-              digitalPresence: company.digital_presence,
-              budgetRange: company.marketing_budget_range,
-            });
+            initialMarket.current = {
+              brand_asset_status: JSON.stringify(company.brand_asset_status || null),
+              competitors: JSON.stringify(serializeCompetitors(parseCompetitors(company.competitors))),
+              products_services: JSON.stringify(serializeProducts(parseProducts(company.products_services))),
+              sales_channels: JSON.stringify(serializeSalesChannels(parseSalesChannels(company.sales_channels))),
+              digital_presence: JSON.stringify(serializePresence(parsePresence(company.digital_presence))),
+              marketing_budget_range: JSON.stringify(serializeBudget(parseBudget(company.marketing_budget_range))),
+            };
           }
         }
       } catch (err) {
@@ -316,27 +316,28 @@ export function AssetUploadForm() {
       const response = await apiClient.patch(`/companies/${companyId}/`, apiData);
 
       if (response.ok) {
-        const currentSnapshot = JSON.stringify({
-          brandAssetStatus,
-          competitors: apiData.competitors,
-          products: apiData.products_services,
-          salesChannels: apiData.sales_channels,
-          digitalPresence: apiData.digital_presence,
-          budgetRange: apiData.marketing_budget_range,
-        });
-        if (currentSnapshot !== initialMarket.current) {
-          const edits: Promise<void>[] = [];
-          const fieldKeys = [
-            'brand_asset_status', 'competitors', 'products_services',
-            'sales_channels', 'digital_presence', 'marketing_budget_range',
-          ] as const;
-          for (const key of fieldKeys) {
-            if (provenanceMap.has(key)) {
-              edits.push(editField(key, apiData[key]));
-            }
+        const currentValues: Record<string, string> = {
+          brand_asset_status: JSON.stringify(apiData.brand_asset_status),
+          competitors: JSON.stringify(apiData.competitors),
+          products_services: JSON.stringify(apiData.products_services),
+          sales_channels: JSON.stringify(apiData.sales_channels),
+          digital_presence: JSON.stringify(apiData.digital_presence),
+          marketing_budget_range: JSON.stringify(apiData.marketing_budget_range),
+        };
+
+        const edits: Promise<void>[] = [];
+        for (const key of Object.keys(currentValues)) {
+          if (
+            provenanceMap.has(key) &&
+            apiData[key] != null &&
+            currentValues[key] !== initialMarket.current[key]
+          ) {
+            edits.push(editField(key, apiData[key]));
           }
-          await Promise.allSettled(edits);
         }
+        if (edits.length > 0) await Promise.allSettled(edits);
+
+        initialMarket.current = currentValues;
         setMarketError('');
       } else {
         const errData = await response.json();
@@ -432,7 +433,7 @@ export function AssetUploadForm() {
   };
 
   const handleSkip = () => {
-    router.push('/onboarding/step-5');
+    router.push(stepPath('/onboarding/step-5'));
   };
 
   const handleDelete = async (fileId: string, fileName: string) => {
@@ -497,7 +498,7 @@ export function AssetUploadForm() {
       setError('Please upload at least one file or click Skip to continue.');
       return;
     }
-    router.push('/onboarding/step-5');
+    router.push(stepPath('/onboarding/step-5'));
   };
 
   const toggleSalesChannel = (channel: string) => {
@@ -970,7 +971,7 @@ export function AssetUploadForm() {
       <div className="flex justify-between pt-6">
         <button
           type="button"
-          onClick={() => router.push('/onboarding/step-3')}
+          onClick={() => router.push(stepPath('/onboarding/step-3'))}
           className="btn-secondary"
         >
           Back

--- a/ai-brand-automator-frontend/src/components/onboarding/AssetUploadForm.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/AssetUploadForm.tsx
@@ -5,14 +5,28 @@ import { useRouter } from 'next/navigation';
 import { apiClient, assetsApi } from '@/lib/api';
 import { getPipelineStatusConfig, PipelineStatus } from '@/types/assets';
 import { AllFilesModal } from '@/components/ui/AllFilesModal';
+import { useWizardProvenance } from '@/hooks/useWizardProvenance';
+import ProvenanceBadge from '@/components/onboarding/ProvenanceBadge';
 
-const POLLING_INTERVAL = 5000; // Poll every 5 seconds
+const POLLING_INTERVAL = 5000;
 const LIMIT_OPTIONS = [3, 6, 9] as const;
+
+const SALES_CHANNEL_OPTIONS = [
+  { value: 'online_store', label: 'Online Store' },
+  { value: 'marketplace', label: 'Marketplace' },
+  { value: 'retail', label: 'Retail' },
+  { value: 'wholesale', label: 'Wholesale' },
+  { value: 'direct', label: 'Direct Sales' },
+  { value: 'social', label: 'Social Commerce' },
+] as const;
+
+const CURRENCY_OPTIONS = ['INR', 'USD', 'EUR', 'GBP', 'AUD', 'CAD'] as const;
+const PERIOD_OPTIONS = ['monthly', 'quarterly', 'annually'] as const;
 
 interface UploadedFile {
   id: string;
   file_name: string;
-  file_type: string; // Changed from asset_type to match backend
+  file_type: string;
   file_size: number;
   pipeline_status: PipelineStatus;
 }
@@ -36,8 +50,151 @@ interface DuplicateConfirmation {
   };
 }
 
+interface Competitor {
+  name: string;
+  url: string;
+  notes: string;
+}
+
+interface ProductService {
+  name: string;
+  description: string;
+  price_range: string;
+}
+
+interface SalesChannel {
+  channel: string;
+  notes: string;
+}
+
+interface DigitalPresence {
+  website: string;
+  instagram: string;
+  facebook: string;
+  linkedin: string;
+  twitter: string;
+  youtube: string;
+}
+
+interface BudgetRange {
+  currency: string;
+  min: string;
+  max: string;
+  period: string;
+}
+
+const emptyCompetitor = (): Competitor => ({ name: '', url: '', notes: '' });
+const emptyProduct = (): ProductService => ({ name: '', description: '', price_range: '' });
+const emptyPresence = (): DigitalPresence => ({
+  website: '', instagram: '', facebook: '', linkedin: '', twitter: '', youtube: '',
+});
+const emptyBudget = (): BudgetRange => ({ currency: 'INR', min: '', max: '', period: 'monthly' });
+
+function parseCompetitors(val: unknown): Competitor[] {
+  if (!Array.isArray(val) || val.length === 0) return [emptyCompetitor()];
+  return val.map((c: Record<string, unknown>) => ({
+    name: String(c.name || ''),
+    url: String(c.url || ''),
+    notes: String(c.notes || ''),
+  }));
+}
+
+function parseProducts(val: unknown): ProductService[] {
+  if (!Array.isArray(val) || val.length === 0) return [emptyProduct()];
+  return val.map((p: Record<string, unknown>) => ({
+    name: String(p.name || ''),
+    description: String(p.description || ''),
+    price_range: String(p.price_range || ''),
+  }));
+}
+
+function parseSalesChannels(val: unknown): SalesChannel[] {
+  if (!Array.isArray(val)) return [];
+  return val.map((s: Record<string, unknown>) => ({
+    channel: String(s.channel || ''),
+    notes: String(s.notes || ''),
+  }));
+}
+
+function parsePresence(val: unknown): DigitalPresence {
+  if (!val || typeof val !== 'object') return emptyPresence();
+  const v = val as Record<string, unknown>;
+  return {
+    website: String(v.website || ''),
+    instagram: String(v.instagram || ''),
+    facebook: String(v.facebook || ''),
+    linkedin: String(v.linkedin || ''),
+    twitter: String(v.twitter || ''),
+    youtube: String(v.youtube || ''),
+  };
+}
+
+function parseBudget(val: unknown): BudgetRange {
+  if (!val || typeof val !== 'object') return emptyBudget();
+  const v = val as Record<string, unknown>;
+  return {
+    currency: String(v.currency || 'INR'),
+    min: v.min != null ? String(v.min) : '',
+    max: v.max != null ? String(v.max) : '',
+    period: String(v.period || 'monthly'),
+  };
+}
+
+function serializeCompetitors(items: Competitor[]): Array<Record<string, string>> | null {
+  const valid = items.filter((c) => c.name.trim());
+  if (valid.length === 0) return null;
+  return valid.map((c) => {
+    const obj: Record<string, string> = { name: c.name.trim() };
+    if (c.url.trim()) obj.url = c.url.trim();
+    if (c.notes.trim()) obj.notes = c.notes.trim();
+    return obj;
+  });
+}
+
+function serializeProducts(items: ProductService[]): Array<Record<string, string>> | null {
+  const valid = items.filter((p) => p.name.trim());
+  if (valid.length === 0) return null;
+  return valid.map((p) => {
+    const obj: Record<string, string> = { name: p.name.trim() };
+    if (p.description.trim()) obj.description = p.description.trim();
+    if (p.price_range.trim()) obj.price_range = p.price_range.trim();
+    return obj;
+  });
+}
+
+function serializeSalesChannels(items: SalesChannel[]): Array<Record<string, string>> | null {
+  if (items.length === 0) return null;
+  return items.map((s) => {
+    const obj: Record<string, string> = { channel: s.channel };
+    if (s.notes.trim()) obj.notes = s.notes.trim();
+    return obj;
+  });
+}
+
+function serializePresence(p: DigitalPresence): Record<string, string> | null {
+  const obj: Record<string, string> = {};
+  if (p.website.trim()) obj.website = p.website.trim();
+  if (p.instagram.trim()) obj.instagram = p.instagram.trim();
+  if (p.facebook.trim()) obj.facebook = p.facebook.trim();
+  if (p.linkedin.trim()) obj.linkedin = p.linkedin.trim();
+  if (p.twitter.trim()) obj.twitter = p.twitter.trim();
+  if (p.youtube.trim()) obj.youtube = p.youtube.trim();
+  return Object.keys(obj).length > 0 ? obj : null;
+}
+
+function serializeBudget(b: BudgetRange): Record<string, unknown> | null {
+  const min = b.min.trim() ? Number(b.min) : null;
+  if (min == null) return null;
+  const obj: Record<string, unknown> = { currency: b.currency, min, period: b.period };
+  const max = b.max.trim() ? Number(b.max) : null;
+  if (max != null) obj.max = max;
+  return obj;
+}
+
 export function AssetUploadForm() {
   const router = useRouter();
+  const { provenanceMap, editField } = useWizardProvenance(4);
+
   const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>([]);
   const [totalCount, setTotalCount] = useState(0);
   const [hasMore, setHasMore] = useState(false);
@@ -50,7 +207,50 @@ export function AssetUploadForm() {
   const [duplicateConfirm, setDuplicateConfirm] = useState<DuplicateConfirmation | null>(null);
   const pollingRef = useRef<NodeJS.Timeout | null>(null);
 
-  // Function to fetch assets with limit
+  const [brandAssetStatus, setBrandAssetStatus] = useState('');
+  const [competitors, setCompetitors] = useState<Competitor[]>([emptyCompetitor()]);
+  const [products, setProducts] = useState<ProductService[]>([emptyProduct()]);
+  const [salesChannels, setSalesChannels] = useState<SalesChannel[]>([]);
+  const [digitalPresence, setDigitalPresence] = useState<DigitalPresence>(emptyPresence());
+  const [budgetRange, setBudgetRange] = useState<BudgetRange>(emptyBudget());
+  const [savingMarket, setSavingMarket] = useState(false);
+  const [marketError, setMarketError] = useState('');
+
+  const initialMarket = useRef<string>('');
+
+  useEffect(() => {
+    const loadCompanyData = async () => {
+      try {
+        const response = await apiClient.get('/companies/');
+        if (response.ok) {
+          const data = await response.json();
+          const companies = data.results || [];
+          if (companies.length > 0) {
+            const company = companies[0];
+            localStorage.setItem('company_id', company.id.toString());
+            setBrandAssetStatus(company.brand_asset_status || '');
+            setCompetitors(parseCompetitors(company.competitors));
+            setProducts(parseProducts(company.products_services));
+            setSalesChannels(parseSalesChannels(company.sales_channels));
+            setDigitalPresence(parsePresence(company.digital_presence));
+            setBudgetRange(parseBudget(company.marketing_budget_range));
+            initialMarket.current = JSON.stringify({
+              brandAssetStatus: company.brand_asset_status || '',
+              competitors: company.competitors,
+              products: company.products_services,
+              salesChannels: company.sales_channels,
+              digitalPresence: company.digital_presence,
+              budgetRange: company.marketing_budget_range,
+            });
+          }
+        }
+      } catch (err) {
+        console.error('Failed to load company data:', err);
+      }
+    };
+    loadCompanyData();
+  }, []);
+
   const fetchAssets = useCallback(async () => {
     try {
       const response = await apiClient.get(`/assets/?limit=${displayLimit}`);
@@ -60,22 +260,19 @@ export function AssetUploadForm() {
         setTotalCount(data.count || 0);
         setHasMore(data.has_more || false);
       }
-    } catch (error) {
-      console.error('Failed to load files:', error);
+    } catch (err) {
+      console.error('Failed to load files:', err);
     }
   }, [displayLimit]);
 
-  // Check if any files are still processing (not indexed or failed)
   const hasPendingFiles = uploadedFiles.some(
-    (f) => f.pipeline_status !== 'indexed' && f.pipeline_status !== 'failed'
+    (f) => f.pipeline_status !== 'indexed' && f.pipeline_status !== 'failed',
   );
 
-  // Load existing uploaded files on mount and set up polling
   useEffect(() => {
     fetchAssets();
   }, [fetchAssets]);
 
-  // Set up polling when there are pending files
   useEffect(() => {
     if (hasPendingFiles) {
       pollingRef.current = setInterval(() => {
@@ -94,6 +291,65 @@ export function AssetUploadForm() {
     };
   }, [hasPendingFiles, fetchAssets]);
 
+  const handleSaveMarket = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSavingMarket(true);
+    setMarketError('');
+
+    try {
+      const companyId = localStorage.getItem('company_id');
+      if (!companyId) {
+        setMarketError('Company ID not found. Please start from step 1.');
+        setSavingMarket(false);
+        return;
+      }
+
+      const apiData: Record<string, unknown> = {
+        brand_asset_status: brandAssetStatus || null,
+        competitors: serializeCompetitors(competitors),
+        products_services: serializeProducts(products),
+        sales_channels: serializeSalesChannels(salesChannels),
+        digital_presence: serializePresence(digitalPresence),
+        marketing_budget_range: serializeBudget(budgetRange),
+      };
+
+      const response = await apiClient.patch(`/companies/${companyId}/`, apiData);
+
+      if (response.ok) {
+        const currentSnapshot = JSON.stringify({
+          brandAssetStatus,
+          competitors: apiData.competitors,
+          products: apiData.products_services,
+          salesChannels: apiData.sales_channels,
+          digitalPresence: apiData.digital_presence,
+          budgetRange: apiData.marketing_budget_range,
+        });
+        if (currentSnapshot !== initialMarket.current) {
+          const edits: Promise<void>[] = [];
+          const fieldKeys = [
+            'brand_asset_status', 'competitors', 'products_services',
+            'sales_channels', 'digital_presence', 'marketing_budget_range',
+          ] as const;
+          for (const key of fieldKeys) {
+            if (provenanceMap.has(key)) {
+              edits.push(editField(key, apiData[key]));
+            }
+          }
+          await Promise.allSettled(edits);
+        }
+        setMarketError('');
+      } else {
+        const errData = await response.json();
+        setMarketError(errData.detail || 'Failed to save market data');
+      }
+    } catch (err) {
+      console.error('Error saving market data:', err);
+      setMarketError('An unexpected error occurred.');
+    } finally {
+      setSavingMarket(false);
+    }
+  };
+
   const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;
     if (!files || files.length === 0) return;
@@ -109,7 +365,6 @@ export function AssetUploadForm() {
         return;
       }
 
-      // Upload each file
       for (const file of Array.from(files)) {
         const formData = new FormData();
         formData.append('file', file);
@@ -132,8 +387,8 @@ export function AssetUploadForm() {
           setError(`Failed to upload ${file.name}: ${errorData.error || errorData.message || 'Unknown error'}`);
         }
       }
-    } catch (error) {
-      console.error('Error uploading files:', error);
+    } catch (err) {
+      console.error('Error uploading files:', err);
       setError('An unexpected error occurred. Please try again.');
     } finally {
       setUploading(false);
@@ -161,7 +416,7 @@ export function AssetUploadForm() {
 
       const response = await apiClient.upload('/assets/upload/', formData);
       if (response.ok) {
-        await fetchAssets(); // Refresh to show updated file
+        await fetchAssets();
       } else {
         const errorData = await response.json();
         setError(`Failed to replace ${file.name}: ${errorData.error || errorData.message || 'Unknown error'}`);
@@ -196,8 +451,8 @@ export function AssetUploadForm() {
         const errorData = await response.json();
         setError(`Failed to delete ${fileName}: ${errorData.message || 'Unknown error'}`);
       }
-    } catch (error) {
-      console.error('Error deleting file:', error);
+    } catch (err) {
+      console.error('Error deleting file:', err);
       setError(`Failed to delete ${fileName}. Please try again.`);
     } finally {
       setDeletingId(null);
@@ -245,8 +500,313 @@ export function AssetUploadForm() {
     router.push('/onboarding/step-5');
   };
 
+  const toggleSalesChannel = (channel: string) => {
+    setSalesChannels((prev) => {
+      const exists = prev.find((s) => s.channel === channel);
+      if (exists) return prev.filter((s) => s.channel !== channel);
+      return [...prev, { channel, notes: '' }];
+    });
+  };
+
+  const updateSalesChannelNotes = (channel: string, notes: string) => {
+    setSalesChannels((prev) =>
+      prev.map((s) => (s.channel === channel ? { ...s, notes } : s)),
+    );
+  };
+
   return (
-    <div className="space-y-6">
+    <div className="space-y-8">
+      {/* ── Market & Business Section ─────────────────────────────── */}
+      <form onSubmit={handleSaveMarket} className="space-y-6">
+        <div>
+          <h3 className="text-lg font-semibold text-white mb-1">Market & Business</h3>
+          <p className="text-xs text-brand-silver mb-4">
+            Tell us about your market position, products, and budget.
+          </p>
+        </div>
+
+        {marketError && (
+          <div className="bg-red-900/30 border border-red-500/50 text-red-300 px-4 py-3 rounded-lg">
+            {marketError}
+          </div>
+        )}
+
+        <div>
+          <label htmlFor="brandAssetStatus" className="label-dark">
+            Brand Asset Status
+            <ProvenanceBadge row={provenanceMap.get('brand_asset_status')} />
+          </label>
+          <select
+            id="brandAssetStatus"
+            value={brandAssetStatus}
+            onChange={(e) => setBrandAssetStatus(e.target.value)}
+            className="select-dark mt-1"
+          >
+            <option value="">Select status</option>
+            <option value="none">None</option>
+            <option value="basic">Basic (logo only)</option>
+            <option value="partial">Partial (logo + some guidelines)</option>
+            <option value="complete">Complete brand kit</option>
+          </select>
+        </div>
+
+        {/* Competitors repeater */}
+        <div>
+          <label className="label-dark">
+            Competitors
+            <ProvenanceBadge row={provenanceMap.get('competitors')} />
+          </label>
+          <div className="mt-1 space-y-2">
+            {competitors.map((comp, i) => (
+              <div key={i} className="grid grid-cols-1 md:grid-cols-3 gap-2 items-start">
+                <input
+                  type="text"
+                  value={comp.name}
+                  onChange={(e) => {
+                    const updated = [...competitors];
+                    updated[i] = { ...comp, name: e.target.value };
+                    setCompetitors(updated);
+                  }}
+                  className="input-dark"
+                  placeholder="Name"
+                />
+                <input
+                  type="text"
+                  value={comp.url}
+                  onChange={(e) => {
+                    const updated = [...competitors];
+                    updated[i] = { ...comp, url: e.target.value };
+                    setCompetitors(updated);
+                  }}
+                  className="input-dark"
+                  placeholder="Website URL"
+                />
+                <div className="flex gap-2">
+                  <input
+                    type="text"
+                    value={comp.notes}
+                    onChange={(e) => {
+                      const updated = [...competitors];
+                      updated[i] = { ...comp, notes: e.target.value };
+                      setCompetitors(updated);
+                    }}
+                    className="input-dark flex-1"
+                    placeholder="Notes"
+                  />
+                  {competitors.length > 1 && (
+                    <button
+                      type="button"
+                      onClick={() => setCompetitors(competitors.filter((_, j) => j !== i))}
+                      className="text-red-400 hover:text-red-300 px-2"
+                      aria-label={`Remove competitor ${i + 1}`}
+                    >
+                      &times;
+                    </button>
+                  )}
+                </div>
+              </div>
+            ))}
+            <button
+              type="button"
+              onClick={() => setCompetitors([...competitors, emptyCompetitor()])}
+              className="text-sm text-brand-electric hover:text-brand-electric/80"
+            >
+              + Add competitor
+            </button>
+          </div>
+        </div>
+
+        {/* Products & Services repeater */}
+        <div>
+          <label className="label-dark">
+            Products & Services
+            <ProvenanceBadge row={provenanceMap.get('products_services')} />
+          </label>
+          <div className="mt-1 space-y-2">
+            {products.map((prod, i) => (
+              <div key={i} className="grid grid-cols-1 md:grid-cols-3 gap-2 items-start">
+                <input
+                  type="text"
+                  value={prod.name}
+                  onChange={(e) => {
+                    const updated = [...products];
+                    updated[i] = { ...prod, name: e.target.value };
+                    setProducts(updated);
+                  }}
+                  className="input-dark"
+                  placeholder="Name"
+                />
+                <input
+                  type="text"
+                  value={prod.description}
+                  onChange={(e) => {
+                    const updated = [...products];
+                    updated[i] = { ...prod, description: e.target.value };
+                    setProducts(updated);
+                  }}
+                  className="input-dark"
+                  placeholder="Description"
+                />
+                <div className="flex gap-2">
+                  <input
+                    type="text"
+                    value={prod.price_range}
+                    onChange={(e) => {
+                      const updated = [...products];
+                      updated[i] = { ...prod, price_range: e.target.value };
+                      setProducts(updated);
+                    }}
+                    className="input-dark flex-1"
+                    placeholder="Price range"
+                  />
+                  {products.length > 1 && (
+                    <button
+                      type="button"
+                      onClick={() => setProducts(products.filter((_, j) => j !== i))}
+                      className="text-red-400 hover:text-red-300 px-2"
+                      aria-label={`Remove product ${i + 1}`}
+                    >
+                      &times;
+                    </button>
+                  )}
+                </div>
+              </div>
+            ))}
+            <button
+              type="button"
+              onClick={() => setProducts([...products, emptyProduct()])}
+              className="text-sm text-brand-electric hover:text-brand-electric/80"
+            >
+              + Add product or service
+            </button>
+          </div>
+        </div>
+
+        {/* Sales Channels checkboxes */}
+        <div>
+          <label className="label-dark">
+            Sales Channels
+            <ProvenanceBadge row={provenanceMap.get('sales_channels')} />
+          </label>
+          <div className="mt-2 space-y-2">
+            {SALES_CHANNEL_OPTIONS.map((opt) => {
+              const active = salesChannels.find((s) => s.channel === opt.value);
+              return (
+                <div key={opt.value}>
+                  <label className="flex items-center gap-2 text-sm text-brand-silver cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={!!active}
+                      onChange={() => toggleSalesChannel(opt.value)}
+                      className="rounded border-white/20 bg-white/5 text-brand-electric focus:ring-brand-electric"
+                    />
+                    {opt.label}
+                  </label>
+                  {active && (
+                    <input
+                      type="text"
+                      value={active.notes}
+                      onChange={(e) => updateSalesChannelNotes(opt.value, e.target.value)}
+                      className="input-dark mt-1 ml-6 text-sm"
+                      placeholder="Notes (optional)"
+                    />
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Digital Presence */}
+        <div>
+          <label className="label-dark">
+            Digital Presence
+            <ProvenanceBadge row={provenanceMap.get('digital_presence')} />
+          </label>
+          <div className="mt-1 grid grid-cols-1 md:grid-cols-2 gap-3">
+            {(
+              [
+                ['website', 'Website URL'],
+                ['instagram', 'Instagram handle'],
+                ['facebook', 'Facebook page'],
+                ['linkedin', 'LinkedIn page'],
+                ['twitter', 'Twitter / X handle'],
+                ['youtube', 'YouTube channel'],
+              ] as const
+            ).map(([key, placeholder]) => (
+              <input
+                key={key}
+                type="text"
+                value={digitalPresence[key]}
+                onChange={(e) =>
+                  setDigitalPresence({ ...digitalPresence, [key]: e.target.value })
+                }
+                className="input-dark"
+                placeholder={placeholder}
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* Marketing Budget Range */}
+        <div>
+          <label className="label-dark">
+            Marketing Budget Range
+            <ProvenanceBadge row={provenanceMap.get('marketing_budget_range')} />
+          </label>
+          <div className="mt-1 grid grid-cols-2 md:grid-cols-4 gap-3">
+            <select
+              value={budgetRange.currency}
+              onChange={(e) => setBudgetRange({ ...budgetRange, currency: e.target.value })}
+              className="select-dark"
+            >
+              {CURRENCY_OPTIONS.map((c) => (
+                <option key={c} value={c}>{c}</option>
+              ))}
+            </select>
+            <input
+              type="number"
+              value={budgetRange.min}
+              onChange={(e) => setBudgetRange({ ...budgetRange, min: e.target.value })}
+              className="input-dark"
+              placeholder="Min"
+              min="0"
+            />
+            <input
+              type="number"
+              value={budgetRange.max}
+              onChange={(e) => setBudgetRange({ ...budgetRange, max: e.target.value })}
+              className="input-dark"
+              placeholder="Max"
+              min="0"
+            />
+            <select
+              value={budgetRange.period}
+              onChange={(e) => setBudgetRange({ ...budgetRange, period: e.target.value })}
+              className="select-dark"
+            >
+              {PERIOD_OPTIONS.map((p) => (
+                <option key={p} value={p}>{p.charAt(0).toUpperCase() + p.slice(1)}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="flex justify-end">
+          <button
+            type="submit"
+            disabled={savingMarket}
+            className="btn-primary text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {savingMarket ? 'Saving...' : 'Save Market Info'}
+          </button>
+        </div>
+      </form>
+
+      {/* ── Divider ──────────────────────────────────────────────── */}
+      <div className="border-t border-white/10" />
+
+      {/* ── File Upload Section (unchanged) ──────────────────────── */}
       {error && (
         <div className="bg-red-900/30 border border-red-500/50 text-red-300 px-4 py-3 rounded-lg">
           {error}
@@ -317,12 +877,11 @@ export function AssetUploadForm() {
               </h3>
               {hasPendingFiles && (
                 <span className="text-xs text-brand-silver/70 animate-pulse">
-                  🔄 Processing...
+                  Processing...
                 </span>
               )}
             </div>
             <div className="flex items-center gap-3">
-              {/* Limit selector */}
               <div className="flex items-center gap-2">
                 <span className="text-xs text-brand-silver/70">Show:</span>
                 <select
@@ -337,7 +896,6 @@ export function AssetUploadForm() {
                   ))}
                 </select>
               </div>
-              {/* View All button */}
               {totalCount > displayLimit && (
                 <button
                   onClick={() => setShowAllFiles(true)}
@@ -371,7 +929,6 @@ export function AssetUploadForm() {
                   <span className="text-xs bg-brand-electric/20 text-brand-electric px-2 py-1 rounded">
                     {file.file_type}
                   </span>
-                  {/* View button - show for indexed/curated files */}
                   {(file.pipeline_status === 'indexed' || file.pipeline_status === 'curated') && (
                     <button
                       type="button"
@@ -380,10 +937,9 @@ export function AssetUploadForm() {
                       className="text-brand-electric hover:text-brand-electric/80 disabled:opacity-50 transition-colors"
                       title="View file"
                     >
-                      {loadingUrlId === file.id ? '⏳' : '👁️'}
+                      {loadingUrlId === file.id ? 'Loading...' : 'View'}
                     </button>
                   )}
-                  {/* Download button - show for indexed/curated files */}
                   {(file.pipeline_status === 'indexed' || file.pipeline_status === 'curated') && (
                     <button
                       type="button"
@@ -392,7 +948,7 @@ export function AssetUploadForm() {
                       className="text-brand-electric hover:text-brand-electric/80 disabled:opacity-50 transition-colors"
                       title="Download file"
                     >
-                      ⬇️
+                      Download
                     </button>
                   )}
                   <button
@@ -402,11 +958,7 @@ export function AssetUploadForm() {
                     className="text-red-400 hover:text-red-300 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                     title="Delete file"
                   >
-                    {deletingId === file.id ? (
-                      <span className="inline-block animate-spin">⏳</span>
-                    ) : (
-                      <span>🗑️</span>
-                    )}
+                    {deletingId === file.id ? 'Deleting...' : 'Delete'}
                   </button>
                 </div>
               </li>
@@ -442,19 +994,17 @@ export function AssetUploadForm() {
         </div>
       </div>
 
-      {/* All Files Modal */}
       <AllFilesModal
         isOpen={showAllFiles}
         onClose={() => {
           setShowAllFiles(false);
-          fetchAssets(); // Refresh the list when modal closes
+          fetchAssets();
         }}
         onDelete={async (fileId, fileName) => {
           await handleDelete(fileId, fileName);
         }}
       />
 
-      {/* Duplicate File Confirmation Dialog */}
       {duplicateConfirm && (
         <div
           className="fixed inset-0 bg-black/60 flex items-center justify-center z-50"

--- a/ai-brand-automator-frontend/src/components/onboarding/BrandForm.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/BrandForm.tsx
@@ -8,7 +8,7 @@ import ProvenanceBadge from '@/components/onboarding/ProvenanceBadge';
 
 export function BrandForm() {
   const router = useRouter();
-  const { provenanceMap, editField } = useWizardProvenance(2);
+  const { provenanceMap, editField, stepPath } = useWizardProvenance(2);
 
   const [formData, setFormData] = useState({
     name: '',
@@ -77,7 +77,7 @@ export function BrandForm() {
 
       if (!companyId) {
         alert('Company ID not found. Please complete step 1 first.');
-        router.push('/onboarding/step-1');
+        router.push(stepPath('/onboarding/step-1'));
         return;
       }
 
@@ -105,7 +105,7 @@ export function BrandForm() {
           await editField('business_goals', formData.businessGoals).catch(() => {});
         }
 
-        router.push('/onboarding/step-3');
+        router.push(stepPath('/onboarding/step-3'));
       } else {
         const error = await response.json();
         const errorMessage = error.detail ||
@@ -226,7 +226,7 @@ export function BrandForm() {
       <div className="flex justify-between">
         <button
           type="button"
-          onClick={() => router.push('/onboarding/step-1')}
+          onClick={() => router.push(stepPath('/onboarding/step-1'))}
           className="btn-secondary"
         >
           Previous

--- a/ai-brand-automator-frontend/src/components/onboarding/BrandForm.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/BrandForm.tsx
@@ -1,11 +1,15 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { apiClient } from '@/lib/api';
+import { useWizardProvenance } from '@/hooks/useWizardProvenance';
+import ProvenanceBadge from '@/components/onboarding/ProvenanceBadge';
 
 export function BrandForm() {
   const router = useRouter();
+  const { provenanceMap, editField } = useWizardProvenance(2);
+
   const [formData, setFormData] = useState({
     name: '',
     description: '',
@@ -17,10 +21,11 @@ export function BrandForm() {
     missionStatement: '',
     values: '',
     positioningStatement: '',
+    businessGoals: '',
   });
   const [isLoading, setIsLoading] = useState(false);
+  const initialValues = useRef<Record<string, string>>({});
 
-  // Load existing company data on mount
   useEffect(() => {
     const loadCompanyData = async () => {
       try {
@@ -30,11 +35,9 @@ export function BrandForm() {
           const companies = data.results || [];
           if (companies.length > 0) {
             const company = companies[0];
-            // Store company ID in localStorage for form submission
             localStorage.setItem('company_id', company.id.toString());
-            
-            // Populate form with existing data (convert snake_case to camelCase)
-            setFormData({
+
+            const loaded = {
               name: company.name || '',
               description: company.description || '',
               industry: company.industry || '',
@@ -45,7 +48,10 @@ export function BrandForm() {
               missionStatement: company.mission_statement || '',
               values: company.values || '',
               positioningStatement: company.positioning_statement || '',
-            });
+              businessGoals: company.business_goals || '',
+            };
+            setFormData(loaded);
+            initialValues.current = { ...loaded };
           }
         }
       } catch (error) {
@@ -68,14 +74,13 @@ export function BrandForm() {
     setIsLoading(true);
     try {
       const companyId = localStorage.getItem('company_id');
-      
+
       if (!companyId) {
         alert('Company ID not found. Please complete step 1 first.');
         router.push('/onboarding/step-1');
         return;
       }
 
-      // Convert camelCase to snake_case for backend
       const apiData = {
         name: formData.name,
         description: formData.description,
@@ -87,21 +92,25 @@ export function BrandForm() {
         mission_statement: formData.missionStatement,
         values: formData.values,
         positioning_statement: formData.positioningStatement,
+        business_goals: formData.businessGoals,
       };
 
       const response = await apiClient.patch(`/companies/${companyId}/`, apiData);
 
       if (response.ok) {
-        const data = await response.json();
-        console.log('Brand data updated:', data);
+        if (
+          provenanceMap.has('business_goals') &&
+          formData.businessGoals !== initialValues.current.businessGoals
+        ) {
+          await editField('business_goals', formData.businessGoals).catch(() => {});
+        }
+
         router.push('/onboarding/step-3');
       } else {
         const error = await response.json();
-        console.error('Validation error:', error);
-        // Show detailed error message
-        const errorMessage = error.detail || 
+        const errorMessage = error.detail ||
           (error.brand_voice && error.brand_voice[0]) ||
-          JSON.stringify(error) || 
+          JSON.stringify(error) ||
           'Failed to save brand data';
         alert(errorMessage);
       }
@@ -195,6 +204,22 @@ export function BrandForm() {
           onChange={handleChange}
           className="input-dark mt-1"
           placeholder="How do you position your brand?"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="businessGoals" className="label-dark">
+          Business Goals
+          <ProvenanceBadge row={provenanceMap.get('business_goals')} />
+        </label>
+        <textarea
+          id="businessGoals"
+          name="businessGoals"
+          rows={3}
+          value={formData.businessGoals}
+          onChange={handleChange}
+          className="input-dark mt-1"
+          placeholder="What does your business want to achieve?"
         />
       </div>
 

--- a/ai-brand-automator-frontend/src/components/onboarding/CompanyForm.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/CompanyForm.tsx
@@ -8,7 +8,7 @@ import ProvenanceBadge from '@/components/onboarding/ProvenanceBadge';
 
 export function CompanyForm() {
   const router = useRouter();
-  const { provenanceMap, editField } = useWizardProvenance(1);
+  const { provenanceMap, editField, stepPath } = useWizardProvenance(1);
 
   const [formData, setFormData] = useState({
     name: '',
@@ -133,7 +133,7 @@ export function CompanyForm() {
         }
         await Promise.allSettled(provenanceEdits);
 
-        router.push('/onboarding/step-2');
+        router.push(stepPath('/onboarding/step-2'));
       } else {
         const error = await response.json();
         alert(error.detail || 'Failed to save company data');

--- a/ai-brand-automator-frontend/src/components/onboarding/CompanyForm.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/CompanyForm.tsx
@@ -1,11 +1,15 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { apiClient } from '@/lib/api';
+import { useWizardProvenance } from '@/hooks/useWizardProvenance';
+import ProvenanceBadge from '@/components/onboarding/ProvenanceBadge';
 
 export function CompanyForm() {
   const router = useRouter();
+  const { provenanceMap, editField } = useWizardProvenance(1);
+
   const [formData, setFormData] = useState({
     name: '',
     description: '',
@@ -18,23 +22,26 @@ export function CompanyForm() {
     stateProvince: '',
     postalCode: '',
     country: '',
+    legalName: '',
+    founderStory: '',
+    trademarkStatus: '',
+    decisionMaker: '',
   });
   const [isLoading, setIsLoading] = useState(false);
   const [existingCompanyId, setExistingCompanyId] = useState<number | null>(null);
+  const initialValues = useRef<Record<string, string>>({});
 
-  // Load existing company data if it exists
   useEffect(() => {
     const loadExistingCompany = async () => {
       try {
         const response = await apiClient.get('/companies/');
         if (response.ok) {
           const data = await response.json();
-          // API returns paginated data with results array
           const companies = data.results || [];
           if (companies.length > 0) {
-            const company = companies[0]; // Get first company (one per tenant)
+            const company = companies[0];
             setExistingCompanyId(company.id);
-            setFormData({
+            const loaded = {
               name: company.name || '',
               description: company.description || '',
               industry: company.industry || '',
@@ -46,8 +53,13 @@ export function CompanyForm() {
               stateProvince: company.state_province || '',
               postalCode: company.postal_code || '',
               country: company.country || '',
-            });
-            // Store company ID for next steps
+              legalName: company.legal_name || '',
+              founderStory: company.founder_story || '',
+              trademarkStatus: company.trademark_status || '',
+              decisionMaker: company.decision_maker || '',
+            };
+            setFormData(loaded);
+            initialValues.current = { ...loaded };
             localStorage.setItem('company_id', company.id.toString());
           }
         }
@@ -65,11 +77,17 @@ export function CompanyForm() {
     });
   };
 
+  const FIELD_MAP: Record<string, string> = {
+    legalName: 'legal_name',
+    founderStory: 'founder_story',
+    trademarkStatus: 'trademark_status',
+    decisionMaker: 'decision_maker',
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setIsLoading(true);
     try {
-      // Convert camelCase to snake_case for backend
       const apiData = {
         name: formData.name,
         description: formData.description,
@@ -82,25 +100,39 @@ export function CompanyForm() {
         state_province: formData.stateProvince,
         postal_code: formData.postalCode,
         country: formData.country,
+        legal_name: formData.legalName,
+        founder_story: formData.founderStory,
+        trademark_status: formData.trademarkStatus,
+        decision_maker: formData.decisionMaker,
       };
-      
+
       let response;
       if (existingCompanyId) {
-        // Partial update existing company (PATCH preserves fields not sent)
         response = await apiClient.patch(`/companies/${existingCompanyId}/`, apiData);
       } else {
-        // Create new company
         response = await apiClient.post('/companies/', apiData);
       }
 
       if (response.ok) {
         const data = await response.json();
-        console.log('Company saved:', data);
-        // Use known ID for updates; for new creates, get from response or refetch
         const companyId = existingCompanyId || data.id;
         if (companyId) {
           localStorage.setItem('company_id', companyId.toString());
         }
+
+        const provenanceEdits: Promise<void>[] = [];
+        for (const [camel, snake] of Object.entries(FIELD_MAP)) {
+          if (
+            provenanceMap.has(snake) &&
+            formData[camel as keyof typeof formData] !== initialValues.current[camel]
+          ) {
+            provenanceEdits.push(
+              editField(snake, formData[camel as keyof typeof formData]),
+            );
+          }
+        }
+        await Promise.allSettled(provenanceEdits);
+
         router.push('/onboarding/step-2');
       } else {
         const error = await response.json();
@@ -127,6 +159,22 @@ export function CompanyForm() {
           value={formData.name}
           onChange={handleChange}
           className="input-dark mt-1"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="legalName" className="label-dark">
+          Legal Name
+          <ProvenanceBadge row={provenanceMap.get('legal_name')} />
+        </label>
+        <input
+          type="text"
+          id="legalName"
+          name="legalName"
+          value={formData.legalName}
+          onChange={handleChange}
+          className="input-dark mt-1"
+          placeholder="Registered legal entity name, if different"
         />
       </div>
 
@@ -288,6 +336,62 @@ export function CompanyForm() {
             value={formData.country}
             onChange={handleChange}
             className="input-dark mt-1"
+          />
+        </div>
+      </div>
+
+      <div className="pt-2">
+        <h3 className="label-dark mb-1">Additional Details</h3>
+      </div>
+
+      <div>
+        <label htmlFor="founderStory" className="label-dark">
+          Founder Story
+          <ProvenanceBadge row={provenanceMap.get('founder_story')} />
+        </label>
+        <textarea
+          id="founderStory"
+          name="founderStory"
+          rows={3}
+          value={formData.founderStory}
+          onChange={handleChange}
+          className="input-dark mt-1"
+          placeholder="How did you start this company?"
+        />
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <label htmlFor="trademarkStatus" className="label-dark">
+            Trademark Status
+            <ProvenanceBadge row={provenanceMap.get('trademark_status')} />
+          </label>
+          <select
+            id="trademarkStatus"
+            name="trademarkStatus"
+            value={formData.trademarkStatus}
+            onChange={handleChange}
+            className="select-dark mt-1"
+          >
+            <option value="">Select status</option>
+            <option value="none">None</option>
+            <option value="pending">Pending</option>
+            <option value="registered">Registered</option>
+          </select>
+        </div>
+        <div>
+          <label htmlFor="decisionMaker" className="label-dark">
+            Decision Maker
+            <ProvenanceBadge row={provenanceMap.get('decision_maker')} />
+          </label>
+          <input
+            type="text"
+            id="decisionMaker"
+            name="decisionMaker"
+            value={formData.decisionMaker}
+            onChange={handleChange}
+            className="input-dark mt-1"
+            placeholder="Who signs off on brand decisions?"
           />
         </div>
       </div>

--- a/ai-brand-automator-frontend/src/components/onboarding/ProvenanceBadge.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/ProvenanceBadge.tsx
@@ -1,0 +1,23 @@
+import type { FieldProvenanceRow } from '@/lib/onboarding-sessions';
+
+interface ProvenanceBadgeProps {
+  row: FieldProvenanceRow | undefined;
+}
+
+export default function ProvenanceBadge({ row }: ProvenanceBadgeProps) {
+  if (!row) return null;
+
+  const confidence = row.confidence != null ? `${Math.round(row.confidence * 100)}%` : '';
+  const title = confidence
+    ? `AI-extracted (${confidence} confidence)`
+    : 'AI-extracted';
+
+  return (
+    <span
+      className="ml-2 inline-flex items-center rounded bg-brand-electric/15 px-1.5 py-0.5 text-[10px] font-medium text-brand-electric"
+      title={title}
+    >
+      AI
+    </span>
+  );
+}

--- a/ai-brand-automator-frontend/src/components/onboarding/TargetAudienceForm.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/TargetAudienceForm.tsx
@@ -1,11 +1,48 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { apiClient } from '@/lib/api';
+import { useWizardProvenance } from '@/hooks/useWizardProvenance';
+import ProvenanceBadge from '@/components/onboarding/ProvenanceBadge';
+
+function parseLanguages(val: unknown): string {
+  if (Array.isArray(val)) return val.join(', ');
+  return '';
+}
+
+function serializeLanguages(text: string): string[] | null {
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+  return trimmed.split(',').map((s) => s.trim()).filter(Boolean);
+}
+
+function parseCustomerProof(val: unknown): string {
+  if (!Array.isArray(val)) return '';
+  return val
+    .map((item: Record<string, unknown>) =>
+      typeof item === 'object' && item !== null ? String(item.text || '') : String(item),
+    )
+    .filter(Boolean)
+    .join('\n');
+}
+
+function serializeCustomerProof(
+  text: string,
+): Array<{ type: string; text: string }> | null {
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+  return trimmed
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => ({ type: 'testimonial', text: line }));
+}
 
 export function TargetAudienceForm() {
   const router = useRouter();
+  const { provenanceMap, editField } = useWizardProvenance(3);
+
   const [formData, setFormData] = useState({
     name: '',
     description: '',
@@ -16,11 +53,13 @@ export function TargetAudienceForm() {
     psychographics: '',
     painPoints: '',
     desiredOutcomes: '',
+    audienceLanguages: '',
+    customerProof: '',
   });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const initialValues = useRef<Record<string, string>>({});
 
-  // Load existing company data on mount
   useEffect(() => {
     const loadCompanyData = async () => {
       try {
@@ -30,11 +69,9 @@ export function TargetAudienceForm() {
           const companies = data.results || [];
           if (companies.length > 0) {
             const company = companies[0];
-            // Store company ID in localStorage
             localStorage.setItem('company_id', company.id.toString());
-            
-            // Populate form with existing data (convert snake_case to camelCase)
-            setFormData({
+
+            const loaded = {
               name: company.name || '',
               description: company.description || '',
               industry: company.industry || '',
@@ -44,7 +81,11 @@ export function TargetAudienceForm() {
               psychographics: company.psychographics || '',
               painPoints: company.pain_points || '',
               desiredOutcomes: company.desired_outcomes || '',
-            });
+              audienceLanguages: parseLanguages(company.audience_languages),
+              customerProof: parseCustomerProof(company.customer_proof),
+            };
+            setFormData(loaded);
+            initialValues.current = { ...loaded };
           }
         }
       } catch (error) {
@@ -68,8 +109,7 @@ export function TargetAudienceForm() {
         return;
       }
 
-      // Update company with all required fields
-      const apiData = {
+      const apiData: Record<string, unknown> = {
         name: formData.name,
         description: formData.description,
         industry: formData.industry,
@@ -79,15 +119,41 @@ export function TargetAudienceForm() {
         psychographics: formData.psychographics,
         pain_points: formData.painPoints,
         desired_outcomes: formData.desiredOutcomes,
+        audience_languages: serializeLanguages(formData.audienceLanguages),
+        customer_proof: serializeCustomerProof(formData.customerProof),
       };
 
       const response = await apiClient.patch(
         `/companies/${companyId}/`,
-        apiData
+        apiData,
       );
 
       if (response.ok) {
-        // Move to next step
+        const provenanceEdits: Promise<void>[] = [];
+        if (
+          provenanceMap.has('audience_languages') &&
+          formData.audienceLanguages !== initialValues.current.audienceLanguages
+        ) {
+          provenanceEdits.push(
+            editField(
+              'audience_languages',
+              serializeLanguages(formData.audienceLanguages),
+            ),
+          );
+        }
+        if (
+          provenanceMap.has('customer_proof') &&
+          formData.customerProof !== initialValues.current.customerProof
+        ) {
+          provenanceEdits.push(
+            editField(
+              'customer_proof',
+              serializeCustomerProof(formData.customerProof),
+            ),
+          );
+        }
+        await Promise.allSettled(provenanceEdits);
+
         router.push('/onboarding/step-4');
       } else {
         const errorData = await response.json();
@@ -194,6 +260,42 @@ export function TargetAudienceForm() {
         />
         <p className="mt-1 text-sm text-brand-silver/70">
           What do they want to achieve?
+        </p>
+      </div>
+
+      <div>
+        <label htmlFor="audienceLanguages" className="label-dark">
+          Audience Languages
+          <ProvenanceBadge row={provenanceMap.get('audience_languages')} />
+        </label>
+        <input
+          type="text"
+          id="audienceLanguages"
+          className="input-dark mt-1"
+          value={formData.audienceLanguages}
+          onChange={(e) => setFormData({ ...formData, audienceLanguages: e.target.value })}
+          placeholder="e.g., en-IN, kn-IN, hi-IN"
+        />
+        <p className="mt-1 text-sm text-brand-silver/70">
+          BCP-47 language tags, comma-separated
+        </p>
+      </div>
+
+      <div>
+        <label htmlFor="customerProof" className="label-dark">
+          Customer Proof
+          <ProvenanceBadge row={provenanceMap.get('customer_proof')} />
+        </label>
+        <textarea
+          id="customerProof"
+          rows={4}
+          className="input-dark mt-1"
+          value={formData.customerProof}
+          onChange={(e) => setFormData({ ...formData, customerProof: e.target.value })}
+          placeholder="One testimonial, review, or case study per line"
+        />
+        <p className="mt-1 text-sm text-brand-silver/70">
+          Testimonials, reviews, awards — one per line
         </p>
       </div>
 

--- a/ai-brand-automator-frontend/src/components/onboarding/TargetAudienceForm.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/TargetAudienceForm.tsx
@@ -41,7 +41,7 @@ function serializeCustomerProof(
 
 export function TargetAudienceForm() {
   const router = useRouter();
-  const { provenanceMap, editField } = useWizardProvenance(3);
+  const { provenanceMap, editField, stepPath } = useWizardProvenance(3);
 
   const [formData, setFormData] = useState({
     name: '',
@@ -154,7 +154,7 @@ export function TargetAudienceForm() {
         }
         await Promise.allSettled(provenanceEdits);
 
-        router.push('/onboarding/step-4');
+        router.push(stepPath('/onboarding/step-4'));
       } else {
         const errorData = await response.json();
         setError(errorData.message || 'Failed to save target audience data');
@@ -302,7 +302,7 @@ export function TargetAudienceForm() {
       <div className="flex justify-between pt-6">
         <button
           type="button"
-          onClick={() => router.push('/onboarding/step-2')}
+          onClick={() => router.push(stepPath('/onboarding/step-2'))}
           className="btn-secondary"
         >
           Back

--- a/ai-brand-automator-frontend/src/components/onboarding/__tests__/AssetUploadForm.test.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/__tests__/AssetUploadForm.test.tsx
@@ -1,17 +1,8 @@
-/**
- * Phase 7.3: Frontend Unit Tests - AssetUploadForm Component
- *
- * Tests for src/components/onboarding/AssetUploadForm.tsx
- * Focusing on file browser integration, pagination, and signed URL features
- */
-
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { AssetUploadForm } from '../AssetUploadForm';
 import { assetsApi, apiClient } from '@/lib/api';
 
-// Mock the api module — apiClient methods return Response-like objects;
-// assetsApi.getSignedUrl returns parsed data directly.
 jest.mock('@/lib/api', () => ({
   assetsApi: {
     getSignedUrl: jest.fn(),
@@ -19,24 +10,35 @@ jest.mock('@/lib/api', () => ({
   apiClient: {
     get: jest.fn(),
     post: jest.fn(),
+    patch: jest.fn(),
     delete: jest.fn(),
     upload: jest.fn(),
   },
 }));
 
-// Mock next/navigation
+let mockSessionId: string | null = null;
 jest.mock('next/navigation', () => ({
   useRouter: () => ({
     push: jest.fn(),
     replace: jest.fn(),
     prefetch: jest.fn(),
   }),
+  useSearchParams: () => ({
+    get: (key: string) => (key === 'sessionId' ? mockSessionId : null),
+  }),
 }));
 
-// Mock AllFilesModal to keep tests focused on AssetUploadForm
 jest.mock('@/components/ui/AllFilesModal', () => ({
   AllFilesModal: ({ isOpen }: { isOpen: boolean }) =>
     isOpen ? <div role="dialog">All Files Modal</div> : null,
+}));
+
+const mockGetSessionProvenance = jest.fn();
+const mockEditProvenance = jest.fn();
+jest.mock('@/lib/onboarding-sessions', () => ({
+  getSessionProvenance: (...args: unknown[]) =>
+    mockGetSessionProvenance(...args),
+  editProvenance: (...args: unknown[]) => mockEditProvenance(...args),
 }));
 
 const mockFiles = [
@@ -63,7 +65,6 @@ const mockFiles = [
   },
 ];
 
-/** Helper to build a Response-like object for apiClient mocks. */
 function mockResponse(data: unknown, ok = true, status = 200) {
   return { ok, status, json: async () => data };
 }
@@ -73,22 +74,19 @@ describe('AssetUploadForm', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockSessionId = null;
 
-    // localStorage — component reads company_id before uploading
     jest.spyOn(Storage.prototype, 'getItem').mockImplementation((key: string) => {
       if (key === 'company_id') return '123';
       return null;
     });
 
-    // window.confirm — component uses native confirm for delete
     window.confirm = jest.fn(() => true);
 
-    // Default: apiClient.get returns the three mock files
     (apiClient.get as jest.Mock).mockResolvedValue(
       mockResponse({ results: mockFiles, count: 3, has_more: false }),
     );
 
-    // Default: apiClient.upload returns a successful new file
     (apiClient.upload as jest.Mock).mockResolvedValue(
       mockResponse({
         id: '4',
@@ -99,14 +97,16 @@ describe('AssetUploadForm', () => {
       }),
     );
 
-    // Default: apiClient.delete returns success
     (apiClient.delete as jest.Mock).mockResolvedValue(mockResponse({}));
 
-    // Default: assetsApi.getSignedUrl returns view + download URLs
     (assetsApi.getSignedUrl as jest.Mock).mockResolvedValue({
       view_url: 'https://storage.googleapis.com/signed-view-url',
       download_url: 'https://storage.googleapis.com/signed-download-url',
     });
+
+    (apiClient.patch as jest.Mock).mockResolvedValue(
+      mockResponse({ id: 123 }),
+    );
   });
 
   afterEach(() => {
@@ -131,7 +131,6 @@ describe('AssetUploadForm', () => {
     });
 
     it('shows view all button when files exist', async () => {
-      // View All only shows when totalCount > displayLimit (default 6)
       (apiClient.get as jest.Mock).mockResolvedValue(
         mockResponse({ results: mockFiles, count: 10, has_more: true }),
       );
@@ -143,6 +142,18 @@ describe('AssetUploadForm', () => {
           screen.getByRole('button', { name: /View All/i }),
         ).toBeInTheDocument();
       });
+    });
+
+    it('renders Market & Business section with K-03 fields', () => {
+      render(<AssetUploadForm />);
+
+      expect(
+        screen.getByLabelText(/brand asset status/i),
+      ).toBeInTheDocument();
+      expect(screen.getByText(/Market & Business/i)).toBeInTheDocument();
+      expect(screen.getByText(/Products & Services/i)).toBeInTheDocument();
+      expect(screen.getByText(/Digital Presence/i)).toBeInTheDocument();
+      expect(screen.getByText(/Marketing Budget/i)).toBeInTheDocument();
     });
   });
 
@@ -171,7 +182,6 @@ describe('AssetUploadForm', () => {
       render(<AssetUploadForm />);
 
       await waitFor(() => {
-        // Header shows "(3/25)" when has_more is true
         expect(screen.getByText(/\/25/)).toBeInTheDocument();
       });
     });
@@ -205,7 +215,6 @@ describe('AssetUploadForm', () => {
     });
 
     it('accepts file drop', async () => {
-      // Component uploads via the file input (not an onDrop handler)
       render(<AssetUploadForm />);
 
       const fileInput = document.querySelector('input[type="file"]');
@@ -242,7 +251,6 @@ describe('AssetUploadForm', () => {
     });
 
     it('shows upload progress', async () => {
-      // Never-resolving promise keeps uploading === true
       (apiClient.upload as jest.Mock).mockReturnValue(
         new Promise(() => {}),
       );
@@ -263,7 +271,6 @@ describe('AssetUploadForm', () => {
     });
 
     it('calls onUploadComplete after successful upload', async () => {
-      // Component adds the uploaded file directly to the rendered list
       render(<AssetUploadForm />);
 
       await waitFor(() => {
@@ -287,7 +294,7 @@ describe('AssetUploadForm', () => {
       render(<AssetUploadForm />);
 
       await waitFor(() => {
-        expect(apiClient.get).toHaveBeenCalledTimes(1);
+        expect(apiClient.get).toHaveBeenCalled();
       });
 
       const fileInput = document.querySelector('input[type="file"]');
@@ -298,7 +305,6 @@ describe('AssetUploadForm', () => {
       });
       fireEvent.change(fileInput!, { target: { files: [file] } });
 
-      // After upload the new file is appended to state (no second fetch)
       await waitFor(() => {
         expect(screen.getByText('new-upload.png')).toBeInTheDocument();
       });
@@ -340,7 +346,6 @@ describe('AssetUploadForm', () => {
         expect(screen.getByText('logo.png')).toBeInTheDocument();
       });
 
-      // Click the first "View file" button (title attribute)
       const viewButtons = screen.getAllByTitle('View file');
       fireEvent.click(viewButtons[0]);
 
@@ -362,11 +367,9 @@ describe('AssetUploadForm', () => {
         expect(screen.getByText('logo.png')).toBeInTheDocument();
       });
 
-      // Click the first "Delete file" button (title attribute)
       const deleteButtons = screen.getAllByTitle('Delete file');
       fireEvent.click(deleteButtons[0]);
 
-      // window.confirm is mocked to return true
       await waitFor(() => {
         expect(apiClient.delete).toHaveBeenCalledWith('/assets/1/');
       });
@@ -382,7 +385,6 @@ describe('AssetUploadForm', () => {
       const deleteButtons = screen.getAllByTitle('Delete file');
       fireEvent.click(deleteButtons[0]);
 
-      // After delete the file is removed from state directly
       await waitFor(() => {
         expect(screen.queryByText('logo.png')).not.toBeInTheDocument();
       });
@@ -422,7 +424,6 @@ describe('AssetUploadForm', () => {
     });
 
     it('rejects invalid file types', async () => {
-      // File type restriction is enforced by the accept attribute on the input
       render(<AssetUploadForm />);
 
       const fileInput = document.querySelector('input[type="file"]');
@@ -432,7 +433,6 @@ describe('AssetUploadForm', () => {
     });
 
     it('rejects files exceeding size limit', async () => {
-      // The component displays a file size limit in the UI
       render(<AssetUploadForm />);
       expect(screen.getByText(/50MB/i)).toBeInTheDocument();
     });
@@ -450,7 +450,6 @@ describe('AssetUploadForm', () => {
       render(<AssetUploadForm />);
 
       await waitFor(() => {
-        // Upload area is shown; file list heading is not
         expect(screen.getByText(/Upload files/i)).toBeInTheDocument();
         expect(
           screen.queryByText(/Uploaded Files/i),
@@ -483,7 +482,6 @@ describe('AssetUploadForm', () => {
       render(<AssetUploadForm />);
 
       await waitFor(() => {
-        // Per-file sizes shown in KB: 102400 / 1024 = 100.0
         expect(screen.getByText(/100\.0 KB/)).toBeInTheDocument();
       });
     });
@@ -492,7 +490,6 @@ describe('AssetUploadForm', () => {
       render(<AssetUploadForm />);
 
       await waitFor(() => {
-        // Header shows the count in parentheses: "(3)"
         expect(screen.getByText(/\(3\)/)).toBeInTheDocument();
       });
     });
@@ -526,10 +523,182 @@ describe('AssetUploadForm', () => {
         expect(screen.getByText('logo.png')).toBeInTheDocument();
       });
 
-      // Verify interactive elements can receive focus
       const nextButton = screen.getByRole('button', { name: /Next Step/i });
       nextButton.focus();
       expect(document.activeElement).toBe(nextButton);
+    });
+  });
+
+  // -------------------------------------------------
+  // K-03: Market & Business Section
+  // -------------------------------------------------
+  describe('Market & Business Section (K-03)', () => {
+    it('renders brand asset status select', () => {
+      render(<AssetUploadForm />);
+
+      const select = screen.getByLabelText(/brand asset status/i);
+      expect(select).toBeInTheDocument();
+      const options = Array.from(select.querySelectorAll('option'));
+      const values = options.map((o) => o.getAttribute('value'));
+      expect(values).toContain('none');
+      expect(values).toContain('basic');
+      expect(values).toContain('partial');
+      expect(values).toContain('complete');
+    });
+
+    it('renders sales channel checkboxes', () => {
+      render(<AssetUploadForm />);
+
+      expect(screen.getByLabelText(/online store/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/marketplace/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/retail/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/wholesale/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/direct sales/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/social commerce/i)).toBeInTheDocument();
+    });
+
+    it('renders Save Market Info button', () => {
+      render(<AssetUploadForm />);
+
+      expect(
+        screen.getByRole('button', { name: /save market info/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('saves market data via Company PATCH', async () => {
+      render(<AssetUploadForm />);
+
+      fireEvent.change(screen.getByLabelText(/brand asset status/i), {
+        target: { value: 'partial' },
+      });
+
+      fireEvent.click(
+        screen.getByRole('button', { name: /save market info/i }),
+      );
+
+      await waitFor(() => {
+        expect(apiClient.patch).toHaveBeenCalledWith(
+          '/companies/123/',
+          expect.objectContaining({
+            brand_asset_status: 'partial',
+          }),
+        );
+      });
+    });
+
+    it('adds and removes competitor rows', () => {
+      render(<AssetUploadForm />);
+
+      const addButton = screen.getByText(/\+ Add competitor/i);
+      fireEvent.click(addButton);
+
+      const removeButtons = screen.getAllByRole('button', {
+        name: /remove competitor/i,
+      });
+      expect(removeButtons.length).toBe(2);
+
+      fireEvent.click(removeButtons[removeButtons.length - 1]);
+
+      expect(
+        screen.queryAllByRole('button', { name: /remove competitor/i }).length,
+      ).toBeLessThan(2);
+    });
+
+    it('works without sessionId — no provenance on market section (AC-2)', async () => {
+      mockSessionId = null;
+
+      render(<AssetUploadForm />);
+
+      fireEvent.change(screen.getByLabelText(/brand asset status/i), {
+        target: { value: 'complete' },
+      });
+
+      fireEvent.click(
+        screen.getByRole('button', { name: /save market info/i }),
+      );
+
+      await waitFor(() => {
+        expect(apiClient.patch).toHaveBeenCalled();
+      });
+
+      expect(mockGetSessionProvenance).not.toHaveBeenCalled();
+      expect(mockEditProvenance).not.toHaveBeenCalled();
+    });
+
+    it('shows provenance badges for agent-filled market fields (AC-3)', async () => {
+      mockSessionId = 'sess-4';
+      mockGetSessionProvenance.mockResolvedValue({
+        session: 4,
+        groups: [
+          {
+            page: 4,
+            label: 'Assets & Market',
+            fields: [
+              {
+                id: 40,
+                field_name: 'brand_asset_status',
+                extracted_value: 'basic',
+                status: 'PENDING',
+                confidence: 0.75,
+                wizard_page: 4,
+              },
+              {
+                id: 41,
+                field_name: 'competitors',
+                extracted_value: [{ name: 'Acme Corp' }],
+                status: 'PENDING',
+                confidence: 0.8,
+                wizard_page: 4,
+              },
+            ],
+          },
+        ],
+      });
+
+      (apiClient.get as jest.Mock).mockResolvedValue(
+        mockResponse({
+          results: mockFiles,
+          count: 3,
+          has_more: false,
+        }),
+      );
+
+      render(<AssetUploadForm />);
+
+      await waitFor(() => {
+        expect(mockGetSessionProvenance).toHaveBeenCalledWith('sess-4');
+      });
+
+      await waitFor(() => {
+        const badges = screen.getAllByText('AI');
+        expect(badges.length).toBeGreaterThanOrEqual(1);
+      });
+    });
+
+    it('file upload section remains unchanged with market section', async () => {
+      render(<AssetUploadForm />);
+
+      await waitFor(() => {
+        expect(screen.getByText('logo.png')).toBeInTheDocument();
+      });
+
+      expect(screen.getByText(/Upload files/i)).toBeInTheDocument();
+      expect(screen.getByText(/drag and drop/i)).toBeInTheDocument();
+
+      const fileInput = document.querySelector('input[type="file"]');
+      expect(fileInput).not.toBeNull();
+
+      const file = new File(['test content'], 'new-upload.png', {
+        type: 'image/png',
+      });
+      fireEvent.change(fileInput!, { target: { files: [file] } });
+
+      await waitFor(() => {
+        expect(apiClient.upload).toHaveBeenCalledWith(
+          '/assets/upload/',
+          expect.any(FormData),
+        );
+      });
     });
   });
 });

--- a/ai-brand-automator-frontend/src/components/onboarding/__tests__/AssetUploadForm.test.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/__tests__/AssetUploadForm.test.tsx
@@ -69,6 +69,17 @@ function mockResponse(data: unknown, ok = true, status = 200) {
   return { ok, status, json: async () => data };
 }
 
+function mockGetWithAssets(assetsData: unknown) {
+  (apiClient.get as jest.Mock).mockImplementation((url: string) => {
+    if (url.startsWith('/companies')) {
+      return Promise.resolve(
+        mockResponse({ results: [{ id: 123, name: 'Test Co' }] }),
+      );
+    }
+    return Promise.resolve(mockResponse(assetsData));
+  });
+}
+
 describe('AssetUploadForm', () => {
   const originalConfirm = window.confirm;
 
@@ -83,9 +94,16 @@ describe('AssetUploadForm', () => {
 
     window.confirm = jest.fn(() => true);
 
-    (apiClient.get as jest.Mock).mockResolvedValue(
-      mockResponse({ results: mockFiles, count: 3, has_more: false }),
-    );
+    (apiClient.get as jest.Mock).mockImplementation((url: string) => {
+      if (url.startsWith('/companies')) {
+        return Promise.resolve(
+          mockResponse({ results: [{ id: 123, name: 'Test Co' }] }),
+        );
+      }
+      return Promise.resolve(
+        mockResponse({ results: mockFiles, count: 3, has_more: false }),
+      );
+    });
 
     (apiClient.upload as jest.Mock).mockResolvedValue(
       mockResponse({
@@ -131,9 +149,7 @@ describe('AssetUploadForm', () => {
     });
 
     it('shows view all button when files exist', async () => {
-      (apiClient.get as jest.Mock).mockResolvedValue(
-        mockResponse({ results: mockFiles, count: 10, has_more: true }),
-      );
+      mockGetWithAssets({ results: mockFiles, count: 10, has_more: true });
 
       render(<AssetUploadForm />);
 
@@ -162,9 +178,7 @@ describe('AssetUploadForm', () => {
   // -------------------------------------------------
   describe('Compact File Browser', () => {
     it('displays limited number of files in compact view', async () => {
-      (apiClient.get as jest.Mock).mockResolvedValue(
-        mockResponse({ results: mockFiles, count: 25, has_more: true }),
-      );
+      mockGetWithAssets({ results: mockFiles, count: 25, has_more: true });
 
       render(<AssetUploadForm />);
 
@@ -175,9 +189,7 @@ describe('AssetUploadForm', () => {
     });
 
     it('shows total file count summary', async () => {
-      (apiClient.get as jest.Mock).mockResolvedValue(
-        mockResponse({ results: mockFiles, count: 25, has_more: true }),
-      );
+      mockGetWithAssets({ results: mockFiles, count: 25, has_more: true });
 
       render(<AssetUploadForm />);
 
@@ -187,9 +199,7 @@ describe('AssetUploadForm', () => {
     });
 
     it('opens modal when View All clicked', async () => {
-      (apiClient.get as jest.Mock).mockResolvedValue(
-        mockResponse({ results: mockFiles, count: 10, has_more: true }),
-      );
+      mockGetWithAssets({ results: mockFiles, count: 10, has_more: true });
 
       render(<AssetUploadForm />);
 
@@ -443,9 +453,7 @@ describe('AssetUploadForm', () => {
   // -------------------------------------------------
   describe('Empty State', () => {
     it('shows empty state when no files', async () => {
-      (apiClient.get as jest.Mock).mockResolvedValue(
-        mockResponse({ results: [], count: 0, has_more: false }),
-      );
+      mockGetWithAssets({ results: [], count: 0, has_more: false });
 
       render(<AssetUploadForm />);
 
@@ -458,9 +466,7 @@ describe('AssetUploadForm', () => {
     });
 
     it('hides View All button when no files', async () => {
-      (apiClient.get as jest.Mock).mockResolvedValue(
-        mockResponse({ results: [], count: 0, has_more: false }),
-      );
+      mockGetWithAssets({ results: [], count: 0, has_more: false });
 
       render(<AssetUploadForm />);
 
@@ -655,13 +661,7 @@ describe('AssetUploadForm', () => {
         ],
       });
 
-      (apiClient.get as jest.Mock).mockResolvedValue(
-        mockResponse({
-          results: mockFiles,
-          count: 3,
-          has_more: false,
-        }),
-      );
+      mockGetWithAssets({ results: mockFiles, count: 3, has_more: false });
 
       render(<AssetUploadForm />);
 

--- a/ai-brand-automator-frontend/src/components/onboarding/__tests__/BrandForm.test.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/__tests__/BrandForm.test.tsx
@@ -2,23 +2,33 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { BrandForm } from '@/components/onboarding/BrandForm'
 import { apiClient } from '@/lib/api'
 
-// Mock the API client
 jest.mock('@/lib/api', () => ({
   apiClient: {
+    get: jest.fn(),
     put: jest.fn(),
     post: jest.fn(),
     patch: jest.fn(),
   },
 }))
 
-// Mock next/navigation
 const mockPush = jest.fn()
+let mockSessionId: string | null = null
 jest.mock('next/navigation', () => ({
   useRouter: () => ({
     push: mockPush,
     replace: jest.fn(),
     prefetch: jest.fn(),
   }),
+  useSearchParams: () => ({
+    get: (key: string) => (key === 'sessionId' ? mockSessionId : null),
+  }),
+}))
+
+const mockGetSessionProvenance = jest.fn()
+const mockEditProvenance = jest.fn()
+jest.mock('@/lib/onboarding-sessions', () => ({
+  getSessionProvenance: (...args: unknown[]) => mockGetSessionProvenance(...args),
+  editProvenance: (...args: unknown[]) => mockEditProvenance(...args),
 }))
 
 describe('BrandForm', () => {
@@ -29,55 +39,56 @@ describe('BrandForm', () => {
     window.alert = jest.fn()
     localStorage.setItem('company_id', '123')
     localStorage.setItem('access_token', 'test-token')
+    mockSessionId = null
+    ;(apiClient.get as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ results: [] }),
+    })
   })
 
-  it('renders all brand strategy fields', () => {
+  it('renders all brand strategy fields including business_goals', () => {
     render(<BrandForm />)
-    
+
     expect(screen.getByLabelText(/brand voice/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/vision statement/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/mission statement/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/core values/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/positioning statement/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/business goals/i)).toBeInTheDocument()
   })
 
   it('validates required fields', () => {
     render(<BrandForm />)
-    
+
     const brandVoiceInput = screen.getByLabelText(/brand voice/i)
     const visionInput = screen.getByLabelText(/vision statement/i)
     const missionInput = screen.getByLabelText(/mission statement/i)
-    
+
     expect(brandVoiceInput).toBeRequired()
-    // Vision and mission are optional
     expect(visionInput).not.toBeRequired()
     expect(missionInput).not.toBeRequired()
   })
 
   it('has brand voice dropdown with options', () => {
     render(<BrandForm />)
-    
+
     const brandVoiceSelect = screen.getByLabelText(/brand voice/i)
     expect(brandVoiceSelect).toBeInTheDocument()
-    
+
     const options = screen.getAllByRole('option')
-    expect(options.length).toBeGreaterThan(3) // At least professional, casual, friendly, authoritative
+    expect(options.length).toBeGreaterThan(3)
   })
 
-  it('submits form with valid data', async () => {
+  it('submits form with business_goals in PATCH payload', async () => {
     const mockResponse = {
       ok: true,
-      json: async () => ({
-        id: 123,
-        vision_statement: 'Test vision',
-        mission_statement: 'Test mission',
-      }),
+      json: async () => ({ id: 123 }),
     }
-    
+
     ;(apiClient.patch as jest.Mock).mockResolvedValue(mockResponse)
-    
+
     render(<BrandForm />)
-    
+
     fireEvent.change(screen.getByLabelText(/brand voice/i), {
       target: { value: 'professional' },
     })
@@ -90,9 +101,12 @@ describe('BrandForm', () => {
     fireEvent.change(screen.getByLabelText(/core values/i), {
       target: { value: 'Innovation, Excellence, Integrity' },
     })
-    
+    fireEvent.change(screen.getByLabelText(/business goals/i), {
+      target: { value: 'Grow revenue 50% YoY' },
+    })
+
     fireEvent.click(screen.getByRole('button', { name: /next step/i }))
-    
+
     await waitFor(() => {
       expect(apiClient.patch).toHaveBeenCalledWith(
         '/companies/123/',
@@ -101,6 +115,7 @@ describe('BrandForm', () => {
           vision_statement: 'To transform the industry through innovation',
           mission_statement: 'We deliver exceptional solutions',
           values: 'Innovation, Excellence, Integrity',
+          business_goals: 'Grow revenue 50% YoY',
         })
       )
     })
@@ -111,23 +126,17 @@ describe('BrandForm', () => {
       ok: true,
       json: async () => ({ id: 123 }),
     }
-    
+
     ;(apiClient.patch as jest.Mock).mockResolvedValue(mockResponse)
-    
+
     render(<BrandForm />)
-    
+
     fireEvent.change(screen.getByLabelText(/brand voice/i), {
       target: { value: 'professional' },
     })
-    fireEvent.change(screen.getByLabelText(/vision statement/i), {
-      target: { value: 'Vision' },
-    })
-    fireEvent.change(screen.getByLabelText(/mission statement/i), {
-      target: { value: 'Mission' },
-    })
-    
+
     fireEvent.click(screen.getByRole('button', { name: /next step/i }))
-    
+
     await waitFor(() => {
       expect(mockPush).toHaveBeenCalledWith('/onboarding/step-3')
     })
@@ -140,29 +149,23 @@ describe('BrandForm', () => {
         detail: 'Failed to update company',
       }),
     }
-    
+
     ;(apiClient.patch as jest.Mock).mockResolvedValue(mockResponse)
     const alertMock = jest.fn()
     window.alert = alertMock
-    
+
     render(<BrandForm />)
-    
+
     fireEvent.change(screen.getByLabelText(/brand voice/i), {
       target: { value: 'professional' },
     })
-    fireEvent.change(screen.getByLabelText(/vision statement/i), {
-      target: { value: 'Vision' },
-    })
-    fireEvent.change(screen.getByLabelText(/mission statement/i), {
-      target: { value: 'Mission' },
-    })
-    
+
     fireEvent.click(screen.getByRole('button', { name: /next step/i }))
-    
+
     await waitFor(() => {
       expect(alertMock).toHaveBeenCalledWith('Failed to update company')
     })
-    
+
     expect(mockPush).not.toHaveBeenCalled()
   })
 
@@ -171,32 +174,166 @@ describe('BrandForm', () => {
       ok: true,
       json: async () => ({ id: 123 }),
     }
-    
-    ;(apiClient.patch as jest.Mock).mockImplementation(() =>
-      new Promise(resolve => setTimeout(() => resolve(mockResponse), 100))
+
+    ;(apiClient.patch as jest.Mock).mockImplementation(
+      () => new Promise((resolve) => setTimeout(() => resolve(mockResponse), 100))
     )
-    
+
     render(<BrandForm />)
-    
+
     fireEvent.change(screen.getByLabelText(/brand voice/i), {
       target: { value: 'professional' },
     })
-    fireEvent.change(screen.getByLabelText(/vision statement/i), {
-      target: { value: 'Vision' },
-    })
-    fireEvent.change(screen.getByLabelText(/mission statement/i), {
-      target: { value: 'Mission' },
-    })
-    
+
     const submitButton = screen.getByRole('button', { name: /next step/i })
     fireEvent.click(submitButton)
-    
+
     await waitFor(() => {
       expect(submitButton).toBeDisabled()
     })
-    
+
+    await waitFor(
+      () => {
+        expect(mockPush).toHaveBeenCalledWith('/onboarding/step-3')
+      },
+      { timeout: 200 }
+    )
+  })
+
+  it('works without sessionId — no provenance fetch (AC-2)', async () => {
+    mockSessionId = null
+    ;(apiClient.patch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 123 }),
+    })
+
+    render(<BrandForm />)
+
+    fireEvent.change(screen.getByLabelText(/brand voice/i), {
+      target: { value: 'bold' },
+    })
+    fireEvent.change(screen.getByLabelText(/business goals/i), {
+      target: { value: 'Scale internationally' },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /next step/i }))
+
     await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith('/onboarding/step-3')
-    }, { timeout: 200 })
+      expect(apiClient.patch).toHaveBeenCalled()
+    })
+
+    expect(mockGetSessionProvenance).not.toHaveBeenCalled()
+    expect(mockEditProvenance).not.toHaveBeenCalled()
+  })
+
+  it('shows provenance badge for agent-filled business_goals (AC-3)', async () => {
+    mockSessionId = 'sess-2'
+    mockGetSessionProvenance.mockResolvedValue({
+      session: 2,
+      groups: [
+        {
+          page: 2,
+          label: 'Brand Voice',
+          fields: [
+            {
+              id: 20,
+              field_name: 'business_goals',
+              extracted_value: 'Expand to APAC',
+              status: 'PENDING',
+              confidence: 0.9,
+              wizard_page: 2,
+            },
+          ],
+        },
+      ],
+    })
+
+    ;(apiClient.get as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        results: [
+          {
+            id: 123,
+            name: 'Test',
+            brand_voice: 'friendly',
+            business_goals: 'Expand to APAC',
+          },
+        ],
+      }),
+    })
+
+    render(<BrandForm />)
+
+    await waitFor(() => {
+      expect(mockGetSessionProvenance).toHaveBeenCalledWith('sess-2')
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('AI')).toBeInTheDocument()
+    })
+  })
+
+  it('calls editProvenance on save when business_goals changes (AC-3)', async () => {
+    mockSessionId = 'sess-2'
+    mockGetSessionProvenance.mockResolvedValue({
+      session: 2,
+      groups: [
+        {
+          page: 2,
+          label: 'Brand Voice',
+          fields: [
+            {
+              id: 20,
+              field_name: 'business_goals',
+              extracted_value: 'Expand to APAC',
+              status: 'PENDING',
+              confidence: 0.9,
+              wizard_page: 2,
+            },
+          ],
+        },
+      ],
+    })
+    mockEditProvenance.mockResolvedValue({})
+
+    ;(apiClient.get as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        results: [
+          {
+            id: 123,
+            name: 'Test',
+            brand_voice: 'professional',
+            business_goals: 'Expand to APAC',
+          },
+        ],
+      }),
+    })
+    ;(apiClient.patch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 123 }),
+    })
+
+    render(<BrandForm />)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/business goals/i)).toHaveValue(
+        'Expand to APAC'
+      )
+    })
+
+    fireEvent.change(screen.getByLabelText(/business goals/i), {
+      target: { value: 'Expand to EMEA instead' },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /next step/i }))
+
+    await waitFor(() => {
+      expect(apiClient.patch).toHaveBeenCalled()
+    })
+
+    await waitFor(() => {
+      expect(mockEditProvenance).toHaveBeenCalledWith(20, 'Expand to EMEA instead')
+    })
   })
 })

--- a/ai-brand-automator-frontend/src/components/onboarding/__tests__/BrandForm.test.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/__tests__/BrandForm.test.tsx
@@ -273,6 +273,32 @@ describe('BrandForm', () => {
     })
   })
 
+  it('forwards sessionId in navigation links when present', async () => {
+    mockSessionId = 'sess-forward'
+    mockGetSessionProvenance.mockResolvedValue({
+      session: 1,
+      groups: [],
+    })
+    ;(apiClient.patch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 123 }),
+    })
+
+    render(<BrandForm />)
+
+    fireEvent.change(screen.getByLabelText(/brand voice/i), {
+      target: { value: 'professional' },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /next step/i }))
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith(
+        '/onboarding/step-3?sessionId=sess-forward'
+      )
+    })
+  })
+
   it('calls editProvenance on save when business_goals changes (AC-3)', async () => {
     mockSessionId = 'sess-2'
     mockGetSessionProvenance.mockResolvedValue({

--- a/ai-brand-automator-frontend/src/components/onboarding/__tests__/CompanyForm.test.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/__tests__/CompanyForm.test.tsx
@@ -11,57 +11,60 @@ jest.mock('@/lib/api', () => ({
 }))
 
 const mockPush = jest.fn()
+let mockSessionId: string | null = null
 jest.mock('next/navigation', () => ({
   useRouter: () => ({
     push: mockPush,
     replace: jest.fn(),
   }),
+  useSearchParams: () => ({
+    get: (key: string) => (key === 'sessionId' ? mockSessionId : null),
+  }),
+}))
+
+const mockGetSessionProvenance = jest.fn()
+const mockEditProvenance = jest.fn()
+jest.mock('@/lib/onboarding-sessions', () => ({
+  getSessionProvenance: (...args: unknown[]) => mockGetSessionProvenance(...args),
+  editProvenance: (...args: unknown[]) => mockEditProvenance(...args),
 }))
 
 describe('CompanyForm', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     window.localStorage.clear()
-    // Default: no existing company
+    mockSessionId = null
     ;(apiClient.get as jest.Mock).mockResolvedValue({
       ok: true,
       json: async () => ({ results: [] }),
     })
   })
 
-  it('renders all form fields', () => {
+  it('renders all form fields including B-03 fields', () => {
     render(<CompanyForm />)
 
     expect(screen.getByLabelText(/company name/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/industry/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/company description/i)).toBeInTheDocument()
-    expect(screen.getByLabelText(/target audience/i)).toBeInTheDocument()
-    expect(screen.getByLabelText(/core problem you solve/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/legal name/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/founder story/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/trademark status/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/decision maker/i)).toBeInTheDocument()
   })
 
   it('validates required fields', () => {
     render(<CompanyForm />)
 
-    const nameInput = screen.getByLabelText(/company name/i)
-    const industrySelect = screen.getByLabelText(/industry/i)
-    const descriptionTextarea = screen.getByLabelText(/company description/i)
-
-    expect(nameInput).toBeRequired()
-    expect(industrySelect).toBeRequired()
-    expect(descriptionTextarea).toBeRequired()
+    expect(screen.getByLabelText(/company name/i)).toBeRequired()
+    expect(screen.getByLabelText(/industry/i)).toBeRequired()
+    expect(screen.getByLabelText(/company description/i)).toBeRequired()
   })
 
-  it('submits form with valid data', async () => {
+  it('submits form with B-03 fields in PATCH payload', async () => {
     const mockResponse = {
       ok: true,
-      json: async () => ({
-        id: 1,
-        name: 'Test Corp',
-        industry: 'technology',
-        description: 'A test company',
-      }),
+      json: async () => ({ id: 1, name: 'Test Corp' }),
     }
-
     ;(apiClient.post as jest.Mock).mockResolvedValue(mockResponse)
 
     render(<CompanyForm />)
@@ -75,31 +78,179 @@ describe('CompanyForm', () => {
     fireEvent.change(screen.getByLabelText(/company description/i), {
       target: { value: 'A test company' },
     })
-    fireEvent.change(screen.getByLabelText(/target audience/i), {
-      target: { value: 'Small businesses' },
+    fireEvent.change(screen.getByLabelText(/legal name/i), {
+      target: { value: 'Test Corp Pvt Ltd' },
     })
-    fireEvent.change(screen.getByLabelText(/core problem you solve/i), {
-      target: { value: 'Marketing automation' },
+    fireEvent.change(screen.getByLabelText(/founder story/i), {
+      target: { value: 'Started in a garage' },
+    })
+    fireEvent.change(screen.getByLabelText(/trademark status/i), {
+      target: { value: 'registered' },
+    })
+    fireEvent.change(screen.getByLabelText(/decision maker/i), {
+      target: { value: 'CEO John' },
     })
 
-    const submitButton = screen.getByRole('button', { name: /next step/i })
-    fireEvent.click(submitButton)
+    fireEvent.click(screen.getByRole('button', { name: /next step/i }))
 
     await waitFor(() => {
       expect(apiClient.post).toHaveBeenCalledWith(
         '/companies/',
         expect.objectContaining({
           name: 'Test Corp',
-          industry: 'technology',
-          description: 'A test company',
-          target_audience: 'Small businesses',
-          core_problem: 'Marketing automation',
+          legal_name: 'Test Corp Pvt Ltd',
+          founder_story: 'Started in a garage',
+          trademark_status: 'registered',
+          decision_maker: 'CEO John',
         })
       )
     })
+  })
+
+  it('works without sessionId — no provenance fetch (AC-2)', async () => {
+    mockSessionId = null
+    const mockResponse = {
+      ok: true,
+      json: async () => ({ id: 1 }),
+    }
+    ;(apiClient.post as jest.Mock).mockResolvedValue(mockResponse)
+
+    render(<CompanyForm />)
+
+    fireEvent.change(screen.getByLabelText(/company name/i), {
+      target: { value: 'Manual Corp' },
+    })
+    fireEvent.change(screen.getByLabelText(/industry/i), {
+      target: { value: 'retail' },
+    })
+    fireEvent.change(screen.getByLabelText(/company description/i), {
+      target: { value: 'A manual entry' },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /next step/i }))
 
     await waitFor(() => {
-      expect(localStorage.getItem('company_id')).toBe('1')
+      expect(apiClient.post).toHaveBeenCalled()
+    })
+
+    expect(mockGetSessionProvenance).not.toHaveBeenCalled()
+    expect(mockEditProvenance).not.toHaveBeenCalled()
+  })
+
+  it('shows provenance badge for agent-filled fields (AC-3)', async () => {
+    mockSessionId = 'sess-1'
+    mockGetSessionProvenance.mockResolvedValue({
+      session: 1,
+      groups: [
+        {
+          page: 1,
+          label: 'Company Info',
+          fields: [
+            {
+              id: 10,
+              session: 1,
+              model_name: 'Company',
+              field_name: 'legal_name',
+              extracted_value: 'Acme Ltd',
+              final_value: null,
+              classification: 'SECONDARY',
+              confidence: 0.85,
+              source_recording: null,
+              source_span: null,
+              source_media: null,
+              status: 'PENDING',
+              reviewed_by: null,
+              reviewed_at: null,
+              wizard_page: 1,
+              wizard_page_label: 'Company Info',
+              created_at: '2026-08-01T00:00:00Z',
+              updated_at: '2026-08-01T00:00:00Z',
+            },
+          ],
+        },
+      ],
+    })
+
+    ;(apiClient.get as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        results: [{ id: 1, name: 'Test', legal_name: 'Acme Ltd' }],
+      }),
+    })
+
+    render(<CompanyForm />)
+
+    await waitFor(() => {
+      expect(mockGetSessionProvenance).toHaveBeenCalledWith('sess-1')
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('AI')).toBeInTheDocument()
+    })
+  })
+
+  it('calls editProvenance on save for changed provenance fields (AC-3)', async () => {
+    mockSessionId = 'sess-1'
+    mockGetSessionProvenance.mockResolvedValue({
+      session: 1,
+      groups: [
+        {
+          page: 1,
+          label: 'Company Info',
+          fields: [
+            {
+              id: 10,
+              field_name: 'legal_name',
+              extracted_value: 'Acme Ltd',
+              status: 'PENDING',
+              confidence: 0.85,
+              wizard_page: 1,
+            },
+          ],
+        },
+      ],
+    })
+    mockEditProvenance.mockResolvedValue({})
+
+    ;(apiClient.get as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        results: [
+          {
+            id: 1,
+            name: 'Test',
+            description: 'Desc',
+            industry: 'technology',
+            legal_name: 'Acme Ltd',
+          },
+        ],
+      }),
+    })
+
+    const patchResponse = {
+      ok: true,
+      json: async () => ({ id: 1 }),
+    }
+    ;(apiClient.patch as jest.Mock).mockResolvedValue(patchResponse)
+
+    render(<CompanyForm />)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/legal name/i)).toHaveValue('Acme Ltd')
+    })
+
+    fireEvent.change(screen.getByLabelText(/legal name/i), {
+      target: { value: 'Acme Limited' },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /update & continue/i }))
+
+    await waitFor(() => {
+      expect(apiClient.patch).toHaveBeenCalled()
+    })
+
+    await waitFor(() => {
+      expect(mockEditProvenance).toHaveBeenCalledWith(10, 'Acme Limited')
     })
   })
 
@@ -108,7 +259,6 @@ describe('CompanyForm', () => {
       ok: true,
       json: async () => ({ id: 1 }),
     }
-
     ;(apiClient.post as jest.Mock).mockResolvedValue(mockResponse)
 
     render(<CompanyForm />)
@@ -122,29 +272,25 @@ describe('CompanyForm', () => {
     fireEvent.change(screen.getByLabelText(/company description/i), {
       target: { value: 'Test' },
     })
-    fireEvent.change(screen.getByLabelText(/target audience/i), {
-      target: { value: 'Test audience' },
-    })
 
     fireEvent.click(screen.getByRole('button', { name: /next step/i }))
 
     await waitFor(() => {
       const callArgs = (apiClient.post as jest.Mock).mock.calls[0][1]
-      expect(callArgs).toHaveProperty('target_audience')
-      expect(callArgs).toHaveProperty('core_problem')
-      expect(callArgs).not.toHaveProperty('targetAudience')
-      expect(callArgs).not.toHaveProperty('coreProblem')
+      expect(callArgs).toHaveProperty('legal_name')
+      expect(callArgs).toHaveProperty('founder_story')
+      expect(callArgs).toHaveProperty('trademark_status')
+      expect(callArgs).toHaveProperty('decision_maker')
+      expect(callArgs).not.toHaveProperty('legalName')
+      expect(callArgs).not.toHaveProperty('founderStory')
     })
   })
 
   it('handles submission errors', async () => {
     const mockResponse = {
       ok: false,
-      json: async () => ({
-        detail: 'Invalid data',
-      }),
+      json: async () => ({ detail: 'Invalid data' }),
     }
-
     ;(apiClient.post as jest.Mock).mockResolvedValue(mockResponse)
 
     const alertMock = jest.spyOn(window, 'alert').mockImplementation(() => {})
@@ -175,13 +321,9 @@ describe('CompanyForm', () => {
 
     const industrySelect = screen.getByLabelText(/industry/i)
     const options = Array.from(industrySelect.querySelectorAll('option'))
-
     const optionTexts = options.map(opt => opt.textContent)
     expect(optionTexts).toContain('Technology')
     expect(optionTexts).toContain('Healthcare')
     expect(optionTexts).toContain('Finance')
-    expect(optionTexts).toContain('Retail')
-    expect(optionTexts).toContain('Education')
-    expect(optionTexts).toContain('Other')
   })
 })

--- a/ai-brand-automator-frontend/src/components/onboarding/__tests__/TargetAudienceForm.test.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/__tests__/TargetAudienceForm.test.tsx
@@ -2,22 +2,33 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { TargetAudienceForm } from '@/components/onboarding/TargetAudienceForm'
 import { apiClient } from '@/lib/api'
 
-// Mock the API client
 jest.mock('@/lib/api', () => ({
   apiClient: {
+    get: jest.fn(),
     put: jest.fn(),
     patch: jest.fn(),
   },
 }))
 
-// Mock next/navigation
 const mockPush = jest.fn()
+let mockSessionId: string | null = null
 jest.mock('next/navigation', () => ({
   useRouter: () => ({
     push: mockPush,
     replace: jest.fn(),
     prefetch: jest.fn(),
   }),
+  useSearchParams: () => ({
+    get: (key: string) => (key === 'sessionId' ? mockSessionId : null),
+  }),
+}))
+
+const mockGetSessionProvenance = jest.fn()
+const mockEditProvenance = jest.fn()
+jest.mock('@/lib/onboarding-sessions', () => ({
+  getSessionProvenance: (...args: unknown[]) =>
+    mockGetSessionProvenance(...args),
+  editProvenance: (...args: unknown[]) => mockEditProvenance(...args),
 }))
 
 describe('TargetAudienceForm', () => {
@@ -27,57 +38,56 @@ describe('TargetAudienceForm', () => {
     window.localStorage.clear()
     localStorage.setItem('company_id', '123')
     localStorage.setItem('access_token', 'test-token')
+    mockSessionId = null
+    ;(apiClient.get as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ results: [] }),
+    })
   })
 
-  it('renders all target audience fields', () => {
+  it('renders all target audience fields including K-03 fields', () => {
     render(<TargetAudienceForm />)
-    
+
     expect(screen.getByLabelText(/target audience/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/demographics/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/psychographics/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/pain points/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/desired outcomes/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/audience languages/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/customer proof/i)).toBeInTheDocument()
   })
 
   it('validates required fields', () => {
     render(<TargetAudienceForm />)
-    
-    const targetAudienceInput = screen.getByLabelText(/primary target audience/i)
+
+    const targetAudienceInput = screen.getByLabelText(
+      /primary target audience/i
+    )
     const painPointsInput = screen.getByLabelText(/key pain points/i)
     const desiredOutcomesInput = screen.getByLabelText(/desired outcomes/i)
-    
+
     expect(targetAudienceInput).toBeRequired()
     expect(painPointsInput).toBeRequired()
     expect(desiredOutcomesInput).toBeRequired()
-    
-    // Demographics and psychographics are optional
+
     const demographicsInput = screen.getByLabelText(/^demographics$/i)
     const psychographicsInput = screen.getByLabelText(/^psychographics$/i)
     expect(demographicsInput).not.toBeRequired()
     expect(psychographicsInput).not.toBeRequired()
   })
 
-  it('submits form with valid data', async () => {
+  it('submits form with audience_languages serialized as JSON array', async () => {
     const mockResponse = {
       ok: true,
-      json: async () => ({
-        id: 123,
-        target_audience: 'Updated demographics',
-      }),
+      json: async () => ({ id: 123 }),
     }
-    
+
     ;(apiClient.patch as jest.Mock).mockResolvedValue(mockResponse)
-    
+
     render(<TargetAudienceForm />)
-    
+
     fireEvent.change(screen.getByLabelText(/primary target audience/i), {
       target: { value: 'Small business owners' },
-    })
-    fireEvent.change(screen.getByLabelText(/^demographics$/i), {
-      target: { value: 'Ages 30-50' },
-    })
-    fireEvent.change(screen.getByLabelText(/^psychographics$/i), {
-      target: { value: 'Value efficiency' },
     })
     fireEvent.change(screen.getByLabelText(/key pain points/i), {
       target: { value: 'Limited time' },
@@ -85,20 +95,87 @@ describe('TargetAudienceForm', () => {
     fireEvent.change(screen.getByLabelText(/desired outcomes/i), {
       target: { value: 'Better productivity' },
     })
-    
+    fireEvent.change(screen.getByLabelText(/audience languages/i), {
+      target: { value: 'en-IN, kn-IN, hi-IN' },
+    })
+
     fireEvent.click(screen.getByRole('button', { name: /next step/i }))
-    
+
     await waitFor(() => {
       expect(apiClient.patch).toHaveBeenCalledWith(
         '/companies/123/',
         expect.objectContaining({
           target_audience: 'Small business owners',
-          demographics: 'Ages 30-50',
-          psychographics: 'Value efficiency',
-          pain_points: 'Limited time',
-          desired_outcomes: 'Better productivity',
+          audience_languages: ['en-IN', 'kn-IN', 'hi-IN'],
         })
       )
+    })
+  })
+
+  it('submits form with customer_proof serialized as testimonial array', async () => {
+    const mockResponse = {
+      ok: true,
+      json: async () => ({ id: 123 }),
+    }
+
+    ;(apiClient.patch as jest.Mock).mockResolvedValue(mockResponse)
+
+    render(<TargetAudienceForm />)
+
+    fireEvent.change(screen.getByLabelText(/primary target audience/i), {
+      target: { value: 'SMBs' },
+    })
+    fireEvent.change(screen.getByLabelText(/key pain points/i), {
+      target: { value: 'Cost' },
+    })
+    fireEvent.change(screen.getByLabelText(/desired outcomes/i), {
+      target: { value: 'Savings' },
+    })
+    fireEvent.change(screen.getByLabelText(/customer proof/i), {
+      target: { value: 'Great product!\nSaved us time' },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /next step/i }))
+
+    await waitFor(() => {
+      expect(apiClient.patch).toHaveBeenCalledWith(
+        '/companies/123/',
+        expect.objectContaining({
+          customer_proof: [
+            { type: 'testimonial', text: 'Great product!' },
+            { type: 'testimonial', text: 'Saved us time' },
+          ],
+        })
+      )
+    })
+  })
+
+  it('sends null for empty audience_languages', async () => {
+    const mockResponse = {
+      ok: true,
+      json: async () => ({ id: 123 }),
+    }
+
+    ;(apiClient.patch as jest.Mock).mockResolvedValue(mockResponse)
+
+    render(<TargetAudienceForm />)
+
+    fireEvent.change(screen.getByLabelText(/primary target audience/i), {
+      target: { value: 'SMBs' },
+    })
+    fireEvent.change(screen.getByLabelText(/key pain points/i), {
+      target: { value: 'Cost' },
+    })
+    fireEvent.change(screen.getByLabelText(/desired outcomes/i), {
+      target: { value: 'Savings' },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /next step/i }))
+
+    await waitFor(() => {
+      const callArgs = (apiClient.patch as jest.Mock).mock.calls[0][1]
+      expect(callArgs.audience_languages).toBeNull()
+      expect(callArgs.customer_proof).toBeNull()
     })
   })
 
@@ -107,11 +184,11 @@ describe('TargetAudienceForm', () => {
       ok: true,
       json: async () => ({ id: 123 }),
     }
-    
+
     ;(apiClient.patch as jest.Mock).mockResolvedValue(mockResponse)
-    
+
     render(<TargetAudienceForm />)
-    
+
     fireEvent.change(screen.getByLabelText(/primary target audience/i), {
       target: { value: 'Test audience' },
     })
@@ -121,9 +198,9 @@ describe('TargetAudienceForm', () => {
     fireEvent.change(screen.getByLabelText(/desired outcomes/i), {
       target: { value: 'Test outcomes' },
     })
-    
+
     fireEvent.click(screen.getByRole('button', { name: /next step/i }))
-    
+
     await waitFor(() => {
       expect(mockPush).toHaveBeenCalledWith('/onboarding/step-4')
     })
@@ -136,11 +213,11 @@ describe('TargetAudienceForm', () => {
         message: 'Invalid data provided',
       }),
     }
-    
+
     ;(apiClient.patch as jest.Mock).mockResolvedValue(mockResponse)
-    
+
     render(<TargetAudienceForm />)
-    
+
     fireEvent.change(screen.getByLabelText(/primary target audience/i), {
       target: { value: 'Test' },
     })
@@ -150,13 +227,13 @@ describe('TargetAudienceForm', () => {
     fireEvent.change(screen.getByLabelText(/desired outcomes/i), {
       target: { value: 'Test outcomes' },
     })
-    
+
     fireEvent.click(screen.getByRole('button', { name: /next step/i }))
-    
+
     await waitFor(() => {
       expect(screen.getByText('Invalid data provided')).toBeInTheDocument()
     })
-    
+
     expect(mockPush).not.toHaveBeenCalled()
   })
 
@@ -165,13 +242,14 @@ describe('TargetAudienceForm', () => {
       ok: true,
       json: async () => ({ id: 123 }),
     }
-    
-    ;(apiClient.patch as jest.Mock).mockImplementation(() =>
-      new Promise(resolve => setTimeout(() => resolve(mockResponse), 100))
+
+    ;(apiClient.patch as jest.Mock).mockImplementation(
+      () =>
+        new Promise((resolve) => setTimeout(() => resolve(mockResponse), 100))
     )
-    
+
     render(<TargetAudienceForm />)
-    
+
     fireEvent.change(screen.getByLabelText(/primary target audience/i), {
       target: { value: 'Target' },
     })
@@ -181,14 +259,198 @@ describe('TargetAudienceForm', () => {
     fireEvent.change(screen.getByLabelText(/desired outcomes/i), {
       target: { value: 'Outcomes' },
     })
-    
+
     const submitButton = screen.getByRole('button', { name: /next step/i })
     fireEvent.click(submitButton)
-    
+
     expect(submitButton).toBeDisabled()
-    
+
+    await waitFor(
+      () => {
+        expect(mockPush).toHaveBeenCalledWith('/onboarding/step-4')
+      },
+      { timeout: 3000 }
+    )
+  })
+
+  it('loads and displays existing audience_languages from API', async () => {
+    ;(apiClient.get as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        results: [
+          {
+            id: 123,
+            name: 'Test',
+            audience_languages: ['en-IN', 'kn-IN'],
+            customer_proof: [
+              { type: 'testimonial', text: 'Excellent service' },
+            ],
+          },
+        ],
+      }),
+    })
+
+    render(<TargetAudienceForm />)
+
     await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith('/onboarding/step-4')
-    }, { timeout: 3000 })
+      expect(screen.getByLabelText(/audience languages/i)).toHaveValue(
+        'en-IN, kn-IN'
+      )
+    })
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/customer proof/i)).toHaveValue(
+        'Excellent service'
+      )
+    })
+  })
+
+  it('works without sessionId — no provenance fetch (AC-2)', async () => {
+    mockSessionId = null
+    ;(apiClient.patch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 123 }),
+    })
+
+    render(<TargetAudienceForm />)
+
+    fireEvent.change(screen.getByLabelText(/primary target audience/i), {
+      target: { value: 'Manual audience' },
+    })
+    fireEvent.change(screen.getByLabelText(/key pain points/i), {
+      target: { value: 'Pain' },
+    })
+    fireEvent.change(screen.getByLabelText(/desired outcomes/i), {
+      target: { value: 'Goals' },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /next step/i }))
+
+    await waitFor(() => {
+      expect(apiClient.patch).toHaveBeenCalled()
+    })
+
+    expect(mockGetSessionProvenance).not.toHaveBeenCalled()
+    expect(mockEditProvenance).not.toHaveBeenCalled()
+  })
+
+  it('shows provenance badges for agent-filled fields (AC-3)', async () => {
+    mockSessionId = 'sess-3'
+    mockGetSessionProvenance.mockResolvedValue({
+      session: 3,
+      groups: [
+        {
+          page: 3,
+          label: 'Target Audience',
+          fields: [
+            {
+              id: 30,
+              field_name: 'audience_languages',
+              extracted_value: ['en-IN'],
+              status: 'PENDING',
+              confidence: 0.8,
+              wizard_page: 3,
+            },
+            {
+              id: 31,
+              field_name: 'customer_proof',
+              extracted_value: [{ type: 'testimonial', text: 'Great' }],
+              status: 'PENDING',
+              confidence: 0.7,
+              wizard_page: 3,
+            },
+          ],
+        },
+      ],
+    })
+
+    ;(apiClient.get as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        results: [
+          {
+            id: 123,
+            name: 'Test',
+            audience_languages: ['en-IN'],
+            customer_proof: [{ type: 'testimonial', text: 'Great' }],
+          },
+        ],
+      }),
+    })
+
+    render(<TargetAudienceForm />)
+
+    await waitFor(() => {
+      expect(mockGetSessionProvenance).toHaveBeenCalledWith('sess-3')
+    })
+
+    await waitFor(() => {
+      const badges = screen.getAllByText('AI')
+      expect(badges.length).toBe(2)
+    })
+  })
+
+  it('calls editProvenance on save for changed provenance fields (AC-3)', async () => {
+    mockSessionId = 'sess-3'
+    mockGetSessionProvenance.mockResolvedValue({
+      session: 3,
+      groups: [
+        {
+          page: 3,
+          label: 'Target Audience',
+          fields: [
+            {
+              id: 30,
+              field_name: 'audience_languages',
+              extracted_value: ['en-IN'],
+              status: 'PENDING',
+              confidence: 0.8,
+              wizard_page: 3,
+            },
+          ],
+        },
+      ],
+    })
+    mockEditProvenance.mockResolvedValue({})
+
+    ;(apiClient.get as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        results: [
+          {
+            id: 123,
+            name: 'Test',
+            target_audience: 'SMBs',
+            pain_points: 'Time',
+            desired_outcomes: 'Speed',
+            audience_languages: ['en-IN'],
+          },
+        ],
+      }),
+    })
+    ;(apiClient.patch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 123 }),
+    })
+
+    render(<TargetAudienceForm />)
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/audience languages/i)).toHaveValue('en-IN')
+    })
+
+    fireEvent.change(screen.getByLabelText(/audience languages/i), {
+      target: { value: 'en-IN, hi-IN' },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /next step/i }))
+
+    await waitFor(() => {
+      expect(apiClient.patch).toHaveBeenCalled()
+    })
+
+    await waitFor(() => {
+      expect(mockEditProvenance).toHaveBeenCalledWith(30, ['en-IN', 'hi-IN'])
+    })
   })
 })

--- a/ai-brand-automator-frontend/src/hooks/useWizardProvenance.ts
+++ b/ai-brand-automator-frontend/src/hooks/useWizardProvenance.ts
@@ -12,6 +12,8 @@ interface UseWizardProvenanceResult {
   provenanceMap: Map<string, FieldProvenanceRow>;
   loading: boolean;
   editField: (fieldName: string, newValue: unknown) => Promise<void>;
+  sessionId: string | null;
+  stepPath: (path: string) => string;
 }
 
 export function useWizardProvenance(page: number): UseWizardProvenanceResult {
@@ -64,5 +66,10 @@ export function useWizardProvenance(page: number): UseWizardProvenanceResult {
     [provenanceMap],
   );
 
-  return { provenanceMap, loading, editField };
+  const stepPath = useCallback(
+    (path: string) => (sessionId ? `${path}?sessionId=${sessionId}` : path),
+    [sessionId],
+  );
+
+  return { provenanceMap, loading, editField, sessionId, stepPath };
 }

--- a/ai-brand-automator-frontend/src/hooks/useWizardProvenance.ts
+++ b/ai-brand-automator-frontend/src/hooks/useWizardProvenance.ts
@@ -1,0 +1,68 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import {
+  editProvenance,
+  getSessionProvenance,
+  type FieldProvenanceRow,
+} from '@/lib/onboarding-sessions';
+
+interface UseWizardProvenanceResult {
+  provenanceMap: Map<string, FieldProvenanceRow>;
+  loading: boolean;
+  editField: (fieldName: string, newValue: unknown) => Promise<void>;
+}
+
+export function useWizardProvenance(page: number): UseWizardProvenanceResult {
+  const searchParams = useSearchParams();
+  const sessionId = searchParams.get('sessionId');
+
+  const [provenanceMap, setProvenanceMap] = useState<
+    Map<string, FieldProvenanceRow>
+  >(new Map());
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!sessionId) return;
+    let cancelled = false;
+
+    const fetchProvenance = async () => {
+      setLoading(true);
+      try {
+        const data = await getSessionProvenance(sessionId);
+        if (cancelled) return;
+
+        const map = new Map<string, FieldProvenanceRow>();
+        for (const group of data.groups) {
+          if (group.page === page) {
+            for (const row of group.fields) {
+              map.set(row.field_name, row);
+            }
+          }
+        }
+        setProvenanceMap(map);
+      } catch {
+        if (!cancelled) setProvenanceMap(new Map());
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    fetchProvenance();
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId, page]);
+
+  const editField = useCallback(
+    async (fieldName: string, newValue: unknown) => {
+      const row = provenanceMap.get(fieldName);
+      if (!row) return;
+      await editProvenance(row.id, newValue);
+    },
+    [provenanceMap],
+  );
+
+  return { provenanceMap, loading, editField };
+}


### PR DESCRIPTION
## Summary
- Adds 13 B-03 Company fields to wizard forms (steps 1–4) as ordinary inputs (AC-1)
- Manual path unchanged — wizard works without sessions, no provenance fetched (AC-2)
- Agent-filled fields carry "AI" provenance badge; editing from wizard calls `editProvenance()` — same write path the review page uses (AC-3)
- New `useWizardProvenance` hook and `ProvenanceBadge` component shared across all four form components
- 67 tests across 4 form test suites covering rendering, serialization, provenance, and AC-2 manual path

### Field distribution
| Page | Form | New fields |
|------|------|-----------|
| 1 | CompanyForm | `legal_name`, `founder_story`, `trademark_status`, `decision_maker` |
| 2 | BrandForm | `business_goals` |
| 3 | TargetAudienceForm | `audience_languages`, `customer_proof` |
| 4 | AssetUploadForm | `brand_asset_status`, `competitors`, `products_services`, `sales_channels`, `digital_presence`, `marketing_budget_range` |

### No backend changes
Company model, serializer, and viewset already accept all 13 fields. Provenance edit endpoint exists from K-01/K-02.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (70 pre-existing warnings)
- [x] `npm test` — 453 passed, 1 skipped (pre-existing)
- [x] K-03 test suites: 67 tests across CompanyForm, BrandForm, TargetAudienceForm, AssetUploadForm
- [ ] Manual: navigate /onboarding/step-1 through step-4, verify 13 fields visible
- [ ] Manual: complete wizard without session — works (AC-2)
- [ ] Manual: deep link from processed session — AI badges shown, provenance edits fire on save (AC-3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)