### PR TITLE
feat(oia): backend outbox buffering (Phase B, Gap 4)

### DIFF
--- a/onboarding-intelligence-agent-svc/app/cache/outbox.py
+++ b/onboarding-intelligence-agent-svc/app/cache/outbox.py
@@ -19,7 +19,7 @@ import asyncio
 import json
 import time
 from collections.abc import Awaitable, Callable
-from typing import Any
+from typing import Any, cast
 
 from app.cache.redis_manager import KEY_PREFIX, TTL_OUTBOX, RedisManager
 from app.circuit_breaker.breaker import CircuitBreaker, State
@@ -79,7 +79,7 @@ class OutboxWriter:
         if length > self._max_entries:
             excess = length - self._max_entries
             for _ in range(excess):
-                await self._redis.client.lpop(key)  # type: ignore[misc]
+                await cast(Any, self._redis.client.lpop(key))
             logger.warning(
                 "outbox_overflow",
                 tenant=tenant_id,
@@ -156,7 +156,7 @@ class OutboxWriter:
         """Drain one tenant's outbox. Returns (count_drained, hit_failure)."""
         drained = 0
         while True:
-            raw = await self._redis.client.lpop(key)  # type: ignore[misc]
+            raw: bytes | str | None = await cast(Any, self._redis.client.lpop(key))
             if raw is None:
                 break
             if isinstance(raw, bytes):
@@ -181,7 +181,7 @@ class OutboxWriter:
                     tenant=entry.get("tenant_id"),
                 )
             else:
-                await self._redis.client.lpush(key, raw)  # type: ignore[misc]
+                await cast(Any, self._redis.client.lpush(key, raw))
                 return drained, True
         return drained, False
 
@@ -195,7 +195,7 @@ class OutboxWriter:
                 cursor=cursor, match=pattern, count=100
             )
             for key in found_keys:
-                total += await self._redis.client.llen(key)  # type: ignore[misc]
+                total += await cast(Any, self._redis.client.llen(key))
             if cursor == 0:
                 break
         return total

--- a/onboarding-intelligence-agent-svc/app/cache/outbox.py
+++ b/onboarding-intelligence-agent-svc/app/cache/outbox.py
@@ -1,0 +1,221 @@
+"""Backend write outbox — buffers writes while the circuit breaker is open.
+
+Phase B, Gap 4 of the OIA resilience plan.
+
+When the ``backend`` circuit breaker opens, writes (POST/PATCH) that would
+otherwise be silently dropped are serialised to a per-tenant Redis list. When
+the breaker recovers (transitions to CLOSED), a drain callback replays the
+queued entries FIFO. Each tenant's queue is bounded; overflow drops the oldest
+entry and emits a warning.
+
+**Reads are not buffered.** A stale read cannot be replayed meaningfully —
+the response is time-dependent — so ``_get`` still returns None when the
+breaker is open.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from app.cache.redis_manager import KEY_PREFIX, TTL_OUTBOX, RedisManager
+from app.circuit_breaker.breaker import CircuitBreaker, State
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+MAX_ENTRIES_DEFAULT = 200
+
+
+class OutboxWriter:
+    """Buffers backend writes in Redis for replay on breaker recovery."""
+
+    def __init__(
+        self,
+        redis: RedisManager,
+        *,
+        max_entries: int = MAX_ENTRIES_DEFAULT,
+    ) -> None:
+        self._redis = redis
+        self._max_entries = max_entries
+        self._draining = False
+
+    async def enqueue(
+        self,
+        *,
+        method: str,
+        path: str,
+        payload: dict[str, Any],
+        tenant_id: str,
+        timeout: float = 5.0,
+    ) -> None:
+        """Append a write to the tenant's outbox list.
+
+        Bounded at ``max_entries``. When the list exceeds the bound, the
+        oldest entries are dropped (LPOP) and a warning is logged.
+        """
+        keys = self._redis.keys_for(tenant_id)
+        key = keys.backend_outbox()
+        entry = json.dumps(
+            {
+                "method": method,
+                "path": path,
+                "payload": payload,
+                "tenant_id": tenant_id,
+                "timeout": timeout,
+                "enqueued_at": time.time(),
+            }
+        )
+
+        pipe = self._redis.client.pipeline()
+        pipe.rpush(key, entry)
+        pipe.expire(key, TTL_OUTBOX)
+        results = await pipe.execute()
+        length: int = results[0]
+
+        if length > self._max_entries:
+            excess = length - self._max_entries
+            for _ in range(excess):
+                await self._redis.client.lpop(key)  # type: ignore[misc]
+            logger.warning(
+                "outbox_overflow",
+                tenant=tenant_id,
+                dropped=excess,
+                bound=self._max_entries,
+            )
+
+        logger.info(
+            "outbox_enqueued",
+            tenant=tenant_id,
+            method=method,
+            path=path,
+            queue_depth=min(length, self._max_entries),
+        )
+
+    async def drain_all(
+        self,
+        replay_fn: Callable[[dict[str, Any]], Awaitable[bool]],
+    ) -> int:
+        """Scan all tenants and replay buffered writes via ``replay_fn``.
+
+        ``replay_fn`` receives a dict with keys ``method``, ``path``,
+        ``payload``, ``tenant_id``, ``timeout`` and returns True on success,
+        False on failure (which stops the drain for that tenant).
+
+        Returns the total number of entries successfully replayed.
+        """
+        if self._draining:
+            logger.info("outbox_drain_already_running")
+            return 0
+        self._draining = True
+        try:
+            return await self._drain_impl(replay_fn)
+        finally:
+            self._draining = False
+
+    async def _drain_impl(
+        self,
+        replay_fn: Callable[[dict[str, Any]], Awaitable[bool]],
+    ) -> int:
+        pattern = f"{KEY_PREFIX}*:outbox:backend"
+        total = 0
+        stopped = False
+        cursor: int = 0
+
+        while True:
+            cursor, found_keys = await self._redis.client.scan(
+                cursor=cursor, match=pattern, count=100
+            )
+            for key in found_keys:
+                key_str = key if isinstance(key, str) else key.decode()
+                count, failed = await self._drain_key(key_str, replay_fn)
+                total += count
+                if failed:
+                    logger.info(
+                        "outbox_drain_stopped",
+                        reason="replay_failed",
+                        total_drained=total,
+                    )
+                    stopped = True
+                    break
+            if stopped or cursor == 0:
+                break
+
+        if total:
+            logger.info("outbox_drain_complete", total=total)
+        return total
+
+    async def _drain_key(
+        self,
+        key: str,
+        replay_fn: Callable[[dict[str, Any]], Awaitable[bool]],
+    ) -> tuple[int, bool]:
+        """Drain one tenant's outbox. Returns (count_drained, hit_failure)."""
+        drained = 0
+        while True:
+            raw = await self._redis.client.lpop(key)  # type: ignore[misc]
+            if raw is None:
+                break
+            if isinstance(raw, bytes):
+                raw = raw.decode()
+            try:
+                entry: dict[str, Any] = json.loads(raw)
+            except (json.JSONDecodeError, TypeError):
+                logger.warning("outbox_corrupt_entry", key=key)
+                continue
+
+            try:
+                ok = await replay_fn(entry)
+            except Exception:
+                ok = False
+
+            if ok:
+                drained += 1
+                logger.info(
+                    "outbox_replayed",
+                    method=entry.get("method"),
+                    path=entry.get("path"),
+                    tenant=entry.get("tenant_id"),
+                )
+            else:
+                await self._redis.client.lpush(key, raw)  # type: ignore[misc]
+                return drained, True
+        return drained, False
+
+    async def pending_count(self) -> int:
+        """Total entries across all tenants (for monitoring)."""
+        pattern = f"{KEY_PREFIX}*:outbox:backend"
+        total = 0
+        cursor: int = 0
+        while True:
+            cursor, found_keys = await self._redis.client.scan(
+                cursor=cursor, match=pattern, count=100
+            )
+            for key in found_keys:
+                total += await self._redis.client.llen(key)  # type: ignore[misc]
+            if cursor == 0:
+                break
+        return total
+
+
+def register_outbox_drain(
+    breaker: CircuitBreaker,
+    outbox: OutboxWriter,
+    replay_fn: Callable[[dict[str, Any]], Awaitable[bool]],
+) -> None:
+    """Wire the backend breaker's recovery to drain the outbox."""
+
+    def _on_backend_recovered(dep: str, old: State, new: State) -> None:
+        if new != State.CLOSED:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            logger.warning("outbox_drain_no_loop")
+            return
+        loop.create_task(outbox.drain_all(replay_fn))
+
+    breaker.add_on_state_change(_on_backend_recovered)

--- a/onboarding-intelligence-agent-svc/app/cache/outbox.py
+++ b/onboarding-intelligence-agent-svc/app/cache/outbox.py
@@ -21,7 +21,7 @@ import time
 from collections.abc import Awaitable, Callable
 from typing import Any, cast
 
-from app.cache.redis_manager import KEY_PREFIX, TTL_OUTBOX, RedisManager
+from app.cache.redis_manager import BACKEND_OUTBOX_SCAN, TTL_OUTBOX, RedisManager
 from app.circuit_breaker.breaker import CircuitBreaker, State
 from app.core.logging import get_logger
 
@@ -38,10 +38,12 @@ class OutboxWriter:
         redis: RedisManager,
         *,
         max_entries: int = MAX_ENTRIES_DEFAULT,
+        on_overflow: Callable[[str, int], Awaitable[None]] | None = None,
     ) -> None:
         self._redis = redis
         self._max_entries = max_entries
         self._draining = False
+        self._on_overflow = on_overflow
 
     async def enqueue(
         self,
@@ -55,7 +57,7 @@ class OutboxWriter:
         """Append a write to the tenant's outbox list.
 
         Bounded at ``max_entries``. When the list exceeds the bound, the
-        oldest entries are dropped (LPOP) and a warning is logged.
+        oldest entries are trimmed atomically via LTRIM.
         """
         keys = self._redis.keys_for(tenant_id)
         key = keys.backend_outbox()
@@ -72,20 +74,24 @@ class OutboxWriter:
 
         pipe = self._redis.client.pipeline()
         pipe.rpush(key, entry)
+        pipe.ltrim(key, -self._max_entries, -1)
         pipe.expire(key, TTL_OUTBOX)
         results = await pipe.execute()
         length: int = results[0]
 
         if length > self._max_entries:
             excess = length - self._max_entries
-            for _ in range(excess):
-                await cast(Any, self._redis.client.lpop(key))
             logger.warning(
                 "outbox_overflow",
                 tenant=tenant_id,
                 dropped=excess,
                 bound=self._max_entries,
             )
+            if self._on_overflow is not None:
+                try:
+                    await self._on_overflow(tenant_id, excess)
+                except Exception:
+                    pass
 
         logger.info(
             "outbox_enqueued",
@@ -103,7 +109,8 @@ class OutboxWriter:
 
         ``replay_fn`` receives a dict with keys ``method``, ``path``,
         ``payload``, ``tenant_id``, ``timeout`` and returns True on success,
-        False on failure (which stops the drain for that tenant).
+        False on failure (which stops the drain for that tenant but continues
+        to the next).
 
         Returns the total number of entries successfully replayed.
         """
@@ -120,9 +127,8 @@ class OutboxWriter:
         self,
         replay_fn: Callable[[dict[str, Any]], Awaitable[bool]],
     ) -> int:
-        pattern = f"{KEY_PREFIX}*:outbox:backend"
+        pattern = BACKEND_OUTBOX_SCAN
         total = 0
-        stopped = False
         cursor: int = 0
 
         while True:
@@ -135,13 +141,12 @@ class OutboxWriter:
                 total += count
                 if failed:
                     logger.info(
-                        "outbox_drain_stopped",
+                        "outbox_drain_tenant_stopped",
+                        key=key_str,
                         reason="replay_failed",
-                        total_drained=total,
+                        tenant_drained=count,
                     )
-                    stopped = True
-                    break
-            if stopped or cursor == 0:
+            if cursor == 0:
                 break
 
         if total:
@@ -187,7 +192,7 @@ class OutboxWriter:
 
     async def pending_count(self) -> int:
         """Total entries across all tenants (for monitoring)."""
-        pattern = f"{KEY_PREFIX}*:outbox:backend"
+        pattern = BACKEND_OUTBOX_SCAN
         total = 0
         cursor: int = 0
         while True:
@@ -208,6 +213,12 @@ def register_outbox_drain(
 ) -> None:
     """Wire the backend breaker's recovery to drain the outbox."""
 
+    async def _safe_drain() -> None:
+        try:
+            await outbox.drain_all(replay_fn)
+        except Exception:
+            logger.exception("outbox_drain_failed")
+
     def _on_backend_recovered(dep: str, old: State, new: State) -> None:
         if new != State.CLOSED:
             return
@@ -216,6 +227,6 @@ def register_outbox_drain(
         except RuntimeError:
             logger.warning("outbox_drain_no_loop")
             return
-        loop.create_task(outbox.drain_all(replay_fn))
+        loop.create_task(_safe_drain())
 
     breaker.add_on_state_change(_on_backend_recovered)

--- a/onboarding-intelligence-agent-svc/app/cache/redis_manager.py
+++ b/onboarding-intelligence-agent-svc/app/cache/redis_manager.py
@@ -172,6 +172,10 @@ class TenantKeys:
         """List · 24 h · Django writes buffered while the backend breaker is open."""
         return f"{self._scope}outbox:{session_id}"
 
+    def backend_outbox(self) -> str:
+        """List · 24 h · tenant-level backend write queue for breaker-open replay."""
+        return f"{self._scope}outbox:backend"
+
     # ── Tenant control ───────────────────────────────────────
     def ratelimit(self, user_id: str) -> str:
         """Counter · 1 min · PREP 10/min per user, WS control-frame throttle."""

--- a/onboarding-intelligence-agent-svc/app/cache/redis_manager.py
+++ b/onboarding-intelligence-agent-svc/app/cache/redis_manager.py
@@ -33,6 +33,10 @@ KEY_PREFIX: Final[str] = "oia:v1:"
 #: POI writes prompt:{name}:production and prompt:{name}:tenant:{tid} keys.
 PROMPT_CACHE_PREFIX: Final[str] = "prompt:"
 
+#: SCAN glob matching all tenants' backend outbox keys. Derived from KEY_PREFIX
+#: so drain_all/pending_count stay in sync with TenantKeys.backend_outbox().
+BACKEND_OUTBOX_SCAN: Final[str] = f"{KEY_PREFIX}*:outbox:backend"
+
 # TTLs from Design §14. Nothing is written without one — on a shared instance
 # an untrimmed key creates pressure on every other service's data.
 TTL_SESSION: Final[int] = 4 * 60 * 60  # sliding

--- a/onboarding-intelligence-agent-svc/app/events/catalog.py
+++ b/onboarding-intelligence-agent-svc/app/events/catalog.py
@@ -47,6 +47,7 @@ class EventType(StrEnum):
     AGENT_CIRCUIT_OPENED = "agent.circuit.opened"  # EVT-011
     AGENT_CIRCUIT_CLOSED = "agent.circuit.closed"  # EVT-011
     AGENT_RATE_LIMITED = "agent.rate_limited"  # EVT-012
+    AGENT_OUTBOX_OVERFLOW = "agent.outbox.overflow"  # EVT-013
 
     # ── §12.2 Domain events ──────────────────────────────────
     CONSENT_VERIFIED = "onboarding.consent.verified"  # EVT-101
@@ -77,6 +78,7 @@ EVENT_IDS: dict[EventType, str] = {
     EventType.AGENT_CIRCUIT_OPENED: "EVT-011",
     EventType.AGENT_CIRCUIT_CLOSED: "EVT-011",
     EventType.AGENT_RATE_LIMITED: "EVT-012",
+    EventType.AGENT_OUTBOX_OVERFLOW: "EVT-013",
     EventType.CONSENT_VERIFIED: "EVT-101",
     EventType.RECORDING_STARTED: "EVT-102",
     EventType.RECORDING_STOPPED: "EVT-102",

--- a/onboarding-intelligence-agent-svc/app/main.py
+++ b/onboarding-intelligence-agent-svc/app/main.py
@@ -163,6 +163,12 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # callbacks observe the real state across all callers.
     app.state.breakers = BreakerRegistry()
 
+    # Phase B: backend write outbox — buffers writes while the breaker is open,
+    # drains on recovery. Created before BackendClient so the client can use it.
+    from app.cache.outbox import OutboxWriter, register_outbox_drain
+
+    app.state.outbox = OutboxWriter(app.state.redis)
+
     # C-02. Built once: loading the registry parses YAML and imports sixteen
     # modules, which is startup work rather than per-request work. The
     # providers are constructed here so a missing key is visible at boot in
@@ -171,6 +177,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         settings.BACKEND_BASE_URL,
         settings.SERVICE_TOKEN,
         breaker=app.state.breakers.get("backend"),
+        outbox=app.state.outbox,
     )
 
     # J-01: PROCESS mode executor. Shares the BackendClient and Redis.
@@ -209,6 +216,18 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                 dep, _STATE_ORDINAL.get(str(new), 0)
             )
         )
+
+    # Phase B: drain outbox on backend breaker recovery, and on startup.
+    register_outbox_drain(
+        app.state.breakers.get("backend"),
+        app.state.outbox,
+        app.state.backend.replay_entry,
+    )
+    startup_drained = await app.state.outbox.drain_all(
+        app.state.backend.replay_entry,
+    )
+    if startup_drained:
+        logger.info("outbox_startup_drain", replayed=startup_drained)
 
     # N-03: OCR retry queue drain on vision breaker recovery.
     from app.logic.ocr_drain import register_drain_callback

--- a/onboarding-intelligence-agent-svc/app/main.py
+++ b/onboarding-intelligence-agent-svc/app/main.py
@@ -166,8 +166,23 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # Phase B: backend write outbox — buffers writes while the breaker is open,
     # drains on recovery. Created before BackendClient so the client can use it.
     from app.cache.outbox import OutboxWriter, register_outbox_drain
+    from app.events.catalog import EventType
 
-    app.state.outbox = OutboxWriter(app.state.redis)
+    async def _emit_overflow(tenant_id: str, dropped: int) -> None:
+        if hasattr(app.state, "events") and app.state.events is not None:
+            import uuid
+
+            await app.state.events.emit(
+                EventType.AGENT_OUTBOX_OVERFLOW,
+                tenant_id=uuid.UUID(tenant_id) if tenant_id else uuid.uuid4(),
+                correlation_id=f"outbox-overflow-{tenant_id}",
+                payload={"tenant_id": tenant_id, "dropped": dropped},
+            )
+
+    app.state.outbox = OutboxWriter(
+        app.state.redis,
+        on_overflow=_emit_overflow,
+    )
 
     # C-02. Built once: loading the registry parses YAML and imports sixteen
     # modules, which is startup work rather than per-request work. The

--- a/onboarding-intelligence-agent-svc/app/services/backend_client.py
+++ b/onboarding-intelligence-agent-svc/app/services/backend_client.py
@@ -334,6 +334,7 @@ class BackendClient:
         payload: dict[str, Any],
         *,
         tenant_id: str,
+        timeout: float = TIMEOUT_S,
     ) -> dict[str, Any] | None:
         if not self.configured:
             logger.warning(
@@ -351,6 +352,7 @@ class BackendClient:
                     path=path,
                     payload=payload,
                     tenant_id=tenant_id,
+                    timeout=timeout,
                 )
                 logger.info(
                     "backend_write_buffered",
@@ -361,7 +363,7 @@ class BackendClient:
                 logger.warning("backend_breaker_open", path=path)
             return None
 
-        client = self._client or httpx.AsyncClient(timeout=TIMEOUT_S)
+        client = self._client or httpx.AsyncClient(timeout=timeout)
         owns_client = self._client is None
         try:
             response = await client.patch(
@@ -371,7 +373,7 @@ class BackendClient:
                     "X-Service-Token": self._token,
                     "X-Tenant-ID": tenant_id,
                 },
-                timeout=TIMEOUT_S,
+                timeout=timeout,
             )
             response.raise_for_status()
             body = response.json()

--- a/onboarding-intelligence-agent-svc/app/services/backend_client.py
+++ b/onboarding-intelligence-agent-svc/app/services/backend_client.py
@@ -16,7 +16,7 @@ detail.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from urllib.parse import quote
 
@@ -28,6 +28,9 @@ from app.circuit_breaker.breaker import (
     CircuitBreakerOpen,
 )
 from app.core.logging import get_logger
+
+if TYPE_CHECKING:
+    from app.cache.outbox import OutboxWriter
 
 logger = get_logger(__name__)
 
@@ -81,11 +84,13 @@ class BackendClient:
         *,
         breaker: CircuitBreaker | None = None,
         client: httpx.AsyncClient | None = None,
+        outbox: OutboxWriter | None = None,
     ) -> None:
         self._base_url = base_url.rstrip("/")
         self._token = service_token
         self._breaker = breaker or BreakerRegistry().get(DEPENDENCY)
         self._client = client
+        self._outbox = outbox
 
     @property
     def configured(self) -> bool:
@@ -115,8 +120,22 @@ class BackendClient:
 
         try:
             self._breaker.before_call()
-        except CircuitBreakerOpen:
-            logger.warning("backend_breaker_open", path=path)
+        except CircuitBreakerOpen as exc:
+            if self._outbox is not None:
+                await self._outbox.enqueue(
+                    method="POST",
+                    path=path,
+                    payload=payload,
+                    tenant_id=tenant_id,
+                    timeout=timeout,
+                )
+                logger.info(
+                    "backend_write_buffered",
+                    path=path,
+                    user_message=exc.user_message,
+                )
+            else:
+                logger.warning("backend_breaker_open", path=path)
             return None
 
         client = self._client or httpx.AsyncClient(timeout=timeout)
@@ -325,8 +344,21 @@ class BackendClient:
 
         try:
             self._breaker.before_call()
-        except CircuitBreakerOpen:
-            logger.warning("backend_breaker_open", path=path)
+        except CircuitBreakerOpen as exc:
+            if self._outbox is not None:
+                await self._outbox.enqueue(
+                    method="PATCH",
+                    path=path,
+                    payload=payload,
+                    tenant_id=tenant_id,
+                )
+                logger.info(
+                    "backend_write_buffered",
+                    path=path,
+                    user_message=exc.user_message,
+                )
+            else:
+                logger.warning("backend_breaker_open", path=path)
             return None
 
         client = self._client or httpx.AsyncClient(timeout=TIMEOUT_S)
@@ -521,3 +553,75 @@ class BackendClient:
         return await self._post(
             path, {}, tenant_id=tenant_id, timeout=GENERATE_TIMEOUT_S
         )
+
+    async def replay_entry(self, entry: dict[str, Any]) -> bool:
+        """Replay a buffered outbox entry. Returns True on success.
+
+        Used by the outbox drain — goes through the breaker but does NOT
+        re-enqueue on failure (that would loop). Non-retryable failures
+        (4xx) are logged and discarded.
+        """
+        method = entry.get("method", "POST")
+        path = entry.get("path", "")
+        payload = entry.get("payload", {})
+        tenant_id = entry.get("tenant_id", "")
+        timeout = float(entry.get("timeout", TIMEOUT_S))
+
+        if not self.configured or not path or not tenant_id:
+            return False
+
+        try:
+            self._breaker.before_call()
+        except CircuitBreakerOpen:
+            return False
+
+        client = self._client or httpx.AsyncClient(timeout=timeout)
+        owns_client = self._client is None
+        try:
+            if method == "PATCH":
+                response = await client.patch(
+                    f"{self._base_url}{path}",
+                    json=payload,
+                    headers={
+                        "X-Service-Token": self._token,
+                        "X-Tenant-ID": tenant_id,
+                    },
+                    timeout=timeout,
+                )
+            else:
+                response = await client.post(
+                    f"{self._base_url}{path}",
+                    json=payload,
+                    headers={
+                        "X-Service-Token": self._token,
+                        "X-Tenant-ID": tenant_id,
+                    },
+                    timeout=timeout,
+                )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code < 500:
+                self._breaker.record_success()
+                logger.warning(
+                    "outbox_replay_client_error",
+                    path=path,
+                    status=exc.response.status_code,
+                )
+                return True
+            self._breaker.record_failure()
+            logger.warning("outbox_replay_server_error", path=path)
+            return False
+        except Exception as exc:
+            self._breaker.record_failure()
+            logger.warning(
+                "outbox_replay_failed",
+                path=path,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+            return False
+        finally:
+            if owns_client:
+                await client.aclose()
+
+        self._breaker.record_success()
+        return True

--- a/onboarding-intelligence-agent-svc/tests/test_events_no_pii.py
+++ b/onboarding-intelligence-agent-svc/tests/test_events_no_pii.py
@@ -75,18 +75,18 @@ def test_occurred_at_is_accepted_as_an_alias_for_timestamp():
 
 
 def test_event_type_enum_complete():
-    """All 22 event IDs from §12 are present in the enum."""
+    """All 23 event IDs from §12 + Phase B are present in the enum."""
     ids = set(EVENT_IDS.values())
-    expected = {f"EVT-{n:03d}" for n in range(1, 13)} | {
+    expected = {f"EVT-{n:03d}" for n in range(1, 14)} | {
         f"EVT-{n}" for n in range(101, 111)
     }
     assert ids == expected, sorted(expected.symmetric_difference(ids))
-    assert len(ids) == 22
+    assert len(ids) == 23
 
 
-def test_enum_has_24_members_for_22_ids():
+def test_enum_has_25_members_for_23_ids():
     """EVT-011 and EVT-102 each name a pair, so members exceed IDs by two."""
-    assert len(list(EventType)) == 24
+    assert len(list(EventType)) == 25
     assert EVENT_IDS[EventType.AGENT_CIRCUIT_OPENED] == "EVT-011"
     assert EVENT_IDS[EventType.AGENT_CIRCUIT_CLOSED] == "EVT-011"
     assert EVENT_IDS[EventType.RECORDING_STARTED] == "EVT-102"

--- a/onboarding-intelligence-agent-svc/tests/test_outbox.py
+++ b/onboarding-intelligence-agent-svc/tests/test_outbox.py
@@ -1,0 +1,543 @@
+"""Phase B · backend write outbox.
+
+Tests cover: enqueue/drain lifecycle, overflow bounding, startup scan,
+breaker recovery trigger, corrupt entry handling, and the backend client
+integration (writes are buffered when the breaker opens, replayed on
+recovery).
+
+Integration tests run against real Redis.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from app.cache.outbox import OutboxWriter, register_outbox_drain
+from app.cache.redis_manager import TTL_OUTBOX
+from app.circuit_breaker.breaker import BreakerConfig, CircuitBreaker, State
+from app.services.backend_client import BackendClient
+
+TENANT = "t-outbox-1"
+TENANT_2 = "t-outbox-2"
+
+
+def breaker(**overrides) -> CircuitBreaker:
+    base = dict(
+        name="backend",
+        failure_threshold=2,
+        window_seconds=30,
+        success_threshold=1,
+        half_open_max_calls=1,
+        reset_timeout_seconds=300,
+        degraded_mode="REDIS_OUTBOX",
+        user_message="Saving is delayed.",
+    )
+    base.update(overrides)
+    return CircuitBreaker(BreakerConfig(**base))
+
+
+@pytest.fixture
+def django_stub():
+    state = {"status": 200, "body": {"ok": True}, "requests": []}
+
+    class Handler(BaseHTTPRequestHandler):
+        def _handle(self):
+            length = int(self.headers.get("Content-Length") or 0)
+            raw = self.rfile.read(length)
+            state["requests"].append(
+                {
+                    "method": self.command,
+                    "path": self.path,
+                    "tenant": self.headers.get("X-Tenant-ID"),
+                    "body": json.loads(raw or b"{}"),
+                }
+            )
+            payload = json.dumps(state["body"]).encode()
+            self.send_response(state["status"])
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        do_POST = _handle
+        do_PATCH = _handle
+
+        def log_message(self, *_args):
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    state["url"] = f"http://127.0.0.1:{server.server_address[1]}"
+    try:
+        yield state
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+async def _cleanup_outbox(redis_mgr, *tenants):
+    for tid in tenants:
+        key = redis_mgr.keys_for(tid).backend_outbox()
+        await redis_mgr.client.delete(key)
+
+
+# ── OutboxWriter: enqueue and drain ──────────────────────────────────
+
+
+@pytest.mark.integration
+async def test_enqueue_adds_entry_to_redis(live_redis):
+    outbox = OutboxWriter(live_redis)
+    try:
+        await outbox.enqueue(
+            method="POST",
+            path="/api/v1/test/",
+            payload={"key": "value"},
+            tenant_id=TENANT,
+        )
+        key = live_redis.keys_for(TENANT).backend_outbox()
+        length = await live_redis.client.llen(key)
+        assert length == 1
+
+        raw = await live_redis.client.lindex(key, 0)
+        entry = json.loads(raw)
+        assert entry["method"] == "POST"
+        assert entry["path"] == "/api/v1/test/"
+        assert entry["payload"] == {"key": "value"}
+        assert entry["tenant_id"] == TENANT
+        assert "enqueued_at" in entry
+    finally:
+        await _cleanup_outbox(live_redis, TENANT)
+
+
+@pytest.mark.integration
+async def test_drain_replays_entries_fifo(live_redis):
+    outbox = OutboxWriter(live_redis)
+    replayed = []
+
+    async def replay_fn(entry):
+        replayed.append(entry)
+        return True
+
+    try:
+        await outbox.enqueue(
+            method="POST", path="/first/", payload={}, tenant_id=TENANT
+        )
+        await outbox.enqueue(
+            method="PATCH", path="/second/", payload={}, tenant_id=TENANT
+        )
+
+        count = await outbox.drain_all(replay_fn)
+
+        assert count == 2
+        assert replayed[0]["path"] == "/first/"
+        assert replayed[1]["path"] == "/second/"
+
+        key = live_redis.keys_for(TENANT).backend_outbox()
+        assert await live_redis.client.llen(key) == 0
+    finally:
+        await _cleanup_outbox(live_redis, TENANT)
+
+
+@pytest.mark.integration
+async def test_drain_stops_on_replay_failure(live_redis):
+    outbox = OutboxWriter(live_redis)
+    call_count = 0
+
+    async def replay_fn(entry):
+        nonlocal call_count
+        call_count += 1
+        return call_count == 1
+
+    try:
+        await outbox.enqueue(method="POST", path="/a/", payload={}, tenant_id=TENANT)
+        await outbox.enqueue(method="POST", path="/b/", payload={}, tenant_id=TENANT)
+        await outbox.enqueue(method="POST", path="/c/", payload={}, tenant_id=TENANT)
+
+        count = await outbox.drain_all(replay_fn)
+
+        assert count == 1
+        key = live_redis.keys_for(TENANT).backend_outbox()
+        remaining = await live_redis.client.llen(key)
+        assert remaining == 2
+
+        raw = await live_redis.client.lindex(key, 0)
+        entry = json.loads(raw)
+        assert entry["path"] == "/b/"
+    finally:
+        await _cleanup_outbox(live_redis, TENANT)
+
+
+# ── Overflow bounding ────────────────────────────────────────────────
+
+
+@pytest.mark.integration
+async def test_overflow_drops_oldest(live_redis):
+    outbox = OutboxWriter(live_redis, max_entries=3)
+
+    try:
+        for i in range(5):
+            await outbox.enqueue(
+                method="POST", path=f"/item-{i}/", payload={}, tenant_id=TENANT
+            )
+
+        key = live_redis.keys_for(TENANT).backend_outbox()
+        length = await live_redis.client.llen(key)
+        assert length == 3
+
+        first = json.loads(await live_redis.client.lindex(key, 0))
+        assert first["path"] == "/item-2/"
+
+        last = json.loads(await live_redis.client.lindex(key, 2))
+        assert last["path"] == "/item-4/"
+    finally:
+        await _cleanup_outbox(live_redis, TENANT)
+
+
+# ── Multi-tenant drain ──────────────────────────────────────────────
+
+
+@pytest.mark.integration
+async def test_drain_covers_multiple_tenants(live_redis):
+    outbox = OutboxWriter(live_redis)
+    replayed = []
+
+    async def replay_fn(entry):
+        replayed.append(entry["tenant_id"])
+        return True
+
+    try:
+        await outbox.enqueue(method="POST", path="/a/", payload={}, tenant_id=TENANT)
+        await outbox.enqueue(method="POST", path="/b/", payload={}, tenant_id=TENANT_2)
+
+        count = await outbox.drain_all(replay_fn)
+
+        assert count == 2
+        assert set(replayed) == {TENANT, TENANT_2}
+    finally:
+        await _cleanup_outbox(live_redis, TENANT, TENANT_2)
+
+
+# ── TTL is set ───────────────────────────────────────────────────────
+
+
+@pytest.mark.integration
+async def test_outbox_key_has_ttl(live_redis):
+    outbox = OutboxWriter(live_redis)
+
+    try:
+        await outbox.enqueue(method="POST", path="/x/", payload={}, tenant_id=TENANT)
+
+        key = live_redis.keys_for(TENANT).backend_outbox()
+        ttl = await live_redis.client.ttl(key)
+        assert 0 < ttl <= TTL_OUTBOX
+    finally:
+        await _cleanup_outbox(live_redis, TENANT)
+
+
+# ── Corrupt entry handling ───────────────────────────────────────────
+
+
+@pytest.mark.integration
+async def test_corrupt_entry_is_skipped(live_redis):
+    outbox = OutboxWriter(live_redis)
+    replayed = []
+
+    async def replay_fn(entry):
+        replayed.append(entry)
+        return True
+
+    try:
+        key = live_redis.keys_for(TENANT).backend_outbox()
+        await live_redis.client.rpush(key, "not-valid-json")
+        await outbox.enqueue(method="POST", path="/good/", payload={}, tenant_id=TENANT)
+
+        count = await outbox.drain_all(replay_fn)
+
+        assert count == 1
+        assert replayed[0]["path"] == "/good/"
+    finally:
+        await _cleanup_outbox(live_redis, TENANT)
+
+
+# ── Pending count ────────────────────────────────────────────────────
+
+
+@pytest.mark.integration
+async def test_pending_count(live_redis):
+    outbox = OutboxWriter(live_redis)
+
+    try:
+        await outbox.enqueue(method="POST", path="/a/", payload={}, tenant_id=TENANT)
+        await outbox.enqueue(method="POST", path="/b/", payload={}, tenant_id=TENANT_2)
+
+        total = await outbox.pending_count()
+        assert total == 2
+    finally:
+        await _cleanup_outbox(live_redis, TENANT, TENANT_2)
+
+
+# ── Concurrent drain guard ──────────────────────────────────────────
+
+
+@pytest.mark.integration
+async def test_concurrent_drain_is_rejected(live_redis):
+    outbox = OutboxWriter(live_redis)
+    outbox._draining = True
+
+    count = await outbox.drain_all(lambda e: True)
+    assert count == 0
+
+    outbox._draining = False
+
+
+# ── BackendClient + Outbox integration ──────────────────────────────
+
+
+@pytest.mark.integration
+async def test_open_breaker_enqueues_post(live_redis, django_stub):
+    outbox = OutboxWriter(live_redis)
+    brk = breaker(failure_threshold=1)
+    brk.record_failure()
+    assert brk.state is State.OPEN
+
+    client = BackendClient(django_stub["url"], "tok", breaker=brk, outbox=outbox)
+
+    try:
+        result = await client.store_research_brief(
+            tenant_id=TENANT,
+            company_name="TestCo",
+            brief={"facts": [], "degraded": False, "company_name": "TestCo"},
+        )
+
+        assert result is False
+        assert django_stub["requests"] == []
+
+        key = live_redis.keys_for(TENANT).backend_outbox()
+        length = await live_redis.client.llen(key)
+        assert length == 1
+
+        entry = json.loads(await live_redis.client.lindex(key, 0))
+        assert entry["method"] == "POST"
+        assert "upsert" in entry["path"]
+        assert entry["tenant_id"] == TENANT
+    finally:
+        await _cleanup_outbox(live_redis, TENANT)
+
+
+@pytest.mark.integration
+async def test_open_breaker_enqueues_patch(live_redis, django_stub):
+    outbox = OutboxWriter(live_redis)
+    brk = breaker(failure_threshold=1)
+    brk.record_failure()
+
+    client = BackendClient(django_stub["url"], "tok", breaker=brk, outbox=outbox)
+
+    try:
+        result = await client.update_asset_ocr(
+            tenant_id=TENANT,
+            asset_id=42,
+            ocr_text="hello",
+            ocr_confidence=0.95,
+            sensitivity_class="PUBLIC",
+            rag_excluded=False,
+        )
+
+        assert result is False
+        key = live_redis.keys_for(TENANT).backend_outbox()
+        length = await live_redis.client.llen(key)
+        assert length == 1
+
+        entry = json.loads(await live_redis.client.lindex(key, 0))
+        assert entry["method"] == "PATCH"
+        assert "42/ocr/" in entry["path"]
+    finally:
+        await _cleanup_outbox(live_redis, TENANT)
+
+
+@pytest.mark.integration
+async def test_replay_entry_succeeds(live_redis, django_stub):
+    brk = breaker()
+    client = BackendClient(django_stub["url"], "tok", breaker=brk)
+
+    ok = await client.replay_entry(
+        {
+            "method": "POST",
+            "path": "/api/v1/test/",
+            "payload": {"x": 1},
+            "tenant_id": TENANT,
+            "timeout": 5.0,
+        }
+    )
+
+    assert ok is True
+    assert len(django_stub["requests"]) == 1
+    assert django_stub["requests"][0]["path"] == "/api/v1/test/"
+
+
+@pytest.mark.integration
+async def test_replay_entry_fails_on_server_error(live_redis, django_stub):
+    django_stub["status"] = 500
+    brk = breaker()
+    client = BackendClient(django_stub["url"], "tok", breaker=brk)
+
+    ok = await client.replay_entry(
+        {
+            "method": "POST",
+            "path": "/api/v1/test/",
+            "payload": {},
+            "tenant_id": TENANT,
+        }
+    )
+
+    assert ok is False
+
+
+@pytest.mark.integration
+async def test_replay_entry_treats_4xx_as_success(live_redis, django_stub):
+    """A 4xx is non-retryable — the request was malformed, not the backend."""
+    django_stub["status"] = 400
+    brk = breaker()
+    client = BackendClient(django_stub["url"], "tok", breaker=brk)
+
+    ok = await client.replay_entry(
+        {
+            "method": "POST",
+            "path": "/api/v1/test/",
+            "payload": {},
+            "tenant_id": TENANT,
+        }
+    )
+
+    assert ok is True
+
+
+@pytest.mark.integration
+async def test_replay_entry_returns_false_when_breaker_open(live_redis, django_stub):
+    brk = breaker(failure_threshold=1)
+    brk.record_failure()
+    client = BackendClient(django_stub["url"], "tok", breaker=brk)
+
+    ok = await client.replay_entry(
+        {"method": "POST", "path": "/x/", "payload": {}, "tenant_id": TENANT}
+    )
+
+    assert ok is False
+    assert django_stub["requests"] == []
+
+
+# ── End-to-end: enqueue → recover → drain ────────────────────────────
+
+
+@pytest.mark.integration
+async def test_full_outbox_lifecycle(live_redis, django_stub):
+    """Open breaker → writes buffered → breaker closes → drain replays."""
+    outbox = OutboxWriter(live_redis)
+    brk = breaker(failure_threshold=1)
+    client = BackendClient(django_stub["url"], "tok", breaker=brk, outbox=outbox)
+
+    try:
+        brk.record_failure()
+        assert brk.state is State.OPEN
+
+        await client.store_research_brief(
+            tenant_id=TENANT,
+            company_name="A",
+            brief={"facts": [], "degraded": False, "company_name": "A"},
+        )
+        await client.update_asset_ocr(
+            tenant_id=TENANT,
+            asset_id=1,
+            ocr_text="t",
+            ocr_confidence=0.9,
+            sensitivity_class="PUBLIC",
+            rag_excluded=False,
+        )
+
+        assert django_stub["requests"] == []
+        key = live_redis.keys_for(TENANT).backend_outbox()
+        assert await live_redis.client.llen(key) == 2
+
+        brk.reset()
+        assert brk.state is State.CLOSED
+
+        count = await outbox.drain_all(client.replay_entry)
+
+        assert count == 2
+        assert len(django_stub["requests"]) == 2
+        assert django_stub["requests"][0]["method"] == "POST"
+        assert django_stub["requests"][1]["method"] == "PATCH"
+        assert await live_redis.client.llen(key) == 0
+    finally:
+        await _cleanup_outbox(live_redis, TENANT)
+
+
+# ── Breaker callback wiring ─────────────────────────────────────────
+
+
+@pytest.mark.integration
+async def test_register_outbox_drain_fires_on_close(live_redis, django_stub):
+    """The drain callback fires when the breaker transitions to CLOSED."""
+    import asyncio
+
+    outbox = OutboxWriter(live_redis)
+    brk = breaker(failure_threshold=1)
+    client = BackendClient(django_stub["url"], "tok", breaker=brk, outbox=outbox)
+
+    register_outbox_drain(brk, outbox, client.replay_entry)
+
+    try:
+        brk.record_failure()
+        key = live_redis.keys_for(TENANT).backend_outbox()
+        await live_redis.client.rpush(
+            key,
+            json.dumps(
+                {
+                    "method": "POST",
+                    "path": "/api/v1/test/",
+                    "payload": {"x": 1},
+                    "tenant_id": TENANT,
+                    "timeout": 5.0,
+                }
+            ),
+        )
+        await live_redis.client.expire(key, TTL_OUTBOX)
+
+        brk.reset()
+
+        await asyncio.sleep(0.3)
+
+        assert len(django_stub["requests"]) == 1
+        assert await live_redis.client.llen(key) == 0
+    finally:
+        await _cleanup_outbox(live_redis, TENANT)
+
+
+# ── No outbox → old behavior preserved ──────────────────────────────
+
+
+@pytest.mark.unit
+async def test_no_outbox_still_returns_none():
+    """Without an outbox, the original drop-on-open behavior is preserved."""
+    brk = breaker(failure_threshold=1)
+    brk.record_failure()
+    client = BackendClient("http://127.0.0.1:1", "tok", breaker=brk)
+
+    result = await client.store_research_brief(
+        tenant_id="t-1",
+        company_name="K",
+        brief={"facts": [], "degraded": False, "company_name": "K"},
+    )
+    assert result is False
+
+
+@pytest.mark.unit
+async def test_replay_entry_returns_false_when_not_configured():
+    client = BackendClient("", "tok", breaker=breaker())
+    ok = await client.replay_entry(
+        {"method": "POST", "path": "/x/", "payload": {}, "tenant_id": "t-1"}
+    )
+    assert ok is False

--- a/onboarding-intelligence-agent-svc/tests/test_outbox.py
+++ b/onboarding-intelligence-agent-svc/tests/test_outbox.py
@@ -197,6 +197,31 @@ async def test_overflow_drops_oldest(live_redis):
         await _cleanup_outbox(live_redis, TENANT)
 
 
+# ── Overflow callback ────────────────────────────────────────────────
+
+
+@pytest.mark.integration
+async def test_overflow_fires_callback(live_redis):
+    overflow_calls = []
+
+    async def on_overflow(tenant_id, dropped):
+        overflow_calls.append((tenant_id, dropped))
+
+    outbox = OutboxWriter(live_redis, max_entries=2, on_overflow=on_overflow)
+
+    try:
+        for i in range(4):
+            await outbox.enqueue(
+                method="POST", path=f"/item-{i}/", payload={}, tenant_id=TENANT
+            )
+
+        assert len(overflow_calls) == 2
+        assert overflow_calls[0] == (TENANT, 1)
+        assert overflow_calls[1] == (TENANT, 1)
+    finally:
+        await _cleanup_outbox(live_redis, TENANT)
+
+
 # ── Multi-tenant drain ──────────────────────────────────────────────
 
 
@@ -219,6 +244,37 @@ async def test_drain_covers_multiple_tenants(live_redis):
         assert set(replayed) == {TENANT, TENANT_2}
     finally:
         await _cleanup_outbox(live_redis, TENANT, TENANT_2)
+
+
+# ── Cross-tenant drain continues ───────────────────────────────────
+
+
+@pytest.mark.integration
+async def test_drain_continues_to_next_tenant_on_failure(live_redis):
+    """A replay failure for one tenant must not block other tenants."""
+    outbox = OutboxWriter(live_redis)
+    FAIL_TENANT = "t-outbox-fail"
+    OK_TENANT = "t-outbox-ok"
+
+    async def replay_fn(entry):
+        return entry["tenant_id"] != FAIL_TENANT
+
+    try:
+        await outbox.enqueue(
+            method="POST", path="/a/", payload={}, tenant_id=FAIL_TENANT
+        )
+        await outbox.enqueue(method="POST", path="/b/", payload={}, tenant_id=OK_TENANT)
+
+        count = await outbox.drain_all(replay_fn)
+
+        assert count >= 1
+        ok_key = live_redis.keys_for(OK_TENANT).backend_outbox()
+        assert await live_redis.client.llen(ok_key) == 0
+
+        fail_key = live_redis.keys_for(FAIL_TENANT).backend_outbox()
+        assert await live_redis.client.llen(fail_key) == 1
+    finally:
+        await _cleanup_outbox(live_redis, FAIL_TENANT, OK_TENANT)
 
 
 # ── TTL is set ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Implements **Phase B, Gap 4** of the OIA Gap Resolution Plan: backend write outbox buffering
- When the backend circuit breaker opens, POST/PATCH writes are buffered in a per-tenant Redis list (`oia:v1:{tenant}:outbox:backend`) instead of being silently dropped
- On breaker recovery (CLOSED transition), a drain callback replays entries FIFO through `BackendClient.replay_entry()`
- Startup drain via SCAN catches leftovers from prior process crashes
- Queue bounded at 200 entries per tenant; overflow drops oldest and emits EVT-013 (`AGENT_OUTBOX_OVERFLOW`)
- `replay_entry` treats 4xx as non-retryable success, 5xx/exception as failure (stops drain), and does NOT re-enqueue on failure to avoid infinite loops

## Files changed

| File | Change |
|------|--------|
| `app/cache/outbox.py` | **New** — `OutboxWriter` (enqueue, drain_all, pending_count) + `register_outbox_drain` |
| `app/cache/redis_manager.py` | `TenantKeys.backend_outbox()` key builder |
| `app/events/catalog.py` | EVT-013 `AGENT_OUTBOX_OVERFLOW` |
| `app/services/backend_client.py` | Outbox integration in `_post`/`_patch`, new `replay_entry()` method |
| `app/main.py` | Wiring: OutboxWriter creation, BackendClient injection, breaker callback, startup drain |
| `tests/test_outbox.py` | **New** — 19 integration tests |
| `tests/test_events_no_pii.py` | Updated event count assertions for EVT-013 |

## Test plan

- [x] 19 new integration tests against real Redis + HTTP server stubs
- [x] Enqueue/drain lifecycle, FIFO ordering, overflow bounding
- [x] Multi-tenant drain, TTL enforcement, corrupt entry handling
- [x] BackendClient+outbox integration (POST and PATCH paths)
- [x] replay_entry: success, failure, 4xx non-retryable, breaker-open
- [x] Full lifecycle: open → buffer → close → drain
- [x] Breaker callback wiring verification
- [x] Backward compatibility (no outbox = old behavior)
- [x] Concurrent drain guard
- [x] All 1153 existing tests pass (pre-existing infra failures only)
- [x] Black, Flake8, mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mJqBGyJYK8Tkc4RxM2TK1