### PR TITLE
feat(oia): multi-stream audio capture (O-02)

### DIFF
--- a/ai-brand-automator-frontend/src/components/onboarding/RecorderControl.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/RecorderControl.tsx
@@ -14,7 +14,7 @@
  * server-side too.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { CloudOff, Mic, Square, UploadCloud } from 'lucide-react';
 
 import {
@@ -23,10 +23,16 @@ import {
   type UseMeetingRecorder,
 } from '@/hooks/useMeetingRecorder';
 import {
+  useMultiMicRecorder,
+  type StreamDevice,
+  type UseMultiMicRecorder,
+} from '@/hooks/useMultiMicRecorder';
+import {
   useChunkUploader,
   type UseChunkUploader,
 } from '@/hooks/useChunkUploader';
 import { finaliseRecording, openRecording } from '@/lib/onboarding-sessions';
+import type { MicAssignment } from '@/hooks/useAudioDevices';
 
 export interface RecorderControlProps {
   /** F-01: false keeps the control inert and pointing at the consent modal. */
@@ -38,6 +44,8 @@ export interface RecorderControlProps {
   sendBinary?: (data: ArrayBuffer | Uint8Array) => void;
   /** F-04: send start/stop control frames to the live WebSocket. */
   sendControl?: (frame: Record<string, unknown>) => void;
+  /** O-01: mic assignments from MicSetup. When present, multi-mic recording is used. */
+  micAssignments?: MicAssignment[];
   /** Injected in tests; the hook is the default. */
   recorder?: UseMeetingRecorder;
   /** Injected in tests; the hook is the default. */
@@ -58,22 +66,24 @@ export default function RecorderControl({
   sessionId,
   sendBinary,
   sendControl,
+  micAssignments = [],
   recorder,
   uploader: injectedUploader,
 }: RecorderControlProps) {
-  /*
-   * The hook is always called and the injection only chooses which result to
-   * use. `recorder ?? useMeetingRecorder()` would read more directly and is a
-   * rules-of-hooks violation that happens to be safe today — the kind that
-   * stops being safe the moment someone makes the prop conditional. An
-   * eslint-disable on that rule is not worth the two lines it saves.
-   *
-   * Injection rather than a context provider: a context to hand one hook to
-   * one component is more machinery than this seam needs, and F-03 and F-04
-   * will consume the hook directly rather than through this component.
-   */
-  const own = useMeetingRecorder();
-  const live = recorder ?? own;
+  const multiDevices: StreamDevice[] = useMemo(
+    () =>
+      micAssignments.map((a) => ({
+        deviceId: a.deviceId,
+        streamIndex: a.streamIndex,
+        label: a.label,
+      })),
+    [micAssignments],
+  );
+  const useMulti = micAssignments.length > 0;
+
+  const singleMic = useMeetingRecorder();
+  const multiMic = useMultiMicRecorder(multiDevices);
+  const live: UseMeetingRecorder | UseMultiMicRecorder = recorder ?? (useMulti ? multiMic : singleMic);
 
   const { state, error, elapsedSeconds, chunksRef, chunkCount, start, stop } = live;
   const recording = state === 'recording';

--- a/ai-brand-automator-frontend/src/components/onboarding/RightRail.tsx
+++ b/ai-brand-automator-frontend/src/components/onboarding/RightRail.tsx
@@ -104,6 +104,7 @@ export default function RightRail({
           onRecordConsent={onRecordConsent}
           sendBinary={sendBinary}
           sendControl={sendControl}
+          micAssignments={micAssignments}
         />
 
         <CaptureControl

--- a/ai-brand-automator-frontend/src/hooks/useMultiMicRecorder.ts
+++ b/ai-brand-automator-frontend/src/hooks/useMultiMicRecorder.ts
@@ -1,0 +1,213 @@
+'use client';
+
+/**
+ * Multi-mic recording for speaker-attributed transcripts (O-02).
+ *
+ * Opens one MediaRecorder per assigned mic. Each produces its own chunk
+ * stream tagged with a streamIndex so downstream consumers (F-04 WebSocket,
+ * F-03 GCS uploader, O-03 multi-stream protocol) know which speaker
+ * produced each chunk.
+ *
+ * A single AudioContext drives the elapsed timer across all streams —
+ * AC-3 requires the timer to be accurate regardless of how many mics
+ * are active.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import {
+  TIMESLICE_MS,
+  SAMPLE_RATE,
+  UNSUPPORTED_MESSAGE,
+  BLOCKED_MESSAGE,
+  supportedOpusMimeType,
+  type RecorderState,
+} from '@/hooks/useMeetingRecorder';
+
+export { SAMPLE_RATE, TIMESLICE_MS };
+
+export interface StreamDevice {
+  deviceId: string;
+  streamIndex: number;
+  label: string;
+}
+
+export interface TaggedChunk {
+  blob: Blob;
+  index: number;
+  streamIndex: number;
+}
+
+export interface UseMultiMicRecorder {
+  state: RecorderState;
+  error: string | null;
+  elapsedSeconds: number;
+  chunksRef: React.RefObject<TaggedChunk[]>;
+  chunkCount: number;
+  mimeType: string | null;
+  start: () => Promise<void>;
+  stop: () => Promise<void>;
+}
+
+interface StreamHandle {
+  streamIndex: number;
+  mediaStream: MediaStream;
+  recorder: MediaRecorder;
+}
+
+export function useMultiMicRecorder(
+  devices: StreamDevice[],
+): UseMultiMicRecorder {
+  const [state, setState] = useState<RecorderState>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [elapsedSeconds, setElapsed] = useState(0);
+  const chunksRef = useRef<TaggedChunk[]>([]);
+  const [chunkCount, setChunkCount] = useState(0);
+  const [mimeType, setMimeType] = useState<string | null>(null);
+
+  const handles = useRef<StreamHandle[]>([]);
+  const audioContext = useRef<AudioContext | null>(null);
+  const startedAt = useRef(0);
+  const ticker = useRef<ReturnType<typeof setInterval> | null>(null);
+  const nextIndex = useRef(0);
+
+  const readElapsed = useCallback(() => {
+    const context = audioContext.current;
+    if (!context) return 0;
+    return Math.max(0, context.currentTime - startedAt.current);
+  }, []);
+
+  const teardown = useCallback(() => {
+    if (ticker.current) {
+      clearInterval(ticker.current);
+      ticker.current = null;
+    }
+    for (const h of handles.current) {
+      if (h.recorder.state !== 'inactive') {
+        try { h.recorder.stop(); } catch { /* already stopped */ }
+      }
+      h.mediaStream.getTracks().forEach((t) => t.stop());
+    }
+    handles.current = [];
+    void audioContext.current?.close?.();
+    audioContext.current = null;
+  }, []);
+
+  const start = useCallback(async () => {
+    setError(null);
+
+    const type = supportedOpusMimeType();
+    if (!type) {
+      setState('unsupported');
+      setError(UNSUPPORTED_MESSAGE);
+      return;
+    }
+
+    if (devices.length === 0) {
+      setState('unsupported');
+      setError('No microphones assigned. Set up microphones first.');
+      return;
+    }
+
+    setState('requesting');
+
+    const opened: StreamHandle[] = [];
+    for (const dev of devices) {
+      let mediaStream: MediaStream;
+      try {
+        mediaStream = await navigator.mediaDevices.getUserMedia({
+          audio: { deviceId: { exact: dev.deviceId }, sampleRate: SAMPLE_RATE, channelCount: 1 },
+        });
+      } catch {
+        for (const h of opened) {
+          h.mediaStream.getTracks().forEach((t) => t.stop());
+        }
+        setState('blocked');
+        setError(BLOCKED_MESSAGE);
+        return;
+      }
+
+      const recorder = new MediaRecorder(mediaStream, { mimeType: type });
+      const streamIndex = dev.streamIndex;
+
+      recorder.ondataavailable = (event: BlobEvent) => {
+        if (!event.data || event.data.size === 0) return;
+        const index = nextIndex.current;
+        nextIndex.current += 1;
+        chunksRef.current.push({ blob: event.data, index, streamIndex });
+        setChunkCount((n) => n + 1);
+      };
+
+      opened.push({ streamIndex, mediaStream, recorder });
+    }
+
+    const context = new AudioContext({ sampleRate: SAMPLE_RATE });
+    if (context.state === 'suspended') {
+      await context.resume();
+    }
+    audioContext.current = context;
+    startedAt.current = context.currentTime;
+
+    handles.current = opened;
+    setMimeType(type);
+
+    for (const h of opened) {
+      h.recorder.start(TIMESLICE_MS);
+    }
+
+    setState('recording');
+    setElapsed(0);
+    ticker.current = setInterval(() => setElapsed(readElapsed()), 200);
+  }, [devices, readElapsed]);
+
+  const stop = useCallback(async () => {
+    const active = handles.current.filter((h) => h.recorder.state !== 'inactive');
+    if (active.length === 0) {
+      setState('idle');
+      teardown();
+      return;
+    }
+
+    setState('stopping');
+
+    await Promise.all(
+      active.map(
+        (h) =>
+          new Promise<void>((resolve) => {
+            h.recorder.onstop = () => resolve();
+            h.recorder.stop();
+          }),
+      ),
+    );
+
+    setElapsed(readElapsed());
+    setState('idle');
+    teardown();
+  }, [readElapsed, teardown]);
+
+  useEffect(() => {
+    if (state !== 'recording') return;
+    const previous = document.title;
+    document.title = `● Recording — ${previous}`;
+    return () => {
+      document.title = previous;
+    };
+  }, [state]);
+
+  useEffect(() => {
+    if (state !== 'recording') return;
+    const warn = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue =
+        'Recording is still running. Closing this tab loses the audio ' +
+        'captured so far.';
+      return event.returnValue;
+    };
+    window.addEventListener('beforeunload', warn);
+    return () => window.removeEventListener('beforeunload', warn);
+  }, [state]);
+
+  useEffect(() => teardown, [teardown]);
+
+  return { state, error, elapsedSeconds, chunksRef, chunkCount, mimeType, start, stop };
+}


### PR DESCRIPTION
## Summary

- **useMultiMicRecorder hook**: Opens one `getUserMedia` + `MediaRecorder` per assigned mic device. Each chunk is tagged with `streamIndex` for downstream speaker attribution (O-03 protocol, O-08 persistence).
- **Single AudioContext**: Shared across all streams for accurate elapsed timer (AC-3).
- **TaggedChunk type**: Extends `RecordedChunk` with `streamIndex` field — structurally compatible with existing `useChunkUploader`.
- **RecorderControl integration**: Accepts `micAssignments` prop; when present, uses multi-mic recorder. Falls back to single-mic `useMeetingRecorder` when no assignments exist (backwards compatible).
- **RightRail**: Passes `micAssignments` through to `RecorderControl`.

## Acceptance Criteria (O-02)

- [x] AC-1: N microphones produce N independent chunk streams (one `MediaRecorder` per device)
- [x] AC-2: Each chunk carries its `streamIndex` for downstream attribution
- [x] AC-3: Elapsed timer is accurate across all streams (single `AudioContext`)
- [x] AC-4: Tab title shows "● Recording" as before
- [x] AC-5: Stopping releases all mic tracks (`teardown` iterates all handles)

## Test Plan

- [x] TypeScript strict mode — zero errors
- [x] ESLint — zero errors (0 errors, pre-existing warnings only)
- [x] Jest — 483 tests pass (37 suites)
- [ ] Manual browser test with 2+ mics: verify both produce chunks, timer runs, tab title updates, stop releases both

🤖 Generated with [Claude Code](https://claude.com/claude-code)