### PR TITLE
feat(oia): extract IdempotencyGuard (Phase C, Gap 5)

### DIFF
--- a/onboarding-intelligence-agent-svc/app/cache/idempotency.py
+++ b/onboarding-intelligence-agent-svc/app/cache/idempotency.py
@@ -1,25 +1,64 @@
 """Write deduplication for retried dispatches.
 
-Design §18.1 · implemented by story B-06.
+Design §18.1 · implemented by B-06 (Gap 5).
 
-Scaffolded by A-05. The body raises NotImplementedError deliberately: a
-stub that silently returns None would let a later story ship a no-op
-that passes its tests.
+Wraps the check/store pattern used by ``ProcessExecutor`` for idempotency
+keys and job state.  Both share the same Redis key namespace
+(``TenantKeys.idempotency``) and the same GET → JSON-parse / SET → JSON-dump
+cycle; this class owns that cycle so every caller gets consistent TTL
+enforcement and corrupt-data handling.
 """
 
 from __future__ import annotations
 
-_NOT_YET = "app.cache.idempotency — implemented by B-06"
+import json
+from typing import Any
+
+from app.cache.redis_manager import RedisManager, TTL_IDEMPOTENCY
 
 
 class IdempotencyGuard:
-    """Not yet implemented.
+    """Check-or-store deduplication backed by Redis.
 
     The PROCESS key is sha256(session_id + evidence_manifest_hash): re-running
     over unchanged evidence returns the original job_id and writes nothing
     twice, while genuinely changed evidence produces a new hash and a real
     re-run.
+
+    Parameters
+    ----------
+    redis : RedisManager
+        The shared Redis manager (DB 2, ``oia:v1:`` prefix).
     """
 
-    def __init__(self, *args: object, **kwargs: object) -> None:
-        raise NotImplementedError(_NOT_YET)
+    def __init__(self, redis: RedisManager) -> None:
+        self._redis = redis
+
+    async def check(self, tenant_id: str, digest: str) -> dict[str, Any] | None:
+        """Return the cached payload for *digest*, or ``None``.
+
+        Corrupt JSON is treated as a miss — the caller will overwrite it on
+        the next store.
+        """
+        keys = self._redis.keys_for(tenant_id)
+        key = keys.idempotency(digest)
+        raw = await self._redis.client.get(key)
+        if raw is None:
+            return None
+        try:
+            data: dict[str, Any] = json.loads(raw)
+            return data
+        except (json.JSONDecodeError, TypeError):
+            return None
+
+    async def store(
+        self,
+        tenant_id: str,
+        digest: str,
+        payload: dict[str, Any],
+        ttl: int = TTL_IDEMPOTENCY,
+    ) -> None:
+        """Persist *payload* under *digest* with the given TTL."""
+        keys = self._redis.keys_for(tenant_id)
+        key = keys.idempotency(digest)
+        await self._redis.client.set(key, json.dumps(payload), ex=ttl)

--- a/onboarding-intelligence-agent-svc/app/cache/idempotency.py
+++ b/onboarding-intelligence-agent-svc/app/cache/idempotency.py
@@ -46,10 +46,12 @@ class IdempotencyGuard:
         if raw is None:
             return None
         try:
-            data: dict[str, Any] = json.loads(raw)
-            return data
+            parsed = json.loads(raw)
         except (json.JSONDecodeError, TypeError):
             return None
+        if not isinstance(parsed, dict):
+            return None
+        return parsed
 
     async def store(
         self,

--- a/onboarding-intelligence-agent-svc/app/logic/process_executor.py
+++ b/onboarding-intelligence-agent-svc/app/logic/process_executor.py
@@ -15,7 +15,8 @@ import uuid
 from typing import Any, Literal
 
 from app.api.schemas import EvidenceManifest, ProcessResponse
-from app.cache.redis_manager import RedisManager, TTL_IDEMPOTENCY, TTL_SESSION
+from app.cache.idempotency import IdempotencyGuard
+from app.cache.redis_manager import RedisManager, TTL_SESSION
 from app.core.logging import get_logger
 from app.events.catalog import EventType
 from app.events.emitter import EventEmitter
@@ -57,6 +58,7 @@ class ProcessExecutor:
         llm: LLMProvider | None = None,
         kafka: KafkaProducer | None = None,
         events: EventEmitter | None = None,
+        guard: IdempotencyGuard | None = None,
     ) -> None:
         self._redis = redis
         self._backend = backend
@@ -64,6 +66,7 @@ class ProcessExecutor:
         self._llm = llm
         self._kafka = kafka
         self._events = events
+        self._guard = guard or IdempotencyGuard(redis)
         self._prompt_loader: Any = None
         self._running_tasks: set[asyncio.Task[None]] = set()
 
@@ -78,7 +81,7 @@ class ProcessExecutor:
         idempotency_key: str,
     ) -> ProcessResponse:
         """Accept a PROCESS job, returning 202 immediately."""
-        cached = await self._check_idempotency(tenant.tenant_id, idempotency_key)
+        cached = await self._guard.check(tenant.tenant_id, f"process:{idempotency_key}")
         if cached is not None:
             logger.info(
                 "process_idempotent_hit",
@@ -101,9 +104,9 @@ class ProcessExecutor:
             "created_at": time.time(),
         }
 
-        keys = self._redis.keys_for(tenant.tenant_id)
-        job_key = keys.idempotency(f"process:job:{job_id}")
-        await self._redis.client.set(job_key, json.dumps(job_state), ex=JOB_TTL)
+        await self._guard.store(
+            tenant.tenant_id, f"process:job:{job_id}", job_state, JOB_TTL
+        )
 
         response = ProcessResponse(
             job_id=job_id,
@@ -112,8 +115,10 @@ class ProcessExecutor:
             callback_url=callback_url,
         )
 
-        await self._store_idempotency(
-            tenant.tenant_id, idempotency_key, response.model_dump()
+        await self._guard.store(
+            tenant.tenant_id,
+            f"process:{idempotency_key}",
+            response.model_dump(),
         )
 
         task = asyncio.create_task(
@@ -133,16 +138,7 @@ class ProcessExecutor:
 
     async def get_job(self, tenant_id: str, job_id: str) -> dict[str, Any] | None:
         """Retrieve job state from Redis."""
-        keys = self._redis.keys_for(tenant_id)
-        job_key = keys.idempotency(f"process:job:{job_id}")
-        raw = await self._redis.client.get(job_key)
-        if raw is None:
-            return None
-        try:
-            data: dict[str, Any] = json.loads(raw)
-            return data
-        except (json.JSONDecodeError, TypeError):
-            return None
+        return await self._guard.check(tenant_id, f"process:job:{job_id}")
 
     async def _run_job(
         self,
@@ -694,24 +690,3 @@ class ProcessExecutor:
                 job_id=job_id,
                 callback_url=callback_url,
             )
-
-    async def _check_idempotency(
-        self, tenant_id: str, idempotency_key: str
-    ) -> dict[str, Any] | None:
-        keys = self._redis.keys_for(tenant_id)
-        key = keys.idempotency(f"process:{idempotency_key}")
-        raw = await self._redis.client.get(key)
-        if raw is None:
-            return None
-        try:
-            data: dict[str, Any] = json.loads(raw)
-            return data
-        except (json.JSONDecodeError, TypeError):
-            return None
-
-    async def _store_idempotency(
-        self, tenant_id: str, idempotency_key: str, response: dict[str, Any]
-    ) -> None:
-        keys = self._redis.keys_for(tenant_id)
-        key = keys.idempotency(f"process:{idempotency_key}")
-        await self._redis.client.set(key, json.dumps(response), ex=TTL_IDEMPOTENCY)

--- a/onboarding-intelligence-agent-svc/app/main.py
+++ b/onboarding-intelligence-agent-svc/app/main.py
@@ -200,8 +200,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     )
 
     # J-01: PROCESS mode executor. Shares the BackendClient and Redis.
+    from app.cache.idempotency import IdempotencyGuard
     from app.logic.process_executor import ProcessExecutor
 
+    app.state.guard = IdempotencyGuard(app.state.redis)
     app.state.process_executor = ProcessExecutor(
         app.state.redis,
         backend=app.state.backend,
@@ -209,6 +211,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         llm=LLMProvider(settings.GEMINI_KEY, breaker=app.state.breakers.get("llm")),
         kafka=app.state.kafka,
         events=None,  # wired below after EventEmitter is created
+        guard=app.state.guard,
     )
 
     app.state.prep = PrepExecutor(

--- a/onboarding-intelligence-agent-svc/app/skills/register_meeting_assets.py
+++ b/onboarding-intelligence-agent-svc/app/skills/register_meeting_assets.py
@@ -14,10 +14,10 @@ has via its update_or_create guard.
 
 from __future__ import annotations
 
-import json
 from typing import Any
 
-from app.cache.redis_manager import RedisManager, TTL_IDEMPOTENCY
+from app.cache.idempotency import IdempotencyGuard
+from app.cache.redis_manager import RedisManager
 from app.core.logging import get_logger
 from app.services.backend_client import BackendClient
 from app.skills.base import BaseSkill
@@ -41,6 +41,7 @@ class RegisterMeetingAssets(BaseSkill):
         super().__init__(meta)
         self._backend = backend
         self._redis = redis
+        self._guard = IdempotencyGuard(redis) if redis is not None else None
 
     async def run(self, context: SkillContext) -> SkillResult:
         session_id = context.input_context.get("session_id")
@@ -65,7 +66,11 @@ class RegisterMeetingAssets(BaseSkill):
                 output={"registered": [], "error": "backend client not configured"},
             )
 
-        cached = await self._check_idempotency(tenant_id, session_id)
+        cached = (
+            await self._guard.check(tenant_id, f"skl11:{session_id}")
+            if self._guard is not None
+            else None
+        )
         if cached is not None:
             logger.info("register_assets_idempotent_hit", session_id=session_id)
             return SkillResult(skill_id=SKILL_ID, output=cached)
@@ -110,36 +115,7 @@ class RegisterMeetingAssets(BaseSkill):
             "failed_count": len(failed),
         }
 
-        if registered:
-            await self._store_idempotency(tenant_id, session_id, output)
+        if registered and self._guard is not None:
+            await self._guard.store(tenant_id, f"skl11:{session_id}", output)
 
         return SkillResult(skill_id=SKILL_ID, output=output)
-
-    # ── Idempotency ──────────────────────────────────────────────────
-
-    async def _check_idempotency(
-        self, tenant_id: str, session_id: str
-    ) -> dict[str, Any] | None:
-        if self._redis is None:
-            return None
-        keys = self._redis.keys_for(tenant_id)
-        key = keys.idempotency(f"skl11:{session_id}")
-        raw = await self._redis.client.get(key)
-        if raw is None:
-            return None
-        try:
-            parsed = json.loads(raw)
-        except (json.JSONDecodeError, TypeError):
-            return None
-        if isinstance(parsed, dict):
-            return parsed
-        return None
-
-    async def _store_idempotency(
-        self, tenant_id: str, session_id: str, output: dict[str, Any]
-    ) -> None:
-        if self._redis is None:
-            return
-        keys = self._redis.keys_for(tenant_id)
-        key = keys.idempotency(f"skl11:{session_id}")
-        await self._redis.client.set(key, json.dumps(output), ex=TTL_IDEMPOTENCY)

--- a/onboarding-intelligence-agent-svc/app/skills/summarize_recording.py
+++ b/onboarding-intelligence-agent-svc/app/skills/summarize_recording.py
@@ -10,7 +10,8 @@ from typing import Any
 
 from app.core.logging import get_logger
 
-from app.cache.redis_manager import RedisManager, TTL_IDEMPOTENCY
+from app.cache.idempotency import IdempotencyGuard
+from app.cache.redis_manager import RedisManager
 from app.providers.llm import LLMProvider
 from app.services.backend_client import BackendClient
 from app.skills.base import BaseSkill
@@ -63,6 +64,7 @@ class SummarizeRecording(BaseSkill):
         self._llm = llm
         self._backend = backend
         self._redis = redis
+        self._guard = IdempotencyGuard(redis) if redis is not None else None
 
     async def run(self, context: SkillContext) -> SkillResult:
         recording_id = context.input_context["recording_id"]
@@ -74,7 +76,11 @@ class SummarizeRecording(BaseSkill):
         if self._redis is None or self._llm is None:
             raise RuntimeError("SummarizeRecording requires llm and redis providers")
 
-        cached = await self._check_idempotency(tenant_id, recording_id)
+        cached = (
+            await self._guard.check(tenant_id, f"skl08:{recording_id}")
+            if self._guard is not None
+            else None
+        )
         if cached is not None and "transcript_segments" in cached:
             logger.info("summary_idempotent_hit", recording_id=recording_id)
             return SkillResult(skill_id=self.meta.skill_id, output=cached)
@@ -107,7 +113,8 @@ class SummarizeRecording(BaseSkill):
                 transcript_segments=segments,
             )
 
-            await self._store_idempotency(tenant_id, recording_id, output)
+            if self._guard is not None:
+                await self._guard.store(tenant_id, f"skl08:{recording_id}", output)
 
         return SkillResult(skill_id=self.meta.skill_id, output=output)
 
@@ -170,31 +177,6 @@ class SummarizeRecording(BaseSkill):
             moments.append({"t": snapped, "label": str(label)})
 
         return {"text": str(text), "key_moments": moments}
-
-    # -- idempotency -----------------------------------------------------------
-
-    async def _check_idempotency(
-        self, tenant_id: str, recording_id: str
-    ) -> dict[str, Any] | None:
-        assert self._redis is not None
-        keys = self._redis.keys_for(tenant_id)
-        key = keys.idempotency(f"skl08:{recording_id}")
-        raw = await self._redis.client.get(key)
-        if raw is None:
-            return None
-        try:
-            parsed: dict[str, Any] = json.loads(raw)
-            return parsed
-        except (json.JSONDecodeError, TypeError):
-            return None
-
-    async def _store_idempotency(
-        self, tenant_id: str, recording_id: str, summary: dict[str, Any]
-    ) -> None:
-        assert self._redis is not None
-        keys = self._redis.keys_for(tenant_id)
-        key = keys.idempotency(f"skl08:{recording_id}")
-        await self._redis.client.set(key, json.dumps(summary), ex=TTL_IDEMPOTENCY)
 
 
 # -- pure helpers (module-level for testability) ------------------------------

--- a/onboarding-intelligence-agent-svc/app/skills/summarize_recording.py
+++ b/onboarding-intelligence-agent-svc/app/skills/summarize_recording.py
@@ -76,11 +76,8 @@ class SummarizeRecording(BaseSkill):
         if self._redis is None or self._llm is None:
             raise RuntimeError("SummarizeRecording requires llm and redis providers")
 
-        cached = (
-            await self._guard.check(tenant_id, f"skl08:{recording_id}")
-            if self._guard is not None
-            else None
-        )
+        assert self._guard is not None  # guaranteed by _redis check above
+        cached = await self._guard.check(tenant_id, f"skl08:{recording_id}")
         if cached is not None and "transcript_segments" in cached:
             logger.info("summary_idempotent_hit", recording_id=recording_id)
             return SkillResult(skill_id=self.meta.skill_id, output=cached)
@@ -113,8 +110,7 @@ class SummarizeRecording(BaseSkill):
                 transcript_segments=segments,
             )
 
-            if self._guard is not None:
-                await self._guard.store(tenant_id, f"skl08:{recording_id}", output)
+            await self._guard.store(tenant_id, f"skl08:{recording_id}", output)
 
         return SkillResult(skill_id=self.meta.skill_id, output=output)
 

--- a/onboarding-intelligence-agent-svc/tests/test_idempotency.py
+++ b/onboarding-intelligence-agent-svc/tests/test_idempotency.py
@@ -1,0 +1,86 @@
+"""B-06 (Gap 5) — IdempotencyGuard unit tests.
+
+No mocks: real Redis for every assertion.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.cache.idempotency import IdempotencyGuard
+from app.cache.redis_manager import RedisManager, TTL_IDEMPOTENCY
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def guard(live_redis: RedisManager) -> IdempotencyGuard:
+    return IdempotencyGuard(live_redis)
+
+
+TENANT = "t-idem-test"
+
+
+async def test_check_returns_none_when_key_missing(guard: IdempotencyGuard):
+    result = await guard.check(TENANT, "nonexistent-digest")
+    assert result is None
+
+
+async def test_store_then_check_returns_stored_payload(guard: IdempotencyGuard):
+    payload = {"job_id": "j1", "status": "ACCEPTED"}
+    await guard.store(TENANT, "digest-abc", payload)
+    cached = await guard.check(TENANT, "digest-abc")
+    assert cached == payload
+
+
+async def test_check_returns_none_on_corrupt_json(
+    guard: IdempotencyGuard, live_redis: RedisManager
+):
+    keys = live_redis.keys_for(TENANT)
+    key = keys.idempotency("corrupt-key")
+    await live_redis.client.set(key, b"not-json{{{", ex=60)
+
+    result = await guard.check(TENANT, "corrupt-key")
+    assert result is None
+
+
+async def test_store_uses_custom_ttl(guard: IdempotencyGuard, live_redis: RedisManager):
+    await guard.store(TENANT, "short-ttl", {"x": 1}, ttl=10)
+    keys = live_redis.keys_for(TENANT)
+    key = keys.idempotency("short-ttl")
+    ttl = await live_redis.client.ttl(key)
+    assert 1 <= ttl <= 10
+
+
+async def test_store_default_ttl_is_24h(
+    guard: IdempotencyGuard, live_redis: RedisManager
+):
+    await guard.store(TENANT, "default-ttl", {"x": 1})
+    keys = live_redis.keys_for(TENANT)
+    key = keys.idempotency("default-ttl")
+    ttl = await live_redis.client.ttl(key)
+    assert TTL_IDEMPOTENCY - 5 <= ttl <= TTL_IDEMPOTENCY
+
+
+async def test_different_tenants_are_isolated(guard: IdempotencyGuard):
+    await guard.store("tenant-a", "same-digest", {"from": "a"})
+    await guard.store("tenant-b", "same-digest", {"from": "b"})
+
+    a = await guard.check("tenant-a", "same-digest")
+    b = await guard.check("tenant-b", "same-digest")
+    assert a == {"from": "a"}
+    assert b == {"from": "b"}
+
+
+async def test_different_digests_are_isolated(guard: IdempotencyGuard):
+    await guard.store(TENANT, "d1", {"v": 1})
+    await guard.store(TENANT, "d2", {"v": 2})
+
+    assert (await guard.check(TENANT, "d1")) == {"v": 1}
+    assert (await guard.check(TENANT, "d2")) == {"v": 2}
+
+
+async def test_store_overwrites_existing(guard: IdempotencyGuard):
+    await guard.store(TENANT, "overwrite", {"v": 1})
+    await guard.store(TENANT, "overwrite", {"v": 2})
+    assert (await guard.check(TENANT, "overwrite")) == {"v": 2}

--- a/onboarding-intelligence-agent-svc/tests/test_idempotency.py
+++ b/onboarding-intelligence-agent-svc/tests/test_idempotency.py
@@ -84,3 +84,14 @@ async def test_store_overwrites_existing(guard: IdempotencyGuard):
     await guard.store(TENANT, "overwrite", {"v": 1})
     await guard.store(TENANT, "overwrite", {"v": 2})
     assert (await guard.check(TENANT, "overwrite")) == {"v": 2}
+
+
+async def test_check_returns_none_for_non_dict_json(
+    guard: IdempotencyGuard, live_redis: RedisManager
+):
+    """Valid JSON that is not a dict (list, string, number) is a miss."""
+    keys = live_redis.keys_for(TENANT)
+    for label, value in [("list", "[1,2,3]"), ("str", '"hello"'), ("num", "42")]:
+        key = keys.idempotency(f"non-dict-{label}")
+        await live_redis.client.set(key, value, ex=60)
+        assert await guard.check(TENANT, f"non-dict-{label}") is None

--- a/onboarding-intelligence-agent-svc/tests/test_scaffold.py
+++ b/onboarding-intelligence-agent-svc/tests/test_scaffold.py
@@ -110,6 +110,9 @@ IMPLEMENTED = {
 #: rather than a silent one.
 IMPLEMENTED |= {"app.api.deps", "app.api.schemas"}
 
+#: B-06 (Gap 5): IdempotencyGuard extracted from ProcessExecutor.
+IMPLEMENTED |= {"app.cache.idempotency"}
+
 #: Implemented by C-02. §18.2 specified config/circuit_breakers.yaml and this
 #: module from the start, but no story owned building them — the scaffold
 #: docstring named A-06, whose acceptance criteria never mention breakers.


### PR DESCRIPTION
## Summary

- Extracts the repeated check/store idempotency pattern from `ProcessExecutor`, `SummarizeRecording` (SKL-OIA-08), and `RegisterMeetingAssets` (SKL-OIA-11) into a shared `IdempotencyGuard` class at `app/cache/idempotency.py`
- The guard provides `check(tenant_id, digest)` → `dict | None` and `store(tenant_id, digest, payload, ttl)` with default TTL_IDEMPOTENCY (24h), consistent corrupt-JSON handling, and key isolation through `TenantKeys.idempotency()`
- `ProcessExecutor` receives the guard via constructor injection; skills construct their own from the `redis` provider they already receive — no provider wiring changes needed
- Net -22 lines across 6 modified files (3 copies → 1 shared class)

## Changes

| File | Change |
|------|--------|
| `app/cache/idempotency.py` | Replaced stub with `IdempotencyGuard(redis)` class |
| `app/logic/process_executor.py` | Removed `_check_idempotency` and `_store_idempotency`; `accept()`, `get_job()` now delegate to `self._guard` |
| `app/main.py` | Constructs `IdempotencyGuard` and injects into `ProcessExecutor` |
| `app/skills/summarize_recording.py` | Removed inline idempotency methods; uses `self._guard` |
| `app/skills/register_meeting_assets.py` | Removed inline idempotency methods; uses `self._guard` |
| `tests/test_scaffold.py` | Marks `app.cache.idempotency` as implemented |
| `tests/test_idempotency.py` | 8 new integration tests (real Redis) |

## Test plan

- [x] 8 new `test_idempotency.py` tests pass (check miss, store→check roundtrip, corrupt JSON, custom TTL, default 24h TTL, tenant isolation, digest isolation, overwrite)
- [x] 5 existing `test_process_endpoint.py` tests pass (idempotent request returns same job)
- [x] 32 existing skill tests pass (`test_summarize_recording.py`, `test_register_meeting_assets.py`)
- [x] 54 key isolation tests pass (`test_redis_key_isolation.py`)
- [x] 63 scaffold tests pass (`test_scaffold.py`)
- [x] flake8 clean, mypy clean (1 pre-existing error in summarize_recording unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mJqBGyJYK8Tkc4RxM2TK1