### PR TITLE
feat(oia): rate limits, quotas, and multi-slot live lock (M-05)

### DIFF
--- a/onboarding-intelligence-agent-svc/app/api/routes.py
+++ b/onboarding-intelligence-agent-svc/app/api/routes.py
@@ -268,7 +268,10 @@ async def execute(request: Request, payload: ExecuteRequest) -> ExecuteResponse:
                 await events.emit(
                     EventType.AGENT_RATE_LIMITED,
                     tenant_id=tenant_id,
-                    correlation_id=(payload.tenant_context.correlation_id or ""),
+                    correlation_id=(
+                        payload.tenant_context.correlation_id
+                        or payload.tenant_context.trace_id
+                    ),
                     session_id=payload.session_id or "",
                     payload={
                         "user_id": user_id,
@@ -331,7 +334,10 @@ async def execute(request: Request, payload: ExecuteRequest) -> ExecuteResponse:
                     await events.emit(
                         EventType.AGENT_INVOKED,
                         tenant_id=tenant_id,
-                        correlation_id=(payload.tenant_context.correlation_id or ""),
+                        correlation_id=(
+                            payload.tenant_context.correlation_id
+                            or payload.tenant_context.trace_id
+                        ),
                         session_id=payload.session_id or "",
                         payload={"prompt_source": "hardcoded_fallback"},
                         outcome="DEGRADED",

--- a/onboarding-intelligence-agent-svc/app/api/routes.py
+++ b/onboarding-intelligence-agent-svc/app/api/routes.py
@@ -33,6 +33,7 @@ from app.api.schemas import (
     UsageReport,
 )
 from app.cache.conversation import ConversationStore
+from app.logic.rate_limiter import check_rate
 from app.logic.prep_executor import QUESTIONNAIRE_SKILL, RESEARCH_SKILL
 from app.skills.models import Origin, SkillContext, TenantContext
 from app.skills.questionnaire_models import GeneratedQuestionnaire
@@ -250,8 +251,43 @@ async def execute(request: Request, payload: ExecuteRequest) -> ExecuteResponse:
     """
     started = time.monotonic()
     tenant_id = payload.tenant_context.tenant_id
+    user_id = payload.tenant_context.user_id or "anonymous"
+    settings = request.app.state.settings
 
-    store = ConversationStore(request.app.state.redis)
+    redis = request.app.state.redis
+    rl_key = redis.keys_for(tenant_id).ratelimit(user_id)
+    rl_count, rl_exceeded = await check_rate(
+        redis.client, rl_key, settings.RATE_LIMIT_PREP_PER_MIN
+    )
+    if rl_exceeded:
+        events = getattr(request.app.state, "events", None)
+        if events is not None:
+            from app.events.catalog import EventType
+
+            try:
+                await events.emit(
+                    EventType.AGENT_RATE_LIMITED,
+                    tenant_id=tenant_id,
+                    correlation_id=(payload.tenant_context.correlation_id or ""),
+                    session_id=payload.session_id or "",
+                    payload={
+                        "user_id": user_id,
+                        "count": rl_count,
+                        "limit": settings.RATE_LIMIT_PREP_PER_MIN,
+                    },
+                    outcome="BLOCKED",
+                )
+            except Exception:  # noqa: BLE001
+                pass
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=(
+                f"Rate limit exceeded: {rl_count}/"
+                f"{settings.RATE_LIMIT_PREP_PER_MIN} per minute"
+            ),
+        )
+
+    store = ConversationStore(redis)
     await store.append(
         tenant_id=tenant_id,
         chat_session_id=payload.chat_session_id,
@@ -303,11 +339,16 @@ async def execute(request: Request, payload: ExecuteRequest) -> ExecuteResponse:
                 except Exception:  # noqa: BLE001
                     pass
 
+    rl_config = {
+        "_ig07_count": rl_count,
+        "_rate_limit": settings.RATE_LIMIT_PREP_PER_MIN,
+    }
     brief, from_cache = await request.app.state.prep.research(
         tenant=tenant,
         input_context=payload.input_context,
         input_prompt=payload.input_prompt,
         correlation_id=payload.tenant_context.correlation_id or "",
+        config=rl_config,
     )
 
     summary = BusinessResearchBrief.model_validate(brief).summary_line()
@@ -332,6 +373,7 @@ async def execute(request: Request, payload: ExecuteRequest) -> ExecuteResponse:
             input_prompt=payload.input_prompt,
             chat_session_id=payload.chat_session_id,
             correlation_id=payload.tenant_context.correlation_id or "",
+            config=rl_config,
         )
         questionnaire = GeneratedQuestionnaire.model_validate(generated)
         # The questionnaire's summary replaces the brief's: it is the answer to

--- a/onboarding-intelligence-agent-svc/app/api/ws.py
+++ b/onboarding-intelligence-agent-svc/app/api/ws.py
@@ -142,11 +142,29 @@ async def live_websocket(websocket: WebSocket, session_id: str) -> None:
 
     lock = None
     if not verdict.refused:
+        max_slots = 1
+        if redis_manager is not None:
+            from app.core.config import get_settings as _get_settings
+
+            _cfg = _get_settings()
+            t_keys = redis_manager.keys_for(verdict.tenant_id)
+            raw = await redis_manager.client.hget(
+                t_keys.config(), "max_concurrent_sessions"
+            )
+            if raw is not None:
+                try:
+                    max_slots = max(1, int(raw))
+                except (ValueError, TypeError):
+                    pass
+            else:
+                max_slots = _cfg.MAX_CONCURRENT_LIVE_PER_COMPANY
+
         lock = await acquire(
             redis_manager,
             tenant_id=verdict.tenant_id,
             company_id=verdict.company_id,
             token=uuid.uuid4().hex,
+            max_slots=max_slots,
         )
         if lock is None:
             verdict = Handshake(
@@ -1122,6 +1140,7 @@ async def _handle_control(
     message: Any,
     *,
     stt_state: dict[str, Any],
+    rate_ctx: dict[str, Any] | None = None,
 ) -> None:
     """Act on one client control frame (§10.2.3).
 
@@ -1139,6 +1158,39 @@ async def _handle_control(
     raw = message.get("text")
     if not raw:
         return
+
+    if rate_ctx is not None:
+        from app.logic.rate_limiter import check_rate
+
+        rl_key = rate_ctx["rl_key"]
+        rl_limit = rate_ctx["rl_limit"]
+        count, exceeded = await check_rate(rate_ctx["redis_client"], rl_key, rl_limit)
+        if exceeded:
+            from app.events.catalog import EventType
+            from app.logic.live_handshake import CLOSE_RATE_LIMITED
+
+            evts = rate_ctx.get("events")
+            if evts is not None:
+                try:
+                    await evts.emit(
+                        EventType.AGENT_RATE_LIMITED,
+                        tenant_id=rate_ctx["tenant_id"],
+                        correlation_id="",
+                        session_id=rate_ctx.get("session_id", ""),
+                        payload={
+                            "user_id": rate_ctx["user_id"],
+                            "count": count,
+                            "limit": rl_limit,
+                        },
+                        outcome="BLOCKED",
+                    )
+                except Exception:  # noqa: BLE001
+                    pass
+            await websocket.close(
+                code=CLOSE_RATE_LIMITED,
+                reason=f"control frame rate exceeded: {count}/{rl_limit}/min",
+            )
+            return
 
     try:
         frame = json.loads(raw)
@@ -1489,6 +1541,19 @@ async def _hold(
         "batcher": batcher,
         "analysis_state": analysis_state,
     }
+
+    rate_ctx: dict[str, Any] | None = None
+    if redis_manager is not None and verdict.user_id:
+        rl_keys = redis_manager.keys_for(verdict.tenant_id)
+        rate_ctx = {
+            "redis_client": redis_manager.client,
+            "rl_key": rl_keys.ratelimit(verdict.user_id),
+            "rl_limit": cfg.RATE_LIMIT_PREP_PER_MIN,
+            "tenant_id": verdict.tenant_id,
+            "user_id": verdict.user_id,
+            "session_id": session_id,
+            "events": events,
+        }
     _breaker_cb = None
     _breaker_ref = None
     if breaker_registry and events:
@@ -1575,7 +1640,13 @@ async def _hold(
                 stt_state["audio_q"].put_nowait(message["bytes"])
                 continue
 
-            await _handle_control(websocket, session, message, stt_state=stt_state)
+            await _handle_control(
+                websocket,
+                session,
+                message,
+                stt_state=stt_state,
+                rate_ctx=rate_ctx,
+            )
     finally:
         WS_SESSIONS_ACTIVE.dec()
 

--- a/onboarding-intelligence-agent-svc/app/api/ws.py
+++ b/onboarding-intelligence-agent-svc/app/api/ws.py
@@ -142,11 +142,11 @@ async def live_websocket(websocket: WebSocket, session_id: str) -> None:
 
     lock = None
     if not verdict.refused:
-        max_slots = 1
-        if redis_manager is not None:
-            from app.core.config import get_settings as _get_settings
+        from app.core.config import get_settings as _get_settings
 
-            _cfg = _get_settings()
+        _cfg = _get_settings()
+        max_slots = _cfg.MAX_CONCURRENT_LIVE_PER_COMPANY
+        if redis_manager is not None:
             t_keys = redis_manager.keys_for(verdict.tenant_id)
             raw = await redis_manager.client.hget(
                 t_keys.config(), "max_concurrent_sessions"
@@ -156,8 +156,6 @@ async def live_websocket(websocket: WebSocket, session_id: str) -> None:
                     max_slots = max(1, int(raw))
                 except (ValueError, TypeError):
                     pass
-            else:
-                max_slots = _cfg.MAX_CONCURRENT_LIVE_PER_COMPANY
 
         lock = await acquire(
             redis_manager,
@@ -1175,7 +1173,7 @@ async def _handle_control(
                     await evts.emit(
                         EventType.AGENT_RATE_LIMITED,
                         tenant_id=rate_ctx["tenant_id"],
-                        correlation_id="",
+                        correlation_id=rate_ctx.get("session_id", ""),
                         session_id=rate_ctx.get("session_id", ""),
                         payload={
                             "user_id": rate_ctx["user_id"],

--- a/onboarding-intelligence-agent-svc/app/cache/redis_manager.py
+++ b/onboarding-intelligence-agent-svc/app/cache/redis_manager.py
@@ -152,6 +152,17 @@ class TenantKeys:
         """
         return f"{self._scope}lock:live:{company_id}"
 
+    def live_lock_slot(self, company_id: str, slot: int) -> str:
+        """String · 2 h · one of N concurrent live slots (M-05 AC-2).
+
+        When ``max_concurrent_sessions > 1``, each slot is a separate key.
+        Slot 0 is equivalent to ``live_lock(company_id)`` for backward
+        compatibility with existing locks.
+        """
+        if slot == 0:
+            return self.live_lock(company_id)
+        return f"{self._scope}lock:live:{company_id}:{slot}"
+
     # ── Write safety ─────────────────────────────────────────
     def idempotency(self, digest: str) -> str:
         """String · 24 h · write dedup, value is the original response."""

--- a/onboarding-intelligence-agent-svc/app/logic/live_lock.py
+++ b/onboarding-intelligence-agent-svc/app/logic/live_lock.py
@@ -83,28 +83,38 @@ def _as_text(value: object) -> str:
 
 
 async def acquire(
-    redis_manager: Any, *, tenant_id: str, company_id: str, token: str
+    redis_manager: Any,
+    *,
+    tenant_id: str,
+    company_id: str,
+    token: str,
+    max_slots: int = 1,
 ) -> LiveLock | None:
-    """Claim the live slot, or return None if somebody else holds it.
+    """Claim a live slot, or return None if all slots are taken.
 
-    `SET key token NX EX ttl` — one round trip, and atomic. A get-then-set
+    ``SET key token NX EX ttl`` — one round trip, and atomic. A get-then-set
     would let two handshakes arriving together both find the key empty and
     both proceed, which is precisely the race AC-2 is about and precisely the
     one that never shows up in a single-threaded test.
+
+    When ``max_slots > 1`` (tenant-configurable per M-05 AC-2), the function
+    tries each slot sequentially. Slot 0 is backward-compatible with the
+    original single-slot key.
     """
     if redis_manager is None or not company_id:
-        # No Redis, or a session whose company we could not resolve. Refusing
-        # is the only safe answer: admitting a second writer to a live meeting
-        # corrupts the transcript for both.
         return None
 
     keys = redis_manager.keys_for(tenant_id)
-    key = keys.live_lock(company_id)
     client = redis_manager.client
 
-    acquired = await client.set(key, token, nx=True, ex=LOCK_TTL_S)
-    if not acquired:
-        logger.info("live_lock_contended", extra={"tenant_id": tenant_id})
-        return None
+    for slot in range(max(1, max_slots)):
+        key = keys.live_lock_slot(company_id, slot)
+        acquired = await client.set(key, token, nx=True, ex=LOCK_TTL_S)
+        if acquired:
+            return LiveLock(key=key, token=token, _client=client)
 
-    return LiveLock(key=key, token=token, _client=client)
+    logger.info(
+        "live_lock_contended",
+        extra={"tenant_id": tenant_id, "slots": max_slots},
+    )
+    return None

--- a/onboarding-intelligence-agent-svc/app/logic/prep_executor.py
+++ b/onboarding-intelligence-agent-svc/app/logic/prep_executor.py
@@ -146,6 +146,7 @@ class PrepExecutor:
         input_prompt: str,
         correlation_id: str = "",
         use_cache: bool = True,
+        config: dict[str, Any] | None = None,
     ) -> tuple[dict[str, Any], bool]:
         """Run SKL-OIA-01, returning ``(brief, came_from_cache)``.
 
@@ -166,6 +167,7 @@ class PrepExecutor:
             input_prompt=input_prompt,
             tenant_context=tenant,
             input_context=dict(input_context),
+            config=dict(config) if config else {},
             correlation_id=correlation_id,
             origin=Origin.EXTERNAL,
         )
@@ -224,6 +226,7 @@ class PrepExecutor:
         input_prompt: str,
         chat_session_id: str = "",
         correlation_id: str = "",
+        config: dict[str, Any] | None = None,
     ) -> tuple[dict[str, Any], dict[str, Any] | None]:
         """Run SKL-OIA-02 and store the result as a DRAFT.
 
@@ -246,6 +249,7 @@ class PrepExecutor:
                 "count": count,
                 "depth": depth,
             },
+            config=dict(config) if config else {},
             correlation_id=correlation_id,
             origin=Origin.EXTERNAL,
         )

--- a/onboarding-intelligence-agent-svc/app/logic/rate_limiter.py
+++ b/onboarding-intelligence-agent-svc/app/logic/rate_limiter.py
@@ -1,0 +1,37 @@
+"""Per-user rate limiting via Redis counters (M-05, §14).
+
+One counter per tenant per user, shared by PREP turns and WS control frames.
+The counter key is ``oia:v1:{tenant}:ratelimit:{user_id}`` with a 60-second
+TTL set on the first increment — a simple sliding window.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+WINDOW_S = 60
+
+
+async def check_rate(redis_client: Any, key: str, limit: int) -> tuple[int, bool]:
+    """Increment the counter and return (count, exceeded).
+
+    ``INCR`` is atomic across Cloud Run instances because it is a single Redis
+    command. The ``EXPIRE`` on the first increment creates the 60-second
+    window; subsequent increments do not reset the TTL.
+    """
+    count: int = await redis_client.incr(key)
+    if count == 1:
+        await redis_client.expire(key, WINDOW_S)
+    exceeded = count > limit
+    if exceeded:
+        logger.warning(
+            "rate_limit_exceeded",
+            key=key,
+            count=count,
+            limit=limit,
+        )
+    return count, exceeded

--- a/onboarding-intelligence-agent-svc/app/logic/rate_limiter.py
+++ b/onboarding-intelligence-agent-svc/app/logic/rate_limiter.py
@@ -15,17 +15,23 @@ logger = get_logger(__name__)
 
 WINDOW_S = 60
 
+_LUA_INCR_WITH_EXPIRE = """
+local count = redis.call('INCR', KEYS[1])
+if count == 1 then
+    redis.call('EXPIRE', KEYS[1], ARGV[1])
+end
+return count
+"""
+
 
 async def check_rate(redis_client: Any, key: str, limit: int) -> tuple[int, bool]:
     """Increment the counter and return (count, exceeded).
 
-    ``INCR`` is atomic across Cloud Run instances because it is a single Redis
-    command. The ``EXPIRE`` on the first increment creates the 60-second
-    window; subsequent increments do not reset the TTL.
+    Uses a Lua script so the ``INCR`` and ``EXPIRE`` execute atomically in
+    a single round trip. Without this, a crash between the two commands
+    would leave a counter with no TTL — permanently rate-limiting the user.
     """
-    count: int = await redis_client.incr(key)
-    if count == 1:
-        await redis_client.expire(key, WINDOW_S)
+    count: int = await redis_client.eval(_LUA_INCR_WITH_EXPIRE, 1, key, WINDOW_S)
     exceeded = count > limit
     if exceeded:
         logger.warning(

--- a/onboarding-intelligence-agent-svc/tests/test_live_lock.py
+++ b/onboarding-intelligence-agent-svc/tests/test_live_lock.py
@@ -1,0 +1,211 @@
+"""M-05 AC-2/AC-3 — live-session lock: company keying, multi-slot, TTL expiry.
+
+Tests hit a real Redis: no mocks. The lock key is
+``oia:v1:{tenant}:lock:live:{company_id}`` with a 90s TTL refreshed every 30s
+by the heartbeat.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import uuid
+
+import pytest
+
+from app.logic.live_lock import LOCK_TTL_S, LiveLock, acquire
+
+pytestmark = pytest.mark.integration
+
+TENANT = "t-lock-test"
+
+
+def _company(suffix: str) -> str:
+    return f"c-{hashlib.md5(suffix.encode()).hexdigest()[:8]}"
+
+
+async def _cleanup(redis_manager, tenant_id: str, company_id: str, slots: int = 5):
+    keys = redis_manager.keys_for(tenant_id)
+    for slot in range(slots):
+        key = keys.live_lock_slot(company_id, slot)
+        await redis_manager.client.delete(key)
+
+
+async def test_live_lock_keyed_on_company(live_redis):
+    """AC-2: two different companies can lock simultaneously; same company
+    contends."""
+    company_a = _company("lock-a")
+    company_b = _company("lock-b")
+    token_a = uuid.uuid4().hex
+    token_b = uuid.uuid4().hex
+
+    try:
+        lock_a = await acquire(
+            live_redis,
+            tenant_id=TENANT,
+            company_id=company_a,
+            token=token_a,
+        )
+        lock_b = await acquire(
+            live_redis,
+            tenant_id=TENANT,
+            company_id=company_b,
+            token=token_b,
+        )
+        assert lock_a is not None
+        assert lock_b is not None
+
+        contender = await acquire(
+            live_redis,
+            tenant_id=TENANT,
+            company_id=company_a,
+            token=uuid.uuid4().hex,
+        )
+        assert contender is None
+    finally:
+        await _cleanup(live_redis, TENANT, company_a)
+        await _cleanup(live_redis, TENANT, company_b)
+
+
+async def test_tenant_configurable_max_concurrent(live_redis):
+    """AC-2: max_concurrent=2 allows two sessions for one company."""
+    company = _company("multi-slot")
+    try:
+        lock1 = await acquire(
+            live_redis,
+            tenant_id=TENANT,
+            company_id=company,
+            token=uuid.uuid4().hex,
+            max_slots=2,
+        )
+        lock2 = await acquire(
+            live_redis,
+            tenant_id=TENANT,
+            company_id=company,
+            token=uuid.uuid4().hex,
+            max_slots=2,
+        )
+        assert lock1 is not None
+        assert lock2 is not None
+        assert lock1.key != lock2.key
+
+        lock3 = await acquire(
+            live_redis,
+            tenant_id=TENANT,
+            company_id=company,
+            token=uuid.uuid4().hex,
+            max_slots=2,
+        )
+        assert lock3 is None
+    finally:
+        await _cleanup(live_redis, TENANT, company)
+
+
+async def test_slot_zero_backward_compatible(live_redis):
+    """Slot 0 produces the same key as live_lock() for backward compatibility."""
+    company = _company("compat")
+    keys = live_redis.keys_for(TENANT)
+    assert keys.live_lock_slot(company, 0) == keys.live_lock(company)
+
+
+async def test_lock_ttl_releases_after_crash(live_redis):
+    """AC-3: a crashed lock cannot strand a company. After TTL expires, a new
+    acquire succeeds.
+
+    Uses a short TTL via direct SET to avoid waiting 90 seconds.
+    """
+    company = _company("crash")
+    keys = live_redis.keys_for(TENANT)
+    key = keys.live_lock(company)
+    client = live_redis.client
+
+    try:
+        await client.set(key, "crashed-token", nx=True, ex=2)
+
+        contender = await acquire(
+            live_redis,
+            tenant_id=TENANT,
+            company_id=company,
+            token=uuid.uuid4().hex,
+        )
+        assert contender is None
+
+        await asyncio.sleep(2.2)
+
+        recovered = await acquire(
+            live_redis,
+            tenant_id=TENANT,
+            company_id=company,
+            token=uuid.uuid4().hex,
+        )
+        assert recovered is not None
+    finally:
+        await _cleanup(live_redis, TENANT, company)
+
+
+async def test_lock_refresh_extends_ttl(live_redis):
+    """AC-3: refresh resets TTL so the lock outlives the initial expiry."""
+    company = _company("refresh")
+    client = live_redis.client
+
+    try:
+        lock = await acquire(
+            live_redis,
+            tenant_id=TENANT,
+            company_id=company,
+            token=uuid.uuid4().hex,
+        )
+        assert lock is not None
+
+        ttl_before = await client.ttl(lock.key)
+        assert 0 < ttl_before <= LOCK_TTL_S
+
+        refreshed = await lock.refresh()
+        assert refreshed is True
+
+        ttl_after = await client.ttl(lock.key)
+        assert ttl_after > 0
+    finally:
+        await _cleanup(live_redis, TENANT, company)
+
+
+async def test_release_only_deletes_own_token(live_redis):
+    """A lock that expired and was re-acquired by another socket must not be
+    released by the original holder."""
+    company = _company("token-check")
+    keys = live_redis.keys_for(TENANT)
+    key = keys.live_lock(company)
+    client = live_redis.client
+
+    try:
+        stale_lock = LiveLock(key=key, token="old-token", _client=client)
+        await client.set(key, "new-owner", ex=LOCK_TTL_S)
+
+        await stale_lock.release()
+
+        value = await client.get(key)
+        assert value == "new-owner"
+    finally:
+        await _cleanup(live_redis, TENANT, company)
+
+
+async def test_acquire_returns_none_without_redis():
+    """No Redis manager → None, not an exception."""
+    lock = await acquire(
+        None,
+        tenant_id=TENANT,
+        company_id="c-1",
+        token="tok",
+    )
+    assert lock is None
+
+
+async def test_acquire_returns_none_without_company(live_redis):
+    """Empty company id → None, not an exception."""
+    lock = await acquire(
+        live_redis,
+        tenant_id=TENANT,
+        company_id="",
+        token="tok",
+    )
+    assert lock is None

--- a/onboarding-intelligence-agent-svc/tests/test_rate_limiter.py
+++ b/onboarding-intelligence-agent-svc/tests/test_rate_limiter.py
@@ -1,0 +1,119 @@
+"""M-05 AC-1 — per-user rate limiting via Redis counters.
+
+Tests hit a real Redis: no mocks. The counter lives at
+``oia:v1:{tenant}:ratelimit:{user_id}`` with a 60-second TTL on the first
+increment, shared by PREP turns and WS control frames.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from app.logic.rate_limiter import WINDOW_S, check_rate
+
+pytestmark = pytest.mark.integration
+
+TENANT = "t-rl-test"
+USER = "u-rl-1"
+
+
+@pytest.fixture
+def rl_key(live_redis):
+    """A ratelimit key scoped to this test run, cleaned up afterward."""
+    keys = live_redis.keys_for(TENANT)
+    key = keys.ratelimit(USER)
+    yield key
+    asyncio.get_event_loop().run_until_complete(live_redis.client.delete(key))
+
+
+async def test_rate_limit_increments_and_expires(live_redis, rl_key):
+    """AC-1: counter increments on each call, and the 60s TTL is set."""
+    client = live_redis.client
+
+    count1, exceeded1 = await check_rate(client, rl_key, 10)
+    assert count1 == 1
+    assert exceeded1 is False
+
+    ttl = await client.ttl(rl_key)
+    assert 0 < ttl <= WINDOW_S
+
+    count2, exceeded2 = await check_rate(client, rl_key, 10)
+    assert count2 == 2
+    assert exceeded2 is False
+
+
+async def test_rate_limit_blocks_after_threshold(live_redis, rl_key):
+    """AC-1: returns exceeded=True when count > limit."""
+    client = live_redis.client
+    limit = 3
+
+    for i in range(1, limit + 1):
+        count, exceeded = await check_rate(client, rl_key, limit)
+        assert count == i
+        assert exceeded is False
+
+    count, exceeded = await check_rate(client, rl_key, limit)
+    assert count == limit + 1
+    assert exceeded is True
+
+
+async def test_rate_limit_ttl_not_reset_on_subsequent_calls(live_redis, rl_key):
+    """The TTL is set once, on the first increment — not refreshed."""
+    client = live_redis.client
+
+    await check_rate(client, rl_key, 10)
+    ttl_after_first = await client.ttl(rl_key)
+
+    await asyncio.sleep(1.1)
+    await check_rate(client, rl_key, 10)
+    ttl_after_second = await client.ttl(rl_key)
+
+    assert ttl_after_second < ttl_after_first
+
+
+def test_prep_returns_429_when_rate_exceeded(app_with_live_redis):
+    """AC-1: ``/v1/execute`` returns HTTP 429 when the rate limit is hit."""
+    import redis as sync_redis
+
+    from app.cache.redis_manager import TenantKeys
+    from tests.conftest import REDIS_URL
+
+    from fastapi.testclient import TestClient
+
+    tenant_id = "t-429-test"
+    user_id = "u-429"
+
+    rl_key = TenantKeys(tenant_id).ratelimit(user_id)
+
+    r = sync_redis.Redis.from_url(REDIS_URL, decode_responses=True)
+    try:
+        r.delete(rl_key)
+        r.set(rl_key, "10", ex=60)
+    finally:
+        r.close()
+
+    with TestClient(app_with_live_redis) as client:
+        settings = app_with_live_redis.state.settings
+        body = {
+            "input_prompt": "Tell me about the brand",
+            "chat_session_id": "chat-429",
+            "tenant_context": {
+                "tenant_id": tenant_id,
+                "user_id": user_id,
+                "role": "EDITOR",
+                "trace_id": "tr-429",
+            },
+        }
+        headers = {"X-Service-Token": settings.SERVICE_TOKEN}
+
+        response = client.post("/v1/execute", json=body, headers=headers)
+        assert response.status_code == 429
+        assert "Rate limit exceeded" in response.json()["detail"]
+
+    r = sync_redis.Redis.from_url(REDIS_URL, decode_responses=True)
+    try:
+        r.delete(rl_key)
+    finally:
+        r.close()

--- a/onboarding-intelligence-agent-svc/tests/test_redis_key_isolation.py
+++ b/onboarding-intelligence-agent-svc/tests/test_redis_key_isolation.py
@@ -78,7 +78,10 @@ def test_constructing_without_a_tenant_fails(bad):
 
 
 def test_circuit_key_is_deliberately_not_tenant_scoped():
-    """A dependency being down is a global fact, not a per-tenant one."""
+    """A dependency being down is a global fact, not a per-tenant one.
+
+    M-05 AC-4: this test proves the circuit key is global (not per-tenant).
+    """
     key = circuit_key("google-stt")
     assert key == f"{KEY_PREFIX}circuit:google-stt"
     assert key.startswith(KEY_PREFIX)


### PR DESCRIPTION
## Summary

- **Rate limiting**: Created `app/logic/rate_limiter.py` with `check_rate()` — a single Redis INCR + EXPIRE counter shared by PREP turns and WS control frames (`oia:v1:{tenant}:ratelimit:{user_id}`, 60s window)
- **PREP 429**: Wired rate check into `/v1/execute` route — returns HTTP 429 with EVT-012 emission when the 10/min limit is exceeded; injects `_ig07_count` into `SkillContext.config` so the previously dead IG-07 guardrail now sees real counts
- **WS 4429**: Wired rate check into `_handle_control()` — closes the socket with the pre-existing 4429 code and emits EVT-012
- **Multi-slot live lock**: `acquire()` now accepts `max_slots` for tenant-configurable concurrency; tries slots 0..N-1 with SET NX. Slot 0 is backward-compatible with the original single-slot key
- **Tenant config**: WS handshake reads `max_concurrent_sessions` from the per-tenant Redis config hash, falling back to the global `MAX_CONCURRENT_LIVE_PER_COMPANY` default

## Test plan

- [x] `tests/test_rate_limiter.py` — counter increment/expiry, threshold blocking, TTL stability, PREP 429 response (4 tests, real Redis)
- [x] `tests/test_live_lock.py` — company keying, multi-slot acquire, slot-0 backward compat, TTL crash recovery, refresh, token-safe release, edge cases (8 tests, real Redis)
- [x] `tests/test_redis_key_isolation.py` — AC-4 comment added to existing circuit key test; `live_lock_slot` builder auto-discovered by reflection
- [x] Full suite: 1117 passed, 29 skipped (8 pre-existing PII/presidio failures unrelated to M-05)

🤖 Generated with [Claude Code](https://claude.com/claude-code)