### PR TITLE
fix(oia): resolve 10 open issues from code review

### DIFF
--- a/onboarding-intelligence-agent-svc/app/api/routes.py
+++ b/onboarding-intelligence-agent-svc/app/api/routes.py
@@ -322,11 +322,13 @@ async def execute(request: Request, payload: ExecuteRequest) -> ExecuteResponse:
             import json as _json
 
             keys = request.app.state.redis.keys_for(tenant_id)
+            session_key = keys.session(payload.session_id)
             await request.app.state.redis.client.hset(
-                keys.session(payload.session_id),
+                session_key,
                 "prompt_versions",
                 _json.dumps(prompt_versions),
             )
+            await request.app.state.redis.client.expire(session_key, 14400, nx=True)
         if degraded:
             events = getattr(request.app.state, "events", None)
             if events is not None:

--- a/onboarding-intelligence-agent-svc/app/api/routes.py
+++ b/onboarding-intelligence-agent-svc/app/api/routes.py
@@ -321,14 +321,18 @@ async def execute(request: Request, payload: ExecuteRequest) -> ExecuteResponse:
         if payload.session_id:
             import json as _json
 
+            from app.cache.redis_manager import TTL_SESSION
+
             keys = request.app.state.redis.keys_for(tenant_id)
             session_key = keys.session(payload.session_id)
-            await request.app.state.redis.client.hset(
+            pipe = request.app.state.redis.client.pipeline(transaction=False)
+            pipe.hset(
                 session_key,
                 "prompt_versions",
                 _json.dumps(prompt_versions),
             )
-            await request.app.state.redis.client.expire(session_key, 14400, nx=True)
+            pipe.expire(session_key, TTL_SESSION)
+            await pipe.execute()
         if degraded:
             events = getattr(request.app.state, "events", None)
             if events is not None:

--- a/onboarding-intelligence-agent-svc/app/logic/evidence_assembler.py
+++ b/onboarding-intelligence-agent-svc/app/logic/evidence_assembler.py
@@ -91,6 +91,8 @@ class EvidenceAssembler:
                 tenant_id, session_id, self._settings.OCR_AWAIT_TIMEOUT_S
             )
             missing_media.extend(await_result)
+            # Re-fetch after OCR wait so newly processed text is included.
+            django_data = await self._fetch_from_django(tenant_id, session_id)
 
         blocks, valid_rec_ids, valid_media_ids = self._build_blocks(
             django_data, redis_questions

--- a/onboarding-intelligence-agent-svc/app/logic/evidence_assembler.py
+++ b/onboarding-intelligence-agent-svc/app/logic/evidence_assembler.py
@@ -91,8 +91,9 @@ class EvidenceAssembler:
                 tenant_id, session_id, self._settings.OCR_AWAIT_TIMEOUT_S
             )
             missing_media.extend(await_result)
-            # Re-fetch after OCR wait so newly processed text is included.
-            django_data = await self._fetch_from_django(tenant_id, session_id)
+            refreshed = await self._fetch_from_django(tenant_id, session_id)
+            if refreshed is not None:
+                django_data = refreshed
 
         blocks, valid_rec_ids, valid_media_ids = self._build_blocks(
             django_data, redis_questions

--- a/onboarding-intelligence-agent-svc/app/logic/field_extractor.py
+++ b/onboarding-intelligence-agent-svc/app/logic/field_extractor.py
@@ -361,7 +361,7 @@ class FieldExtractor:
                 med_ok = (
                     med_id in valid_media_ids
                     if med_id and valid_media_ids is not None
-                    else bool(med_id)
+                    else False
                 )
 
                 if not rec_ok and not med_ok:

--- a/onboarding-intelligence-agent-svc/app/logic/field_extractor.py
+++ b/onboarding-intelligence-agent-svc/app/logic/field_extractor.py
@@ -356,7 +356,7 @@ class FieldExtractor:
                 rec_ok = (
                     rec_id in valid_recording_ids
                     if rec_id and valid_recording_ids is not None
-                    else bool(rec_id)
+                    else False
                 )
                 med_ok = (
                     med_id in valid_media_ids

--- a/onboarding-intelligence-agent-svc/app/logic/process_executor.py
+++ b/onboarding-intelligence-agent-svc/app/logic/process_executor.py
@@ -160,11 +160,7 @@ class ProcessExecutor:
         prompt_versions: dict[str, str] = {}
 
         try:
-            await self._redis.client.set(
-                job_key,
-                json.dumps({"job_id": job_id, "status": JOB_STATUS_RUNNING}),
-                ex=JOB_TTL,
-            )
+            await self._update_job_status(job_key, job_id, JOB_STATUS_RUNNING)
 
             # L-01: resolve and pin prompt versions before processing.
             loader = getattr(self, "_prompt_loader", None)
@@ -175,11 +171,13 @@ class ProcessExecutor:
                     PROCESS_PROMPTS, tenant.tenant_id
                 )
                 prompt_versions = {pid: r.version for pid, r in resolved.items()}
+                session_key = keys.session(session_id)
                 await self._redis.client.hset(
-                    keys.session(session_id),
+                    session_key,
                     "prompt_versions",
                     json.dumps(prompt_versions),
                 )
+                await self._redis.client.expire(session_key, JOB_TTL, nx=True)
                 if degraded and self._events is not None:
                     from app.events.catalog import EventType
 
@@ -411,12 +409,13 @@ class ProcessExecutor:
             )
             summary = {"error": f"Cancelled: {exc}"}
             cb_status = JOB_STATUS_FAILED
+            # Decrement the cancellation counter so the cleanup awaits
+            # below do not re-raise CancelledError (Python 3.12+).
+            task = asyncio.current_task()
+            if task is not None:
+                task.uncancel()
 
-        await self._redis.client.set(
-            job_key,
-            json.dumps({"job_id": job_id, "status": cb_status}),
-            ex=JOB_TTL,
-        )
+        await self._update_job_status(job_key, job_id, cb_status)
 
         if self._backend is not None and callback_url:
             await self._callback(
@@ -428,6 +427,21 @@ class ProcessExecutor:
                 prompt_versions=prompt_versions,
             )
 
+    async def _update_job_status(
+        self, job_key: str, job_id: str, status: JobStatus
+    ) -> None:
+        """Merge status into existing job state so accept()-time fields survive."""
+        existing_raw = await self._redis.client.get(job_key)
+        merged: dict[str, Any] = {}
+        if existing_raw is not None:
+            try:
+                merged = json.loads(existing_raw)
+            except (json.JSONDecodeError, TypeError):
+                pass
+        merged["job_id"] = job_id
+        merged["status"] = status
+        await self._redis.client.set(job_key, json.dumps(merged), ex=JOB_TTL)
+
     async def _handle_conflicts(
         self,
         *,
@@ -437,9 +451,14 @@ class ProcessExecutor:
         job_id: str,
     ) -> None:
         """J-05: create CONFLICT provenance, publish escalations, emit EVT-007."""
-        # Fail-fast: parse UUIDs before any writes to avoid partial state
-        tenant_uuid = uuid.UUID(tenant.tenant_id)
-        session_uuid = uuid.UUID(session_id) if session_id else None
+        try:
+            tenant_uuid = uuid.UUID(tenant.tenant_id)
+        except (ValueError, AttributeError):
+            tenant_uuid = uuid.uuid5(uuid.NAMESPACE_URL, tenant.tenant_id)
+        try:
+            session_uuid = uuid.UUID(session_id) if session_id else None
+        except (ValueError, AttributeError):
+            session_uuid = uuid.uuid5(uuid.NAMESPACE_URL, session_id)
 
         # 1. Create CONFLICT provenance records
         if self._backend is not None:
@@ -651,10 +670,10 @@ class ProcessExecutor:
             logger.error("process_callback_no_backend", job_id=job_id)
             return
 
-        from urllib.parse import urlparse
+        from urllib.parse import urlparse, urlunparse
 
         parsed = urlparse(callback_url)
-        path = parsed.path
+        path = urlunparse(("", "", parsed.path, parsed.params, parsed.query, ""))
         payload: dict[str, Any] = {
             "job_id": job_id,
             "status": status,
@@ -662,7 +681,7 @@ class ProcessExecutor:
         }
         if prompt_versions:
             payload["prompt_versions"] = prompt_versions
-        result = await self._backend._post(
+        result = await self._backend.send_callback(
             path,
             payload,
             tenant_id=tenant_id,

--- a/onboarding-intelligence-agent-svc/app/logic/process_executor.py
+++ b/onboarding-intelligence-agent-svc/app/logic/process_executor.py
@@ -15,7 +15,7 @@ import uuid
 from typing import Any, Literal
 
 from app.api.schemas import EvidenceManifest, ProcessResponse
-from app.cache.redis_manager import RedisManager, TTL_IDEMPOTENCY
+from app.cache.redis_manager import RedisManager, TTL_IDEMPOTENCY, TTL_SESSION
 from app.core.logging import get_logger
 from app.events.catalog import EventType
 from app.events.emitter import EventEmitter
@@ -172,12 +172,14 @@ class ProcessExecutor:
                 )
                 prompt_versions = {pid: r.version for pid, r in resolved.items()}
                 session_key = keys.session(session_id)
-                await self._redis.client.hset(
+                pipe = self._redis.client.pipeline(transaction=False)
+                pipe.hset(
                     session_key,
                     "prompt_versions",
                     json.dumps(prompt_versions),
                 )
-                await self._redis.client.expire(session_key, JOB_TTL, nx=True)
+                pipe.expire(session_key, TTL_SESSION)
+                await pipe.execute()
                 if degraded and self._events is not None:
                     from app.events.catalog import EventType
 

--- a/onboarding-intelligence-agent-svc/app/services/backend_client.py
+++ b/onboarding-intelligence-agent-svc/app/services/backend_client.py
@@ -159,6 +159,17 @@ class BackendClient:
         self._breaker.record_success()
         return body if isinstance(body, dict) else None
 
+    async def send_callback(
+        self,
+        path: str,
+        payload: dict[str, Any],
+        *,
+        tenant_id: str,
+        timeout: float = 30.0,
+    ) -> dict[str, Any] | None:
+        """POST a callback payload to Django with an appropriate timeout."""
+        return await self._post(path, payload, tenant_id=tenant_id, timeout=timeout)
+
     async def store_research_brief(
         self,
         *,

--- a/onboarding-intelligence-agent-svc/app/skills/extract_and_map_fields.py
+++ b/onboarding-intelligence-agent-svc/app/skills/extract_and_map_fields.py
@@ -12,10 +12,24 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.logic.evidence_assembler import EvidenceBlock
 from app.logic.field_extractor import ExtractionResult, FieldExtractor
 from app.providers.llm import LLMProvider
 from app.skills.base import BaseSkill
 from app.skills.models import SkillContext, SkillResult
+
+
+def _coerce_evidence_blocks(raw: list[Any]) -> list[EvidenceBlock]:
+    """Convert dicts from JSON deserialization to EvidenceBlock instances."""
+    blocks: list[EvidenceBlock] = []
+    for item in raw:
+        if isinstance(item, EvidenceBlock):
+            blocks.append(item)
+        elif isinstance(item, dict):
+            blocks.append(EvidenceBlock(**item))
+        else:
+            blocks.append(item)
+    return blocks
 
 
 class ExtractAndMapFields(BaseSkill):
@@ -37,7 +51,9 @@ class ExtractAndMapFields(BaseSkill):
         settings = get_settings()
         extractor = FieldExtractor(llm=self._llm, settings=settings)
 
-        evidence_blocks = context.input_context.get("evidence_blocks", [])
+        evidence_blocks = _coerce_evidence_blocks(
+            context.input_context.get("evidence_blocks", [])
+        )
         existing_provenance = context.input_context.get("existing_provenance", [])
 
         raw_rec = context.input_context.get("valid_recording_ids")

--- a/onboarding-intelligence-agent-svc/app/skills/extract_and_map_fields.py
+++ b/onboarding-intelligence-agent-svc/app/skills/extract_and_map_fields.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.api.schemas import EvidenceSpan
 from app.logic.evidence_assembler import EvidenceBlock
 from app.logic.field_extractor import ExtractionResult, FieldExtractor
 from app.providers.llm import LLMProvider
@@ -19,14 +20,32 @@ from app.skills.base import BaseSkill
 from app.skills.models import SkillContext, SkillResult
 
 
+def _coerce_spans(raw_spans: list[Any]) -> list[EvidenceSpan]:
+    """Convert dicts to EvidenceSpan instances."""
+    spans: list[EvidenceSpan] = []
+    for s in raw_spans:
+        if isinstance(s, EvidenceSpan):
+            spans.append(s)
+        elif isinstance(s, dict):
+            spans.append(EvidenceSpan(**s))
+        else:
+            spans.append(s)
+    return spans
+
+
 def _coerce_evidence_blocks(raw: list[Any]) -> list[EvidenceBlock]:
     """Convert dicts from JSON deserialization to EvidenceBlock instances."""
     blocks: list[EvidenceBlock] = []
     for item in raw:
         if isinstance(item, EvidenceBlock):
+            item.spans = _coerce_spans(item.spans)
             blocks.append(item)
         elif isinstance(item, dict):
-            blocks.append(EvidenceBlock(**item))
+            raw_spans = item.get("spans", [])
+            kwargs = {k: v for k, v in item.items() if k != "spans"}
+            block = EvidenceBlock(**kwargs)
+            block.spans = _coerce_spans(raw_spans)
+            blocks.append(block)
         else:
             blocks.append(item)
     return blocks
@@ -62,8 +81,8 @@ class ExtractAndMapFields(BaseSkill):
         result: ExtractionResult = await extractor.extract_all(
             evidence_blocks=evidence_blocks,
             existing_provenance=existing_provenance,
-            valid_recording_ids=set(raw_rec) if raw_rec else None,
-            valid_media_ids=set(raw_med) if raw_med else None,
+            valid_recording_ids=set(raw_rec) if raw_rec is not None else None,
+            valid_media_ids=set(raw_med) if raw_med is not None else None,
             tenant_id=context.tenant_context.tenant_id,
         )
 


### PR DESCRIPTION
## Summary

Fixes all 10 open OIA code issues identified during code review:

- **#613** — `CancelledError` re-cancellation in Python 3.12+: added `task.uncancel()` before cleanup awaits
- **#614** — Redis job state overwrite losing manifest/options: new `_update_job_status()` merges status into existing state
- **#615** — TTL-less keys on shared Redis after `hset`: added `expire(key, ttl, nx=True)` in process_executor and routes
- **#616** — `uuid.UUID()` crash on non-UUID tenant IDs: try/except with `uuid5` fallback
- **#617** — SKL-OIA-10 raw dicts vs `EvidenceBlock` dataclass: added `_coerce_evidence_blocks()` at skill boundary
- **#618** — Hallucinated `media_id` passing grounding check when `valid_media_ids` is `None`: changed to `else False`
- **#619** — Stale `django_data` after OCR wait: re-fetch after `_await_pending_ocr` completes
- **#620** — Dropped query parameters from callback URL: use `urlunparse` preserving path, params, and query
- **#621** — Already fixed in current codebase (shared `BreakerRegistry` created in `main.py`)
- **#622** — Private `_post()` usage: added public `send_callback()` method to `BackendClient`

Closes #613, closes #614, closes #615, closes #616, closes #617, closes #618, closes #619, closes #620, closes #621, closes #622.

## Files changed

- `app/logic/process_executor.py` — #613, #614, #615, #616, #620, #622
- `app/api/routes.py` — #615
- `app/logic/field_extractor.py` — #618
- `app/logic/evidence_assembler.py` — #619
- `app/skills/extract_and_map_fields.py` — #617
- `app/services/backend_client.py` — #622

## Test plan

- [x] `pytest -q` — 877 passed (4 pre-existing failures unrelated to these changes)
- [x] `black app/ tests/` — clean
- [x] `flake8 app/ tests/` — clean
- [x] mypy — only pre-existing `hset` return type warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)