### PR TITLE
feat(onboarding): PDF extension — meeting evidence and key findings (K-05)

### DIFF
--- a/ai-brand-automator/apps/onboarding/tests/test_pdf_snapshot.py
+++ b/ai-brand-automator/apps/onboarding/tests/test_pdf_snapshot.py
@@ -28,6 +28,20 @@ from onboarding.models import Company
 from onboarding.serializers import ONBOARDING_FIELDS
 from onboarding.views import build_onboarding_pdf
 
+from apps.onboarding.tests.factories import (
+    make_session,
+    make_recording,
+    make_consent,
+    make_brand_asset,
+    make_provenance,
+)
+from apps.onboarding.models import (
+    FieldClassification,
+    ProvenanceStatus,
+    RecordingStatus,
+    SessionStatus,
+)
+
 pytestmark = [pytest.mark.django_db, pytest.mark.unit]
 
 #: The labels the onboarding PDF emitted before B-03, in order. Committed as
@@ -116,7 +130,7 @@ def make_company() -> Company:
     )
 
 
-def pdf_text(company: Company) -> str:
+def pdf_text(company: Company, session=None) -> str:
     """Readable text out of the PDF bytes.
 
     fpdf2 Flate-compresses its content streams, so the text operators have to
@@ -125,7 +139,7 @@ def pdf_text(company: Company) -> str:
     below pass against an empty haystack. Hence the guard at the end: a text
     extraction that finds nothing is a broken test, not a clean result.
     """
-    raw = build_onboarding_pdf(company)
+    raw = build_onboarding_pdf(company, session=session)
 
     chunks: list[bytes] = []
     for match in re.finditer(rb"stream\r?\n(.*?)\r?\nendstream", raw, re.S):
@@ -213,3 +227,116 @@ def test_the_wizard_create_payload_is_unchanged():
     company = serializer.save()
     for field in ONBOARDING_FIELDS:
         assert getattr(company, field) is None, f"{field} was set by the wizard"
+
+
+# ── K-05: Meeting Evidence and Key Findings ────────────────────────
+
+
+def _session_with_evidence(company):
+    """A session with recordings, consent, captures, and KEY provenance."""
+    session = make_session(
+        company=company,
+        status=SessionStatus.CONFIRMED,
+    )
+    make_recording(
+        session=session,
+        status=RecordingStatus.SUMMARIZED,
+        duration_s=155,
+        summary={
+            "text": "Brand owner described founding story and market position.",
+            "key_moments": [
+                {"t": 12, "label": "Founding story begins"},
+                {"t": 85, "label": "Market differentiator"},
+            ],
+        },
+    )
+    make_consent(
+        session=session,
+        subject_name="Asha Kalyani",
+    )
+    make_brand_asset(
+        company=company,
+        file_name="whiteboard.jpg",
+        usage_tag="business_photo",
+        onboarding_session=session,
+        ocr_text="Store layout with pricing board",
+    )
+    make_provenance(
+        session=session,
+        field_name="legal_name",
+        extracted_value="Kalyani Coffee Roasters Pvt Ltd",
+        classification=FieldClassification.KEY,
+        status=ProvenanceStatus.CONFIRMED,
+    )
+    make_provenance(
+        session=session,
+        field_name="industry",
+        extracted_value="Food & Beverage",
+        classification=FieldClassification.SECONDARY,
+    )
+    return session
+
+
+def test_pdf_with_session_includes_evidence_and_findings():
+    """AC-1: both new sections appear with full evidence."""
+    company = make_company()
+    session = _session_with_evidence(company)
+    text = pdf_text(company, session=session)
+
+    assert "Meeting Evidence" in text
+    assert "Recording 1" in text
+    assert "2m 35s" in text
+    assert "Brand owner described founding story" in text
+    assert "Founding story begins" in text
+    assert "Market differentiator" in text
+
+    assert "Consent" in text
+    assert "Verbal, recorded" in text
+
+    assert "whiteboard.jpg" in text
+    assert "Store layout with pricing board" in text
+
+    assert "Key Findings" in text
+    assert "Legal Name" in text
+    assert "Confirmed" in text
+    assert "Kalyani Coffee Roasters Pvt Ltd" in text
+
+
+def test_pdf_without_session_unchanged():
+    """AC-4: no session produces the exact same labels as before."""
+    text = pdf_text(make_company())
+
+    for label in PDF_LABELS_BEFORE_B03:
+        assert label in text, f"the PDF lost the label {label!r}"
+
+    assert "Meeting Evidence" not in text
+    assert "Key Findings" not in text
+
+
+def test_pdf_empty_session_no_empty_headings():
+    """AC-4 edge: a session with no evidence must not render empty headings."""
+    company = make_company()
+    session = make_session(company=company, status=SessionStatus.CONFIRMED)
+    text = pdf_text(company, session=session)
+
+    assert "Meeting Evidence" not in text
+    assert "Key Findings" not in text
+
+
+def test_consent_subject_name_never_in_pdf():
+    """Privacy: subject_name must never appear even when it exists on the model."""
+    company = make_company()
+    session = _session_with_evidence(company)
+    text = pdf_text(company, session=session)
+
+    assert "Asha Kalyani" not in text
+
+
+def test_provenance_secondary_fields_absent():
+    """Only KEY classification appears in Key Findings, not SECONDARY."""
+    company = make_company()
+    session = _session_with_evidence(company)
+    text = pdf_text(company, session=session)
+
+    assert "Legal Name [Confirmed]" in text
+    assert "Industry [Pending]" not in text

--- a/ai-brand-automator/onboarding/views.py
+++ b/ai-brand-automator/onboarding/views.py
@@ -35,7 +35,7 @@ from tenants.permissions import (
 logger = logging.getLogger(__name__)
 
 
-def build_onboarding_pdf(company) -> bytes:
+def build_onboarding_pdf(company, session=None) -> bytes:
     """Render the onboarding summary PDF for *company*.
 
     Extracted from ``CompanyViewSet.generate_onboarding_pdf`` so the
@@ -156,6 +156,91 @@ def build_onboarding_pdf(company) -> bytes:
         _field("Color Palette", company.color_palette_desc)
         _field("Font Recommendations", company.font_recommendations)
         _field("Messaging Guide", company.messaging_guide)
+
+    # ── Meeting Evidence (K-05) ──────────────────────────────────────
+    if session is not None:
+        recordings = list(
+            session.recordings.filter(
+                status__in=["SUMMARIZED", "TRANSCRIBED"]
+            ).order_by("started_at")
+        )
+        consents = list(session.consent_records.filter(revoked_at__isnull=True))
+        captures = list(session.captured_media.all().order_by("uploaded_at"))
+
+        if recordings or consents or captures:
+            _section("Meeting Evidence")
+
+            for idx, rec in enumerate(recordings, 1):
+                dur = rec.duration_s
+                if dur is not None:
+                    mins, secs = divmod(dur, 60)
+                    dur_label = f" ({mins}m {secs:02d}s)"
+                else:
+                    dur_label = ""
+                pdf.set_font("Helvetica", "B", 11)
+                pdf.cell(
+                    0,
+                    7,
+                    _sanitize(f"Recording {idx}{dur_label}"),
+                    new_x="LMARGIN",
+                    new_y="NEXT",
+                )
+                summary = rec.summary or {}
+                summary_text = summary.get("text", "")
+                if summary_text:
+                    pdf.set_font("Helvetica", "", 10)
+                    pdf.multi_cell(0, 5, _wrap_text(summary_text))
+                    pdf.ln(1)
+                for moment in summary.get("key_moments", []):
+                    t = moment.get("t", "")
+                    label = moment.get("label", "")
+                    if label:
+                        pdf.set_font("Helvetica", "", 9)
+                        pdf.cell(
+                            0,
+                            5,
+                            _sanitize(f"  [{t}s] {label}"),
+                            new_x="LMARGIN",
+                            new_y="NEXT",
+                        )
+                pdf.ln(2)
+
+            for consent in consents:
+                method_label = consent.get_method_display()
+                date_str = (
+                    consent.granted_at.strftime("%Y-%m-%d")
+                    if consent.granted_at
+                    else "unknown"
+                )
+                _field("Consent", f"{method_label} on {date_str}")
+
+            for cap in captures:
+                tag_display = cap.get_usage_tag_display() if cap.usage_tag else "Asset"
+                desc = cap.ocr_text or "No description available"
+                _field(
+                    f"{tag_display}: {cap.file_name}",
+                    desc,
+                )
+
+        # ── Key Findings (K-05) ───────────────────────────────────────
+        key_provenance = list(
+            session.provenance.filter(classification="KEY").order_by("field_name")
+        )
+        if key_provenance:
+            _section("Key Findings")
+            for prov in key_provenance:
+                label = prov.field_name.replace("_", " ").title()
+                status_label = prov.get_status_display()
+                value = (
+                    prov.final_value
+                    if prov.final_value is not None
+                    else prov.extracted_value
+                )
+                if not isinstance(value, str):
+                    import json as _json
+
+                    value = _json.dumps(value)
+                _field(f"{label} [{status_label}]", value)
 
     raw_pdf = pdf.output()
     if isinstance(raw_pdf, bytearray):
@@ -326,7 +411,14 @@ class CompanyViewSet(RoleBasedPermissionMixin, viewsets.ModelViewSet):
             )
 
         # --- Build the PDF (extracted; see build_onboarding_pdf) ---
-        pdf_bytes = build_onboarding_pdf(company)
+        session = (
+            company.onboarding_sessions.filter(
+                status__in=["REVIEW_PENDING", "CONFIRMED", "COMPLETED"]
+            )
+            .order_by("-created_at")
+            .first()
+        )
+        pdf_bytes = build_onboarding_pdf(company, session=session)
 
         # --- Upload to GCS and create BrandAsset ---
         safe_filename = "onboarding_data.pdf"


### PR DESCRIPTION
## Summary
- Extends `build_onboarding_pdf` with optional `session` parameter to render **Meeting Evidence** (recording summaries with key moments, consent method+date, captured media with redacted OCR) and **Key Findings** (KEY-classified provenance fields with confirmation status)
- Action resolves the most recent processed session from the company; no frontend changes needed
- Companies without a session produce the original PDF unchanged (AC-4)

## Test plan
- [x] All 5 existing PDF snapshot tests pass (no regression)
- [x] `test_pdf_with_session_includes_evidence_and_findings` — AC-1: both sections render with full evidence
- [x] `test_pdf_without_session_unchanged` — AC-4: no session = original PDF
- [x] `test_pdf_empty_session_no_empty_headings` — AC-4 edge: session with no evidence = no empty headings
- [x] `test_consent_subject_name_never_in_pdf` — Privacy: subject_name excluded
- [x] `test_provenance_secondary_fields_absent` — Only KEY fields appear, not SECONDARY
- [x] `black --check` and `flake8` pass
- [ ] Full onboarding test suite (641 tests) — in progress, no failures so far

🤖 Generated with [Claude Code](https://claude.com/claude-code)