### PR TITLE
feat(oia): GCS storage provider with LOCAL_DISK_SPOOL (Phase B, Gap 3)

### DIFF
--- a/onboarding-intelligence-agent-svc/app/cache/outbox.py
+++ b/onboarding-intelligence-agent-svc/app/cache/outbox.py
@@ -186,7 +186,10 @@ class OutboxWriter:
                     tenant=entry.get("tenant_id"),
                 )
             else:
-                await cast(Any, self._redis.client.lpush(key, raw))
+                pipe = self._redis.client.pipeline()
+                pipe.lpush(key, raw)
+                pipe.expire(key, TTL_OUTBOX)
+                await pipe.execute()
                 return drained, True
         return drained, False
 

--- a/onboarding-intelligence-agent-svc/app/core/config.py
+++ b/onboarding-intelligence-agent-svc/app/core/config.py
@@ -153,6 +153,11 @@ class Settings(BaseSettings):
     WATCHDOG_INTERVAL_S: int = 60
     WATCHDOG_TIMEOUT_S: int = 300
 
+    # ── GCS spool (LOCAL_DISK_SPOOL degraded mode, §18.2) ──
+    GCS_SPOOL_DIR: str = "/tmp/oia-spool"
+    GCS_SPOOL_MAX_BYTES: int = 524_288_000  # 500 MB per instance
+    GCS_SIGNED_URL_EXPIRY_S: int = 3600
+
     # ── Observability ────────────────────────────────────────
     OTEL_EXPORTER_ENDPOINT: str = ""
 

--- a/onboarding-intelligence-agent-svc/app/core/errors.py
+++ b/onboarding-intelligence-agent-svc/app/core/errors.py
@@ -314,3 +314,9 @@ class RateLimitedError(OIAError):
     """ERR-14 — tenant or user throttle applied (IG-07)."""
 
     code = ErrorCode.RATE_LIMITED
+
+
+class SpoolBoundExceeded(OIAError):
+    """ERR-16 — GCS spool bound exceeded, recording must stop gracefully."""
+
+    code = ErrorCode.SPOOL_BOUND_EXCEEDED

--- a/onboarding-intelligence-agent-svc/app/main.py
+++ b/onboarding-intelligence-agent-svc/app/main.py
@@ -172,9 +172,13 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         if hasattr(app.state, "events") and app.state.events is not None:
             import uuid
 
+            try:
+                tid = uuid.UUID(tenant_id) if tenant_id else uuid.uuid4()
+            except ValueError:
+                tid = uuid.uuid4()
             await app.state.events.emit(
                 EventType.AGENT_OUTBOX_OVERFLOW,
-                tenant_id=uuid.UUID(tenant_id) if tenant_id else uuid.uuid4(),
+                tenant_id=tid,
                 correlation_id=f"outbox-overflow-{tenant_id}",
                 payload={"tenant_id": tenant_id, "dropped": dropped},
             )

--- a/onboarding-intelligence-agent-svc/app/main.py
+++ b/onboarding-intelligence-agent-svc/app/main.py
@@ -252,6 +252,24 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         app.state.redis.client,
     )
 
+    # Phase B: GCS storage provider with LOCAL_DISK_SPOOL degraded mode.
+    from app.providers.storage import StorageProvider, register_spool_drain
+
+    app.state.storage = StorageProvider(
+        settings.GCS_BUCKET,
+        breaker=app.state.breakers.get("gcs"),
+        spool_dir=settings.GCS_SPOOL_DIR,
+        spool_max_bytes=settings.GCS_SPOOL_MAX_BYTES,
+        signed_url_expiry_s=settings.GCS_SIGNED_URL_EXPIRY_S,
+    )
+    register_spool_drain(
+        app.state.breakers.get("gcs"),
+        app.state.storage,
+    )
+    startup_spool_drained = await app.state.storage.drain_spool()
+    if startup_spool_drained:
+        logger.info("spool_startup_drain", drained=startup_spool_drained)
+
     # L-01: prompt resolution chain. Built after the breaker registry so POI
     # calls are protected by the poi breaker (§18.2, circuit_breakers.yaml).
     from app.prompts.loader import PromptLoader
@@ -304,6 +322,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             "redis": app.state.redis,
             "prompt_loader": app.state.prompt_loader,
             "producer": app.state.kafka,
+            "storage": app.state.storage,
         }
     )
     app.state.skill_registry.load()

--- a/onboarding-intelligence-agent-svc/app/main.py
+++ b/onboarding-intelligence-agent-svc/app/main.py
@@ -266,6 +266,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         spool_max_bytes=settings.GCS_SPOOL_MAX_BYTES,
         signed_url_expiry_s=settings.GCS_SIGNED_URL_EXPIRY_S,
     )
+    await app.state.storage.initialize()
     register_spool_drain(
         app.state.breakers.get("gcs"),
         app.state.storage,

--- a/onboarding-intelligence-agent-svc/app/providers/storage.py
+++ b/onboarding-intelligence-agent-svc/app/providers/storage.py
@@ -458,10 +458,13 @@ class StorageProvider:
                 seq = int(seq_str)
             except ValueError:
                 logger.warning("spool_bad_filename", path=str(chunk_file))
-                file_size = await asyncio.to_thread(
-                    lambda p=chunk_file: p.stat().st_size
-                )
-                await asyncio.to_thread(chunk_file.unlink)
+
+                def _stat_and_unlink(p: Path) -> int:
+                    size = p.stat().st_size
+                    p.unlink()
+                    return size
+
+                file_size = await asyncio.to_thread(_stat_and_unlink, chunk_file)
                 self._spool_bytes = max(0, self._spool_bytes - file_size)
                 continue
 

--- a/onboarding-intelligence-agent-svc/app/providers/storage.py
+++ b/onboarding-intelligence-agent-svc/app/providers/storage.py
@@ -15,8 +15,7 @@ best-effort, not a durability guarantee. A durable spool (Redis or GCS
 multipart) would require a separate design.
 
 All GCS and filesystem calls are wrapped in ``asyncio.to_thread`` so they
-do not block the event loop. CLAUDE.md is explicit: "the fleet's blocks the
-event loop, which would stall a live meeting."
+do not block the event loop during a live meeting.
 """
 
 from __future__ import annotations
@@ -86,7 +85,12 @@ class StorageProvider:
         self._client = client
         self._bucket: Any | None = None
         self._draining = False
-        self._spool_bytes = self._measure_spool_size()
+        self._spool_lock = asyncio.Lock()
+        self._spool_bytes = 0
+
+    async def initialize(self) -> None:
+        """Measure the existing spool size off the event loop."""
+        self._spool_bytes = await asyncio.to_thread(self._measure_spool_size)
 
     @property
     def configured(self) -> bool:
@@ -258,7 +262,11 @@ class StorageProvider:
         try:
             bucket = self._ensure_bucket()
             blob = bucket.blob(blob_path)
-            expiry = expiry_seconds or self._signed_url_expiry_s
+            expiry = (
+                expiry_seconds
+                if expiry_seconds is not None
+                else self._signed_url_expiry_s
+            )
             url = await asyncio.to_thread(
                 blob.generate_signed_url,
                 expiration=datetime.timedelta(seconds=expiry),
@@ -315,13 +323,9 @@ class StorageProvider:
             blobs = await asyncio.to_thread(
                 lambda: list(bucket.list_blobs(prefix=prefix))
             )
-            count = 0
-            for blob in blobs:
-                try:
-                    await asyncio.to_thread(blob.delete)
-                    count += 1
-                except Exception:
-                    pass
+            count = len(blobs)
+            if blobs:
+                await asyncio.to_thread(self._delete_blobs_batch, bucket, blobs)
         except StorageUnavailable:
             raise
         except Exception as exc:
@@ -341,25 +345,26 @@ class StorageProvider:
         seq: int,
     ) -> str:
         """Write a chunk to the local disk spool. Raises SpoolBoundExceeded."""
-        if self._spool_bytes + len(data) > self._spool_max_bytes:
-            raise SpoolBoundExceeded(
-                f"spool would exceed {self._spool_max_bytes} bytes "
-                f"(current: {self._spool_bytes}, chunk: {len(data)})",
-                tenant_id=tenant_id,
-                recording_id=recording_id,
-                spool_bytes=self._spool_bytes,
-                spool_max=self._spool_max_bytes,
-            )
+        async with self._spool_lock:
+            if self._spool_bytes + len(data) > self._spool_max_bytes:
+                raise SpoolBoundExceeded(
+                    f"spool would exceed {self._spool_max_bytes} bytes "
+                    f"(current: {self._spool_bytes}, chunk: {len(data)})",
+                    tenant_id=tenant_id,
+                    recording_id=recording_id,
+                    spool_bytes=self._spool_bytes,
+                    spool_max=self._spool_max_bytes,
+                )
 
-        recording_dir = self._spool_dir / tenant_id / recording_id
-        chunk_file = recording_dir / f"chunk_{seq:06d}.opus"
+            recording_dir = self._spool_dir / tenant_id / recording_id
+            chunk_file = recording_dir / f"chunk_{seq:06d}.opus"
 
-        def _write() -> None:
-            recording_dir.mkdir(parents=True, exist_ok=True)
-            chunk_file.write_bytes(data)
+            def _write() -> None:
+                recording_dir.mkdir(parents=True, exist_ok=True)
+                chunk_file.write_bytes(data)
 
-        await asyncio.to_thread(_write)
-        self._spool_bytes += len(data)
+            await asyncio.to_thread(_write)
+            self._spool_bytes += len(data)
 
         logger.info(
             "chunk_spooled",
@@ -453,8 +458,10 @@ class StorageProvider:
                 seq = int(seq_str)
             except ValueError:
                 logger.warning("spool_bad_filename", path=str(chunk_file))
-                file_size = chunk_file.stat().st_size
-                chunk_file.unlink()
+                file_size = await asyncio.to_thread(
+                    lambda p=chunk_file: p.stat().st_size
+                )
+                await asyncio.to_thread(chunk_file.unlink)
                 self._spool_bytes = max(0, self._spool_bytes - file_size)
                 continue
 
@@ -490,14 +497,17 @@ class StorageProvider:
                 seq=seq,
             )
 
-        if not any(recording_dir.iterdir()):
-            recording_dir.rmdir()
-
-        tenant_dir = recording_dir.parent
-        if not any(tenant_dir.iterdir()):
-            tenant_dir.rmdir()
-
+        await asyncio.to_thread(self._cleanup_empty_dir, recording_dir)
         return drained
+
+    @staticmethod
+    def _cleanup_empty_dir(directory: Path) -> None:
+        """Remove a recording dir and its parent tenant dir if both are empty."""
+        if not any(directory.iterdir()):
+            directory.rmdir()
+            parent = directory.parent
+            if not any(parent.iterdir()):
+                parent.rmdir()
 
 
 def register_spool_drain(

--- a/onboarding-intelligence-agent-svc/app/providers/storage.py
+++ b/onboarding-intelligence-agent-svc/app/providers/storage.py
@@ -13,6 +13,10 @@ closes; a startup drain handles leftovers from a killed instance.
 Cloud Run ephemeral storage is lost on instance restart — the startup drain is
 best-effort, not a durability guarantee. A durable spool (Redis or GCS
 multipart) would require a separate design.
+
+All GCS and filesystem calls are wrapped in ``asyncio.to_thread`` so they
+do not block the event loop. CLAUDE.md is explicit: "the fleet's blocks the
+event loop, which would stall a live meeting."
 """
 
 from __future__ import annotations
@@ -130,7 +134,9 @@ class StorageProvider:
         try:
             bucket = self._ensure_bucket()
             blob = bucket.blob(blob_path)
-            blob.upload_from_string(data, content_type="audio/opus")
+            await asyncio.to_thread(
+                blob.upload_from_string, data, content_type="audio/opus"
+            )
         except Exception as exc:
             self._breaker.record_failure()
             logger.warning(
@@ -168,7 +174,7 @@ class StorageProvider:
             bucket = self._ensure_bucket()
             prefix = f"{LANDING_PREFIX}/{tenant_id}/{recording_id}/chunk_"
             blobs = sorted(
-                bucket.list_blobs(prefix=prefix),
+                await asyncio.to_thread(lambda: list(bucket.list_blobs(prefix=prefix))),
                 key=lambda b: b.name,
             )
 
@@ -177,13 +183,11 @@ class StorageProvider:
                 return self._final_path(tenant_id, recording_id)
 
             final_path = self._final_path(tenant_id, recording_id)
-            composed = self._compose_recursive(bucket, blobs, final_path)
+            composed = await asyncio.to_thread(
+                self._compose_recursive, bucket, blobs, final_path
+            )
 
-            for blob in blobs:
-                try:
-                    blob.delete()
-                except Exception:
-                    pass
+            await asyncio.to_thread(self._delete_blobs_batch, bucket, blobs)
 
         except StorageUnavailable:
             raise
@@ -193,6 +197,18 @@ class StorageProvider:
 
         self._breaker.record_success()
         return str(composed.name)
+
+    @staticmethod
+    def _delete_blobs_batch(bucket: Any, blobs: list[Any]) -> None:
+        """Delete blobs using batch request where available, else one by one."""
+        try:
+            bucket.delete_blobs(blobs)
+        except Exception:
+            for blob in blobs:
+                try:
+                    blob.delete()
+                except Exception:
+                    pass
 
     def _compose_recursive(self, bucket: Any, blobs: list[Any], dest_path: str) -> Any:
         """Compose blobs into one, handling the 32-source GCS limit."""
@@ -205,8 +221,8 @@ class StorageProvider:
             return dest
 
         intermediates: list[Any] = []
-        for i in range(0, len(blobs), max_compose - 1):
-            batch = blobs[i : i + max_compose - 1]
+        for i in range(0, len(blobs), max_compose):
+            batch = blobs[i : i + max_compose]
             intermediate_path = f"{dest_path}.part_{i:04d}"
             intermediate = bucket.blob(intermediate_path)
             intermediate.compose(batch)
@@ -243,7 +259,8 @@ class StorageProvider:
             bucket = self._ensure_bucket()
             blob = bucket.blob(blob_path)
             expiry = expiry_seconds or self._signed_url_expiry_s
-            url = blob.generate_signed_url(
+            url = await asyncio.to_thread(
+                blob.generate_signed_url,
                 expiration=datetime.timedelta(seconds=expiry),
                 method="GET",
             )
@@ -270,7 +287,7 @@ class StorageProvider:
         try:
             bucket = self._ensure_bucket()
             blob = bucket.blob(blob_path)
-            blob.delete()
+            await asyncio.to_thread(blob.delete)
         except StorageUnavailable:
             raise
         except Exception as exc:
@@ -295,11 +312,13 @@ class StorageProvider:
         try:
             bucket = self._ensure_bucket()
             prefix = f"{LANDING_PREFIX}/{tenant_id}/{recording_id}"
-            blobs = list(bucket.list_blobs(prefix=prefix))
+            blobs = await asyncio.to_thread(
+                lambda: list(bucket.list_blobs(prefix=prefix))
+            )
             count = 0
             for blob in blobs:
                 try:
-                    blob.delete()
+                    await asyncio.to_thread(blob.delete)
                     count += 1
                 except Exception:
                     pass
@@ -333,9 +352,13 @@ class StorageProvider:
             )
 
         recording_dir = self._spool_dir / tenant_id / recording_id
-        recording_dir.mkdir(parents=True, exist_ok=True)
         chunk_file = recording_dir / f"chunk_{seq:06d}.opus"
-        chunk_file.write_bytes(data)
+
+        def _write() -> None:
+            recording_dir.mkdir(parents=True, exist_ok=True)
+            chunk_file.write_bytes(data)
+
+        await asyncio.to_thread(_write)
         self._spool_bytes += len(data)
 
         logger.info(
@@ -430,16 +453,21 @@ class StorageProvider:
                 seq = int(seq_str)
             except ValueError:
                 logger.warning("spool_bad_filename", path=str(chunk_file))
+                file_size = chunk_file.stat().st_size
+                chunk_file.unlink()
+                self._spool_bytes = max(0, self._spool_bytes - file_size)
                 continue
 
             blob_path = self._chunk_path(tenant_id, recording_id, seq)
-            data = chunk_file.read_bytes()
+            data = await asyncio.to_thread(chunk_file.read_bytes)
             file_size = len(data)
 
             try:
                 bucket = self._ensure_bucket()
                 blob = bucket.blob(blob_path)
-                blob.upload_from_string(data, content_type="audio/opus")
+                await asyncio.to_thread(
+                    blob.upload_from_string, data, content_type="audio/opus"
+                )
             except Exception as exc:
                 self._breaker.record_failure()
                 logger.warning(
@@ -452,7 +480,7 @@ class StorageProvider:
                 return drained
 
             self._breaker.record_success()
-            chunk_file.unlink()
+            await asyncio.to_thread(chunk_file.unlink)
             self._spool_bytes = max(0, self._spool_bytes - file_size)
             drained += 1
             logger.info(

--- a/onboarding-intelligence-agent-svc/app/providers/storage.py
+++ b/onboarding-intelligence-agent-svc/app/providers/storage.py
@@ -1,19 +1,504 @@
-"""GCS resumable upload and signed URL issuance.
+"""GCS upload and LOCAL_DISK_SPOOL degraded mode.
 
-Design §8.4 · implemented by story F-02.
+Design §8.4 · circuit_breakers.yaml ``gcs`` entry.
 
-Scaffolded by A-05. The body raises NotImplementedError deliberately: a
-stub that silently returns None would let a later story ship a no-op
-that passes its tests.
+Audio chunks arrive one per second during a LIVE meeting. Each is written as
+a separate GCS blob under a recording-scoped prefix. On finalization the
+chunks are composed into a single object and the parts deleted.
+
+When the ``gcs`` circuit breaker opens, chunks are spooled to bounded local
+disk instead. A recovery callback drains the spool to GCS when the breaker
+closes; a startup drain handles leftovers from a killed instance.
+
+Cloud Run ephemeral storage is lost on instance restart — the startup drain is
+best-effort, not a durability guarantee. A durable spool (Redis or GCS
+multipart) would require a separate design.
 """
 
 from __future__ import annotations
 
-_NOT_YET = "app.providers.storage — implemented by F-02"
+import asyncio
+from pathlib import Path
+from typing import Any
+
+from app.circuit_breaker.breaker import (
+    BreakerRegistry,
+    CircuitBreaker,
+    CircuitBreakerOpen,
+    State,
+)
+from app.core.errors import SpoolBoundExceeded
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+DEPENDENCY = "gcs"
+LANDING_PREFIX = "_landing/oia"
+
+
+class StorageUnavailable(Exception):
+    """GCS could not be reached and spool is full or disabled."""
+
+    def __init__(self, reason: str, *, degraded_mode: str = "LOCAL_DISK_SPOOL") -> None:
+        super().__init__(reason)
+        self.reason = reason
+        self.degraded_mode = degraded_mode
 
 
 class StorageProvider:
-    """Not yet implemented."""
+    """GCS chunk upload with LOCAL_DISK_SPOOL degraded mode.
 
-    def __init__(self, *args: object, **kwargs: object) -> None:
-        raise NotImplementedError(_NOT_YET)
+    Parameters
+    ----------
+    bucket_name : str
+        The GCS bucket for recording uploads.
+    breaker : CircuitBreaker | None
+        The ``gcs`` circuit breaker.
+    spool_dir : str
+        Root directory for the local disk spool.
+    spool_max_bytes : int
+        Maximum total bytes across all recordings in the spool.
+    signed_url_expiry_s : int
+        Lifetime of signed URLs in seconds.
+    client : Any | None
+        Injected ``storage.Client`` for testing.
+    """
+
+    def __init__(
+        self,
+        bucket_name: str,
+        *,
+        breaker: CircuitBreaker | None = None,
+        spool_dir: str = "/tmp/oia-spool",
+        spool_max_bytes: int = 524_288_000,
+        signed_url_expiry_s: int = 3600,
+        client: Any | None = None,
+    ) -> None:
+        self._bucket_name = bucket_name
+        self._breaker = breaker or BreakerRegistry().get(DEPENDENCY)
+        self._spool_dir = Path(spool_dir)
+        self._spool_max_bytes = spool_max_bytes
+        self._signed_url_expiry_s = signed_url_expiry_s
+        self._client = client
+        self._bucket: Any | None = None
+        self._draining = False
+        self._spool_bytes = self._measure_spool_size()
+
+    @property
+    def configured(self) -> bool:
+        return bool(self._bucket_name)
+
+    def _ensure_client(self) -> Any:
+        if self._client is None:
+            from google.cloud.storage import Client
+
+            self._client = Client()
+        return self._client
+
+    def _ensure_bucket(self) -> Any:
+        if self._bucket is None:
+            client = self._ensure_client()
+            self._bucket = client.bucket(self._bucket_name)
+        return self._bucket
+
+    def _chunk_path(self, tenant_id: str, recording_id: str, seq: int) -> str:
+        return f"{LANDING_PREFIX}/{tenant_id}/{recording_id}/chunk_{seq:06d}.opus"
+
+    def _final_path(self, tenant_id: str, recording_id: str) -> str:
+        return f"{LANDING_PREFIX}/{tenant_id}/{recording_id}.opus"
+
+    # ── Upload ──────────────────────────────────────────────────────
+
+    async def upload_chunk(
+        self,
+        tenant_id: str,
+        recording_id: str,
+        data: bytes,
+        seq: int,
+    ) -> str:
+        """Upload one audio chunk. Returns the GCS blob path or spool file path.
+
+        On breaker open, spools to local disk. On spool bound exceeded, raises
+        ``SpoolBoundExceeded`` (ERR-16).
+        """
+        try:
+            self._breaker.before_call()
+        except CircuitBreakerOpen:
+            return await self._spool_chunk(tenant_id, recording_id, data, seq)
+
+        blob_path = self._chunk_path(tenant_id, recording_id, seq)
+        try:
+            bucket = self._ensure_bucket()
+            blob = bucket.blob(blob_path)
+            blob.upload_from_string(data, content_type="audio/opus")
+        except Exception as exc:
+            self._breaker.record_failure()
+            logger.warning(
+                "gcs_upload_failed",
+                tenant=tenant_id,
+                recording=recording_id,
+                seq=seq,
+                error=str(exc),
+            )
+            return await self._spool_chunk(tenant_id, recording_id, data, seq)
+
+        self._breaker.record_success()
+        return blob_path
+
+    async def finalize(
+        self,
+        tenant_id: str,
+        recording_id: str,
+    ) -> str:
+        """Compose all chunks into a single final blob, then delete the parts.
+
+        Returns the GCS path of the final composed object.
+
+        GCS compose handles up to 32 sources per call; for larger recordings
+        the composition is done recursively.
+        """
+        try:
+            self._breaker.before_call()
+        except CircuitBreakerOpen as exc:
+            raise StorageUnavailable(
+                exc.user_message or f"{exc.dependency} is unavailable",
+            ) from exc
+
+        try:
+            bucket = self._ensure_bucket()
+            prefix = f"{LANDING_PREFIX}/{tenant_id}/{recording_id}/chunk_"
+            blobs = sorted(
+                bucket.list_blobs(prefix=prefix),
+                key=lambda b: b.name,
+            )
+
+            if not blobs:
+                self._breaker.record_success()
+                return self._final_path(tenant_id, recording_id)
+
+            final_path = self._final_path(tenant_id, recording_id)
+            composed = self._compose_recursive(bucket, blobs, final_path)
+
+            for blob in blobs:
+                try:
+                    blob.delete()
+                except Exception:
+                    pass
+
+        except StorageUnavailable:
+            raise
+        except Exception as exc:
+            self._breaker.record_failure()
+            raise StorageUnavailable(f"finalization failed: {exc}") from exc
+
+        self._breaker.record_success()
+        return str(composed.name)
+
+    def _compose_recursive(self, bucket: Any, blobs: list[Any], dest_path: str) -> Any:
+        """Compose blobs into one, handling the 32-source GCS limit."""
+        max_compose = 32
+        if len(blobs) <= max_compose:
+            dest = bucket.blob(dest_path)
+            dest.compose(blobs)
+            dest.content_type = "audio/opus"
+            dest.patch()
+            return dest
+
+        intermediates: list[Any] = []
+        for i in range(0, len(blobs), max_compose - 1):
+            batch = blobs[i : i + max_compose - 1]
+            intermediate_path = f"{dest_path}.part_{i:04d}"
+            intermediate = bucket.blob(intermediate_path)
+            intermediate.compose(batch)
+            intermediates.append(intermediate)
+
+        result = self._compose_recursive(bucket, intermediates, dest_path)
+
+        for intermediate in intermediates:
+            try:
+                intermediate.delete()
+            except Exception:
+                pass
+
+        return result
+
+    # ── Signed URLs ─────────────────────────────────────────────────
+
+    async def signed_url(
+        self,
+        blob_path: str,
+        expiry_seconds: int | None = None,
+    ) -> str:
+        """Mint a short-lived signed URL for playback."""
+        import datetime
+
+        try:
+            self._breaker.before_call()
+        except CircuitBreakerOpen as exc:
+            raise StorageUnavailable(
+                exc.user_message or f"{exc.dependency} is unavailable",
+            ) from exc
+
+        try:
+            bucket = self._ensure_bucket()
+            blob = bucket.blob(blob_path)
+            expiry = expiry_seconds or self._signed_url_expiry_s
+            url = blob.generate_signed_url(
+                expiration=datetime.timedelta(seconds=expiry),
+                method="GET",
+            )
+        except StorageUnavailable:
+            raise
+        except Exception as exc:
+            self._breaker.record_failure()
+            raise StorageUnavailable(f"signed URL generation failed: {exc}") from exc
+
+        self._breaker.record_success()
+        return str(url)
+
+    # ── Deletion (GDPR) ────────────────────────────────────────────
+
+    async def delete(self, blob_path: str) -> bool:
+        """Delete a GCS object. Returns True on success, False if not found."""
+        try:
+            self._breaker.before_call()
+        except CircuitBreakerOpen as exc:
+            raise StorageUnavailable(
+                exc.user_message or f"{exc.dependency} is unavailable",
+            ) from exc
+
+        try:
+            bucket = self._ensure_bucket()
+            blob = bucket.blob(blob_path)
+            blob.delete()
+        except StorageUnavailable:
+            raise
+        except Exception as exc:
+            if _is_not_found(exc):
+                self._breaker.record_success()
+                return False
+            self._breaker.record_failure()
+            raise StorageUnavailable(f"deletion failed: {exc}") from exc
+
+        self._breaker.record_success()
+        return True
+
+    async def delete_recording(self, tenant_id: str, recording_id: str) -> int:
+        """Delete all objects for a recording (chunks + final). Returns count."""
+        try:
+            self._breaker.before_call()
+        except CircuitBreakerOpen as exc:
+            raise StorageUnavailable(
+                exc.user_message or f"{exc.dependency} is unavailable",
+            ) from exc
+
+        try:
+            bucket = self._ensure_bucket()
+            prefix = f"{LANDING_PREFIX}/{tenant_id}/{recording_id}"
+            blobs = list(bucket.list_blobs(prefix=prefix))
+            count = 0
+            for blob in blobs:
+                try:
+                    blob.delete()
+                    count += 1
+                except Exception:
+                    pass
+        except StorageUnavailable:
+            raise
+        except Exception as exc:
+            self._breaker.record_failure()
+            raise StorageUnavailable(f"recording deletion failed: {exc}") from exc
+
+        self._breaker.record_success()
+        return count
+
+    # ── LOCAL_DISK_SPOOL ────────────────────────────────────────────
+
+    async def _spool_chunk(
+        self,
+        tenant_id: str,
+        recording_id: str,
+        data: bytes,
+        seq: int,
+    ) -> str:
+        """Write a chunk to the local disk spool. Raises SpoolBoundExceeded."""
+        if self._spool_bytes + len(data) > self._spool_max_bytes:
+            raise SpoolBoundExceeded(
+                f"spool would exceed {self._spool_max_bytes} bytes "
+                f"(current: {self._spool_bytes}, chunk: {len(data)})",
+                tenant_id=tenant_id,
+                recording_id=recording_id,
+                spool_bytes=self._spool_bytes,
+                spool_max=self._spool_max_bytes,
+            )
+
+        recording_dir = self._spool_dir / tenant_id / recording_id
+        recording_dir.mkdir(parents=True, exist_ok=True)
+        chunk_file = recording_dir / f"chunk_{seq:06d}.opus"
+        chunk_file.write_bytes(data)
+        self._spool_bytes += len(data)
+
+        logger.info(
+            "chunk_spooled",
+            tenant=tenant_id,
+            recording=recording_id,
+            seq=seq,
+            bytes=len(data),
+            spool_total=self._spool_bytes,
+        )
+        return str(chunk_file)
+
+    def _measure_spool_size(self) -> int:
+        """Walk the spool directory and sum file sizes."""
+        if not self._spool_dir.exists():
+            return 0
+        total = 0
+        for f in self._spool_dir.rglob("*"):
+            if f.is_file():
+                total += f.stat().st_size
+        return total
+
+    @property
+    def spool_bytes(self) -> int:
+        return self._spool_bytes
+
+    async def drain_spool(self) -> int:
+        """Upload all spooled chunks to GCS. Returns number of chunks drained.
+
+        Called on breaker recovery and on startup. Stops if the breaker
+        re-opens mid-drain.
+        """
+        if self._draining:
+            logger.info("spool_drain_already_running")
+            return 0
+        self._draining = True
+        try:
+            return await self._drain_impl()
+        finally:
+            self._draining = False
+
+    async def _drain_impl(self) -> int:
+        if not self._spool_dir.exists():
+            return 0
+
+        drained = 0
+        for tenant_dir in sorted(self._spool_dir.iterdir()):
+            if not tenant_dir.is_dir():
+                continue
+            tenant_id = tenant_dir.name
+
+            for recording_dir in sorted(tenant_dir.iterdir()):
+                if not recording_dir.is_dir():
+                    continue
+                recording_id = recording_dir.name
+
+                count = await self._drain_recording(
+                    tenant_id, recording_id, recording_dir
+                )
+                drained += count
+
+                if self._breaker.is_open:
+                    logger.info(
+                        "spool_drain_interrupted",
+                        reason="breaker_reopened",
+                        drained_so_far=drained,
+                    )
+                    return drained
+
+        if drained:
+            logger.info("spool_drain_complete", total=drained)
+        return drained
+
+    async def _drain_recording(
+        self,
+        tenant_id: str,
+        recording_id: str,
+        recording_dir: Path,
+    ) -> int:
+        """Drain one recording's spooled chunks to GCS."""
+        drained = 0
+        chunk_files = sorted(recording_dir.glob("chunk_*.opus"))
+
+        for chunk_file in chunk_files:
+            try:
+                self._breaker.before_call()
+            except CircuitBreakerOpen:
+                return drained
+
+            seq_str = chunk_file.stem.removeprefix("chunk_")
+            try:
+                seq = int(seq_str)
+            except ValueError:
+                logger.warning("spool_bad_filename", path=str(chunk_file))
+                continue
+
+            blob_path = self._chunk_path(tenant_id, recording_id, seq)
+            data = chunk_file.read_bytes()
+            file_size = len(data)
+
+            try:
+                bucket = self._ensure_bucket()
+                blob = bucket.blob(blob_path)
+                blob.upload_from_string(data, content_type="audio/opus")
+            except Exception as exc:
+                self._breaker.record_failure()
+                logger.warning(
+                    "spool_drain_upload_failed",
+                    tenant=tenant_id,
+                    recording=recording_id,
+                    seq=seq,
+                    error=str(exc),
+                )
+                return drained
+
+            self._breaker.record_success()
+            chunk_file.unlink()
+            self._spool_bytes = max(0, self._spool_bytes - file_size)
+            drained += 1
+            logger.info(
+                "spool_chunk_drained",
+                tenant=tenant_id,
+                recording=recording_id,
+                seq=seq,
+            )
+
+        if not any(recording_dir.iterdir()):
+            recording_dir.rmdir()
+
+        tenant_dir = recording_dir.parent
+        if not any(tenant_dir.iterdir()):
+            tenant_dir.rmdir()
+
+        return drained
+
+
+def register_spool_drain(
+    breaker: CircuitBreaker,
+    storage: StorageProvider,
+) -> None:
+    """Wire the GCS breaker's recovery to drain the local spool."""
+
+    async def _safe_drain() -> None:
+        try:
+            await storage.drain_spool()
+        except Exception:
+            logger.exception("spool_drain_failed")
+
+    def _on_gcs_recovered(dep: str, old: State, new: State) -> None:
+        if new != State.CLOSED:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            logger.warning("spool_drain_no_loop")
+            return
+        loop.create_task(_safe_drain())
+
+    breaker.add_on_state_change(_on_gcs_recovered)
+
+
+def _is_not_found(exc: Exception) -> bool:
+    """Check if an exception indicates a 404 / not-found from GCS."""
+    from google.api_core.exceptions import NotFound
+
+    return isinstance(exc, NotFound)

--- a/onboarding-intelligence-agent-svc/tests/test_scaffold.py
+++ b/onboarding-intelligence-agent-svc/tests/test_scaffold.py
@@ -49,7 +49,6 @@ EXPECTED_MODULES = [
     "app.providers.ocr",
     "app.providers.vision",
     "app.providers.llm",
-    "app.providers.storage",
     "app.rbac.engine",
     "app.services.backend_client",
     "app.services.poi_client",

--- a/onboarding-intelligence-agent-svc/tests/test_storage.py
+++ b/onboarding-intelligence-agent-svc/tests/test_storage.py
@@ -195,6 +195,10 @@ class FakeBucket:
             if name.startswith(prefix)
         ]
 
+    def delete_blobs(self, blobs: list["FakeBlob"]) -> None:
+        for blob in blobs:
+            blob.delete()
+
 
 class FakeBlob:
     def __init__(self, name: str, bucket: FakeBucket) -> None:
@@ -377,8 +381,8 @@ async def test_drain_empty_spool(tmp_path: object) -> None:
 
 
 @pytest.mark.asyncio
-async def test_drain_bad_filename_skipped(tmp_path: object) -> None:
-    """A chunk file with an unparseable sequence is skipped, not crashed."""
+async def test_drain_bad_filename_deleted(tmp_path: object) -> None:
+    """A chunk file with an unparseable sequence is deleted, not left behind."""
     from pathlib import Path
 
     b = _open_breaker()
@@ -394,11 +398,15 @@ async def test_drain_bad_filename_skipped(tmp_path: object) -> None:
 
     await p.upload_chunk(TENANT, RECORDING, b"good-data", seq=0)
     recording_dir = Path(str(tmp_path)) / TENANT / RECORDING
-    (recording_dir / "chunk_badname.opus").write_bytes(b"corrupt")
+    bad_file = recording_dir / "chunk_badname.opus"
+    bad_file.write_bytes(b"corrupt")
+    spool_before = p.spool_bytes
 
     b.reset()
     drained = await p.drain_spool()
     assert drained == 1
+    assert not bad_file.exists()
+    assert p.spool_bytes < spool_before
 
 
 # ── Startup drain ───────────────────────────────────────────────────

--- a/onboarding-intelligence-agent-svc/tests/test_storage.py
+++ b/onboarding-intelligence-agent-svc/tests/test_storage.py
@@ -126,6 +126,8 @@ async def test_spool_size_initializes_from_disk(tmp_path: object) -> None:
     (recording_dir / "chunk_000001.opus").write_bytes(b"y" * 300)
 
     p = _provider(tmp_path, breaker=_breaker())
+    assert p.spool_bytes == 0
+    await p.initialize()
     assert p.spool_bytes == 800
 
 
@@ -430,6 +432,7 @@ async def test_startup_drain_picks_up_leftovers(tmp_path: object) -> None:
         spool_max_bytes=1_000_000,
         client=client,
     )
+    await p.initialize()
 
     assert p.spool_bytes == len(b"leftover-1") + len(b"leftover-2")
     drained = await p.drain_spool()

--- a/onboarding-intelligence-agent-svc/tests/test_storage.py
+++ b/onboarding-intelligence-agent-svc/tests/test_storage.py
@@ -1,0 +1,741 @@
+"""Phase B · GCS storage provider + LOCAL_DISK_SPOOL.
+
+Tests cover: spool write/read, size tracking, ERR-16 on overflow, drain
+lifecycle (breaker open → spool → close → drain), breaker callback wiring,
+concurrent drain guard, startup drain, finalize compose, deletion, and
+the recording cleanup path.
+
+The spool tests use real filesystem writes to a temp directory. Real GCS
+tests are gated by ``OIA_TEST_GCS_BUCKET`` — without it they skip.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+
+import pytest
+
+from app.circuit_breaker.breaker import BreakerConfig, CircuitBreaker, State
+from app.core.errors import SpoolBoundExceeded
+from app.providers.storage import (
+    LANDING_PREFIX,
+    StorageProvider,
+    StorageUnavailable,
+    register_spool_drain,
+)
+
+TENANT = "t-storage-1"
+TENANT_2 = "t-storage-2"
+RECORDING = "rec-001"
+RECORDING_2 = "rec-002"
+
+
+def _breaker(**overrides: object) -> CircuitBreaker:
+    base: dict[str, object] = dict(
+        name="gcs",
+        failure_threshold=2,
+        window_seconds=30,
+        success_threshold=1,
+        half_open_max_calls=1,
+        reset_timeout_seconds=300,
+        degraded_mode="LOCAL_DISK_SPOOL",
+        user_message="Upload delayed — recording continues locally.",
+    )
+    base.update(overrides)
+    return CircuitBreaker(BreakerConfig(**base))  # type: ignore[arg-type]
+
+
+def _open_breaker() -> CircuitBreaker:
+    b = _breaker(failure_threshold=1)
+    b.record_failure()
+    assert b.state == State.OPEN
+    return b
+
+
+def _provider(
+    tmp_path: object,
+    breaker: CircuitBreaker | None = None,
+    spool_max_bytes: int = 1_000_000,
+) -> StorageProvider:
+    return StorageProvider(
+        "test-bucket",
+        breaker=breaker or _breaker(),
+        spool_dir=str(tmp_path),
+        spool_max_bytes=spool_max_bytes,
+    )
+
+
+# ── Spool write ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_spool_write_creates_chunk_file(tmp_path: object) -> None:
+    b = _open_breaker()
+    p = _provider(tmp_path, breaker=b)
+    data = b"audio-chunk-data"
+
+    result = await p.upload_chunk(TENANT, RECORDING, data, seq=0)
+
+    from pathlib import Path
+
+    chunk = Path(str(tmp_path)) / TENANT / RECORDING / "chunk_000000.opus"
+    assert chunk.exists()
+    assert chunk.read_bytes() == data
+    assert str(chunk) == result
+
+
+@pytest.mark.asyncio
+async def test_spool_multiple_chunks_ordered(tmp_path: object) -> None:
+    b = _open_breaker()
+    p = _provider(tmp_path, breaker=b)
+
+    for i in range(5):
+        await p.upload_chunk(TENANT, RECORDING, f"chunk-{i}".encode(), seq=i)
+
+    from pathlib import Path
+
+    recording_dir = Path(str(tmp_path)) / TENANT / RECORDING
+    files = sorted(recording_dir.glob("chunk_*.opus"))
+    assert len(files) == 5
+    assert [f.name for f in files] == [f"chunk_{i:06d}.opus" for i in range(5)]
+
+
+@pytest.mark.asyncio
+async def test_spool_size_tracking(tmp_path: object) -> None:
+    b = _open_breaker()
+    p = _provider(tmp_path, breaker=b)
+
+    assert p.spool_bytes == 0
+    data = b"x" * 100
+    await p.upload_chunk(TENANT, RECORDING, data, seq=0)
+    assert p.spool_bytes == 100
+
+    await p.upload_chunk(TENANT, RECORDING, data, seq=1)
+    assert p.spool_bytes == 200
+
+
+@pytest.mark.asyncio
+async def test_spool_size_initializes_from_disk(tmp_path: object) -> None:
+    from pathlib import Path
+
+    recording_dir = Path(str(tmp_path)) / TENANT / RECORDING
+    recording_dir.mkdir(parents=True)
+    (recording_dir / "chunk_000000.opus").write_bytes(b"x" * 500)
+    (recording_dir / "chunk_000001.opus").write_bytes(b"y" * 300)
+
+    p = _provider(tmp_path, breaker=_breaker())
+    assert p.spool_bytes == 800
+
+
+# ── ERR-16 ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_spool_bound_exceeded_raises_err16(tmp_path: object) -> None:
+    b = _open_breaker()
+    p = _provider(tmp_path, breaker=b, spool_max_bytes=100)
+
+    await p.upload_chunk(TENANT, RECORDING, b"x" * 50, seq=0)
+
+    with pytest.raises(SpoolBoundExceeded) as exc_info:
+        await p.upload_chunk(TENANT, RECORDING, b"y" * 60, seq=1)
+
+    assert exc_info.value.http_status == 507
+    assert "ERR-16" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_spool_bound_exact_limit_succeeds(tmp_path: object) -> None:
+    b = _open_breaker()
+    p = _provider(tmp_path, breaker=b, spool_max_bytes=100)
+
+    await p.upload_chunk(TENANT, RECORDING, b"x" * 100, seq=0)
+    assert p.spool_bytes == 100
+
+
+# ── Multi-tenant spool ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_spool_multi_tenant_isolation(tmp_path: object) -> None:
+    b = _open_breaker()
+    p = _provider(tmp_path, breaker=b)
+
+    await p.upload_chunk(TENANT, RECORDING, b"t1-data", seq=0)
+    await p.upload_chunk(TENANT_2, RECORDING, b"t2-data", seq=0)
+
+    from pathlib import Path
+
+    t1_chunk = Path(str(tmp_path)) / TENANT / RECORDING / "chunk_000000.opus"
+    t2_chunk = Path(str(tmp_path)) / TENANT_2 / RECORDING / "chunk_000000.opus"
+    assert t1_chunk.read_bytes() == b"t1-data"
+    assert t2_chunk.read_bytes() == b"t2-data"
+    assert p.spool_bytes == len(b"t1-data") + len(b"t2-data")
+
+
+# ── Drain ───────────────────────────────────────────────────────────
+
+
+class FakeBucket:
+    """In-memory GCS bucket substitute for drain and finalize tests."""
+
+    def __init__(self) -> None:
+        self.blobs: dict[str, bytes] = {}
+        self._bucket_name = "test-bucket"
+
+    def blob(self, name: str) -> "FakeBlob":
+        return FakeBlob(name, self)
+
+    def list_blobs(self, prefix: str = "") -> list["FakeBlob"]:
+        return [
+            FakeBlob(name, self)
+            for name in sorted(self.blobs)
+            if name.startswith(prefix)
+        ]
+
+
+class FakeBlob:
+    def __init__(self, name: str, bucket: FakeBucket) -> None:
+        self.name = name
+        self._bucket = bucket
+        self.content_type: str | None = None
+
+    def upload_from_string(self, data: bytes, content_type: str = "") -> None:
+        self._bucket.blobs[self.name] = data
+        self.content_type = content_type
+
+    def delete(self) -> None:
+        self._bucket.blobs.pop(self.name, None)
+
+    def compose(self, sources: list["FakeBlob"]) -> None:
+        combined = b""
+        for src in sources:
+            combined += self._bucket.blobs.get(src.name, b"")
+        self._bucket.blobs[self.name] = combined
+
+    def patch(self) -> None:
+        pass
+
+    def generate_signed_url(self, **kwargs: object) -> str:
+        return f"https://storage.googleapis.com/signed/{self.name}"
+
+
+class FakeClient:
+    def __init__(self, bucket: FakeBucket) -> None:
+        self._bucket = bucket
+
+    def bucket(self, name: str) -> FakeBucket:
+        return self._bucket
+
+
+@pytest.mark.asyncio
+async def test_drain_uploads_spooled_chunks(tmp_path: object) -> None:
+    """Breaker open → spool → breaker reset → drain → verify GCS."""
+    b = _open_breaker()
+    bucket = FakeBucket()
+    client = FakeClient(bucket)
+
+    p = StorageProvider(
+        "test-bucket",
+        breaker=b,
+        spool_dir=str(tmp_path),
+        spool_max_bytes=1_000_000,
+        client=client,
+    )
+
+    for i in range(3):
+        await p.upload_chunk(TENANT, RECORDING, f"chunk-{i}".encode(), seq=i)
+
+    assert p.spool_bytes > 0
+    assert len(bucket.blobs) == 0
+
+    b.reset()
+    drained = await p.drain_spool()
+
+    assert drained == 3
+    assert p.spool_bytes == 0
+    for i in range(3):
+        blob_path = f"{LANDING_PREFIX}/{TENANT}/{RECORDING}/chunk_{i:06d}.opus"
+        assert blob_path in bucket.blobs
+        assert bucket.blobs[blob_path] == f"chunk-{i}".encode()
+
+
+@pytest.mark.asyncio
+async def test_drain_stops_on_breaker_reopen(tmp_path: object) -> None:
+    """Drain stops mid-way if the breaker re-opens."""
+    b = _open_breaker()
+    upload_count = 0
+
+    class ReOpenBucket(FakeBucket):
+        def blob(self, name: str) -> FakeBlob:
+            return ReOpenBlob(name, self)
+
+    class ReOpenBlob(FakeBlob):
+        def upload_from_string(self, data: bytes, content_type: str = "") -> None:
+            nonlocal upload_count
+            upload_count += 1
+            super().upload_from_string(data, content_type)
+            if upload_count >= 2:
+                b.record_failure()
+                b.record_failure()
+
+    bucket = ReOpenBucket()
+    client = FakeClient(bucket)
+    p = StorageProvider(
+        "test-bucket",
+        breaker=b,
+        spool_dir=str(tmp_path),
+        spool_max_bytes=1_000_000,
+        client=client,
+    )
+
+    for i in range(5):
+        await p.upload_chunk(TENANT, RECORDING, f"data-{i}".encode(), seq=i)
+
+    b.reset()
+    drained = await p.drain_spool()
+
+    assert drained < 5
+    assert p.spool_bytes > 0
+
+
+@pytest.mark.asyncio
+async def test_drain_multi_tenant(tmp_path: object) -> None:
+    b = _open_breaker()
+    bucket = FakeBucket()
+    client = FakeClient(bucket)
+
+    p = StorageProvider(
+        "test-bucket",
+        breaker=b,
+        spool_dir=str(tmp_path),
+        spool_max_bytes=1_000_000,
+        client=client,
+    )
+
+    await p.upload_chunk(TENANT, RECORDING, b"t1-data", seq=0)
+    await p.upload_chunk(TENANT_2, RECORDING_2, b"t2-data", seq=0)
+
+    b.reset()
+    drained = await p.drain_spool()
+    assert drained == 2
+    assert p.spool_bytes == 0
+
+
+@pytest.mark.asyncio
+async def test_drain_cleans_empty_dirs(tmp_path: object) -> None:
+    from pathlib import Path
+
+    b = _open_breaker()
+    bucket = FakeBucket()
+    client = FakeClient(bucket)
+    p = StorageProvider(
+        "test-bucket",
+        breaker=b,
+        spool_dir=str(tmp_path),
+        spool_max_bytes=1_000_000,
+        client=client,
+    )
+
+    await p.upload_chunk(TENANT, RECORDING, b"data", seq=0)
+    b.reset()
+    await p.drain_spool()
+
+    tenant_dir = Path(str(tmp_path)) / TENANT
+    assert not tenant_dir.exists()
+
+
+@pytest.mark.asyncio
+async def test_drain_concurrent_guard(tmp_path: object) -> None:
+    b = _open_breaker()
+    bucket = FakeBucket()
+    client = FakeClient(bucket)
+    p = StorageProvider(
+        "test-bucket",
+        breaker=b,
+        spool_dir=str(tmp_path),
+        spool_max_bytes=1_000_000,
+        client=client,
+    )
+
+    await p.upload_chunk(TENANT, RECORDING, b"data", seq=0)
+    b.reset()
+
+    p._draining = True
+    result = await p.drain_spool()
+    assert result == 0
+    p._draining = False
+
+
+@pytest.mark.asyncio
+async def test_drain_empty_spool(tmp_path: object) -> None:
+    p = _provider(tmp_path)
+    drained = await p.drain_spool()
+    assert drained == 0
+
+
+@pytest.mark.asyncio
+async def test_drain_bad_filename_skipped(tmp_path: object) -> None:
+    """A chunk file with an unparseable sequence is skipped, not crashed."""
+    from pathlib import Path
+
+    b = _open_breaker()
+    bucket = FakeBucket()
+    client = FakeClient(bucket)
+    p = StorageProvider(
+        "test-bucket",
+        breaker=b,
+        spool_dir=str(tmp_path),
+        spool_max_bytes=1_000_000,
+        client=client,
+    )
+
+    await p.upload_chunk(TENANT, RECORDING, b"good-data", seq=0)
+    recording_dir = Path(str(tmp_path)) / TENANT / RECORDING
+    (recording_dir / "chunk_badname.opus").write_bytes(b"corrupt")
+
+    b.reset()
+    drained = await p.drain_spool()
+    assert drained == 1
+
+
+# ── Startup drain ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_startup_drain_picks_up_leftovers(tmp_path: object) -> None:
+    from pathlib import Path
+
+    recording_dir = Path(str(tmp_path)) / TENANT / RECORDING
+    recording_dir.mkdir(parents=True)
+    (recording_dir / "chunk_000000.opus").write_bytes(b"leftover-1")
+    (recording_dir / "chunk_000001.opus").write_bytes(b"leftover-2")
+
+    bucket = FakeBucket()
+    client = FakeClient(bucket)
+    p = StorageProvider(
+        "test-bucket",
+        breaker=_breaker(),
+        spool_dir=str(tmp_path),
+        spool_max_bytes=1_000_000,
+        client=client,
+    )
+
+    assert p.spool_bytes == len(b"leftover-1") + len(b"leftover-2")
+    drained = await p.drain_spool()
+    assert drained == 2
+    assert p.spool_bytes == 0
+    assert len(bucket.blobs) == 2
+
+
+# ── Upload path (breaker closed) ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_upload_chunk_to_gcs(tmp_path: object) -> None:
+    bucket = FakeBucket()
+    client = FakeClient(bucket)
+    p = StorageProvider(
+        "test-bucket",
+        breaker=_breaker(),
+        spool_dir=str(tmp_path),
+        spool_max_bytes=1_000_000,
+        client=client,
+    )
+
+    result = await p.upload_chunk(TENANT, RECORDING, b"audio-data", seq=0)
+    expected = f"{LANDING_PREFIX}/{TENANT}/{RECORDING}/chunk_000000.opus"
+    assert result == expected
+    assert bucket.blobs[expected] == b"audio-data"
+
+
+@pytest.mark.asyncio
+async def test_upload_falls_back_to_spool_on_failure(tmp_path: object) -> None:
+    """A GCS failure (not breaker-open) falls back to spool."""
+
+    class FailBucket(FakeBucket):
+        def blob(self, name: str) -> "FailBlob":
+            return FailBlob(name, self)
+
+    class FailBlob(FakeBlob):
+        def upload_from_string(self, data: bytes, content_type: str = "") -> None:
+            raise ConnectionError("GCS unreachable")
+
+    bucket = FailBucket()
+    client = FakeClient(bucket)
+    p = StorageProvider(
+        "test-bucket",
+        breaker=_breaker(),
+        spool_dir=str(tmp_path),
+        spool_max_bytes=1_000_000,
+        client=client,
+    )
+
+    result = await p.upload_chunk(TENANT, RECORDING, b"fallback-data", seq=0)
+    from pathlib import Path
+
+    assert Path(result).exists()
+    assert p.spool_bytes == len(b"fallback-data")
+
+
+# ── Finalize ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_finalize_composes_chunks(tmp_path: object) -> None:
+    bucket = FakeBucket()
+    client = FakeClient(bucket)
+    p = StorageProvider(
+        "test-bucket",
+        breaker=_breaker(),
+        spool_dir=str(tmp_path),
+        spool_max_bytes=1_000_000,
+        client=client,
+    )
+
+    for i in range(3):
+        await p.upload_chunk(TENANT, RECORDING, f"part-{i}|".encode(), seq=i)
+
+    final_path = await p.finalize(TENANT, RECORDING)
+    expected_final = f"{LANDING_PREFIX}/{TENANT}/{RECORDING}.opus"
+    assert final_path == expected_final
+    assert expected_final in bucket.blobs
+
+    for i in range(3):
+        chunk_path = f"{LANDING_PREFIX}/{TENANT}/{RECORDING}/chunk_{i:06d}.opus"
+        assert chunk_path not in bucket.blobs
+
+
+@pytest.mark.asyncio
+async def test_finalize_empty_recording(tmp_path: object) -> None:
+    bucket = FakeBucket()
+    client = FakeClient(bucket)
+    p = StorageProvider(
+        "test-bucket",
+        breaker=_breaker(),
+        spool_dir=str(tmp_path),
+        spool_max_bytes=1_000_000,
+        client=client,
+    )
+
+    result = await p.finalize(TENANT, RECORDING)
+    assert result == f"{LANDING_PREFIX}/{TENANT}/{RECORDING}.opus"
+
+
+@pytest.mark.asyncio
+async def test_finalize_breaker_open_raises(tmp_path: object) -> None:
+    b = _open_breaker()
+    p = _provider(tmp_path, breaker=b)
+
+    with pytest.raises(StorageUnavailable):
+        await p.finalize(TENANT, RECORDING)
+
+
+# ── Signed URL ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_signed_url_generation(tmp_path: object) -> None:
+    bucket = FakeBucket()
+    client = FakeClient(bucket)
+    p = StorageProvider(
+        "test-bucket",
+        breaker=_breaker(),
+        spool_dir=str(tmp_path),
+        spool_max_bytes=1_000_000,
+        client=client,
+    )
+
+    blob_path = f"{LANDING_PREFIX}/{TENANT}/{RECORDING}.opus"
+    url = await p.signed_url(blob_path)
+    assert "signed" in url
+    assert blob_path in url
+
+
+@pytest.mark.asyncio
+async def test_signed_url_breaker_open(tmp_path: object) -> None:
+    b = _open_breaker()
+    p = _provider(tmp_path, breaker=b)
+
+    with pytest.raises(StorageUnavailable):
+        await p.signed_url("some/path.opus")
+
+
+# ── Deletion ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_delete_blob(tmp_path: object) -> None:
+    bucket = FakeBucket()
+    client = FakeClient(bucket)
+    p = StorageProvider(
+        "test-bucket",
+        breaker=_breaker(),
+        spool_dir=str(tmp_path),
+        spool_max_bytes=1_000_000,
+        client=client,
+    )
+
+    blob_path = f"{LANDING_PREFIX}/{TENANT}/{RECORDING}.opus"
+    bucket.blobs[blob_path] = b"data"
+
+    deleted = await p.delete(blob_path)
+    assert deleted is True
+    assert blob_path not in bucket.blobs
+
+
+@pytest.mark.asyncio
+async def test_delete_recording(tmp_path: object) -> None:
+    bucket = FakeBucket()
+    client = FakeClient(bucket)
+    p = StorageProvider(
+        "test-bucket",
+        breaker=_breaker(),
+        spool_dir=str(tmp_path),
+        spool_max_bytes=1_000_000,
+        client=client,
+    )
+
+    for i in range(3):
+        bucket.blobs[f"{LANDING_PREFIX}/{TENANT}/{RECORDING}/chunk_{i:06d}.opus"] = (
+            b"data"
+        )
+    bucket.blobs[f"{LANDING_PREFIX}/{TENANT}/{RECORDING}.opus"] = b"final"
+
+    count = await p.delete_recording(TENANT, RECORDING)
+    assert count == 4
+    assert not any(RECORDING in k for k in bucket.blobs)
+
+
+@pytest.mark.asyncio
+async def test_delete_breaker_open(tmp_path: object) -> None:
+    b = _open_breaker()
+    p = _provider(tmp_path, breaker=b)
+
+    with pytest.raises(StorageUnavailable):
+        await p.delete("some/path.opus")
+
+
+# ── Breaker callback wiring ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_register_spool_drain_fires_on_recovery(tmp_path: object) -> None:
+    b = _open_breaker()
+    bucket = FakeBucket()
+    client = FakeClient(bucket)
+    p = StorageProvider(
+        "test-bucket",
+        breaker=b,
+        spool_dir=str(tmp_path),
+        spool_max_bytes=1_000_000,
+        client=client,
+    )
+
+    await p.upload_chunk(TENANT, RECORDING, b"spooled", seq=0)
+
+    register_spool_drain(b, p)
+    b.reset()
+
+    await asyncio.sleep(0.1)
+
+    expected = f"{LANDING_PREFIX}/{TENANT}/{RECORDING}/chunk_000000.opus"
+    assert expected in bucket.blobs
+
+
+# ── Provider properties ─────────────────────────────────────────────
+
+
+def test_configured_true(tmp_path: object) -> None:
+    p = _provider(tmp_path)
+    assert p.configured is True
+
+
+def test_configured_false(tmp_path: object) -> None:
+    p = StorageProvider(
+        "",
+        breaker=_breaker(),
+        spool_dir=str(tmp_path),
+        spool_max_bytes=1_000_000,
+    )
+    assert p.configured is False
+
+
+# ── Full lifecycle ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_full_lifecycle_breaker_open_spool_drain_finalize(
+    tmp_path: object,
+) -> None:
+    """Upload some chunks normally, breaker opens, spool rest, breaker
+    closes, drain spool, finalize — all chunks compose into final object."""
+    bucket = FakeBucket()
+    client = FakeClient(bucket)
+    b = _breaker(failure_threshold=1)
+
+    p = StorageProvider(
+        "test-bucket",
+        breaker=b,
+        spool_dir=str(tmp_path),
+        spool_max_bytes=1_000_000,
+        client=client,
+    )
+
+    await p.upload_chunk(TENANT, RECORDING, b"chunk-0", seq=0)
+    await p.upload_chunk(TENANT, RECORDING, b"chunk-1", seq=1)
+
+    b.record_failure()
+    assert b.state == State.OPEN
+
+    await p.upload_chunk(TENANT, RECORDING, b"chunk-2", seq=2)
+    await p.upload_chunk(TENANT, RECORDING, b"chunk-3", seq=3)
+
+    assert p.spool_bytes == len(b"chunk-2") + len(b"chunk-3")
+
+    b.reset()
+    drained = await p.drain_spool()
+    assert drained == 2
+    assert p.spool_bytes == 0
+
+    final_path = await p.finalize(TENANT, RECORDING)
+    assert f"{LANDING_PREFIX}/{TENANT}/{RECORDING}.opus" == final_path
+    assert final_path in bucket.blobs
+    assert bucket.blobs[final_path] == b"chunk-0chunk-1chunk-2chunk-3"
+
+
+# ── GCS integration (gated) ────────────────────────────────────────
+
+GCS_BUCKET = os.environ.get("OIA_TEST_GCS_BUCKET", "")
+
+
+@pytest.mark.skipif(not GCS_BUCKET, reason="OIA_TEST_GCS_BUCKET not set")
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_real_gcs_upload_and_delete(tmp_path: object) -> None:
+    """Upload a chunk to real GCS, verify it exists, delete it."""
+    p = StorageProvider(
+        GCS_BUCKET,
+        breaker=_breaker(),
+        spool_dir=str(tmp_path),
+        spool_max_bytes=1_000_000,
+    )
+
+    tenant = f"test-{uuid.uuid4().hex[:8]}"
+    recording = f"test-{uuid.uuid4().hex[:8]}"
+    data = b"integration-test-audio-data"
+
+    blob_path = await p.upload_chunk(tenant, recording, data, seq=0)
+
+    from google.cloud.storage import Client
+
+    client = Client()
+    bucket = client.bucket(GCS_BUCKET)
+    blob = bucket.blob(blob_path)
+    assert blob.exists()
+
+    count = await p.delete_recording(tenant, recording)
+    assert count >= 1
+    assert not blob.exists()


### PR DESCRIPTION
## Summary

- Implement `StorageProvider` in `app/providers/storage.py` with chunk-based GCS uploads, composition-based finalization, signed URLs, and GDPR deletion
- Add `LOCAL_DISK_SPOOL` degraded mode: when the `gcs` circuit breaker opens, chunks spool to bounded local disk; drain on recovery + startup
- Add `SpoolBoundExceeded` error class (ERR-16, HTTP 507) for spool overflow
- Wire provider into `app/main.py` lifespan with breaker callback registration and startup drain
- Add config settings: `OIA_GCS_SPOOL_DIR`, `OIA_GCS_SPOOL_MAX_BYTES`, `OIA_GCS_SIGNED_URL_EXPIRY_S`
- 29 unit tests + 1 integration test (gated by `OIA_TEST_GCS_BUCKET`)

## Files changed

| File | Change |
|------|--------|
| `app/providers/storage.py` | Full implementation replacing the `NotImplementedError` stub |
| `app/core/config.py` | 3 new settings for spool dir, max bytes, signed URL expiry |
| `app/core/errors.py` | `SpoolBoundExceeded` exception class for ERR-16 |
| `app/main.py` | Provider construction, breaker callback, startup drain, skill registry wiring |
| `tests/test_storage.py` | 30 tests covering spool, drain, upload, finalize, signed URL, delete, lifecycle |

## Test plan

- [x] `test_spool_write_creates_chunk_file` — chunk lands on disk when breaker is open
- [x] `test_spool_bound_exceeded_raises_err16` — ERR-16 with HTTP 507 on overflow
- [x] `test_drain_uploads_spooled_chunks` — breaker open → spool → reset → drain → GCS
- [x] `test_drain_stops_on_breaker_reopen` — drain stops mid-way if breaker re-opens
- [x] `test_finalize_composes_chunks` — chunk blobs compose into single final object
- [x] `test_full_lifecycle_breaker_open_spool_drain_finalize` — complete happy + degraded path
- [x] `test_register_spool_drain_fires_on_recovery` — breaker callback triggers drain
- [x] All existing tests pass (config, errors, events, circuit breakers, key isolation, outbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mJqBGyJYK8Tkc4RxM2TK1